### PR TITLE
autotools: introduce skip_move on file patterns

### DIFF
--- a/plugins/autotools/autotools.php
+++ b/plugins/autotools/autotools.php
@@ -10,6 +10,7 @@ class rAutoTools
 	public $label_template = "{DIR}";
 	public $enable_move = 0;
 	public $path_to_finished = "";
+	public $skip_move_for_files = "";
 	public $fileop_type = "Move";
 	public $enable_watch = 0;
 	public $path_to_watch = "";
@@ -48,6 +49,7 @@ class rAutoTools
 			$this->enable_move = 0;
 			$this->fileop_type = "Move";
 			$this->path_to_finished = "";
+			$this->skip_move_for_files= "*.rar; *.zip";
 			$this->enable_watch = 0;
 			$this->path_to_watch = "";
 			$this->watch_start = 0;
@@ -85,6 +87,10 @@ class rAutoTools
 					if(!rTorrentSettings::get()->correctDirectory($this->path_to_finished))
 						$this->path_to_finished = '';
 				}
+				else if( $parts[0] == "skip_move_for_files" )
+				{
+					$this->skip_move_for_files = $parts[1];
+				}
 				else if( $parts[0] == "enable_watch" )
 				{
 					$this->enable_watch = $parts[1];
@@ -120,6 +126,7 @@ class rAutoTools
 		$ret .= ", EnableMove: ".$this->enable_move;
 		$ret .= ", FileOpType: '".$this->fileop_type."'";
 		$ret .= ", PathToFinished: '".addslashes( $this->path_to_finished )."'";
+		$ret .= ", SkipMoveForFiles: '" . $this->skip_move_for_files . "'";
 		$ret .= ", EnableWatch: ".$this->enable_watch;
 		$ret .= ", PathToWatch: '".addslashes( $this->path_to_watch )."'";
 		$ret .= ", MoveFilter: '".addslashes( $this->automove_filter )."'";		

--- a/plugins/autotools/autotools.php
+++ b/plugins/autotools/autotools.php
@@ -49,7 +49,7 @@ class rAutoTools
 			$this->enable_move = 0;
 			$this->fileop_type = "Move";
 			$this->path_to_finished = "";
-			$this->skip_move_for_files= "*.rar; *.zip";
+			$this->skip_move_for_files= "/\.rar|\.zip/";
 			$this->enable_watch = 0;
 			$this->path_to_watch = "";
 			$this->watch_start = 0;
@@ -126,7 +126,7 @@ class rAutoTools
 		$ret .= ", EnableMove: ".$this->enable_move;
 		$ret .= ", FileOpType: '".$this->fileop_type."'";
 		$ret .= ", PathToFinished: '".addslashes( $this->path_to_finished )."'";
-		$ret .= ", SkipMoveForFiles: '" . $this->skip_move_for_files . "'";
+		$ret .= ", SkipMoveForFiles: '" . addslashes( $this->skip_move_for_files ). "'";
 		$ret .= ", EnableWatch: ".$this->enable_watch;
 		$ret .= ", PathToWatch: '".addslashes( $this->path_to_watch )."'";
 		$ret .= ", MoveFilter: '".addslashes( $this->automove_filter )."'";		

--- a/plugins/autotools/init.js
+++ b/plugins/autotools/init.js
@@ -13,7 +13,8 @@ if(plugin.canChangeOptions())
 			linked( $$('enable_label'), 0, ['label_template'] );
 			$$('enable_move').checked  = ( theWebUI.autotools.EnableMove  == 1 );
 			$$('path_to_finished').value = theWebUI.autotools.PathToFinished;
-			linked( $$('enable_move'), 0, ['automove_filter', 'path_to_finished', 'automove_browse_btn', 'fileop_type', 'auto_add_label', 'auto_add_name'] );
+			$$('skip_move_for_files').value = theWebUI.autotools.SkipMoveForFiles;
+			linked( $$('enable_move'), 0, ['automove_filter', 'path_to_finished', 'skip_move_for_files', 'automove_browse_btn', 'fileop_type', 'auto_add_label', 'auto_add_name'] );
 			$$('fileop_type').value = theWebUI.autotools.FileOpType;
 			$$('enable_watch').checked  = ( theWebUI.autotools.EnableWatch  == 1 );
 			$$('path_to_watch').value = theWebUI.autotools.PathToWatch;
@@ -39,6 +40,8 @@ if(plugin.canChangeOptions())
 		if( $$('enable_move').checked  != ( theWebUI.autotools.EnableMove  == 1 ) )
 			return true;
 		if( $$('path_to_finished').value != theWebUI.autotools.PathToFinished )
+			return true;
+		if( $$('skip_move_for_files').value != theWebUI.autotools.SkipMoveForFiles )
 			return true;
 		if( $$('enable_watch').checked  != ( theWebUI.autotools.EnableWatch  == 1 ) )
 			return true;
@@ -71,6 +74,7 @@ if(plugin.canChangeOptions())
 			"&label_template=" + $$('label_template').value +
 			"&enable_move=" + ( $$('enable_move').checked  ? '1' : '0' ) +
 			"&path_to_finished=" + $$('path_to_finished').value +
+			"&skip_move_for_files=" + $$('skip_move_for_files').value +
 			"&fileop_type=" + $$('fileop_type').value +
 			"&enable_watch=" + ( $$('enable_watch').checked  ? '1' : '0' ) +
 			"&add_label=" + ( $$('auto_add_label').checked  ? '1' : '0' ) +
@@ -114,7 +118,10 @@ plugin.onLangLoaded = function()
 			"</tr>"+
 			"<tr>"+
 				"<td class='ctrls_level2' colspan=2>"+
-					"<label id='lbl_path_to_finished' for='path_to_finished' class='disabled' disabled='true'>"+
+					"<label id='lbl_skip_move_for_files' for='skip_move_for_files' class='disabled' disabled='true'>"+
+					theUILang.autotoolsSkipMoveForFiles + ":</label><br>"+
+					"<input type='text' id='skip_move_for_files' class='TextBoxLarge' maxlength='30' />"+
+					"<br><label id='lbl_path_to_finished' for='path_to_finished' class='disabled' disabled='true'>"+
 					theUILang.autotoolsPathToFinished +":</label><br>"+
 					"<input type='text' id='path_to_finished' class='TextboxLarge' maxlength='100' />"+
 					"<input type='button' id='automove_browse_btn' class='Button' value='...' />"+

--- a/plugins/autotools/init.js
+++ b/plugins/autotools/init.js
@@ -109,7 +109,7 @@ plugin.onLangLoaded = function()
 			"<tr>"+
 				"<td>"+
 					"<input type='checkbox' id='enable_move' checked='false' "+
-					"onchange='linked(this, 0, [\"automove_filter\", \"path_to_finished\", \"automove_browse_btn\", \"fileop_type\", \"auto_add_label\", \"auto_add_name\" ]);' />"+
+					"onchange='linked(this, 0, [\"automove_filter\", \"skip_move_for_files\", \"path_to_finished\", \"automove_browse_btn\", \"fileop_type\", \"auto_add_label\", \"auto_add_name\" ]);' />"+
 						"<label for='enable_move'>"+ theUILang.autotoolsEnableMove +"</label>"+
 				"</td>"+
 				"<td class='alr'>"+
@@ -117,10 +117,17 @@ plugin.onLangLoaded = function()
 				"</td>"+
 			"</tr>"+
 			"<tr>"+
-				"<td class='ctrls_level2' colspan=2>"+
+				"<td>"+
 					"<label id='lbl_skip_move_for_files' for='skip_move_for_files' class='disabled' disabled='true'>"+
-					theUILang.autotoolsSkipMoveForFiles + ":</label><br>"+
+					theUILang.autotoolsSkipMoveForFiles + "</label><br>"+
+				"</td>"+
+				"<td class='alr'>"+
 					"<input type='text' id='skip_move_for_files' class='TextBoxLarge' maxlength='30' />"+
+				"</td>"+
+
+			"</tr>"+
+			"<tr>"+
+				"<td class='ctrls_level2' colspan=2>"+
 					"<br><label id='lbl_path_to_finished' for='path_to_finished' class='disabled' disabled='true'>"+
 					theUILang.autotoolsPathToFinished +":</label><br>"+
 					"<input type='text' id='path_to_finished' class='TextboxLarge' maxlength='100' />"+

--- a/plugins/autotools/lang/en.js
+++ b/plugins/autotools/lang/en.js
@@ -12,6 +12,7 @@
  theUILang.autotoolsEnableLabel 	= "Enable \"AutoLabel\" feature, Template:";
  theUILang.autotoolsEnableMove		= "Enable \"AutoMove\" if torrent's label matches filter";
  theUILang.autotoolsPathToFinished	= "Path to finished downloads";
+ theUILang.autotoolsSkipMoveForFiles	= "Skip Move if torrent contains this file";
  theUILang.autotoolsEnableWatch 	= "Enable \"AutoWatch\" feature";
  theUILang.autotoolsPathToWatch 	= "Path to base watch directory";
  theUILang.autotoolsWatchStart		= "Start download automatically";

--- a/plugins/autotools/lang/en.js
+++ b/plugins/autotools/lang/en.js
@@ -12,7 +12,11 @@
  theUILang.autotoolsEnableLabel 	= "Enable \"AutoLabel\" feature, Template:";
  theUILang.autotoolsEnableMove		= "Enable \"AutoMove\" if torrent's label matches filter";
  theUILang.autotoolsPathToFinished	= "Path to finished downloads";
+<<<<<<< HEAD
  theUILang.autotoolsSkipMoveForFiles	= "Skip Move if torrent contains this file";
+=======
+ theUILang.autotoolsSkipMoveForFiles	= "Skip torrents that contain files matching pattern";
+>>>>>>> autotools: introduce skip_move on file patterns
  theUILang.autotoolsEnableWatch 	= "Enable \"AutoWatch\" feature";
  theUILang.autotoolsPathToWatch 	= "Path to base watch directory";
  theUILang.autotoolsWatchStart		= "Start download automatically";

--- a/plugins/autotools/move.php
+++ b/plugins/autotools/move.php
@@ -17,6 +17,24 @@ function Debug( $str )
 	if( $autodebug_enabled ) rtDbg( "AutoMove", $str );
 }
 
