### PR TITLE
Kill child process before task process.

### DIFF
--- a/plugins/_task/task.php
+++ b/plugins/_task/task.php
@@ -216,7 +216,8 @@ class rTask
 				if(is_null($flags))
 					$flags = intval(file_get_contents($dir.'/flags'));
 				$pid = trim(file_get_contents($dir.'/pid'));
-				self::run("kill -9 ".$pid." ; kill -9 `".getExternal("pgrep")." -P ".$pid."`", ($flags & self::FLG_RUN_AS_WEB) | self::FLG_WAIT | self::FLG_RUN_AS_CMD );
+				self::run("kill -9 `".getExternal("pgrep")." -P ".$pid."`", ($flags & self::FLG_RUN_AS_WEB) | self::FLG_WAIT | self::FLG_RUN_AS_CMD );
+				self::run("kill -9 ".$pid, ($flags & self::FLG_RUN_AS_WEB) | self::FLG_WAIT | self::FLG_RUN_AS_CMD );
 			}				
 			self::clean($dir);
 		}


### PR DESCRIPTION
When you killed a task, you first closed the task before killing its children and therefore their were not closed.
Now I act in the other way, by killing the children before.