### PR TITLE
Fix AutoWatch and AutoMove with add label duplicate path

### DIFF
--- a/plugins/autotools/move.php
+++ b/plugins/autotools/move.php
@@ -121,7 +121,8 @@ if( $at->enable_move && (@preg_match($at->automove_filter.'u',$label)==1) )
 				{
 					if( $rel_path == './' ) $rel_path = '';
 					$dest_path = rtAddTailSlash( $path_to_finished.$rel_path );
-					if($at->addLabel && ($label!=''))
+					// last condition avoids appending duplicate path from combining folder and label (eg autowatch and autolabel)
+					if($at->addLabel && ($label!='') && strpos($dest_path, $label) === false)
 		        			$dest_path.=addslash($label);
 			        	if($at->addName && ($name!=''))
 						$dest_path.=addslash($name);					

--- a/plugins/autotools/move.php
+++ b/plugins/autotools/move.php
@@ -122,7 +122,7 @@ if( $at->enable_move && (@preg_match($at->automove_filter.'u',$label)==1) )
 					if( $rel_path == './' ) $rel_path = '';
 					$dest_path = rtAddTailSlash( $path_to_finished.$rel_path );
 					// last condition avoids appending duplicate path from combining folder and label (eg autowatch and autolabel)
-					if($at->addLabel && ($label!='') && strpos($dest_path, $label) === false)
+					if($at->addLabel && ($label!='') && ($label!=trim($rel_path,'/')))
 		        			$dest_path.=addslash($label);
 			        	if($at->addName && ($name!=''))
 						$dest_path.=addslash($name);					


### PR DESCRIPTION
Fix duplicate path from combining autowatch and automove. If the folder already contains the label in the path don't add it again.

Fixes #1513