### PR TITLE
Unpack - Fix mv command

### DIFF
--- a/plugins/unpack/unrar_dir.sh
+++ b/plugins/unpack/unrar_dir.sh
@@ -43,8 +43,9 @@ if [ $ret -eq 0 ] && [ "$5" != '' ] ; then
 fi
 
 if [ "$6" != '' ] ; then
-	mkdir -p "$3"
-	mv "$6"* "$3"
+	cd "$6"
+	find . -type d -exec mkdir -p "${3}"/\{} \;
+	find . -type f -exec mv -f \{} "${3}"/\{} \;
 	[ $? -eq 0 ] && rm -r "$6"
 fi
 

--- a/plugins/unpack/unrar_file.sh
+++ b/plugins/unpack/unrar_file.sh
@@ -19,7 +19,8 @@ if [ $ret -eq 0 ] && [ "$5" != '' ] ; then
 fi
 
 if [ "$6" != '' ] ; then
-	mkdir -p "$3"
-	mv "$6"* "$3"
+	cd "$6"
+	find . -type d -exec mkdir -p "${3}"/\{} \;
+	find . -type f -exec mv -f \{} "${3}"/\{} \;
 	[ $? -eq 0 ] && rm -r "$6"
 fi

--- a/plugins/unpack/unzip_dir.sh
+++ b/plugins/unpack/unzip_dir.sh
@@ -49,8 +49,9 @@ if [ $ret -eq 0 ] && [ "$5" != '' ] ; then
 fi
 
 if [ "$6" != '' ] ; then
-	mkdir -p "$3"
-	mv "$6"* "$3"
+	cd "$6"
+	find . -type d -exec mkdir -p "${3}"/\{} \;
+	find . -type f -exec mv -f \{} "${3}"/\{} \;
 	[ $? -eq 0 ] && rm -r "$6"
 fi
 

--- a/plugins/unpack/unzip_file.sh
+++ b/plugins/unpack/unzip_file.sh
@@ -23,7 +23,9 @@ if [ $ret -eq 0 ] && [ "$5" != '' ] ; then
 fi
 
 if [ "$6" != '' ] ; then
-	mv "$6"* "$3"
+	cd "$6"
+	find . -type d -exec mkdir -p "${3}"/\{} \;
+	find . -type f -exec mv -f \{} "${3}"/\{} \;
 	[ $? -eq 0 ] && rm -r "$6"
 fi
 


### PR DESCRIPTION
The mv command does not support merging existing directories.  You will get a 'Directory not empty' error.  See here: http://unix.stackexchange.com/questions/127712/merging-folders-with-mv

The problem manifests itself when there is a subdirectory containing an archive file in the torrent structure.  In this case the mv will fail.
This solution manually creates the directory structure and then moves the files individually, which solves the problem.