### PR TITLE
Add .gitattributes to prevent irrelevant files in releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/.gitattributes	export-ignore
+/.gitignore	export-ignore


### PR DESCRIPTION
This file will prevent specific cruft files from being present in release archives, currently both .gitignore and .gitattributes.
  