### PR TITLE
Reduce layout thrashing by optimizing dxSTable row creation

### DIFF
--- a/js/stable.js
+++ b/js/stable.js
@@ -86,7 +86,6 @@ var dxSTable = function()
 	this.mni = 0;
 	this.mxi = 0;
 	this.maxViewRows = 100;
-	this.trHeight = TR_HEIGHT;
 }
 
 dxSTable.prototype.setPaletteByURL = function(url) 

--- a/js/stable.js
+++ b/js/stable.js
@@ -1272,7 +1272,7 @@ dxSTable.prototype.selectRow = function(e, row)
 	return(false);
 }
 
-dxSTable.prototype.addRowById = function(ids, sId, icon, attr, mRows)
+dxSTable.prototype.addRowById = function(ids, sId, icon, attr, fast = false)
 {
         var cols = [];
         for(var i=0; i<this.cols; i++)
@@ -1283,10 +1283,10 @@ dxSTable.prototype.addRowById = function(ids, sId, icon, attr, mRows)
 		if(no>=0)
 			cols[no] = ids[i];
 	}
-	this.addRow(cols, sId, icon, attr, mRows);
+	this.addRow(cols, sId, icon, attr, fast);
 }
 
-dxSTable.prototype.addRow = function(cols, sId, icon, attr, mRows) 
+dxSTable.prototype.addRow = function(cols, sId, icon, attr, fast = false) 
 {
 	if(cols.length != this.cols) 
 		return;
@@ -1298,13 +1298,25 @@ dxSTable.prototype.addRow = function(cols, sId, icon, attr, mRows)
 	this.rowdata[sId] = {"data" : cols, "icon" : icon, "attr" : attr, "enabled" : true, fmtdata: this.format(this,cols.slice(0))};
 	this.rowSel[sId] = false;
 	this.rowIDs.push(sId);
-	var maxRows = mRows ? mRows : this.getMaxRows();
-	if(this.viewRows < maxRows) 
-		this.tBody.tb.appendChild(this.createRow(cols, sId, icon, attr));
-	this.rows++;
-	this.viewRows++;
-	if(this.viewRows > maxRows) 
-		this.bpad.style.height = ((this.viewRows - maxRows) * TR_HEIGHT) + "px";
+	
+	// When adding hundreds or thousands of rows at once, it's faster to skip a few steps
+	// This is safe as long as we call dxSTable.prototype.refreshRows() when we're done
+	if (!fast)
+	{
+		var maxRows = this.getMaxRows();
+		if(this.viewRows < maxRows)
+			this.tBody.tb.appendChild(this.createRow(cols, sId, icon, attr));
+		this.rows++;
+		this.viewRows++;
+		if(this.viewRows > maxRows) 
+			this.bpad.style.height = ((this.viewRows - maxRows) * TR_HEIGHT) + "px";		
+	}
+	else
+	{
+		this.rows++;
+		this.viewRows++;		
+	}
+	
 	var self = this;
 	if((this.sIndex !=- 1) && !this.noSort)
 		this.sortTimeout = window.setTimeout(function() { self.Sort(); }, 200);

--- a/js/stable.js
+++ b/js/stable.js
@@ -1308,17 +1308,17 @@ dxSTable.prototype.addRow = function(cols, sId, icon, attr, fast = false)
 		this.rows++;
 		this.viewRows++;
 		if(this.viewRows > maxRows) 
-			this.bpad.style.height = ((this.viewRows - maxRows) * TR_HEIGHT) + "px";		
+			this.bpad.style.height = ((this.viewRows - maxRows) * TR_HEIGHT) + "px";
+
+		var self = this;
+		if((this.sIndex !=- 1) && !this.noSort)
+			this.sortTimeout = window.setTimeout(function() { self.Sort(); }, 200);
 	}
 	else
 	{
 		this.rows++;
-		this.viewRows++;		
+		this.viewRows++;
 	}
-	
-	var self = this;
-	if((this.sIndex !=- 1) && !this.noSort)
-		this.sortTimeout = window.setTimeout(function() { self.Sort(); }, 200);
 }
 
 dxSTable.prototype.createRow = function(cols, sId, icon, attr) 

--- a/js/stable.js
+++ b/js/stable.js
@@ -86,6 +86,7 @@ var dxSTable = function()
 	this.mni = 0;
 	this.mxi = 0;
 	this.maxViewRows = 100;
+	this.trHeight = TR_HEIGHT;
 }
 
 dxSTable.prototype.setPaletteByURL = function(url) 
@@ -1271,7 +1272,7 @@ dxSTable.prototype.selectRow = function(e, row)
 	return(false);
 }
 
