### PR TITLE
EraseData: better polish translations

### DIFF
--- a/plugins/erasedata/lang/pl.js
+++ b/plugins/erasedata/lang/pl.js
@@ -3,11 +3,12 @@
  *
  * Polish language file.
  *
- * Author: 
+ * Initial author: dolohow
+ * Author: mmalisz
  */
 
- theUILang.Rem_torrents_content_prompt		= "Do you really want to remove the selected torrent(s)? WARNING: To usunię zawartość torrent'a.";
- theUILang.Delete_data_with_path		= "Ścieżka do usunięcia";
- theUILang.Rem_torrents_with_path_prompt	= "Czy na pewno chcesz usunąć zaznaczone torrent'y? OSTRZEŻENIE: To usunię wszystkie pliki w biężącym katalogu torrent'a.";
+ theUILang.Rem_torrents_content_prompt		= "Czy napewno chcesz usunąć wybrany torrent(y)? UWAGA: Zostaną usunięte wszystkie pliki z katalogu torrent'a!";
+ theUILang.Delete_data_with_path		= "Usuń dane (łącznie z katalogiem)";
+ theUILang.Rem_torrents_with_path_prompt	= "Czy napewno chcesz usunąć wybrany torrent(y)? UWAGA: Zostaną usunięte cały katalog torrent'a!";
 
 thePlugins.get("erasedata").langLoaded();


### PR DESCRIPTION
Fixed lang strings for the earedata plugin.
Beside not being completely translated, they were bit misleading.