### PR TITLE
 Update .htaccess directives for Apache 2.4 

### DIFF
--- a/conf/.htaccess
+++ b/conf/.htaccess
@@ -1,1 +1,1 @@
-deny from all
+require all denied

--- a/share/.htaccess
+++ b/share/.htaccess
@@ -1,2 +1,2 @@
-deny from all
+require all denied
 Options -Indexes


### PR DESCRIPTION
As of Apache 2.4 the way .htaccess files work has changed slightly. Improper .htaccess configuration might expose config files to the www in the future.

See: https://httpd.apache.org/docs/current/upgrading.html