### PR TITLE
Fix private tracker recognition

### DIFF
--- a/js/webui.js
+++ b/js/webui.js
@@ -901,6 +901,8 @@ var theWebUI =
 	trkIsPrivate: function(url)
 	{
 		return(
+			(/(http|https|udp):\/\/(?:[0-9]{1,3}\.){3}[0-9]{1,3}((:(\d){2,5})|).*\/an.*\?.+=.+/i).test(url) ||
+			(/(http|https|udp):\/\/(?:[0-9]{1,3}\.){3}[0-9]{1,3}((:(\d){2,5})|)\/.*[0-9a-z]{8,32}\/an/i).test(url) ||
 			(/(http|https|udp):\/\/[a-z0-9-\.]+\.[a-z]{2,4}((:(\d){2,5})|).*\/an.*\?.+=.+/i).test(url) ||
 			(/(http|https|udp):\/\/[a-z0-9-\.]+\.[a-z]{2,4}((:(\d){2,5})|)\/.*[0-9a-z]{8,32}\/an/i).test(url) ? 1 : 0 );
 	},

--- a/plugins/extratio/rules.php
+++ b/plugins/extratio/rules.php
@@ -39,7 +39,9 @@ class rRatioRule
 			rTorrentSettings::get()->pushEvent( "CheckTracker", array( "announce"=>$trk, "result"=>&$ret ) );
 			if( $ret ||
 				(is_null($ret) &&
-					(preg_match( '`^(http|https|udp)://[a-z0-9-\.]+\.[a-z]{2,4}((:(\d){2,5})|).*/an.*\?.+=.+`i', $trk ) ||
+					(preg_match( '`^(http|https|udp)://(?:[0-9]{1,3}\.){3}[0-9]{1,3}((:(\d){2,5})|).*/an.*\?.+=.+`i', $trk ) ||
+					preg_match( '`^(http|https|udp)://(?:[0-9]{1,3}\.){3}[0-9]{1,3}((:(\d){2,5})|)/.*[0-9a-z]{8,32}/an`i', $trk ) ||
+					preg_match( '`^(http|https|udp)://[a-z0-9-\.]+\.[a-z]{2,4}((:(\d){2,5})|).*/an.*\?.+=.+`i', $trk ) ||
 					preg_match( '`^(http|https|udp)://[a-z0-9-\.]+\.[a-z]{2,4}((:(\d){2,5})|)/.*[0-9a-z]{8,32}/an`i', $trk ))) )
 				return(true);
 		}


### PR DESCRIPTION
Fix recognition for private tracker URL (e.g.: t411.io - French tracker) with an IP format instead of a domain name.