### PR TITLE
Have check_port bind to the same interface as rtorrent

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -23,6 +23,7 @@ class rTorrentSettings
 	public $server = '';
 	public $portRange = '6890-6999';
 	public $port = '6890';
+	public $bind = '0.0.0.0';
 	public $idNotFound = false;
 	public $home = '';
 
@@ -167,6 +168,7 @@ class rTorrentSettings
 					new rXMLRPCCommand("set_xmlrpc_size_limit",67108863),
 					new rXMLRPCCommand("get_name"),
 					new rXMLRPCCommand("get_port_range"),
+					new rXMLRPCCommand("get_bind"),
 					) );
 				if($req->success())
 				{
@@ -176,6 +178,7 @@ class rTorrentSettings
 					$this->server = $req->val[4];
 					$this->portRange = $req->val[5];
 					$this->port = intval($this->portRange);
+					$this->bind = $req->val[6];
 
 					if($this->iVersion>=0x809)
 					{


### PR DESCRIPTION
This patch allows the check_port plugin to function correctly when rtorrent is bound to a non-default network interface, such as in scenarios where a VPN is used. Requires the curl PHP module.