### PR TITLE
PHP: Use 'time' function to get unixtime for timestamp

### DIFF
--- a/php/util.php
+++ b/php/util.php
@@ -449,7 +449,7 @@ function findEXE( $exe )
 
 function cachedEcho( $content, $type = null, $cacheable = false, $exit = true )
 {
-	header("X-Server-Timestamp: ".strftime('%s'));
+	header("X-Server-Timestamp: ".time());
 	if($cacheable && isset($_SERVER['REQUEST_METHOD']) && ($_SERVER['REQUEST_METHOD']=='GET'))
 	{
 		$etag = '"'.strtoupper(dechex(crc32($content))).'"';


### PR DESCRIPTION
`Strftime('%s')` and `time()` is equivalent, but using  `time` avoids the error:
> 2015/02/11 07:29:46 [error] 3181#0: *9322 FastCGI sent in stderr: "PHP message: PHP Warning:  strftime(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in /usr/share/webapps/rutorrent/php/util.php on line 452" while reading response header from upstream, client: 192.168.1.103, server: localhost, request: "POST /plugins/httprpc/action.php HTTP/1.1", upstream: "fastcgi://unix:/run/php-fpm/php-fpm.sock:", host: "192.168.1.1:1234", referrer: "http://192.168.1.1:1234/"