### PR TITLE
Add GazelleGames.net to the available Accounts list

### DIFF
--- a/plugins/loginmgr/accounts/GazelleGames.php
+++ b/plugins/loginmgr/accounts/GazelleGames.php
@@ -1,0 +1,29 @@
+<?php
+
+class GazelleGamesAccount extends commonAccount
+{
+	public $url = "https://gazellegames.net";
+
+	protected function isOK($client)
+	{
+		return(strpos($client->results, '<form class="auth_form" name="login" id="loginform"')===false);
+	}
+	protected function login($client,$login,$password,&$url,&$method,&$content_type,&$body,&$is_result_fetched)
+	{
+
+		$is_result_fetched = false;
+		if($client->fetch( $this->url."/login.php" ))
+		{
+                        $client->setcookies();
+			$client->referer = $this->url."/login.php";
+
+        		if($client->fetch( $this->url."/login.php","POST","application/x-www-form-urlencoded", 
+				"username=".rawurlencode($login)."&password=".rawurlencode($password)."&keeplogged=1&login=Login" ))
+			{
+				$client->setcookies();
+				return(true);
+			}
+		}
+		return(false);
+	}
+}


### PR DESCRIPTION
With the help of one of the site's Admins, this file was edited from the original WhatCD php file already in the repo ( See said file at https://github.com/Novik/ruTorrent/blob/master/plugins/loginmgr/accounts/WhatCD.php ) and modified to fit the needs of the GazelleGames.net login page to successfully login with this plugin.

Thanks for the ~15 minutes of work that Gedrean and xFyrios have done to get this written and working. All I did was submit it for the request, haha.