### PR TITLE
Correct wrong use of correctDirectory, fixes #1072

### DIFF
--- a/php/rtorrent.php
+++ b/php/rtorrent.php
@@ -46,8 +46,7 @@ class rTorrent
 			$req = new rXMLRPCRequest();				
 			if($directory && (strlen($directory)>0))
 			{
-				if(!rTorrentSettings::get()->correctDirectory($directory))
-					return(false);
+				rTorrentSettings::get()->correctDirectory($directory);
 				$req->addCommand( new rXMLRPCCommand( 'execute', array('mkdir','-p',$directory) ) );
 				$cmd->addParameter( ($isAddPath ? getCmd("d.set_directory=")."\"" : getCmd("d.set_directory_base=")."\"").$directory."\"" );
 			}


### PR DESCRIPTION
If sendTorrent is called with a non-empty $directory parameter, it will always fail because correctDirectory returns a comparison with $topDirectory which is part of the app's URL, and not at all related for the filesystem. This commit fixes the problem so that if a $directory parameter is passed, the function will not fail.