### PR TITLE
Missing parameter on YggTorrent extsearch.

### DIFF
--- a/plugins/extsearch/engines/YggTorrent.php
+++ b/plugins/extsearch/engines/YggTorrent.php
@@ -88,7 +88,7 @@ class YggTorrentEngine extends commonEngine
         $what = rawurlencode(rawurldecode($what));
 
         // Initial search to retrieve the page count
-        $search = self::URL . '/engine/search/?name=' . $what . $catParameters . '&do=search';
+        $search = self::URL . '/engine/search/?name=' . $what . $catParameters . '&do=search&attempt=1';
         $cli = $this->fetch($search);
         // Check if we have results
         if ($cli == false) {


### PR DESCRIPTION
YggTorrent returns a 301 if `attempt=1` GET parameter is missing. Note that 301 should be correctly handled by the extsearch/engines.php web client (https://github.com/Novik/ruTorrent/blob/master/plugins/extsearch/engines.php#L52).

This commit does not fix web client, it only adds `attempt` parameter to avoid the 301 and make YggTorrent external search works as expected.