### PR TITLE
Update RARbgTorrentAPI.php

### DIFF
--- a/plugins/extsearch/engines/RARbgTorrentAPI.php
+++ b/plugins/extsearch/engines/RARbgTorrentAPI.php
@@ -101,7 +101,7 @@ class RARbgTorrentAPIEngine extends commonEngine
 					{
 						$item = $this->getNewEntry();
 						$item["cat"] = $torrent->category;
-				                $item["desc"] = $torrent->info_page;
+				                $item["desc"] = $torrent->info_page.'&app_id=ruTorrent_extsearch';
 				                $item["name"] = $torrent->title;
 				                $item["size"] = $torrent->size;
 				                $item["seeds"] = $torrent->seeders;


### PR DESCRIPTION
Update for info url.
It is https://torrentapi.org/redirect_to_info.php?token=29rbdcfk1o&p=1_6_7_2_9_0_8__34afb86cc9
should be https://torrentapi.org/redirect_to_info.php?token=29rbdcfk1o&p=1_6_7_2_9_0_8__34afb86cc9&app_id=ruTorrent_extsearch