### PR TITLE
Convert PHP4 constructors to PHP5 constructors.

### DIFF
--- a/php/cache.php
+++ b/php/cache.php
@@ -5,7 +5,7 @@ class rCache
 {
 	protected $dir;
 
-	public function rCache( $name = '' )
+	public function __construct( $name = '' )
 	{
 		$this->dir = getSettingsPath().$name;
 		if(!is_dir($this->dir))

--- a/php/xmlrpc.php
+++ b/php/xmlrpc.php
@@ -8,7 +8,7 @@ class rXMLRPCParam
 	public $type;
 	public $value;
 
-	public function rXMLRPCParam( $aType, $aValue )
+	public function __construct( $aType, $aValue )
 	{
 		$this->type = $aType;
 		if(($this->type=="i8") || ($this->type=="i4"))
@@ -23,7 +23,7 @@ class rXMLRPCCommand
 	public $command;
 	public $params;
 
-	public function rXMLRPCCommand( $cmd, $args = null )
+	public function __construct( $cmd, $args = null )
 	{
 		$this->command = getCmd($cmd);
 		$this->params = array();
@@ -78,7 +78,7 @@ class rXMLRPCRequest
 	public $parseByTypes = false;
 	public $important = true;
 
-	public function rXMLRPCRequest( $cmds = null )
+	public function __construct( $cmds = null )
 	{
 		if($cmds)
 		{

--- a/plugins/extratio/rules.php
+++ b/plugins/extratio/rules.php
@@ -20,7 +20,7 @@ class rRatioRule
 	public $ratio;
 	public $channel;
 
-	public function	rRatioRule( $name, $reason = RR_LABEL_CONTAIN, $pattern = '', $enabled = 0, $no = 0, $ratio = '', $channel = '' )
+	public function	__construct( $name, $reason = RR_LABEL_CONTAIN, $pattern = '', $enabled = 0, $no = 0, $ratio = '', $channel = '' )
 	{
 		$this->name = $name;
 		$this->reason = $reason;

--- a/plugins/httprpc/rpccache.php
+++ b/plugins/httprpc/rpccache.php
@@ -34,7 +34,7 @@ class rpcCache
 
 	protected $dir;
         
-        public function rpcCache()
+        public function __construct()
         {
 		$this->dir = getSettingsPath()."/httprpc";
 		if(!is_dir($this->dir))

--- a/plugins/loginmgr/accounts.php
+++ b/plugins/loginmgr/accounts.php
@@ -28,7 +28,7 @@ class privateData
 		return($rt);
 	}
 
-	public function privateData( $owner )
+	public function __construct( $owner )
 	{
 		$this->hash = $owner.".dat";
 		$this->loaded = false;

--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -23,7 +23,7 @@ class rRSS
 	private $atomtags = array('title', 'updated');
 	private $entrytags = array('title', 'link', 'updated', 'content', 'summary');
 
-	public function rRSS( $url = null )
+	public function __construct( $url = null )
 	{
 		$this->version = 1;
 		if($url)
@@ -407,7 +407,7 @@ class rRSSHistory
 	public $changed = false;
 	public $version = 0;
 
-	public function rRSSHistory()
+	public function __construct()
 	{
 		$this->version = 2;
 	}
@@ -531,7 +531,7 @@ class rRSSFilter
 		'${21}', '${22}', '${23}', '${24}', '${25}', '${26}', '${27}', '${28}', '${29}', '${30}',
 	);
 
-	public function	rRSSFilter( $name, $pattern = '', $exclude = '', $enabled = 0, $rssHash = '', 
+	public function	__construct( $name, $pattern = '', $exclude = '', $enabled = 0, $rssHash = '', 
 		$start = 0, $addPath = 1, $directory = null, $label = null, 
 		$titleCheck = 1, $descCheck = 0, $linkCheck = 0,
 		$throttle = null, $ratio = null, $no = -1, $interval = -1 )
@@ -659,7 +659,7 @@ class rRSSGroup
 	public $hash;
 	public $lst = array();
 
-	public function	rRSSGroup( $name, $hash = null )
+	public function	__construct( $name, $hash = null )
 	{
 		$this->name = $name;
 		if(is_null($hash))
@@ -832,7 +832,7 @@ class rRSSManager
 	public $groups = null;
 	public $data = null;
 
-	public function rRSSManager()
+	public function __construct()
 	{
 		$this->cache  = new rCache( '/rss/cache' );
 		$this->rssList = new rRSSMetaList();

--- a/plugins/rssurlrewrite/rules.php
+++ b/plugins/rssurlrewrite/rules.php
@@ -14,7 +14,7 @@ class rURLRewriteRule
 	public $hrefAsSrc;
 	public $hrefAsDest;
 
-	public function	rURLRewriteRule( $name, $pattern = '', $replacement = '', $enabled = 0, $rssHash = '', 
+	public function	__construct( $name, $pattern = '', $replacement = '', $enabled = 0, $rssHash = '', 
 		$hrefAsSrc = 0, $hrefAsDest = 0 )
 	{
 		$this->name = $name;

--- a/plugins/trafic/stat.php
+++ b/plugins/trafic/stat.php
@@ -16,7 +16,7 @@ class rStat
 	public $yearHitTimes = array(0,0,0,0,0,0,0,0,0,0,0,0);
 	public $fname = "";
 
-	public function rStat( $prefix )
+	public function __construct( $prefix )
 	{
 		$this->fname = getSettingsPath().'/trafic/'.$prefix;
 		if($file=@fopen($this->fname,"r"))


### PR DESCRIPTION
It has been [voted and decided](https://wiki.php.net/rfc/remove_php4_constructors) that a future version of PHP will remove support for the PHP4 style constructors. Since ruTorrent only supports PHP5 there's no harm in converting now and preparing for the future.