### PR TITLE
Added access control swapping

### DIFF
--- a/conf/access-swap.sh
+++ b/conf/access-swap.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script will quickly and easily swap between two different configurations so that access to configuration
+# options can be easily turned on or off, this can help to protect against unauthorised setting changes.
+
+STR=$(cat access.ini | head -n1| cut -c4)
+GOOD=$(cat access_yes)
+BAD=$(cat access_no)
+
+echo $STR
+
+if [ $STR = 0 ]
+then
+        echo -e "\x1B[31m Access Opened \x1B[0m"
+        echo "$GOOD" > access.ini
+else
+        echo -e "\x1B[32m Access Closed \x1B[0m"
+        echo "$BAD" > access.ini
+fi

--- a/conf/access.ini
+++ b/conf/access.ini
@@ -3,17 +3,17 @@
 ;; All flags are assumed to be yes by default.
 
 [settings]
-showDownloadsPage = no
-showConnectionPage = no
-showBittorentPage = no
-showAdvancedPage = no
+showDownloadsPage = yes
+showConnectionPage = yes
+showBittorentPage = yes
+showAdvancedPage = yes
 
 [tabs]
-showPluginsTab = no
+showPluginsTab = yes
 
 [statusbar]
-canChangeULRate = no
-canChangeDLRate = no
+canChangeULRate = yes
+canChangeDLRate = yes
 
 [dialogs]
-canChangeTorrentProperties = no
+canChangeTorrentProperties = yes

--- a/conf/access.ini
+++ b/conf/access.ini
@@ -1,4 +1,4 @@
-;; 0
+;; 1
 ;; ruTorrent permissions.
 ;; All flags are assumed to be yes by default.
 

--- a/conf/access_no
+++ b/conf/access_no
@@ -17,3 +17,4 @@ canChangeDLRate = no
 
 [dialogs]
 canChangeTorrentProperties = no
+

--- a/conf/access_yes
+++ b/conf/access_yes
@@ -1,0 +1,19 @@
+;; 1
+;; ruTorrent permissions.
+;; All flags are assumed to be yes by default.
+
+[settings]
+showDownloadsPage = yes
+showConnectionPage = yes
+showBittorentPage = yes
+showAdvancedPage = yes
+
+[tabs]
+showPluginsTab = yes
+
+[statusbar]
+canChangeULRate = yes
+canChangeDLRate = yes
+
+[dialogs]
+canChangeTorrentProperties = yes


### PR DESCRIPTION
A simple way to open and close the access configurations.

access-swap.sh swaps out the contents of access.ini with the contents of
access_yes or access_no

This is use full for multi user situations were the admin needs to maintain control over the configuration settings.