### PR TITLE
Add var for different space monitoring path (old way)

### DIFF
--- a/plugins/diskspace/action.php
+++ b/plugins/diskspace/action.php
@@ -1,3 +1,4 @@
 <?php
 	require_once( '../../php/util.php' );
-	cachedEcho('{ "total": '.disk_total_space($topDirectory).', "free": '.disk_free_space($topDirectory).' }',"application/json");
+	require_once( 'conf.php' );
+	cachedEcho('{ "total": '.disk_total_space(($dirToMonSpace?$dirToMonSpace:$topDirectory)).', "free": '.disk_free_space(($dirToMonSpace?$dirToMonSpace:$topDirectory)).' }',"application/json");

--- a/plugins/diskspace/conf.php
+++ b/plugins/diskspace/conf.php
@@ -1,4 +1,5 @@
 <?php
 
+$dirToMonSpace = '/data/';      // path to dir, which space we will count (if null, then $topDirectory used)
 $diskUpdateInterval = 10;	// in seconds
 $notifySpaceLimit = 512;	// in Mb

--- a/plugins/diskspace/conf.php
+++ b/plugins/diskspace/conf.php
@@ -1,5 +1,5 @@
 <?php
 
-$dirToMonSpace = '/data/';      // path to dir, which space we will count (if null, then $topDirectory used)
+$dirToMonSpace = '';      // path to dir, which space we will count (if null, then $topDirectory used)
 $diskUpdateInterval = 10;	// in seconds
 $notifySpaceLimit = 512;	// in Mb


### PR DESCRIPTION
If download dir is in another mounted disk, we'll need to write path to it for right space monitoring.
Added new var for path to folder, which is needed to be monitored.