### PR TITLE
Another fix for IPT search for older versions of php-xml

### DIFF
--- a/plugins/extsearch/engines/IPTorrents.php
+++ b/plugins/extsearch/engines/IPTorrents.php
@@ -55,7 +55,7 @@ class IPTorrentsEngine extends commonEngine
                     }
 
                     $tds = $tr->getElementsByTagName('td');
-                    if (count($tds) !== 9) continue; //bail if table rows isn't as expected
+                    if ($tds->length !== 9) continue; //bail if table rows isn't as expected
 
                     try {
                         preg_match('/\| (.*) (minutes|hours|days|weeks|months|years) ago/',


### PR DESCRIPTION
tldr;

everything below php7.2 can't use countable, so count($tds) would result in 1 