### PR TITLE
fix #2033 RIPEURL -> IPQUERYURL

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -353,7 +353,7 @@ var theURLs =
 	GetSettingsURL		: "php/getsettings.php",
 	GetPluginsURL		: "php/getplugins.php",
 	GetDonePluginsURL	: "php/doneplugins.php",
-	RIPEURL			: "https://apps.db.ripe.net/search/query.html?searchtext="
+	IPQUERYURL		: "https://ipinfo.io/"
 };
 
 var theOptionsSwitcher =

--- a/js/webui.js
+++ b/js/webui.js
@@ -109,7 +109,7 @@ var theWebUI =
 			ondblclick:	function(obj) 
 			{ 
 				if(obj.id && theWebUI.peers[obj.id])
-					window.open(theURLs.RIPEURL + theWebUI.peers[obj.id].ip.replace(/^\[?(.+?)\]?$/, '$1'), "_blank");
+					window.open(theURLs.IPQUERYURL + theWebUI.peers[obj.id].ip.replace(/^\[?(.+?)\]?$/, '$1'), "_blank");
 				return(false);
 			}
 		},


### PR DESCRIPTION
fix #2033 
RIPEURL var replaced with IPQUERYURL and now points to ipinfo.io service, instead of RIPE