### PR TITLE
Fix double URL encoding of torrent labels

### DIFF
--- a/js/webui.js
+++ b/js/webui.js
@@ -2033,7 +2033,7 @@ var theWebUI =
    		for(var k in sr) 
    		{
       			if(sr[k] && (this.torrents[k].label != lbl))
-      				req += ("&hash=" + k + "&s=label&v=" + encodeURIComponent(lbl));
+      				req += ("&hash=" + k + "&s=label&v=" + lbl);
 		}
 		if(req.length>0)
 			this.request("?action=setlabel"+req+"&list=1",[this.addTorrents, this]);
@@ -2070,7 +2070,7 @@ var theWebUI =
 			for(var k in sr) 
 			{
       				if(sr[k] && (this.torrents[k].label != lbl))
-	         			req+=("&hash=" + k + "&s=label&v=" + encodeURIComponent(lbl));
+	         			req+=("&hash=" + k + "&s=label&v=" + lbl);
 	         	}
 			if(req.length>0)
 				this.request("?action=setlabel"+req+"&list=1",[this.addTorrents, this]);


### PR DESCRIPTION
`webui.js` encodes the label text before dispatching the web request, where the `setlabel()` function in the httprpc plugin`init.js` file also does a URL encode of the label text. The end result is the label looks and acts fine in the web-ui, but it is actually setting a URL encoded string of the label in rTorrent. This can cause unexpected behaviour.