### PR TITLE
Disallow passing XML strings with `execute` to rTorrent

### DIFF
--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -458,7 +458,7 @@ switch($mode)
 	}
 	default:
 	{
-		if(isset($HTTP_RAW_POST_DATA))
+		if(isset($HTTP_RAW_POST_DATA) && strpos(preg_replace('/\s+/S', '', $HTTP_RAW_POST_DATA), "execute") === false)
 		{
 			$result = rXMLRPCRequest::send($HTTP_RAW_POST_DATA,false);
 			if(!empty($result))


### PR DESCRIPTION
We have gotten reported a case were a customer was able to pass specifically-crafted rTorrent XML data containing execute commands, resulting in creating a reverse shell and exposing the environment.

This fixes that vulnerability. 