### PR TITLE
Add the ability to set a source value in the create plugin

### DIFF
--- a/php/Torrent.php
+++ b/php/Torrent.php
@@ -335,7 +335,20 @@ class Torrent
         	return(is_null( $name ) ?
 			isset( $this->info['name'] ) ? $this->info['name'] : null :
 			$this->touch( $this->info['name'] = (string) $name ));
-	}
+    }
+
+    /** Getter and setter of the source
+     * @param null|string source (optional, if omitted it's a getter)
+     * @return string|null source or null if not set
+     */
+    public function source( $source = null )
+    {
+        if (is_null($source)) {
+            return isset($this->info["source"]) ? $this->info["source"] : null;
+        } else {
+            $this->touch($this->info['source'] = (string)$source);
+        }
+    }
 
 	/** Getter and setter of private flag
 	 * @param null|boolean is private or not (optional, if omitted it's a getter)

--- a/plugins/create/action.php
+++ b/plugins/create/action.php
@@ -125,6 +125,7 @@ if(isset($_REQUEST['cmd']))
 						'path_edit'=>$_REQUEST['path_edit'],
 						'trackers'=>$_REQUEST['trackers'],
 						'comment'=>$_REQUEST['comment'],
+						'source'=>$_REQUEST['source'],
 						'start_seeding'=>$_REQUEST['start_seeding'],
 						'piece_size'=>$_REQUEST['piece_size'],
 						'private'=>$_REQUEST['private']

--- a/plugins/create/createtorrent.php
+++ b/plugins/create/createtorrent.php
@@ -62,6 +62,10 @@ if( count( $argv ) > 1 )
 		else
                	        $torrent = new Torrent($path_edit,array(),$piece_size,$callback_log,$callback_err);
 
+        if (isset($request['source']) && strlen($request['source']) !== 0) {
+            $torrent->source(trim($request['source']));
+        }
+
 		if(isset($request['comment']))
 		{
 			$comment = trim($request['comment']);

--- a/plugins/create/init.js
+++ b/plugins/create/init.js
@@ -18,6 +18,7 @@ theWebUI.checkCreate = function()
 		"trackers" : trk,
 		"path_edit" : $.trim($("#path_edit").val()), 
 		"comment" : $.trim($("#comment").val()),
+		"source" : $.trim($("#source").val()),
 		"private" : $('#private').prop('checked') ? 1 : 0,
 		"start_seeding" : $('#start_seeding').prop('checked') ? 1 : 0		
 	},
@@ -128,6 +129,8 @@ plugin.onLangLoaded = function()
 					"<textarea id='trackers' name='trackers'></textarea><br/>"+
         	                       	       "<label>"+theUILang.Comment+": </label>"+
         		               	"<input type='text' id='comment' name='comment' class='TextboxLarge'/><br/>"+
+        	                       	       "<label>" + theUILang.source + ": </label>"+
+        		               	"<input type='text' id='source' name='source' class='TextboxLarge'/><br/>"+
 					pieceSize+	
 				"</fieldset>"+
 				"<fieldset>"+

--- a/plugins/create/lang/en.js
+++ b/plugins/create/lang/en.js
@@ -25,5 +25,6 @@
  theUILang.torrentKill			= "Stop";
  theUILang.torrentKilled		= "Process was stopped.";
  theUILang.recentTrackers		= "Recent trackers";
+ theUILang.source = "Source";
 
 thePlugins.get("create").langLoaded();


### PR DESCRIPTION
This is useful for private trackers that set a value like that, which is primary used for cross-seeding across trackers. With a different source value the infohash will change even if the files are the same.