### PR TITLE
work around for file system which is marked as noexec fixes #997

### DIFF
--- a/php/getplugins.php
+++ b/php/getplugins.php
@@ -171,8 +171,8 @@ function findRemoteEXE( $exe, $err, &$remoteRequests )
 		global $pathToExternals;
 		$add = '';
 		if(isset($pathToExternals[$exe]) && !empty($pathToExternals[$exe]))
-			$add = " ".escapeshellarg($pathToExternals[$exe]);
-		$req = new rXMLRPCRequest(new rXMLRPCCommand("execute", array( "sh", "-c", "/bin/sh ".escapeshellarg(addslash($path)."test.sh")." ".$exe." ".escapeshellarg($st).$add)));
+		  $add = $pathToExternals[$exe];
+		$req = new rXMLRPCRequest(new rXMLRPCCommand("execute", array( "sh", addslash($path)."test.sh", $exe, $st, $add)));
 		$req->run();
 		$remoteRequests[$exe] = array( "path"=>$st, "err"=>array() );
 	}

--- a/php/getplugins.php
+++ b/php/getplugins.php
@@ -172,7 +172,7 @@ function findRemoteEXE( $exe, $err, &$remoteRequests )
 		$add = '';
 		if(isset($pathToExternals[$exe]) && !empty($pathToExternals[$exe]))
 			$add = " ".escapeshellarg($pathToExternals[$exe]);
-		$req = new rXMLRPCRequest(new rXMLRPCCommand("execute", array( "sh", "-c", escapeshellarg(addslash($path)."test.sh")." ".$exe." ".escapeshellarg($st).$add)));
+		$req = new rXMLRPCRequest(new rXMLRPCCommand("execute", array( "sh", "-c", "/bin/sh ".escapeshellarg(addslash($path)."test.sh")." ".$exe." ".escapeshellarg($st).$add)));
 		$req->run();
 		$remoteRequests[$exe] = array( "path"=>$st, "err"=>array() );
 	}


### PR DESCRIPTION
Fixes the problem of loading the plugins if ruTorrent is stored on a noexec file system.