### PR TITLE
update config.php with default executables

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -46,12 +46,16 @@
 
 	$XMLRPCMountPoint = "/RPC2";		// DO NOT DELETE THIS LINE!!! DO NOT COMMENT THIS LINE!!!
 
+	// Set default path for each executable.
+	// Since by default PATH is not set, an empty exe would not be found.
 	$pathToExternals = array(
-		"php" 	=> '',			// Something like /usr/bin/php. If empty, will be found in PATH.
-		"curl"	=> '',			// Something like /usr/bin/curl. If empty, will be found in PATH.
-		"gzip"	=> '',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
-		"id"	=> '',			// Something like /usr/bin/id. If empty, will be found in PATH.
-		"stat"	=> '',			// Something like /usr/bin/stat. If empty, will be found in PATH.
+		"php"	=> '/usr/bin/php',
+		"curl"	=> '/usr/bin/curl',
+		"gzip"	=> '/bin/gzip',
+		"id"	=> '/usr/bin/id',
+		"stat"	=> '/usr/bin/stat',
+		"python"=> '/usr/bin/python',
+		"pgrep"	=> '/usr/bin/pgrep',
 	);
 
 	$localhosts = array( 			// list of local interfaces

--- a/conf/config.php
+++ b/conf/config.php
@@ -46,16 +46,14 @@
 
 	$XMLRPCMountPoint = "/RPC2";		// DO NOT DELETE THIS LINE!!! DO NOT COMMENT THIS LINE!!!
 
-	// Set default path for each executable.
-	// Since by default PATH is not set, an empty exe would not be found.
 	$pathToExternals = array(
-		"php"	=> '/usr/bin/php',
-		"curl"	=> '/usr/bin/curl',
-		"gzip"	=> '/bin/gzip',
-		"id"	=> '/usr/bin/id',
-		"stat"	=> '/usr/bin/stat',
-		"python"=> '/usr/bin/python',
-		"pgrep"	=> '/usr/bin/pgrep',
+		"php" 	=> '',			// Something like /usr/bin/php. If empty, will be found in PATH.
+		"curl"	=> '',			// Something like /usr/bin/curl. If empty, will be found in PATH.
+		"gzip"	=> '',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
+		"id"	=> '',			// Something like /usr/bin/id. If empty, will be found in PATH.
+		"stat"	=> '',			// Something like /usr/bin/stat. If empty, will be found in PATH.
+		"python"=> '',			// Something like /usr/bin/python. If empty, will be found in PATH.
+		"pgrep"	=> '',			// Something like /usr/bin/pgrep. If empty, will be found in PATH.
 	);
 
 	$localhosts = array( 			// list of local interfaces


### PR DESCRIPTION
this change would allow plenty of instances to work out of the box.
since `PATH` by default is not set, leaving those blank strings does not result in the executables being found, anyway.

close #1380
close #1635
close #1900
close #1967