### PR TITLE
Update getdirs.php

### DIFF
--- a/plugins/_getdir/getdirs.php
+++ b/plugins/_getdir/getdirs.php
@@ -63,7 +63,7 @@ if($dh)
 			( $theSettings->uid<0 || (!$checkUserPermissions || isUserHavePermission($theSettings->uid,$theSettings->gid,$path,0x0007)) )
 			)
 		{
-			$files[$file." "] = addslash($path);
+			$files[$file.""] = addslash($path);
 		}
         }
         closedir($dh);


### PR DESCRIPTION
Seems to fix the "." (and ".." too I think) directory to be always to the top. See pictures below:

Before: https://puu.sh/oi1Sd/552b8e7b58.png
After: https://puu.sh/oi1qQ/c60540bb1c.png