### PR TITLE
Disable PHP GZIP by default

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -20,7 +20,7 @@
 	@define('LOG_RPC_FAULTS', true, true);
 
 	// for php
-	@define('PHP_USE_GZIP', false, true);
+	@define('PHP_USE_GZIP', false, false);
 	@define('PHP_GZIP_LEVEL', 2, true);
 
 	$schedule_rand = 10;			// rand for schedulers start, +0..X seconds


### PR DESCRIPTION
This feature has no noticeable impact on bandwidth consumption. It requires writing to a file first because [cachedEcho](https://github.com/Novik/ruTorrent/blob/da0a621dff0bb1ac7f4560ddc9f2680083729ce3/php/util.php#L496-L504) does not use [gzcompress()](https://www.php.net/manual/en/function.gzcompress.php) like it should. In many cases where there is very little disk i/o available, it will increase loading times of files such as `getplugins.php` by a factor of 3-5x longer than normal.  My benchmarks show 1.67s network transfer on `getplugins.php` with PHP GZIP disabled. And 8.35s network transfer with PHP GZIP enabled. In this case, page loading times were increased by approximately 6.5s. This feature currently is not polished enough IMHO to have it enabled by default.