### PR TITLE
check rtorrent working directory free space in diskspace plugin 

### DIFF
--- a/plugins/diskspace/action.php
+++ b/plugins/diskspace/action.php
@@ -1,3 +1,3 @@
 <?php
 	require_once( '../../php/util.php' );
-	cachedEcho('{ "total": '.disk_total_space($topDirectory).', "free": '.disk_free_space($topDirectory).' }',"application/json");
+	cachedEcho('{ "total": '.disk_total_space($_GET["p"]).', "free": '.disk_free_space($_GET["p"]).' }',"application/json");

--- a/plugins/diskspace/init.js
+++ b/plugins/diskspace/init.js
@@ -48,7 +48,7 @@ plugin.init = function()
 				timeout: theWebUI.settings["webui.reqtimeout"],
 			        async : true,
 			        cache: false,
-				url : "plugins/diskspace/action.php",
+				url : "plugins/diskspace/action.php?p="+plugin.folderToScan,
 				dataType : "json",
 				cache: false,
 				success : function(data)

--- a/plugins/diskspace/init.php
+++ b/plugins/diskspace/init.php
@@ -7,6 +7,6 @@ if(!function_exists('disk_total_space') || !function_exists('disk_free_space') |
 	$jResult .= "plugin.disable();";
 else
 {
-	$jResult.="plugin.interval = ".$diskUpdateInterval."; plugin.notifySpaceLimit = ".($notifySpaceLimit*1024*1024).";";
+	$jResult.="plugin.interval = ".$diskUpdateInterval."; plugin.notifySpaceLimit = ".($notifySpaceLimit*1024*1024)."; plugin.folderToScan = '".rTorrentSettings::get()->directory."';";
 	$theSettings->registerPlugin($plugin["name"],$pInfo["perms"]);
 }


### PR DESCRIPTION
Before - we check $topDirectory (rutorrent main directory)
After - we check rtorrent working directory free space

This change will display valid data in situations when rtorrent working directory is on another drive.

If there is an option to get rtorrent working directory in plugin on server side - please tell me, it would be more elegant.