### PR TITLE
Fix PHP Warning: uisettings.json

### DIFF
--- a/php/setsettings.php
+++ b/php/setsettings.php
@@ -16,8 +16,10 @@ if(isset($_REQUEST['v']))
 			{
 	        		
 				flock( $fp, LOCK_UN );
-				if( fclose( $fp ) !== false )
-	       				rename( $name.'.tmp', $name );
+				if( fclose( $fp ) !== false ){
+					if (file_exists ($name.'.tmp'))
+	       					rename( $name.'.tmp', $name );
+				}
 				else	       				
 					unlink( $name.'.tmp' );
 			}


### PR DESCRIPTION
This seems to fix the numerous warnings I'm seeing in my error.log:

`PHP Warning:  rename(/var/www/rutorrent/share/users/user/settings/uisettings.json.tmp,/var/www/rutorrent/share/users/user/settings/uisettings.json): No such file or directory in /var/www/rutorrent/php/setsettings.php on line 20`

My guess is sometimes the update happens so fast that sometimes ruTorrent tries to rename a file that has already been renamed

Issue: https://github.com/Novik/ruTorrent/issues/1128