### PR TITLE
'NNM-Club' tracker support for 'rutracker_check' plugin.

### DIFF
--- a/plugins/rutracker_check/check.php
+++ b/plugins/rutracker_check/check.php
@@ -6,6 +6,7 @@ require_once( "../../php/rtorrent.php" );
 require_once( "trackers/rutracker.php" );
 require_once( "trackers/anidub.php" );
 require_once( "trackers/kinozal.php" );
+require_once( "trackers/nnmclub.php" );
 
 class ruTrackerChecker
 {

--- a/plugins/rutracker_check/trackers/nnmclub.php
+++ b/plugins/rutracker_check/trackers/nnmclub.php
@@ -1,0 +1,27 @@
+<?php
+
+class NNMClubCheckImpl
+{
+    static public function download_torrent($url, $hash, $old_torrent)
+    {
+        $client = ruTrackerChecker::makeClient($url);
+        if($client->status==200 &&
+            preg_match('`btih:(?P<hash>[0-9A-Fa-f]{40})&tr`', $client->results, $matches))
+        {
+            if(strtoupper($matches["hash"])==$hash)
+            {
+                return  ruTrackerChecker::STE_UPTODATE;
+            }
+            if (preg_match('`\"download.php\?id=(?P<id>\d+)\"`', $client->results, $matches))
+            {
+                $client->setcookies();
+                $client->fetchComplex("http://nnm-club.ws/download.php?id=".$matches["id"]);
+                if ($client->status != 200) return (($client->status < 0) ? ruTrackerChecker::STE_CANT_REACH_TRACKER : ruTrackerChecker::STE_DELETED);
+                return ruTrackerChecker::createTorrent($client->results, $hash);
+            }
+        }
+        return ruTrackerChecker::STE_NOT_NEED;
+    }
+}
+
+ruTrackerChecker::registerTracker("/nnm-club\./", "/nnm-club\./", "NNMClubCheckImpl::download_torrent");


### PR DESCRIPTION
Closes '#1045'