### PR TITLE
Update KAT.php

### DIFF
--- a/plugins/extsearch/engines/KAT.php
+++ b/plugins/extsearch/engines/KAT.php
@@ -87,7 +87,7 @@ class KATEngine extends commonEngine
 			{
 				for( $i=0; $i<$res; $i++)
 				{
-					$link = "magnet:".$matches["link"][$i];
+					$link = "magnet:". htmlspecialchars_decode($matches["link"][$i]);
 					if(!array_key_exists($link,$ret))
 					{
 						$item = $this->getNewEntry();


### PR DESCRIPTION
$link = "magnet:". $matches["link"][$i];
on this line magnet link's seems like 

> magnet:?xt=urn:btih:3ece3dff77edf59675ef11499fa0f279c95b6898& a m p;dn=The Matrix (1999) x 1600 (2160p) HDR 5 1 x265 10bit Phun Psyz&a m p;tr=udp://tracker.coppersurfer.tk:6969&a m p; tr=udp://tracker.opentrackr.org:1337&a m p;tr=udp://tracker.pirateparty.gr:6969&a m p;tr=udp://9.rarbg.to:2710&a m p;tr=udp://9.rarbg.me:2710

As you can see & symbol seems as & a m p ;

so torrent doesn't start.