### PR TITLE
Take into account lowercased content-encoding header

### DIFF
--- a/php/Snoopy.class.inc
+++ b/php/Snoopy.class.inc
@@ -431,7 +431,7 @@ class Snoopy
 				$this->response_code = $currentHeader;
 			}
 
-			if (preg_match("/Content-Encoding: gzip/", $currentHeader) )
+			if (preg_match("/Content-Encoding: gzip/i", $currentHeader) )
 				$is_gzipped = true;
 
 			$this->headers[] = $currentHeader;
@@ -581,7 +581,7 @@ class Snoopy
 					if(preg_match("|^HTTP/[^\s]*\s(.*?)\s|",$this->response_code, $match))
 						$this->status= $match[1];
 				}
-				if (preg_match("/Content-Encoding: gzip/", $header) )
+				if (preg_match("/Content-Encoding: gzip/i", $header) )
 					$is_gzipped = true;
 				$this->headers[] = $header;
 			}


### PR DESCRIPTION
It's impossible to add RSS if content is encoded with gzip and `Content-Encoding` header is in lower case, such as `http://insearch.site/rssdd.xml`, this change fixes this behavior.