-dxSTable.prototype.addRowById = function(ids, sId, icon, attr)
+dxSTable.prototype.addRowById = function(ids, sId, icon, attr, mRows)
 {
         var cols = [];
         for(var i=0; i<this.cols; i++)
@@ -1282,10 +1283,10 @@ dxSTable.prototype.addRowById = function(ids, sId, icon, attr)
 		if(no>=0)
 			cols[no] = ids[i];
 	}
-	this.addRow(cols, sId, icon, attr);
+	this.addRow(cols, sId, icon, attr, mRows);
 }
 
-dxSTable.prototype.addRow = function(cols, sId, icon, attr) 
+dxSTable.prototype.addRow = function(cols, sId, icon, attr, mRows) 
 {
 	if(cols.length != this.cols) 
 		return;
@@ -1297,7 +1298,7 @@ dxSTable.prototype.addRow = function(cols, sId, icon, attr)
 	this.rowdata[sId] = {"data" : cols, "icon" : icon, "attr" : attr, "enabled" : true, fmtdata: this.format(this,cols.slice(0))};
 	this.rowSel[sId] = false;
 	this.rowIDs.push(sId);
-	var maxRows = this.getMaxRows();
+	var maxRows = mRows ? mRows : this.getMaxRows();
 	if(this.viewRows < maxRows) 
 		this.tBody.tb.appendChild(this.createRow(cols, sId, icon, attr));
 	this.rows++;

--- a/js/webui.js
+++ b/js/webui.js
@@ -1633,6 +1633,7 @@ var theWebUI =
    		var tul = 0;
 		var tdl = 0;
 		var tArray = [];
+		var tMaxRows = Math.ceil(Math.min(table.dBody.clientHeight,table.dCont.clientHeight) / table.trHeight);
 		$.each(data.torrents,
 		/**
 		 * @param {string} hash - torrent hash
@@ -1648,7 +1649,7 @@ var theWebUI =
 			if(!$type(theWebUI.torrents[hash]))
 			{
 				theWebUI.labels[hash] = lbl;
-				table.addRowById(torrent, hash, sInfo[0], {label : lbl});
+				table.addRowById(torrent, hash, sInfo[0], {label : lbl}, tMaxRows);
 				tArray.push(hash);
 				theWebUI.filterByLabel(hash);
 			}

--- a/js/webui.js
+++ b/js/webui.js
@@ -1633,7 +1633,8 @@ var theWebUI =
    		var tul = 0;
 		var tdl = 0;
 		var tArray = [];
-		var tMaxRows = Math.ceil(Math.min(table.dBody.clientHeight,table.dCont.clientHeight) / table.trHeight);
+		var firstLoad = this.firstLoad;
+		
 		$.each(data.torrents,
 		/**
 		 * @param {string} hash - torrent hash
@@ -1649,7 +1650,7 @@ var theWebUI =
 			if(!$type(theWebUI.torrents[hash]))
 			{
 				theWebUI.labels[hash] = lbl;
-				table.addRowById(torrent, hash, sInfo[0], {label : lbl}, tMaxRows);
+				table.addRowById(torrent, hash, sInfo[0], {label : lbl}, firstLoad);
 				tArray.push(hash);
 				theWebUI.filterByLabel(hash);
 			}
@@ -1748,8 +1749,8 @@ var theWebUI =
 		else 
 		{
 			table.refreshRows();
+			table.Sort();
 		}
-		table.Sort();
 		this.setInterval();
 		this.updateDetails();
    	},


### PR DESCRIPTION
This [resource](https://developers.google.com/web/fundamentals/performance/rendering/avoid-large-complex-layouts-and-layout-thrashing?utm_source=devtools#avoid_layout_thrashing) explains the issue in more detail. ruTorrent was taking 20s to load with 5000 torrents, when I refreshed the page. I ran a profile and found this function was thrashing the layout. After implementing this fix, my loading time was down to 5s. 

**Benchmarks for theWebUI.addTorrents()**
Loading times with 500 torrents are reduced from 800ms to 250ms. Approximately 150ms is a performance penalty.
Loading times with 5000 torrents are reduced from 18s to 1s. Approximately 400ms is a performance penalty.

There is a **performance penalty** for this fix. `theWebUI.loadTorrents()` must be run afterwards to display the 20 to 30 rows of torrents that will be initially visible to the user. This can no longer be done during `theWebUI.addTorrents()`. However, as demonstrated above, the page loading speed benefit is greater than the performance penalty, in virtually every situation. The user may see approximately 100ms longer loading times with only 50 torrents. This is relatively small and trivial though.