### PR TITLE
Option to delete archive files after successful auto unpacking

### DIFF
--- a/plugins/unpack/conf.php
+++ b/plugins/unpack/conf.php
@@ -7,4 +7,4 @@ $pathToExternals['unzip'] = '';		// Something like /usr/bin/unzip. If empty, wil
 $pathToExternals['unrar'] = '';		// Something like /usr/bin/unrar. If empty, will be found in PATH.
 
 $cleanupAutoTasks = false;		// Remove autounpack tasks parameters after finish, otherwise will be shown in the 'Tasks' tab
-$deleteAutoArchives = false;	// Delete archive files after successful auto unpack. Do not enable if you are seeding from the complete directory.
+$deleteAutoArchives = false;	// Delete archive files after successful auto unpack. Will not remove archives unless AutoMove is enabled and the operation type is not Move.

--- a/plugins/unpack/conf.php
+++ b/plugins/unpack/conf.php
@@ -7,3 +7,4 @@ $pathToExternals['unzip'] = '';		// Something like /usr/bin/unzip. If empty, wil
 $pathToExternals['unrar'] = '';		// Something like /usr/bin/unrar. If empty, will be found in PATH.
 
 $cleanupAutoTasks = false;		// Remove autounpack tasks parameters after finish, otherwise will be shown in the 'Tasks' tab
+$deleteAutoArchives = false;	// Delete archive files after successful auto unpack. Do not enable if you are seeding from the complete directory.

--- a/plugins/unpack/unall_dir.sh
+++ b/plugins/unpack/unall_dir.sh
@@ -4,12 +4,13 @@
 # $2 - intput directory with tail slash
 # $3 - output directory with tail slash
 # $4 - unzip
+# $5 - delete archives after auto unpack
 
 ret=0
-"$(dirname $0)"/unrar_dir.sh "$1" "$2" "$3"
+"$(dirname $0)"/unrar_dir.sh "$1" "$2" "$3" "$4" "$5"
 last=$?
 [ $last -gt 1 ] && ret=$last
-"$(dirname $0)"/unzip_dir.sh "$4" "$2" "$3"
+"$(dirname $0)"/unzip_dir.sh "$4" "$2" "$3" "$1" "$5"
 last=$?
 [ $last -gt 1 ] && ret=$last
 exit $ret

--- a/plugins/unpack/unpack.php
+++ b/plugins/unpack/unpack.php
@@ -81,6 +81,12 @@ class rUnpack
 			if(!$qt->check())
 				return;
 		}
+		if(rTorrentSettings::get()->isPluginRegistered('autotools'))
+		{
+			require_once( dirname(__FILE__)."/../autotools/autotools.php" );
+			$at = rAutoTools::load();
+			$performArchiveDeletion = ($deleteAutoArchives && $at->enable_move && ($at->fileop_type != 'Move'));
+		}
 
 		$pathToUnrar = getExternal("unrar");
 		$pathToUnzip = getExternal("unzip");
@@ -123,7 +129,7 @@ class rUnpack
 				escapeshellarg($basename)." ".
 				escapeshellarg($outPath)." ".
 				escapeshellarg($pathToUnzip)." ".