+
+//------------------------------------------------------------------------------
+function skip_move($files) {
+    global $at;
+    $filters = array_map(trim, explode(';',$at->skip_move_for_files));
+    foreach($filters as $filter) {
+        Debug("using filter:".$filter);
+        foreach($files as $file) {
+            if (fnmatch($filter, $file,FNM_CASEFOLD)) {
+                Debug("File:".$file . ". matches filter:" . $filter);
+                return true;
+            }
+        }
+    }
+    Debug("filters:" . implode(";",$filters) . "did not match any files in" . implode("|",$files) .".end");
+    return false;
+}
+
 //------------------------------------------------------------------------------
 function operationOnTorrentFiles($torrent,&$base_path,$base_file,$is_multy_file,$dest_path,$fileop_type)
 {
@@ -42,6 +60,11 @@ function operationOnTorrentFiles($torrent,&$base_path,$base_file,$is_multy_file,
 			$files[] = implode('/',$file['path']);
 	else
 		$files[] = $info['name'];
+
+    if (skip_move($files)){
+        $ret = false;
+        return ($ret);
+    }
 
 	if( $base_path != $dest_path && is_dir( $base_path ) )
 	{

--- a/plugins/autotools/move.php
+++ b/plugins/autotools/move.php
@@ -21,17 +21,14 @@ function Debug( $str )
 //------------------------------------------------------------------------------
 function skip_move($files) {
     global $at;
-    $filters = array_map(trim, explode(';',$at->skip_move_for_files));
-    foreach($filters as $filter) {
-        Debug("using filter:".$filter);
-        foreach($files as $file) {
-            if (fnmatch($filter, $file,FNM_CASEFOLD)) {
-                Debug("File:".$file . ". matches filter:" . $filter);
-                return true;
-            }
-        }
+    $filter = $at->skip_move_for_files;
+    Debug("using filter:".$filter);
+    foreach($files as $file) {
+       if ( preg_match($filter.'u',$file)==1) {
+           return true;
+	}
     }
-    Debug("filters:" . implode(";",$filters) . "did not match any files in" . implode("|",$files) .".end");
+    Debug("filter: " . $filter . " did not match any files in" . implode(" | ",$files) .". end");
     return false;
 }
 


### PR DESCRIPTION
The idea was to either auto unpack or auto move the content of a torrent.
It looked easier to test for archives inside a torrent than to check if unpack found nothing and the chain-call auto move, as unpack runs asynchronous. So:
- ui: added list of file patterns separated with ;
- if any pattern matches a file inside the torrent, move is skipped
- fnmatch is used, so shell patterns are possible
