### PR TITLE
Fixed broken 'Open in Browser' links for KickAssTorrents in extsearch plugin

### DIFF
--- a/plugins/extsearch/engines/KickAssTorrents.php
+++ b/plugins/extsearch/engines/KickAssTorrents.php
@@ -24,7 +24,7 @@ class KickAssTorrentsEngine extends commonEngine
 			$cli = $this->fetch( $url.'/usearch/'.$what.$cat.'/'.$pg.'/?field=seeders&sorder=desc' );
 			if( ($cli==false) || (strpos($cli->results, "<h2>Nothing found!</h2>")!==false) )
 				break;
-			$res = preg_match_all('`href="magnet:(?P<link>.*)".*<div class="torrentname">.*'.
+			$res = preg_match_all('`href="magnet:(?P<link>.*)".*<div class="torrentname">.*<div class="markeredBlock.*'.
 				'<a href="(?P<desc>.*)" class="cellMainLink">(?P<name>.*)</a>.*'.
 				'<span id="cat_\d+">(?P<cat>.*)</span>.*'.
 				'<td class="nobr.*">(?P<size>.*)</td>.*'.


### PR DESCRIPTION
Looks like the site formatting has changed slightly on the KickAss search results page. It was causing the `preg_match_all()` in the engine to grab the wrong <a> tag. The results looked like this:

![screenshot - 02212015 - 09 09 34 am](https://cloud.githubusercontent.com/assets/298414/6314835/43825404-b9ab-11e4-88a1-160dc80aeb41.png)

With this change the correct <a> tag is being now being matched, therefore returning the correct link.