### PR TITLE
unrar exit code 10 fix

### DIFF
--- a/plugins/unpack/unall_dir.sh
+++ b/plugins/unpack/unall_dir.sh
@@ -10,8 +10,8 @@
 ret=0
 "$(dirname $0)"/unrar_dir.sh "$1" "$2" "$3" "$4" "$5" "$6"
 last=$?
-[ $last -gt 1 ] && ret=$last
+[ $last -ge 1 ] && ret=$last
 "$(dirname $0)"/unzip_dir.sh "$4" "$2" "$3" "$1" "$5" "$6"
 last=$?
-[ $last -gt 1 ] && ret=$last
+[ $last -ge 1 ] && ret=$last
 exit $ret

--- a/plugins/unpack/unrar_dir.sh
+++ b/plugins/unpack/unrar_dir.sh
@@ -12,13 +12,13 @@ process_directory()
 {
 	"$1" x -ai -c- -kb -o+ -p- -y -v -- "$2." "$3"
 	last=$?
-	[ $last -ge 1 ] && ret=$last
+	[ $last -ge 1 ] && [ $last -ne 10 ] && ret=$last
 	for fn in "$2"* ; do
 		if [ -d "${fn}" ] && [ ! -L "${fn}" ] ; then
 			name=$(basename "${fn}")
 			process_directory "$1" "${fn}/" "$3${name}/"
 			last=$?
-			[ $last -ge 1 ] && ret=$last
+			[ $last -ge 1 ] && [ $last -ne 10 ] && ret=$last
 		fi
 	done
 	return $ret
@@ -49,3 +49,4 @@ if [ "$6" != '' ] ; then
 	[ $? -eq 0 ] && rm -r "$6"
 fi
 
+exit $ret

--- a/plugins/unpack/unrar_file.sh
+++ b/plugins/unpack/unrar_file.sh
@@ -24,3 +24,5 @@ if [ "$6" != '' ] ; then
 	find . -type f -exec mv -f \{} "${3}"/\{} \;
 	[ $? -eq 0 ] && rm -r "$6"
 fi
+
+exit $ret

--- a/plugins/unpack/unzip_dir.sh
+++ b/plugins/unpack/unzip_dir.sh
@@ -55,5 +55,4 @@ if [ "$6" != '' ] ; then
 	[ $? -eq 0 ] && rm -r "$6"
 fi
 
-
 exit $ret


### PR DESCRIPTION
This fixes a case where the rar files were not deleted even though they were unpacked successfully.
Do not consider exit code 10 from unrar a failure.  Code 10 means there were no rar files found to extract.  This could happen when there is a Sample directory.  It would unrar the files successfully in the root directory and then return exit code 10 from the Samples directory because it didn't contain any rar files.  So an exit code 10 is an acceptable return code and should be considered successful.

Also updated unall_dir.sh to reflect the decision that exit code 1 is not successful, like we did in the other files.