### PR TITLE
Fix scrollbar thumb blending with background

### DIFF
--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -210,4 +210,18 @@ span.det {color:#fff;}
 
 .meter-value-start-color { background-color: #E05400 }
 .meter-value-end-color { background-color: #8FBC00 }
-::-webkit-scrollbar {width:12px;height:12px;padding:0px;margin:0px;}
+::-webkit-scrollbar {
+    width: 15px;
+    height: 15px;
+}
+::-webkit-scrollbar-thumb {
+    height: 12px;
+    border: 3px solid rgba(0, 0, 0, 0);
+    background-clip: padding-box;
+    background-color: rgba(0, 0, 0, 0.3);
+}
+::-webkit-scrollbar-button {
+    width: 0;
+    height: 0;
+    display: none;
+}


### PR DESCRIPTION
 When "Alternate list background colour" is enabled, the torrent list blends with the scrollbar thumb

![before](https://cloud.githubusercontent.com/assets/4564104/6833547/5340b058-d304-11e4-9752-623eaa9a41a6.PNG)
![after](https://cloud.githubusercontent.com/assets/4564104/6833548/592db268-d304-11e4-8d6e-0fb73b7815df.PNG)