### PR TITLE
Allow "$XMLRPCMountPoint" variable to be optional in config.php

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -44,7 +44,7 @@
 	// $scgi_port = 0;
 	// $scgi_host = "unix:///tmp/rpc.socket";
 
-	$XMLRPCMountPoint = "/RPC2";		// DO NOT DELETE THIS LINE!!! DO NOT COMMENT THIS LINE!!!
+	$XMLRPCMountPoint = "/RPC2";		// If you enable RPC plugin -OR- HTTPRPC plugin in "plugins.ini", you can delete or comment this line.
 
 	$pathToExternals = array(
 		"php" 	=> '',			// Something like /usr/bin/php. If empty, will be found in PATH.

--- a/conf/plugins.ini
+++ b/conf/plugins.ini
@@ -25,3 +25,9 @@ canChangeColumns = yes
 canChangeStatusBar = yes
 canChangeCategory = yes
 canBeShutdowned = yes
+
+[rpc]
+enabled = no
+
+[httprpc]
+enabled = no

--- a/js/common.js
+++ b/js/common.js
@@ -347,7 +347,7 @@ function propsCount(obj)
 
 var theURLs =
 {
-	XMLRPCMountPoint 	: "/RPC2",
+	XMLRPCMountPoint 	: "",
 	AddTorrentURL 		: "php/addtorrent.php",
 	SetSettingsURL		: "php/setsettings.php",
 	GetSettingsURL		: "php/getsettings.php",

--- a/php/getplugins.php
+++ b/php/getplugins.php
@@ -220,7 +220,8 @@ foreach($settingsFlags as $flagName=>$flagVal)
 	if(!array_key_exists($flagName,$permissions) || $permissions[$flagName])
 		$perms|=$flagVal;
 $jResult .= "theWebUI.showFlags = ".$perms.";\n";
-$jResult .= "theURLs.XMLRPCMountPoint = '".$XMLRPCMountPoint."';\n";
+if(isset($XMLRPCMountPoint))
+	$jResult .= "theURLs.XMLRPCMountPoint = '".$XMLRPCMountPoint."';\n";
 $jResult.="theWebUI.systemInfo = {};\ntheWebUI.systemInfo.php = { canHandleBigFiles : ".((PHP_INT_SIZE<=4) ? "false" : "true")." };\n";
 
 if($handle = opendir('../plugins')) 


### PR DESCRIPTION
#1895
- Remove useless "/RPC2" default value for XMLRPCMountPoint (`js/common.js`) => Already set in `conf/config.php`
- RPC and HTTPRPC plugins are disabled by default (`conf/plugins.ini`)
- New comment line for $XMLRPCMountPoint variable (`conf/config.php`)
- Do not get PHP Notice log messages if $XMLRPCMountPoint variable is not set (`php/getplugins.php`)