### PR TITLE
Minor german translation improvement

### DIFF
--- a/lang/de.js
+++ b/lang/de.js
@@ -43,7 +43,7 @@ var theUILang =
  Size				: "Grösse",
  Done				: "Fertig",
  Downloaded			: "Geladen",
- Uploaded			: "Upgeloadet",
+ Uploaded			: "Hochgeladen",
  Ratio				: "Rate",
  DL				: "DL",
  UL				: "UL",


### PR DESCRIPTION
"Upgeloadet" is not a german word and sounds awful. "Downloaded" wasn't translated as "Downgeloadet" either...
"Hochgeladen" is a much more natural sounding translation. 