### PR TITLE
Make labels easier to add

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -240,6 +240,10 @@ function makeContent()
 		'<div class="aright buttons-list"><input type="button" class="OK Button" value="'+theUILang.ok+'" onclick="theWebUI.createLabel();theDialogManager.hide(\'dlgLabel\');return(false);" />'+
 			'<input type="button" class="Cancel Button" value="'+theUILang.Cancel+'"/></div>',
 		true);
+	theDialogManager.setHandler('dlgLabel','afterShow',function()
+	{
+		setTimeout(function(){$("#txtLabel").off('focus').on('focus',function() { $(this).select(); } ).focus();}, 0);
+	});
 	theDialogManager.make("yesnoDlg","",
 		'<div class="content" id="yesnoDlg-content"></div>'+
 		'<div id="yesnoDlg-buttons" class="aright buttons-list"><input type="button" class="OK Button" value="'+theUILang.ok+'" id="yesnoOK">'+


### PR DESCRIPTION
When the label add dialog box is shown, this focuses the text box and selects all text in it.
This allows you to just start typing your label, then press the enter key to set it.