### PR TITLE
Option to delete archive files after successful auto unpacking.

### DIFF
--- a/plugins/unpack/conf.php
+++ b/plugins/unpack/conf.php
@@ -7,3 +7,6 @@ $pathToExternals['unzip'] = '';		// Something like /usr/bin/unzip. If empty, wil
 $pathToExternals['unrar'] = '';		// Something like /usr/bin/unrar. If empty, will be found in PATH.
 
 $cleanupAutoTasks = false;		// Remove autounpack tasks parameters after finish, otherwise will be shown in the 'Tasks' tab
+$deleteAutoArchives = false;	// Delete archive files after successful auto unpack. Will not remove archives unless AutoMove is enabled and the operation type is not Move.
+
+$unpack_debug_enabled = false;		// set "true" to enable debug output

--- a/plugins/unpack/unall_dir.sh
+++ b/plugins/unpack/unall_dir.sh
@@ -4,12 +4,13 @@
 # $2 - intput directory with tail slash
 # $3 - output directory with tail slash
 # $4 - unzip
+# $5 - archive files to delete
 
 ret=0
-"$(dirname $0)"/unrar_dir.sh "$1" "$2" "$3"
+"$(dirname $0)"/unrar_dir.sh "$1" "$2" "$3" "$4" "$5"
 last=$?
 [ $last -gt 1 ] && ret=$last
-"$(dirname $0)"/unzip_dir.sh "$4" "$2" "$3"
+"$(dirname $0)"/unzip_dir.sh "$4" "$2" "$3" "$1" "$5"
 last=$?
 [ $last -gt 1 ] && ret=$last
 exit $ret

--- a/plugins/unpack/unrar_dir.sh
+++ b/plugins/unpack/unrar_dir.sh
@@ -3,6 +3,7 @@
 # $1 - unrar
 # $2 - input directory with tail slash
 # $3 - output directory with tail slash
+# $5 - archive files to delete
 
 ret=0
 
@@ -23,3 +24,14 @@ process_directory()
 }
 
 process_directory "$1" "$2" "$3"
+
+ret=$?
+if [ $ret -le 1 ] && [ "$5" != '' ] ; then
+	OIFS=$IFS
+	IFS=';'
+	for file in "$5"
+	do
+		rm $file
+	done
+	IFS=$OIFS
+fi

--- a/plugins/unpack/unrar_file.sh
+++ b/plugins/unpack/unrar_file.sh
@@ -3,6 +3,11 @@
 # $1 - unrar
 # $2 - archive
 # $3 - output directory with tail slash
+# $5 - archive files to delete
 
 "$1" x -ai -c- -kb -o+ -p- -y -v -- "$2" "$3"
 
+ret=$?
+if [ $ret -le 1 ] && [ "$5" != '' ] ; then
+	rm "$5"
+fi

--- a/plugins/unpack/unzip_dir.sh
+++ b/plugins/unpack/unzip_dir.sh
@@ -3,6 +3,7 @@
 # $1 - unzip
 # $2 - input directory with tail slash
 # $3 - output directory with tail slash
+# $5 - archive files to delete
 
 ret=0
 
@@ -31,5 +32,14 @@ process_directory "$1" "$2" "$3"
 
 ret=$?
 [ $ret -le 1 ] && echo 'All OK'
+if [ $ret -le 1 ] && [ "$5" != '' ] ; then
+	OIFS=$IFS
+	IFS=';'
+	for file in "$5"
+	do
+		rm $file
+	done
+	IFS=$OIFS
+fi
 
 exit $ret

--- a/plugins/unpack/unzip_file.sh
+++ b/plugins/unpack/unzip_file.sh
@@ -3,11 +3,15 @@
 # $1 - unzip
 # $2 - archive
 # $3 - output directory with tail slash
+# $5 - archive files to delete
 
 mkdir -p "$3"
 "$1" -o "$2" -d "$3"
 
 ret=$?
 [ $ret -le 1 ] && echo 'All OK'
+if [ $ret -le 1 ] && [ "$5" != '' ] ; then
+	rm "$5"
+fi
 
 exit $ret

--- a/plugins/unpack/update.php
+++ b/plugins/unpack/update.php
@@ -13,9 +13,10 @@ if( chdir( dirname( __FILE__) ) )
 		{
 			$dir_name = ($argv[7]=='') ? $argv[1] : $argv[7];
 			$base_name = (intval($argv[3]) ? $dir_name : addslash($dir_name).$argv[2]);
+			$download_name = (intval($argv[3]) ? $argv[1] : addslash($argv[1]).$argv[2]);
 			$label = rawurldecode($argv[4]);
 			if(@preg_match($up->filter.'u',$label)==1)
-				$up->startSilentTask($base_name,$label,$argv[5],$argv[6]);
+				$up->startSilentTask($base_name,$download_name,$label,$argv[5],$argv[6]);
 		}
 	}
 }


### PR DESCRIPTION
Set $deleteAutoArchives variable to true in conf.php to enable. This will only delete the archives if AutoTools AutoMove is enabled with an operation of Copy, Soft Link or Hard Link and when auto unpacking, not manual unpacking.

This uses some logic to determine what type of AutoMove operation was used, if any.  If the download location and complete location are the same then it wasn't moved and it won't delete files.  Otherwise, if the download location doesn't exist anymore then the operation was Move and we won't delete files.  Otherwise, if it's a soft link or hard link it's ok to delete files and the last possibility is Copy and it's ok to delete files.

The rar and zip files are passed to the .sh files and then parsed so that only those files are delete, which ensures there are no accidental deletions.