### PR TITLE
Add source field to torrents created externally

### DIFF
--- a/plugins/create/correct.php
+++ b/plugins/create/correct.php
@@ -68,6 +68,12 @@ if( count( $argv ) > 1 )
 		{
 			$torrent->is_private(true);
 		}
+		if(isset($request['source']))
+		{
+			$source = trim($request['source']);
+			if(strlen($source))
+				$torrent->source($source);
+		}
 		$fname = rTask::formatPath($taskNo)."/result.torrent";
 		$torrent->save($fname);
 


### PR DESCRIPTION
The source field was not being set when torrents were created with an external tool.