### PR TITLE
Update to detect iOS

### DIFF
--- a/plugins/data/init.js
+++ b/plugins/data/init.js
@@ -82,11 +82,19 @@ plugin.onLangLoaded = function()
 		if(d && (d.location.href != "about:blank"))
 			try { eval(d.body.textContent ? d.body.textContent : d.body.innerText); } catch(e) {}
 	}));
-	$(document.body).append(
-		$('<form action="plugins/data/action.php" id="getdata" method="get" target="datafrm">'+
-			'<input type="hidden" name="hash" id="datahash" value="">'+
-			'<input type="hidden" name="no" id="datano" value="">'+
-		'</form>').width(0).height(0));
+	var iOS = /(iPad|iPhone|iPod)/g.test(navigator.userAgent);
+ 	if (iOS) {
+        	$(document.body).append(
+                $('<form action="plugins/data/action.php" id="getdata" method="get" target="_blank">'+
+                        '<input type="hidden" name="hash" id="datahash" value="">'+
+                        '<input type="hidden" name="no" id="datano" value="">'+
+                '</form>').width(0).height(0)); }
+        else {
+         	$(document.body).append(
+                $('<form action="plugins/data/action.php" id="getdata" method="get" target="datafrm">'+
+                        '<input type="hidden" name="hash" id="datahash" value="">'+
+                        '<input type="hidden" name="no" id="datano" value="">'+
+                '</form>').width(0).height(0)); }
 }
 
 plugin.onRemove = function()


### PR DESCRIPTION
iOS security blocks AJAX downloads of PDF files via hidden frames like datafrm. By detecting if iOS is running and then changing the target, we can allow PDF files to download in a new tab, allowing direct downloading and reading or importation to iBooks or any other reader.

Another way might be a function to create a new _blank with a direct link to action.php, but this works.