-				escapeshellarg(var_export($deleteAutoArchives, true));
+				escapeshellarg(var_export($performArchiveDeletion, true));
 			if($cleanupAutoTasks)
 				$commands[] = 'rm -r "${dir}"';	
 			$task = new rTask( array

--- a/plugins/unpack/unpack.php
+++ b/plugins/unpack/unpack.php
@@ -73,6 +73,7 @@ class rUnpack
 	{
 		global $rootPath;
 		global $cleanupAutoTasks;
+		global $deleteAutoArchives;
 		if(rTorrentSettings::get()->isPluginRegistered('quotaspace'))
 		{
 			require_once( dirname(__FILE__)."/../quotaspace/rquota.php" );
@@ -107,7 +108,6 @@ class rUnpack
 			if($outPath=='')
 				$outPath = dirname($basename);
 			$mode = ($zipPresent ? 'zip' : ($rarPresent ? 'rar' : null));
-		        $pathToUnzip = "";
 		}
 		if($mode)
 		{
@@ -122,7 +122,8 @@ class rUnpack
 				escapeshellarg($arh)." ".
 				escapeshellarg($basename)." ".
 				escapeshellarg($outPath)." ".
-				escapeshellarg($pathToUnzip);
+				escapeshellarg($pathToUnzip)." ".
+				escapeshellarg(var_export($deleteAutoArchives, true));
 			if($cleanupAutoTasks)
 				$commands[] = 'rm -r "${dir}"';	
 			$task = new rTask( array

--- a/plugins/unpack/unrar_dir.sh
+++ b/plugins/unpack/unrar_dir.sh
@@ -3,6 +3,7 @@
 # $1 - unrar
 # $2 - input directory with tail slash
 # $3 - output directory with tail slash
+# $5 - delete archives after auto unpack
 
 ret=0
 
@@ -23,3 +24,8 @@ process_directory()
 }
 
 process_directory "$1" "$2" "$3"
+
+ret=$?
+if [ $ret -le 1 ] && [ "$5" = 'true' ] ; then
+	find "$2" \( -name '*.rar' -o -name '*.raR' -o -name '*.rAr' -o -name '*.rAR' -o -name '*.Rar' -o -name '*.RaR' -o -name '*.RAr' -o -name '*.RAR' -o -name '*.r[0-9][0-9]' -o -name '*.R[0-9][0-9]' -o -name '*.[0-9][0-9][0-9]' \) -exec rm {} +
+fi

--- a/plugins/unpack/unrar_file.sh
+++ b/plugins/unpack/unrar_file.sh
@@ -3,6 +3,11 @@
 # $1 - unrar
 # $2 - archive
 # $3 - output directory with tail slash
+# $5 - delete archive after auto unpack
 
 "$1" x -ai -c- -kb -o+ -p- -y -v -- "$2" "$3"
 
+ret=$?
+if [ $ret -le 1 ] && [  "$5" = 'true' ] ; then
+	rm "$2"
+fi

--- a/plugins/unpack/unzip_dir.sh
+++ b/plugins/unpack/unzip_dir.sh
@@ -3,6 +3,7 @@
 # $1 - unzip
 # $2 - input directory with tail slash
 # $3 - output directory with tail slash
+# $5 - delete archives after auto unpack
 
 ret=0
 
@@ -31,5 +32,8 @@ process_directory "$1" "$2" "$3"
 
 ret=$?
 [ $ret -le 1 ] && echo 'All OK'
+if [ $ret -le 1 ] && [ "$5" = 'true' ] ; then
+	find "$2" \( -name '*.zip' -o -name '*.ziP' -o -name '*.zIp' -o -name '*.zIP' -o -name '*.Zip' -o -name '*.ZiP' -o -name '*.ZIp' -o -name '*.ZIP' \) -exec rm {} +
+fi
 
 exit $ret

--- a/plugins/unpack/unzip_file.sh
+++ b/plugins/unpack/unzip_file.sh
@@ -3,11 +3,15 @@
 # $1 - unzip
 # $2 - archive
 # $3 - output directory with tail slash
+# $5 - delete archive after auto unpack
 
 mkdir -p "$3"
 "$1" -o "$2" -d "$3"
 
 ret=$?
 [ $ret -le 1 ] && echo 'All OK'
+if [ $ret -le 1 ] && [ "$5" = 'true' ] ; then
+	rm "$2"
+fi
 
 exit $ret


### PR DESCRIPTION
Option to delete archive files after successful auto unpacking.  Set $deleteAutoArchives variable to true in conf.php to enable.  This should only be enable with AutoTools AutoMove enabled with an operation of Copy, Soft Link or Hard Link. Otherwise this will delete the files you are seeding from.  This will only delete archives when auto unpacking, not manual unpacking.

I tried to make the commands in the .sh files as portable as possible.  It should be fully POSIX compatible and is not using any extensions to the 'find' command.