### PR TITLE
Rename .htaccess to ensure installation works out of the box

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,0 @@
-AuthType Basic
-AuthName "rutorrent"
-AuthUserFile  "/var/www/ruTorrent/.htpasswd"
-require valid-user

--- a/htaccess-example
+++ b/htaccess-example
@@ -1,0 +1,6 @@
+# If you are running Apache, you can rename this file to .htaccess and generate a .htpasswd to enable authentication
+# See https://httpd.apache.org/docs/2.4/howto/auth.html for more information
+AuthType Basic
+AuthName "rutorrent"
+AuthUserFile  "/var/www/ruTorrent/.htpasswd"
+require valid-user


### PR DESCRIPTION
The existing .htaccess file was invalid without further configuration (e.g. creating the htpasswd file).
Now it's marked as an example and provides additional documentation for Apache httpd users.