### PR TITLE
fragment rTorrentStub and rXMLRPCCommand multicall commands (fix #1471)

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -398,6 +398,13 @@ class rTorrentSettings
 			(($this->iVersion>=0x904) && (strpos($cmd->command,"group2.")===0)))
 			$cmd->addParameter("");
 	}
+	public function maxContentSize()
+	{
+		if($this->apiVersion>=11) {
+			return 2 << 23;
+		}
+		return 2 << 20;
+	}
 	public function patchDeprecatedRequest($commands)
 	{
 		if($this->iVersion>=0x904)


### PR DESCRIPTION
I had the same issue as in #1471 and came up with my own fix.
~3700 torrents caused the 'getalltrackers' request to be larger than max_content_size=2MiB (rtorrent 0.9.8).
Size limitation is 16MiB on rtorrent master: [https://github.com/rakshasa/rtorrent/pull/905](https://github.com/rakshasa/rtorrent/pull/905)
but for those who do not want to update rtorrent (master) it still might make sense to fix this in ruTorrent.

My fix is to fragment the multicall request in rTorrentStub and rXMLRPCCommand if it gets too large.
The request completes once all fragments are successful.

