### PR TITLE
Fix saving cookies

### DIFF
--- a/plugins/cookies/cookies.php
+++ b/plugins/cookies/cookies.php
@@ -35,7 +35,7 @@ class rCookies
 					if(strlen($value))
 					{
 						$tmp = explode("|",$value);
-						if(count($tmp>1) && (trim($tmp[1])!=''))
+						if((count($tmp)>1) && (trim($tmp[1])!=''))
 						{
 							$cookies = array();
 							$tmp1 = explode(";",$tmp[1]);


### PR DESCRIPTION
When attempting a save cookies, an error was thrown:
"Uncaught TypeError: count(): Argument # 1 ($var) must be of type Countable|array, bool given" 

Added parenthesis to fix order of operations