### PR TITLE
For IOS compatibility

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -105,7 +105,7 @@ function makeContent()
 				'</span>'+
 				'<label>'+theUILang.Label+':</label><input type="text" id="tadd_label" name="tadd_label" class="TextboxLarge" /><select id="tadd_label_select"></select><br/>'+
 				'<hr/>'+
-				'<label>'+theUILang.Torrent_file+':</label><input type="file" multiple="multiple" name="torrent_file[]" id="torrent_file" accept=".torrent,application/x-bittorrent" class="TextboxLarge"/><br/>'+
+				'<label>'+theUILang.Torrent_file+':</label><input type="file" multiple="multiple" name="torrent_file[]" id="torrent_file" accept=".torrent" class="TextboxLarge"/><br/>'+
 				'<label>&nbsp;</label><input type="submit" value="'+theUILang.add_button+'" id="add_button" class="Button" /><br/>'+
 			'</form>'+
 			'<hr/>'+


### PR DESCRIPTION
I remove the filter ",application/x-bittorrent" to avoid issue on IOS (iphone, ipad, ...).
The issue is : we can't add files because all files are disabled in the IOS Browser.
I just let ".torrent" in the filter.

So, it's work on IOS and other systems.