### PR TITLE
Update throttle.php

### DIFF
--- a/plugins/throttle/throttle.php
+++ b/plugins/throttle/throttle.php
@@ -3,7 +3,7 @@ require_once( dirname(__FILE__)."/../../php/xmlrpc.php" );
 require_once( $rootPath.'/php/cache.php');
 eval(getPluginConf('throttle'));
 
-@define('MAX_SPEED', 100*1024*1024);
+@define('MAX_SPEED', 0);
 
 class rThrottle
 {


### PR DESCRIPTION
set ruTorrent max speed to 0, previous behavior would set rTorrent throttle limits to 102400, on ruTorrent first lauch, when unlimited set in .rtorrent.rc

Issue: https://github.com/Novik/ruTorrent/issues/1452