### PR TITLE
Fix href search in enclosure element

### DIFF
--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -178,7 +178,7 @@ class rRSS
 						foreach($this->itemtags as $itemtag)
 						{
 							if($itemtag=='enclosure')
-								$temp = $this->search("'<enclosure.*url\s*=\s*[\"|\'](.*?)[\"|\'].*>'si", $rssItem);
+								$temp = $this->search("'<enclosure.*?url\s*=\s*[\"|\'](.*?)[\"|\'].*>'si", $rssItem);
 							else
 							if($itemtag=='source')
 								$temp = $this->search("'<source\s*url\s*=\s*[\"|\'](.*?)[\"|\'].*>.*</source>'si", $rssItem);


### PR DESCRIPTION
Fix greedy regex getting `href2` in `<enclosure url="href1" /><foo url="href2">bar</foo>`.