### PR TITLE
Update YggTorrent tracker URL for 'extsearch' plugin

### DIFF
--- a/plugins/extsearch/engines/YggTorrent.php
+++ b/plugins/extsearch/engines/YggTorrent.php
@@ -131,8 +131,11 @@ class YggTorrentEngine extends commonEngine
             );
 
             if ($res) {
+                // Get current URL
+                preg_match('`.+?(?=/torrent)`', $matches["desc"][0], $url);
+
                 for ($i = 0; $i < $res; $i++) {
-                    $link = self::URL . "/engine/download_torrent?id=" . $matches["id"][$i];
+                    $link = $url[0] . "/engine/download_torrent?id=" . $matches["id"][$i];
                     if (!array_key_exists($link, $ret)) {
                         $item = $this->getNewEntry();
                         $item["desc"] = $matches["desc"][$i];
@@ -144,7 +147,7 @@ class YggTorrentEngine extends commonEngine
                         $item["size"] = self::formatSize(preg_replace('/([0-9.]+)(\w+)/', '$1 $2', $matches["size"][$i]));
 
                         // To be able to display categories, we need to parse them directly from the torrent URL
-                        $cat = preg_match_all('`' . self::URL . '/torrent/(?P<cat1>.*)/(?P<cat2>.*)/`', $item['desc'], $catRes);
+                        $cat = preg_match_all('`' . $url[0] . '/torrent/(?P<cat1>.*)/(?P<cat2>.*)/`', $item['desc'], $catRes);
                         if ($cat) {
                             $cat1 = $this->getPrettyCategoryName($catRes['cat1'][0]);
                             $cat2 = $this->getPrettyCategoryName($catRes['cat2'][0]);

--- a/plugins/loginmgr/accounts/YggTorrent.php
+++ b/plugins/loginmgr/accounts/YggTorrent.php
@@ -2,7 +2,7 @@
 
 class YggTorrentAccount extends commonAccount
 {
-    public $url = "https://yggtorrent.to";
+    public $url = "https://www3.yggtorrent.to";
 
     protected function isOK($client)
     {


### PR DESCRIPTION
_- Use "get_headers" function to obtain the current working URL for 'loginmgr' plugin (tired from these URL modifications...)_ (not good => https://github.com/Novik/ruTorrent/pull/1768#discussion_r224352012)
- Change YggTorrent.php extsearch engine to display the current working URL for .torrent download links