### PR TITLE
Update "AutoTools" Plugin

### DIFF
--- a/plugins/autotools/autotools.php
+++ b/plugins/autotools/autotools.php
@@ -28,7 +28,7 @@ class rAutoTools
 			$at->automove_filter = "/.*/";
 		if( !property_exists( $at, "skip_move_for_files" ) || 
 			(strlen($at->skip_move_for_files) && (@preg_match($at->skip_move_for_files."u", null) === false)) )
-			$at->skip_move_for_files = "/\.rar|\.zip/";
+			$at->skip_move_for_files = "/(?:\.rar|\.zip)$/";
 		if( !property_exists( $at, "addName" ) )
 			$at->addName = 0;
 		if( !property_exists( $at, "addLabel" ) )
@@ -52,7 +52,7 @@ class rAutoTools
 			$this->enable_move = 0;
 			$this->fileop_type = "Move";
 			$this->path_to_finished = "";
-			$this->skip_move_for_files= "/\.rar|\.zip/";
+			$this->skip_move_for_files= "/(?:\.rar|\.zip)$/";
 			$this->enable_watch = 0;
 			$this->path_to_watch = "";
 			$this->watch_start = 0;
@@ -94,7 +94,7 @@ class rAutoTools
 				{
 					$this->skip_move_for_files = $parts[1];
 					if(strlen($this->skip_move_for_files) && (@preg_match($this->skip_move_for_files."u", null) === false))
-						$this->skip_move_for_files = "/\.rar|\.zip/";
+						$this->skip_move_for_files = "/(?:\.rar|\.zip)$/";
 				}
 				else if( $parts[0] == "enable_watch" )
 				{


### PR DESCRIPTION
- Fix default regex for "skip_move_for_files" parameter