### PR TITLE
rutracker_check refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ plugins/plimits
 plugins/localnews
 plugins/hints
 plugins/dmca
+.idea/*
+*.iml

--- a/plugins/loginmgr/accounts/AniDUB.php
+++ b/plugins/loginmgr/accounts/AniDUB.php
@@ -1,0 +1,32 @@
+<?php
+
+class AniDUBAccount extends commonAccount
+{
+    public $url = "http://tr.anidub.com";
+
+    protected function isOK($client)
+    {
+        return(strpos($client->results, '<input type="text" name="login_name" id="login_name">')===false);
+    }
+    protected function login($client,$login,$password,&$url,&$method,&$content_type,&$body,&$is_result_fetched)
+    {
+        $is_result_fetched = false;
+        if($client->fetch( $this->url."/" ))
+        {
+            $client->setcookies();
+            $client->referer = $this->url."/";
+
+            if($client->fetch( $this->url."/","POST","application/x-www-form-urlencoded",
+                "login_name=".rawurlencode($login)."&login_password=".rawurlencode($password)."&login=submit" ))
+            {
+                $client->setcookies();
+                return(true);
+            }
+        }
+        return(false);
+    }
+    public function test($url)
+    {
+        return(preg_match( "/^http:\/\/tr\.anidub\.com\//si", $url ));
+    }
+}

--- a/plugins/rutracker_check/check.php
+++ b/plugins/rutracker_check/check.php
@@ -3,6 +3,10 @@
 require_once( "../../php/Snoopy.class.inc" );
 require_once( "../../php/rtorrent.php" );
 
+require_once( "trackers/rutracker.php" );
+require_once( "trackers/anidub.php" );
+require_once( "trackers/kinozal.php" );
+
 class ruTrackerChecker
 {
 	const STE_INPROGRESS		= 1;
@@ -12,8 +16,20 @@ class ruTrackerChecker
 	const STE_CANT_REACH_TRACKER	= 5;
 	const STE_ERROR			= 6;
 	const STE_NOT_NEED		= 7;
-
+	
 	const MAX_LOCK_TIME		= 900;	// 15 min
+	
+	private static $TRACKERS = array();
+
+	static public function registerTracker($name, $handler){
+		if (!array_key_exists($name, self::$TRACKERS)) {
+			self::$TRACKERS[$name] = $handler;
+		}
+	}
+
+	static public function supportedTrackers(){
+		return array_keys(self::$TRACKERS);
+	}
 
 	static protected function setState( $hash, $state )
 	{
@@ -49,6 +65,61 @@ class ruTrackerChecker
 		}
 	}
 
+	static public function createTorrent($torrent, $hash){
+		global $saveUploadedTorrents;
+		$torrent = new Torrent( $torrent );
+
+		if( $torrent->errors() ) return self::STE_DELETED;
+
+		if( $torrent->hash_info()==$hash ) return self::STE_UPTODATE;
+		$req =  new rXMLRPCRequest( array(
+			new rXMLRPCCommand("d.get_directory_base",$hash),
+			new rXMLRPCCommand("d.get_custom1",$hash),
+			new rXMLRPCCommand("d.get_throttle_name",$hash),
+			new rXMLRPCCommand("d.get_connection_seed",$hash),
+			new rXMLRPCCommand("d.is_open",$hash),
+			new rXMLRPCCommand("d.is_active",$hash),
+			new rXMLRPCCommand("d.get_state",$hash),
+			new rXMLRPCCommand("d.stop",$hash),
+			new rXMLRPCCommand("d.close",$hash),
+		));
+
+		if($req->success()){
+			$addition = array(
+				getCmd("d.set_connection_seed=").$req->val[3],
+				getCmd("d.set_custom")."=chk-state,".self::STE_UPDATED,
+				getCmd("d.set_custom")."=chk-time,".time(),
+				getCmd("d.set_custom")."=chk-stime,".time()
+			);
+			$isStart = (($req->val[4]!=0) && ($req->val[5]!=0) && ($req->val[6]!=0));
+			if(!empty($req->val[2]))
+				$addition[] = getCmd("d.set_throttle_name=").$req->val[2];
+			if(preg_match('/rat_(\d+)/',$req->val[3],$ratio))
+				$addition[] = getCmd("view.set_visible=")."rat_".$ratio;
+			$label = rawurldecode($req->val[1]);
+			if(rTorrent::sendTorrent($torrent, $isStart, false, $req->val[0],
+				$label, $saveUploadedTorrents, false, true, $addition))
+			{
+				$req = new rXMLRPCRequest( new rXMLRPCCommand("d.erase", $hash ) );
+				if($req->success())
+					return null;
+			}
+		}
+		return self::STE_ERROR;
+	}
+
+	static public function run_ex($hash, $fname){
+		$torrent = new Torrent( $fname );
+		if(!$torrent->errors()){
+			foreach (self::$TRACKERS as $key => $value){
+				if (strpos($torrent->comment(), $key) !==FALSE) {
+					return call_user_func($value, $torrent->comment(), $hash, $torrent);
+				}
+			}
+		}
+		return self::STE_NOT_NEED;
+	}
+
 	static public function makeClient( $url, $method="GET", $content_type="", $body="" )
 	{
 		$client = new Snoopy();
@@ -58,131 +129,21 @@ class ruTrackerChecker
 		return($client);
 	}
 
-
 	static public function run( $hash, $state = null, $time = null, $successful_time = null )
 	{
-		global $saveUploadedTorrents;
-		if(is_null($state))
-			self::getState( $hash, $state, $time, $successful_time );
-		if(($state==self::STE_INPROGRESS) && ((time()-$time)>self::MAX_LOCK_TIME))
-			$state = 0;
-		if($state!=self::STE_INPROGRESS)
-		{
+		if(is_null($state)) self::getState( $hash, $state, $time, $successful_time );
+		if(($state==self::STE_INPROGRESS) && ((time()-$time)>self::MAX_LOCK_TIME)) $state = 0;
+
+		if($state!==self::STE_INPROGRESS){
 			$state = self::STE_INPROGRESS;
-			if(!self::setState( $hash, $state ))
-				return(false);
+			if(!self::setState( $hash, $state )) return(false);
+
 			$fname = rTorrentSettings::get()->session.$hash.".torrent";
-			if(is_readable($fname))
-			{
-				$torrent = new Torrent( $fname );
-				if( !$torrent->errors() )
-				{
-                        		if( preg_match( '`^http://(?P<tracker>rutracker)\.org/forum/viewtopic\.php\?t=(?P<id>\d+)$`',$torrent->comment(), $matches ) ||
-					    preg_match( '`^http://(?P<tracker>kinozal)\.tv/details\.php\?id=(?P<id>\d+)$`',$torrent->comment(), $matches ))
-					{
-					    if ($matches["tracker"] == "rutracker")
-					    {
-						$client = self::makeClient($torrent->comment());
-						if(($client->status==200) &&
-							preg_match( "`ajax.form_token\s*=\s*'(?P<form_token>[^']+)';.*topic_id\s*:\s*(?P<topic_id>\d+),\s*t_hash\s*:\s*'(?P<t_hash>[^']+)'`s",$client->results, $matches1 ))
-						{
-							$client->setcookies();
-							$client->fetch("http://rutracker.org/forum/ajax.php","POST","application/x-www-form-urlencoded; charset=UTF-8",
-								"action=get_info_hash".
-                                                                "&topic_id=".$matches1["topic_id"].
-								"&t_hash=".$matches1["t_hash"].
-								"&form_token=".$matches1["form_token"]);
-							if($client->status==200)
-							{
-								$ret = json_decode($client->results,true);
-								if($ret && array_key_exists("ih_hex",$ret) && (strtoupper($ret["ih_hex"])==$hash))
-								{
-									self::setState( $hash,  self::STE_UPTODATE );
-									return(true);
-								}
-							}
-						}
-						$client->setcookies();
-						$client->fetchComplex("http://dl.rutracker.org/forum/dl.php?t=".$matches["id"]);
-					    }
-					    else if ($matches["tracker"] == "kinozal")
-					    {
-						$client = self::makeClient("http://kinozal.tv/get_srv_details.php?action=2&id=".$matches["id"]);
-						if($client->status==200 &&
-						    preg_match('`<li>.*(?P<hash>[0-9A-Fa-f]{40})</li>`', $client->results, $matches1))
-						{
-						    if((strtoupper($matches1["hash"])==$hash))
-						    {
-							self::setState( $hash,  self::STE_UPTODATE );
-							return(true);
-						    }
-						}
-						$client->setcookies();
-						$client->fetchComplex("http://dl.kinozal.tv/download.php?id=".$matches["id"]);
-					    }
-					    else
-					    {
-						self::setState($hash, self::STE_NOT_NEED);
-						return(true);
-					    }
-						if($client->status==200)
-						{
-							$torrent = new Torrent( $client->results );
-							if( !$torrent->errors() )
-							{
-								if( $torrent->hash_info()!=$hash )
-								{
-									$req =  new rXMLRPCRequest( array(
-										new rXMLRPCCommand("d.get_directory_base",$hash),								
-										new rXMLRPCCommand("d.get_custom1",$hash),
-										new rXMLRPCCommand("d.get_throttle_name",$hash),
-										new rXMLRPCCommand("d.get_connection_seed",$hash),
-										new rXMLRPCCommand("d.is_open",$hash),
-										new rXMLRPCCommand("d.is_active",$hash),
-										new rXMLRPCCommand("d.get_state",$hash),
-										new rXMLRPCCommand("d.stop",$hash),
-										new rXMLRPCCommand("d.close",$hash),
-										));
-									if($req->success())
-									{
-										$addition = array( 
-											getCmd("d.set_connection_seed=").$req->val[3],
-											getCmd("d.set_custom")."=chk-state,".self::STE_UPDATED, 
-											getCmd("d.set_custom")."=chk-time,".time(),
-											getCmd("d.set_custom")."=chk-stime,".time()
-											);
-										$isStart = (($req->val[4]!=0) && ($req->val[5]!=0) && ($req->val[6]!=0));
-										if(!empty($req->val[2]))
-											$addition[] = getCmd("d.set_throttle_name=").$req->val[2];
-										if(preg_match('/rat_(\d+)/',$req->val[3],$ratio))
-											$addition[] = getCmd("view.set_visible=")."rat_".$ratio;
-										$label = rawurldecode($req->val[1]);
-										if(rTorrent::sendTorrent($torrent, $isStart, false, $req->val[0], 
-											$label, $saveUploadedTorrents, false, true, $addition))
-										{
-											$req = new rXMLRPCRequest( new rXMLRPCCommand("d.erase", $hash ) );
-											if($req->success())
-												$state = null;
-										}
-									}
-								}
-								else
-									$state = self::STE_UPTODATE;
-							}
-							else
-								$state = self::STE_DELETED;
-						}
-						else
-							$state = (($client->status<0) ? self::STE_CANT_REACH_TRACKER : self::STE_DELETED );
-					}
-					else
-						$state = self::STE_NOT_NEED;
-				}
-			}
-			if($state==self::STE_INPROGRESS) 
-				$state==self::STE_ERROR;
-			if(!is_null($state))
-				self::setState( $hash, $state );
+
+			if(is_readable($fname))	$state = self::run_ex($hash, $fname);
+			if($state==self::STE_INPROGRESS) $state=self::STE_ERROR;
+
+			if(!is_null($state)) self::setState( $hash, $state );
 		}
 		return($state != self::STE_CANT_REACH_TRACKER);
 	}

--- a/plugins/rutracker_check/trackers/anidub.php
+++ b/plugins/rutracker_check/trackers/anidub.php
@@ -1,0 +1,55 @@
+<?php
+
+
+class AniDUBCheckImpl{
+    static public function download_torrent($url, $hash, $old_torrent){
+        if( preg_match( '`^http://tr\.anidub\.com/\?newsid=(?P<id>\d+)$`',$url, $matches ) ) {
+            $topic_id = $matches["id"];
+            $torrent_name = $old_torrent->name();
+            $torrent_quality = null;
+            $torrent_quality_type = "";
+
+            # checking torrent quality from torrent file name
+            if (preg_match('/\_\[((?<vq>\d{1,3})p)|(?<vq1>PSP)|(?<vq2>HWP)|(bdrip(?<vq3>\d{1,3})p)\]\_/i',
+                $torrent_name, $qmatches)){
+
+                if (array_key_exists("vq", $qmatches)){
+                    $torrent_quality = $qmatches["vq"];  # tv quality
+                    $torrent_quality_type = "tv";
+                }
+                if (array_key_exists("vq3", $qmatches)) {
+                    $torrent_quality = strtolower($qmatches["vq3"]); # bd quality
+                    $torrent_quality_type = "bd";
+                }
+                if (array_key_exists("vq1", $qmatches)) $torrent_quality = strtolower($qmatches["vq1"]);
+                if (array_key_exists("vq2", $qmatches)) $torrent_quality = strtolower($qmatches["vq2"]);
+            }
+
+            // ToDo: if torrent doesn't contain any quality tag, try to guess in other ways
+
+            # exit, no way to get torrent file without this
+            if ($torrent_quality === null) return ruTrackerChecker::STE_NOT_NEED;
+
+            $client = ruTrackerChecker::makeClient($url);
+            if($client->status!=200) return ruTrackerChecker::STE_CANT_REACH_TRACKER;
+
+            $resp = preg_replace( "/\r|\n/", "", $client->results);
+            $q =$torrent_quality_type.$torrent_quality;  // e.g. tv.720
+            $pattern = sprintf('/\<div\sid\=\"%s\"\>\<div\sid=\'[\d\w\_]+\'\>\s+\<div\sclass=\"torrent\_h\"\>\s+\<a\shref=\"(?P<url>[\w\d\_\/\.\=\?]+)\"\s/i', $q);
+            if (!preg_match($pattern, $resp, $url_matches)) ruTrackerChecker::STE_CANT_REACH_TRACKER;
+
+            if (!preg_match('/\/engine\/download\.php\?id=\d{1,10}/i', $url_matches["url"], $m)) ruTrackerChecker::STE_CANT_REACH_TRACKER;
+
+            $client->setcookies();
+            $client->fetchComplex("http://tr.anidub.com" . $url_matches["url"]);
+
+            if(intval($client->status)!=200) return (($client->status<0) ? ruTrackerChecker::STE_CANT_REACH_TRACKER : ruTrackerChecker::STE_DELETED );
+
+            return ruTrackerChecker::createTorrent($client->results, $hash);
+        }
+
+        return ruTrackerChecker::STE_NOT_NEED;
+    }
+}
+
+ruTrackerChecker::registerTracker("tr.anidub.com", "AniDUBCheckImpl::download_torrent");

--- a/plugins/rutracker_check/trackers/kinozal.php
+++ b/plugins/rutracker_check/trackers/kinozal.php
@@ -1,0 +1,28 @@
+<?php
+
+class KinozalCheckImpl
+{
+    static public function download_torrent($url, $hash, $old_torrent)
+    {
+        if (preg_match('`^http://(?P<tracker>kinozal)\.tv/details\.php\?id=(?P<id>\d+)$`', $url, $matches)) {
+            $topic_id = $matches["id"];
+            $client = ruTrackerChecker::makeClient("http://kinozal.tv/get_srv_details.php?action=2&id=".$topic_id);
+            if($client->status==200 &&
+                preg_match('`<li>.*(?P<hash>[0-9A-Fa-f]{40})</li>`', $client->results, $matches1))
+            {
+                if((strtoupper($matches1["hash"])==$hash))
+                {
+                    return  ruTrackerChecker::STE_UPTODATE;
+                }
+            }
+            $client->setcookies();
+            $client->fetchComplex("http://dl.kinozal.tv/download.php?id=".$matches["id"]);
+            if ($client->status !== 200) return (($client->status < 0) ? ruTrackerChecker::STE_CANT_REACH_TRACKER : ruTrackerChecker::STE_DELETED);
+            return ruTrackerChecker::createTorrent($client->results, $hash);
+        }
+        return ruTrackerChecker::STE_NOT_NEED;
+    }
+}
+
+
+ruTrackerChecker::registerTracker("kinozal.tv", "KinozalCheckImpl::download_torrent");

--- a/plugins/rutracker_check/trackers/rutracker.php
+++ b/plugins/rutracker_check/trackers/rutracker.php
@@ -1,0 +1,28 @@
+<?php
+
+class RuTrackerCheckImpl
+{
+    static public function download_torrent($url, $hash, $old_torrent)
+    {
+        if (preg_match('`^http://rutracker\.org/forum/viewtopic\.php\?t=(?P<id>\d+)$`', $url, $matches)) {
+            $topic_id = $matches["id"];
+            $req_url = "http://api.rutracker.org/v1/get_tor_hash?by=topic_id&val=" . $topic_id;
+            $client = ruTrackerChecker::makeClient($req_url);
+            if ($client->status == 200) {
+                $ret = json_decode($client->results, true);
+                if (array_key_exists("result", $ret)) $ret = $ret["result"];
+                if ($ret && array_key_exists($topic_id, $ret) && (strtoupper($ret[$topic_id]) == $hash)) {
+                    return ruTrackerChecker::STE_UPTODATE;
+                }
+            }
+            $client->setcookies();
+            $client->fetchComplex("http://dl.rutracker.org/forum/dl.php?t=" . $topic_id);
+            if ($client->status !== 200) return (($client->status < 0) ? ruTrackerChecker::STE_CANT_REACH_TRACKER : ruTrackerChecker::STE_DELETED);
+            return ruTrackerChecker::createTorrent($client->results, $hash);
+        }
+        return ruTrackerChecker::STE_NOT_NEED;
+    }
+}
+
+
+ruTrackerChecker::registerTracker("rutracker.org", "RuTrackerCheckImpl::download_torrent");

--- a/plugins/rutracker_check/update.php
+++ b/plugins/rutracker_check/update.php
@@ -19,11 +19,15 @@ $req =  new rXMLRPCRequest(
 	);
 if($req->success())
 {
+	$can_break = false;
 	for($i = 0; $i<count($req->val); $i+=5)
 	{
-		if(strpos( $req->val[$i+4], ".rutracker.org/" )!==false ||
-		   strpos( $req->val[$i+4], ".kinozal.tv/" )!==false)
-			if(!ruTrackerChecker::run($req->val[$i],$req->val[$i+1],$req->val[$i+2],$req->val[$i+3]))
-				break;
+		foreach(ruTrackerChecker::supportedTrackers() as $tracker) {
+			if (strpos($req->val[$i + 4], $tracker) !== false)
+				if (!ruTrackerChecker::run($req->val[$i], $req->val[$i + 1], $req->val[$i + 2], $req->val[$i + 3]))
+					$can_break = true;
+					break;
+		}
+		if ($can_break) break;
 	}
 }


### PR DESCRIPTION
rutracker_check refactoring. Move out tracker-specific logic from rutracker_check to separate files. By doing this we achieve:

support more easy and clean adding of new torrent trackers
keeping plugin core clean and compact.