### PR TITLE
Fixed markdown formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-#ruTorrent
+# ruTorrent
 
 ruTorrent is a front-end for the popular Bittorrent client [rtorrent](http://rakshasa.github.io/rtorrent).
 
 This project is released under the GPLv3 license, for more details, take a look at the LICENSE.md file in the source.
 
-##Main features
+## Main features
 
 * Lightweight server side, so it can be installed on old and low-end servers and even on some SOHO routers
 * Extensible - there are several plugins and everybody can create their own one
 * Nice look ;) 
 
-##Screenshots
+## Screenshots
 
 [![](https://github.com/Novik/ruTorrent/wiki/images/scr1_small.jpg)](https://github.com/Novik/ruTorrent/wiki/images/scr1_big.jpg)
 [![](https://github.com/Novik/ruTorrent/wiki/images/scr2_small.jpg)](https://github.com/Novik/ruTorrent/wiki/images/scr2_big.jpg)
 [![](https://github.com/Novik/ruTorrent/wiki/images/scr3_small.jpg)](https://github.com/Novik/ruTorrent/wiki/images/scr3_big.jpg)
 
-##Download
+## Download
 
  * [Development version](https://github.com/Novik/ruTorrent/tarball/master)
  * [Stable version](https://bintray.com/novik65/generic/ruTorrent)
 
-##Getting started
+## Getting started
 
   * There's no installation routine or compilation necessary. The sources are cloned/unpacked into a directory which is setup as document root of a web server of your choice (for detailed instructions see the [webserver wiki article](https://github.com/Novik/ruTorrent/wiki/WebSERVER).
   * After setting up the webserver `ruTorrent` itself needs to be configured. Instructions can be found in various articles in the [wiki](https://github.com/Novik/ruTorrent/wiki).


### PR DESCRIPTION
The `#`s (for headers) should be separated from the headers by a space.