### PR TITLE
Unpack: Don't delete files if there was a warning or error

### DIFF
--- a/plugins/unpack/unrar_dir.sh
+++ b/plugins/unpack/unrar_dir.sh
@@ -12,13 +12,13 @@ process_directory()
 {
 	"$1" x -ai -c- -kb -o+ -p- -y -v -- "$2." "$3"
 	last=$?
-	[ $last -le 1 ] && ret=$last
+	[ $last -ge 1 ] && ret=$last
 	for fn in "$2"* ; do
 		if [ -d "${fn}" ] && [ ! -L "${fn}" ] ; then
 			name=$(basename "${fn}")
 			process_directory "$1" "${fn}/" "$3${name}/"
 			last=$?
-			[ $last -gt 1 ] && ret=$last
+			[ $last -ge 1 ] && ret=$last
 		fi
 	done
 	return $ret
@@ -32,8 +32,7 @@ else
 	ret=$?
 fi
 
-ret=$?
-if [ $ret -le 1 ] && [ "$5" != '' ] ; then
+if [ $ret -eq 0 ] && [ "$5" != '' ] ; then
 	OIFS=$IFS
 	IFS=';'
 	for file in "$5"
@@ -46,6 +45,6 @@ fi
 if [ "$6" != '' ] ; then
 	mkdir -p "$3"
 	mv "$6"* "$3"
-	rm -r "$6"
+	[ $? -eq 0 ] && rm -r "$6"
 fi
 

--- a/plugins/unpack/unrar_file.sh
+++ b/plugins/unpack/unrar_file.sh
@@ -14,13 +14,12 @@ else
 	ret=$?
 fi
 
-ret=$?
-if [ $ret -le 1 ] && [ "$5" != '' ] ; then
+if [ $ret -eq 0 ] && [ "$5" != '' ] ; then
 	rm "$5"
 fi
 
 if [ "$6" != '' ] ; then
 	mkdir -p "$3"
 	mv "$6"* "$3"
-	rm -r "$6"
+	[ $? -eq 0 ] && rm -r "$6"
 fi

--- a/plugins/unpack/unzip_dir.sh
+++ b/plugins/unpack/unzip_dir.sh
@@ -15,7 +15,7 @@ process_directory()
 	        	mkdir -p "$3"
 			"$1" -o "${fn}" -d "$3"
 			last=$?
-			[ $last -gt 1 ] && ret=$last
+			[ $last -ge 1 ] && ret=$last
 		fi
 	done
 	for fn in "$2"* ; do
@@ -23,14 +23,13 @@ process_directory()
 			name=$(basename "${fn}")
 			process_directory "$1" "${fn}/" "$3${name}/"
 			last=$?
-			[ $last -gt 1 ] && ret=$last
+			[ $last -ge 1 ] && ret=$last
 		fi
 	done
 	return $ret
 }
 
 if [ "$6" != '' ] ; then
-	mkdir -p "$6"
 	process_directory "$1" "$2" "$6"
 	ret=$?
 else
@@ -38,9 +37,8 @@ else
 	ret=$?
 fi
 
-ret=$?
-[ $ret -le 1 ] && echo 'All OK'
-if [ $ret -le 1 ] && [ "$5" != '' ] ; then
+[ $ret -eq 0 ] && echo 'All OK'
+if [ $ret -eq 0 ] && [ "$5" != '' ] ; then
 	OIFS=$IFS
 	IFS=';'
 	for file in "$5"
@@ -53,7 +51,7 @@ fi
 if [ "$6" != '' ] ; then
 	mkdir -p "$3"
 	mv "$6"* "$3"
-	rm -r "$6"
+	[ $? -eq 0 ] && rm -r "$6"
 fi
 
 

--- a/plugins/unpack/unzip_file.sh
+++ b/plugins/unpack/unzip_file.sh
@@ -17,14 +17,14 @@ else
 	ret=$?
 fi
 
-[ $ret -le 1 ] && echo 'All OK'
-if [ $ret -le 1 ] && [ "$5" != '' ] ; then
+[ $ret -eq 0 ] && echo 'All OK'
+if [ $ret -eq 0 ] && [ "$5" != '' ] ; then
 	rm "$5"
 fi
 
 if [ "$6" != '' ] ; then
 	mv "$6"* "$3"
-	rm -r "$6"
+	[ $? -eq 0 ] && rm -r "$6"
 fi
 
 exit $ret


### PR DESCRIPTION
Added some checks before deleting files that the previous command returned a 0.  For the _dir files it seems to me that the comparative operators for the return values were wrong.  It seems like it should be -ge 1 to assign the $ret value to anything that is not 0.  Let me know if I'm missing something here.