### PR TITLE
Changed the order of the location it checks for label images.

### DIFF
--- a/plugins/tracklabels/action.php
+++ b/plugins/tracklabels/action.php
@@ -9,16 +9,16 @@ set_time_limit(0);
 if(isset($_REQUEST["label"]))
 {
 	$label = strtolower(rawurldecode($_REQUEST["label"]));
-	$name = dirname(__FILE__)."/labels/".$label.".png";
+	$name = getSettingsPath().'/labels';
+	if(!is_dir($name))
+		makeDirectory($name);
+	$name.=('/'.$label.".png");
 	if(is_readable($name))
 	{
 		sendFile( $name, "image/png" );
 		exit;
 	}
-	$name = getSettingsPath().'/labels';
-	if(!is_dir($name))
-		makeDirectory($name);
-	$name.=('/'.$label.".png");
+	$name = dirname(__FILE__)."/labels/".$label.".png";
 	if(is_readable($name))
 	{
 		sendFile( $name, "image/png" );


### PR DESCRIPTION
Before it was the global plugin dir first, then the user settings path. Now it check the user settings path first then the global.  This gives the user settings path higher priority, so that if both locations contain an image of the same name, the user settings path one will be used.  Fixes #1016