### PR TITLE
Fix jQuery 3.6 regression

### DIFF
--- a/plugins/theme/themes/Blue/init.js
+++ b/plugins/theme/themes/Blue/init.js
@@ -121,7 +121,7 @@ plugin.allDone = function()
 		{
 			$(this).css( { "border-color": "#7eadd9" } );
 		});
-		$(this).on('blur',( function()
+		$(this).on('blur', function()
 		{
 			$(this).css( { "border-color": "#b5b8c8" } );
 		});


### PR DESCRIPTION
There is a typo in the "Blue" theme for init.js. This syntax error is causing the theme not to work properly.

I have retested all the themes. It's just this one theme that broke.