### PR TITLE
screenshots: Wait for ffmpeg processes to finish

### DIFF
--- a/plugins/screenshots/action.php
+++ b/plugins/screenshots/action.php
@@ -58,7 +58,7 @@ if(isset($_REQUEST['cmd']))
 						'hash'=>$_REQUEST['hash'], 
 						'no'=>$_REQUEST['no'] 
 					));
-					$ret = $task->start($commands, rTask::FLG_NO_ERR);
+					$ret = $task->start($commands, rTask::FLG_NO_ERR | rTask::FLG_WAIT);
 				}
 			}
 			break;


### PR DESCRIPTION
Without this, when generating 1080p PNG screenshots some of the images appear as broken as it tries to load them before they're generated.