### PR TITLE
IPv6 fixes

### DIFF
--- a/js/webui.js
+++ b/js/webui.js
@@ -109,7 +109,7 @@ var theWebUI =
 			ondblclick:	function(obj) 
 			{ 
 				if(obj.id && theWebUI.peers[obj.id])
-					window.open(theURLs.RIPEURL + theWebUI.peers[obj.id].ip, "_blank");
+					window.open(theURLs.RIPEURL + theWebUI.peers[obj.id].ip.replace(/^\[?(.+?)\]?$/, '$1'), "_blank");
 				return(false);
 			}
 		},

--- a/plugins/geoip/lookup.php
+++ b/plugins/geoip/lookup.php
@@ -83,9 +83,18 @@
 						{
 							$pkt = pack("n", $randbase + $idx) . "\1\0\0\1\0\0\0\0\0\0";
 							$ipmap[$value] = $idx++;
-							foreach (array_reverse(explode(".", $value)) as $part)
-								$pkt .= chr(strlen($part)) . $part;
-							$pkt .= "\7in-addr\4arpa\0\0\x0C\0\1";
+							if (substr($value, 0, 1) == '[')
+							{
+								$a = '';
+								foreach(str_split(inet_pton(substr($value, 1, -1))) as $char) $a .= str_pad(dechex(ord($char)), 2, '0', STR_PAD_LEFT);
+								$pkt .= "\1" . implode("\1", str_split(strrev($a))) . "\3ip6\4arpa\0\0\x0C\0\1";
+							}
+							else
+							{
+								foreach (array_reverse(explode(".", $value)) as $part)
+									$pkt .= chr(strlen($part)) . $part;
+								$pkt .= "\7in-addr\4arpa\0\0\x0C\0\1";
+							}
 							fwrite($dns, $pkt);
 							fflush($dns);
 							$host = $value;

--- a/plugins/geoip/lookup.php
+++ b/plugins/geoip/lookup.php
@@ -21,7 +21,7 @@
 		if($dnsResolver && $retrieveHost)
 		{
 			$dns = fsockopen("udp://".$dnsResolver, 53);
-			$randbase = rand(0, 256) * 256;
+			$randbase = rand(0, 32000);
 			$idx = 0;
 		}
 		$vars = explode('&', $HTTP_RAW_POST_DATA);

--- a/plugins/geoip/lookup.php
+++ b/plugins/geoip/lookup.php
@@ -10,6 +10,7 @@
 	}
 
 	$retrieveCountry = ($retrieveCountry && function_exists("geoip_country_code_by_name"));
+	$retrieveCountryIPv6 = ($retrieveCountry && function_exists("geoip_country_code_by_name_v6"));
 	$retrieveComments = ($retrieveComments && sqlite_exists());
 	$ret = array();
 	$dns = null;
@@ -49,6 +50,8 @@
 						}
 						if(!isValidCode($country) )
 							$country = @geoip_country_code_by_name( $value );
+						if(!isValidCode($country) && substr($value, 0, 1) == '[' && $retrieveCountryIPv6)
+							$country = @geoip_country_code_by_name_v6( substr($value, 1, -1) );
 						if(!isValidCode($country))
 							$country = "un";
 						else

--- a/plugins/geoip/lookup.php
+++ b/plugins/geoip/lookup.php
@@ -92,7 +92,7 @@
 						} 
 						else 
 						{
-                                                	$host = gethostbyaddr($value);
+                                                	$host = gethostbyaddr(preg_replace('/^\[?(.+?)\]?$/', '$1', $value));
 	                                                if(empty($host) || (strlen($host)<2))
         	                                                $host = $value;
 						}

--- a/plugins/geoip/lookup.php
+++ b/plugins/geoip/lookup.php
@@ -115,6 +115,7 @@
 			{
 				$pos = 12;
 				$ip = array();
+				$id = ord($buf[0]) * 256 + ord($buf[1]) - $randbase;
 				while($count = ord($buf[$pos++])) 
 				{
 					if(count($ip) < 4)
@@ -149,7 +150,7 @@
 				if($host) 
 				{
 					$host = implode(".", $host);
-					$ret[$ipmap[$ip]]["info"]["host"] = $host;
+					$ret[$id]["info"]["host"] = $host;
 				}
 			}
 			fclose($dns);

--- a/plugins/geoip/lookup.php
+++ b/plugins/geoip/lookup.php
@@ -21,7 +21,7 @@
 		if($dnsResolver && $retrieveHost)
 		{
 			$dns = fsockopen("udp://".$dnsResolver, 53);
-			$randbase = rand(0, 32000);
+			$randbase = rand(0, 255) * 256;
 			$idx = 0;
 		}
 		$vars = explode('&', $HTTP_RAW_POST_DATA);

--- a/plugins/geoip/lookup.php
+++ b/plugins/geoip/lookup.php
@@ -21,7 +21,7 @@
 		if($dnsResolver && $retrieveHost)
 		{
 			$dns = fsockopen("udp://".$dnsResolver, 53);
-			$randbase = rand(0, 32000);
+			$randbase = rand(0, 256) * 256;
 			$idx = 0;
 		}
 		$vars = explode('&', $HTTP_RAW_POST_DATA);


### PR DESCRIPTION
These patches fix the following issues:

- WebUI

1. send correct IPv6 address (by removing [ and ]) to RIPEURL when double clicking on IPv6 peer

- Plugin GeoIP:

1. perform IPv6 GeoIP lookup if php-geoip >= 1.1.1;
2. perform correct IPv6 rDNS query through gethostbyaddr and custom DNS server
