### PR TITLE
Update YggTorrent.php

### DIFF
--- a/plugins/loginmgr/accounts/YggTorrent.php
+++ b/plugins/loginmgr/accounts/YggTorrent.php
@@ -2,7 +2,7 @@
 
 class YggTorrentAccount extends commonAccount
 {
-    public $url = "https://yggtorrent.is";
+    public $url = "https://ww1.yggtorrent.is";
 
     protected function isOK($client)
     {


### PR DESCRIPTION
The base address is now `https://ww1.yggtorrent.is` otherwise we got a _301 Moved Permanently_