### PR TITLE
Replace the custom javascript json_encode with JSON.stringify

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1570,42 +1570,6 @@ function getCRC( str, crc )
 	return(crc);
 }
 
-function json_encode(obj)
-{
-	switch($type(obj))
-	{
-		case "number":
-			return(String(obj));
-		case "boolean":
-			return(obj ? "1" : "0");
-		case "string":
-			return('"'+addslashes(obj)+'"');
-		case "array":
-		{
-		        var s = '';
-		        $.each(obj,function(key,item)
-		        {
-		                if(s.length)
-                			s+=",";
-		        	s += json_encode(item);
-		        });
-			return("["+s+"]");
-		}
-		case "object":
-		{
-		        var s = '';
-		        $.each(obj,function(key,item)
-		        {
-		                if(s.length)
-                			s+=",";
-		        	s += ('"'+key+'":'+json_encode(item));
-		        });
-			return("{"+s+"}");
-		}
-	}
-	return("null");
-}
-
 function strip_tags(input, allowed)
 {
 	allowed = (((allowed || '') + '')

--- a/js/webui.js
+++ b/js/webui.js
@@ -801,7 +801,7 @@ var theWebUI =
 			if((/^webui\./).test(i))
 				cookie[i] = v;
 		});
-		theWebUI.request("?action=setuisettings&v=" + json_encode(cookie),reply);
+		theWebUI.request("?action=setuisettings&v=" + JSON.stringify(cookie),reply);
 	},
 
 //
@@ -1552,7 +1552,7 @@ var theWebUI =
 			{	 
 				theWebUI.systemInfo.rTorrent.started = false;
 	   			theWebUI.error(status,text); 
-				if(theWebUI.settings["webui.retry_on_error"]!=0)
+				if(theWebUI.settings["webui.retry_on_error"])
 					theWebUI.setInterval( iv(theWebUI.settings["webui.retry_on_error"])*1000 );
 		   	});
    	},


### PR DESCRIPTION
JSON.stringify is supported in all browsers updated at any point
in the past 10 years. This allows us to avoid providing a custom
function for encoding json.