### PR TITLE
Fix unstable table sort

### DIFF
--- a/js/stable.js
+++ b/js/stable.js
@@ -786,7 +786,8 @@ dxSTable.prototype.sortSecondary = function(x, y)
       		n = tmp;
 	}
 	var ret = this.colsdata[this.secIndex].type;
-	return( (ret==0) ? theSort.AlphaNumeric(m, n) : ((ret==1) || (ret==4)) ? theSort.Numeric(m, n) : theSort.Default(m, n) );
+	var order = (ret==0) ? theSort.AlphaNumeric(m, n) : ((ret==1) || (ret==4)) ? theSort.Numeric(m, n) : theSort.Default(m, n);
+	return( order !== 0 ? order : theSort.Default(x.key, y.key) );
 }
 
 var theSort = 


### PR DESCRIPTION

**Bug:** The table sorting is not consistent if there are more than one torrent with the same name.  
- Have two rows with identical torrent names
- Clicking on one row -> triggers resorting
- The sort swaps the two rows and the non-clicked row is selected

I just added a ternary sorting by the torrent hash.