### PR TITLE
Add 6 day interval to default intervals in RSS feed plugin

### DIFF
--- a/plugins/rss/init.js
+++ b/plugins/rss/init.js
@@ -1553,6 +1553,7 @@ plugin.onLangLoaded = function()
 					        "<option value='48'>"+theUILang.rssInterval2d+"</option>"+
 					        "<option value='72'>"+theUILang.rssInterval3d+"</option>"+
 					        "<option value='96'>"+theUILang.rssInterval4d+"</option>"+
+						"<option value='144'>"+theUILang.rssInterval6d+"</option>"+
 					        "<option value='168'>"+theUILang.rssInterval1w+"</option>"+
 					        "<option value='336'>"+theUILang.rssInterval2w+"</option>"+
 					        "<option value='504'>"+theUILang.rssInterval3w+"</option>"+

--- a/plugins/rss/lang/cs.js
+++ b/plugins/rss/lang/cs.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/da.js
+++ b/plugins/rss/lang/da.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/de.js
+++ b/plugins/rss/lang/de.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/el.js
+++ b/plugins/rss/lang/el.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 ημέρες";
  theUILang.rssInterval3d		= "3 ημέρες";
  theUILang.rssInterval4d		= "4 ημέρες";
+ theUILang.rssInterval6d		= "6 ημέρες";
  theUILang.rssInterval1w		= "1 εβδομάδα";
  theUILang.rssInterval2w		= "2 εβδομάδες";
  theUILang.rssInterval3w		= "3 εβδομάδες";

--- a/plugins/rss/lang/en.js
+++ b/plugins/rss/lang/en.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/es.js
+++ b/plugins/rss/lang/es.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 dias";
  theUILang.rssInterval3d		= "3 dias";
  theUILang.rssInterval4d		= "4 dias";
+ theUILang.rssInterval6d		= "6 dias";
  theUILang.rssInterval1w		= "1 semana";
  theUILang.rssInterval2w		= "2 semanas";
  theUILang.rssInterval3w		= "3 semanas";

--- a/plugins/rss/lang/fi.js
+++ b/plugins/rss/lang/fi.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/fr.js
+++ b/plugins/rss/lang/fr.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 jours";
  theUILang.rssInterval3d		= "3 jours";
  theUILang.rssInterval4d		= "4 jours";
+ theUILang.rssInterval6d		= "6 jours";
  theUILang.rssInterval1w		= "1 semaine";
  theUILang.rssInterval2w		= "2 semaines";
  theUILang.rssInterval3w		= "3 semaines";

--- a/plugins/rss/lang/hu.js
+++ b/plugins/rss/lang/hu.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/it.js
+++ b/plugins/rss/lang/it.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/ko.js
+++ b/plugins/rss/lang/ko.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 일";
  theUILang.rssInterval3d		= "3 일";
  theUILang.rssInterval4d		= "4 일";
+ theUILang.rssInterval6d		= "6 일";
  theUILang.rssInterval1w		= "1 주";
  theUILang.rssInterval2w		= "2 주";
  theUILang.rssInterval3w		= "3 주";

--- a/plugins/rss/lang/lv.js
+++ b/plugins/rss/lang/lv.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/nl.js
+++ b/plugins/rss/lang/nl.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 dagen";
  theUILang.rssInterval3d		= "3 dagen";
  theUILang.rssInterval4d		= "4 dagen";
+ theUILang.rssInterval6d		= "6 dagen";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weken";
  theUILang.rssInterval3w		= "3 weken";

--- a/plugins/rss/lang/no.js
+++ b/plugins/rss/lang/no.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/pl.js
+++ b/plugins/rss/lang/pl.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 dni";
  theUILang.rssInterval3d		= "3 dni";
  theUILang.rssInterval4d		= "4 dni";
+ theUILang.rssInterval6d		= "6 dni";
  theUILang.rssInterval1w		= "1 tydzień";
  theUILang.rssInterval2w		= "2 tygodnie";
  theUILang.rssInterval3w		= "3 tygodnie";

--- a/plugins/rss/lang/pt.js
+++ b/plugins/rss/lang/pt.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/ru.js
+++ b/plugins/rss/lang/ru.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 дня";
  theUILang.rssInterval3d		= "3 дня";
  theUILang.rssInterval4d		= "4 дня";
+ theUILang.rssInterval6d		= "6 дня";
  theUILang.rssInterval1w		= "1 неделя";
  theUILang.rssInterval2w		= "2 недели";
  theUILang.rssInterval3w		= "3 недели";

--- a/plugins/rss/lang/sk.js
+++ b/plugins/rss/lang/sk.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/sr.js
+++ b/plugins/rss/lang/sr.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/sv.js
+++ b/plugins/rss/lang/sv.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 dagar";
  theUILang.rssInterval3d		= "3 dagar";
  theUILang.rssInterval4d		= "4 dagar";
+ theUILang.rssInterval6d		= "6 dagar";
  theUILang.rssInterval1w		= "1 vecka";
  theUILang.rssInterval2w		= "2 veckor";
  theUILang.rssInterval3w		= "3 veckor";

--- a/plugins/rss/lang/tr.js
+++ b/plugins/rss/lang/tr.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";

--- a/plugins/rss/lang/uk.js
+++ b/plugins/rss/lang/uk.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 дні";
  theUILang.rssInterval3d		= "3 дні";
  theUILang.rssInterval4d		= "4 дні";
+ theUILang.rssInterval6d		= "6 дні";
  theUILang.rssInterval1w		= "1 тиждень";
  theUILang.rssInterval2w		= "2 тижні";
  theUILang.rssInterval3w		= "3 тижні";

--- a/plugins/rss/lang/vi.js
+++ b/plugins/rss/lang/vi.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 ngày";
  theUILang.rssInterval3d		= "3 ngày";
  theUILang.rssInterval4d		= "4 ngày";
+ theUILang.rssInterval6d		= "6 ngày";
  theUILang.rssInterval1w		= "1 tuần";
  theUILang.rssInterval2w		= "2 tuần";
  theUILang.rssInterval3w		= "3 tuần";

--- a/plugins/rss/lang/zh-cn.js
+++ b/plugins/rss/lang/zh-cn.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 天";
  theUILang.rssInterval3d		= "3 天";
  theUILang.rssInterval4d		= "4 天";
+ theUILang.rssInterval6d		= "6 天";
  theUILang.rssInterval1w		= "1 周";
  theUILang.rssInterval2w		= "2 周";
  theUILang.rssInterval3w		= "3 周";

--- a/plugins/rss/lang/zh-tw.js
+++ b/plugins/rss/lang/zh-tw.js
@@ -51,6 +51,7 @@
  theUILang.rssInterval2d		= "2 days";
  theUILang.rssInterval3d		= "3 days";
  theUILang.rssInterval4d		= "4 days";
+ theUILang.rssInterval6d		= "6 days";
  theUILang.rssInterval1w		= "1 week";
  theUILang.rssInterval2w		= "2 weeks";
  theUILang.rssInterval3w		= "3 weeks";


### PR DESCRIPTION
I added a 6 day (144h) RSS interval with translations to the RSS plugin. I think users who need weekly refreshes will benefit from this. The built in 1 week interval was too large for me to capture the feed I wanted.