### PR TITLE
Fix geoip plugin 'onRemove' function

### DIFF
--- a/plugins/geoip/init.js
+++ b/plugins/geoip/init.js
@@ -226,5 +226,5 @@ plugin.onRemove = function()
         if(plugin.retrieveCountry)
 		theWebUI.getTable("prs").removeColumnById("country");
         if(plugin.retrieveComments)
-		theWebUI.getTable("prs").removeColumnById("country");
+		theWebUI.getTable("prs").removeColumnById("comment");
 }


### PR DESCRIPTION
Fix the removing of "comment" column when 'onRemove' is called.