### PR TITLE
RSS Plugin: Fix fetching a RSS URL that requires a cookie

### DIFF
--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -124,7 +124,7 @@ class rRSS
 			$headers['If-None-Match'] = trim($this->etag);
 		if($this->lastModified)
 	                $headers['If-Last-Modified'] = trim($this->lastModified);
-		$cli = self::fetchURL($this->url,null,$headers);
+		$cli = self::fetchURL($this->url,$this->cookies,$headers);
 		if($cli->status==304)
 			return(true);
 		$this->etag = null;


### PR DESCRIPTION
The `cookie` variable was not being passed to `fetchURL` method, which would prevent to receive a RSS feed that requires a cookie