### PR TITLE
fix for rtorrent 0.9.8 compatibility

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -1043,17 +1043,17 @@ function correctContent()
 			"load"			:	{ name: "load.normal", prm: 1 }
 		});
 	}
-	if(theWebUI.systemInfo.rTorrent.apiVersion>=10)
+	if(theWebUI.systemInfo.rTorrent.apiVersion>=10 && theWebUI.systemInfo.rTorrent.iVersion<0x908)
 	{
 		$.extend(theRequestManager.aliases,
 		{
-			"get_port_open"		: { name: "network.listen.is_open", prm: 0 },
-			"get_port_random" 	: { name: "network.port.randomize", prm: 0 },
-			"get_port_range" 	: { name: "network.port.range", prm: 0 },
-			"set_port_open"		: { name: "network.listen.open", prm: 1 },
-			"set_port_random"	: { name: "network.port.randomize.set", prm: 1 },
-			"set_port_range"	: { name: "network.port.range.set", prm: 1 },
-			"network.listen.port" 	: { name: "network.port", prm: 0 }
+			"get_port_open"		:	{ name: "network.listen.is_open", prm: 0 },
+			"get_port_random"	:	{ name: "network.port.randomize", prm: 0 },
+			"get_port_range"	:	{ name: "network.port.range", prm: 0 },
+			"set_port_open"		:	{ name: "network.listen.open", prm: 1 },
+			"set_port_random"	:	{ name: "network.port.randomize.set", prm: 1 },
+			"set_port_range"	:	{ name: "network.port.range.set", prm: 1 },
+			"network.listen.port"	:	{ name: "network.port", prm: 0 }
 		});
 	}
 	$("#rtorrentv").text(theWebUI.systemInfo.rTorrent.version+"/"+theWebUI.systemInfo.rTorrent.libVersion);

--- a/php/settings.php
+++ b/php/settings.php
@@ -182,8 +182,7 @@ class rTorrentSettings
 				if($req->success())
 					$this->apiVersion = $req->val[0];
 			}
-
-			if($this->apiVersion >= 10)
+			if($this->apiVersion>=10 && $this->iVersion<0x908)
 			{
 				$this->aliases = array_merge($this->aliases,array
 				(


### PR DESCRIPTION
rtorrent "feature-bind" branch (rtorrent 0.9.7) => API version = 10 with changed commands names
rtorrent 0.9.8 official release / "master" branch => API version = 10 without changed commands names

EDIT: See rakshasa/rtorrent#896 for rTorrent author's explanation.