### PR TITLE
Use target=_blank to work around iOS security

### DIFF
--- a/plugins/data/init.js
+++ b/plugins/data/init.js
@@ -82,11 +82,15 @@ plugin.onLangLoaded = function()
 		if(d && (d.location.href != "about:blank"))
 			try { eval(d.body.textContent ? d.body.textContent : d.body.innerText); } catch(e) {}
 	}));
-	$(document.body).append(
-		$('<form action="plugins/data/action.php" id="getdata" method="get" target="datafrm">'+
-			'<input type="hidden" name="hash" id="datahash" value="">'+
-			'<input type="hidden" name="no" id="datano" value="">'+
-		'</form>').width(0).height(0));
+$(document.body).append(
+           $('<form action="plugins/data/action.php" id="getdata" method="get" '+
+		   				(function () {
+							   if(iOS) {return 'target="_blank">';}
+							   else {return 'target="datafrm">';}
+						   }) +
+                        '<input type="hidden" name="hash" id="datahash" value="">'+
+                        '<input type="hidden" name="no" id="datano" value="">'+
+                '</form>').width(0).height(0));;
 }
 
 plugin.onRemove = function()


### PR DESCRIPTION
iOS browsers prevent the download of PDF files into small windows like datafrm. By testing for iOS and then using the new tab target _blank, we can work around this.