### PR TITLE
Proper center alignment of default theme progress indicator text

### DIFF
--- a/css/stable.css
+++ b/css/stable.css
@@ -35,7 +35,7 @@
 .stable-head .rowcover { position: absolute; left: 0; top: 0; height: 20px; width: 1000px; background: transparent; display: none; }
 
 .meter-value { float: left; background-color: #99D699; border: 1px inset #BBBBBB; border-bottom: none;}
-.meter-text { position: relative; text-align: left; float: left; width: 0px; height: 0px; overflow: visible; left: 40%; font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif;	z-index: 1; }
+.meter-text { position: relative; text-align: center; float: left; width: 100%; height: 0px; overflow: visible; font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif; z-index: 1; }
 
 .meter-value-start-color { background-color: #FFFF00 }
 .meter-value-end-color { background-color: #99D699 }


### PR DESCRIPTION
It's much nicer visually and aesthetically to have center-aligned text in progress indicators, instead of left: 40% hack. Tested in Firefox and Chrome.