### PR TITLE
 Improve memory management

### DIFF
--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -1180,26 +1180,10 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout)
 		global: true
 	});
 	
-	request.always(function(data, textStatus, errorThrown) 
-	{
-		if(theWebUI.deltaTime==0)
-		{
-			var diff = 0;
-			try {
-				diff = new Date().getTime()-Date.parse(request.getResponseHeader("Date"));
-			} catch(e) { diff = 0; };
-			theWebUI.deltaTime = iv(diff);
-		}
-		if(theWebUI.serverDeltaTime==0)
-		{
-			var timestamp = request.getResponseHeader("X-Server-Timestamp");
-			if(timestamp != null)
-				theWebUI.serverDeltaTime = new Date().getTime()-iv(timestamp)*1000;
-		}
-	});
-	
 	request.fail(function(jqXHR, textStatus, errorThrown)
 	{
+		Ajax_UpdateTime(jqXHR);
+		
 		if((textStatus=="timeout") && ($type(onTimeout) == "function"))
 			onTimeout();
 		else if($type(onError) == "function")
@@ -1211,16 +1195,19 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout)
 				response = errorThrown;
 			onError(status+" ["+textStatus+","+stub.action+"]",response);
 		}
+		stub = null; // Cleanup memory leak
 	});
 	
 	request.done(function(data, textStatus, jqXHR)
 	{
-		var responseText = stub.getResponse(data);
+		Ajax_UpdateTime(jqXHR);
+		
 		stub.logErrorMessages();
 		if(stub.listRequired)
 			Ajax("?list=1", isASync, onComplete, onTimeout, onError, reqTimeout);
 		else if(!stub.isError())
 	    {
+			var responseText = stub.getResponse(data);
 			switch($type(onComplete))
 			{
 				case "function":
@@ -1234,8 +1221,35 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout)
 					break;
 				}
 			}
+			responseText = null; // Cleanup memory leak
 		}
+		stub = null; // Cleanup memory leak
 	});
+	
+	// Nullify ajax request varriables to cleanup up memory leaks
+	request.onreadystatechange = null;
+	request.abort = null;
+	request = null;
+}
+
+function Ajax_UpdateTime(jqXHR)
+{
+	if(theWebUI.deltaTime==0)
+	{
+		var diff = 0;
+		try { diff = new Date().getTime()-Date.parse(jqXHR.getResponseHeader("Date")); } catch(e) { diff = 0; };
+		theWebUI.deltaTime = iv(diff);
+		diff = null; // Cleanup memory leak
+	}
+	
+	if(theWebUI.serverDeltaTime==0)
+	{
+		var timestamp = jqXHR.getResponseHeader("X-Server-Timestamp");
+		if(timestamp != null)
+			theWebUI.serverDeltaTime = new Date().getTime()-iv(timestamp)*1000;
+		timestamp = null; // Cleanup memory leak
+	}
+	jqXHR = null; // Cleanup memory leak
 }
 
 $(document).ready(function() 

--- a/js/webui.js
+++ b/js/webui.js
@@ -1726,6 +1726,9 @@ var theWebUI =
 
 		$('#viewrows').text(table.viewRows + '/' + table.rows);
 
+		// Cleanup memory leaks
+		tArray = null;
+		table = null;
 		data = null;
 	},
 

--- a/plugins/httprpc/init.js
+++ b/plugins/httprpc/init.js
@@ -132,7 +132,9 @@ rTorrentStub.prototype.listResponse = function(data)
 					handler.response( hash, torrent, (handler.ndx===null) ? null : values[handler.ndx-1] );
 			});
 			ret.torrents[hash] = torrent;
+			torrent = null; // clean up memory leak
 		});
+		data = null; // clean up memory leak
 		return( ret );
 	}
 	return(plugin.origlistResponse.call(this,data));


### PR DESCRIPTION
This pull request fixes some critical memory leaks with AJAX calls and the HTTPRPC plugin. It also reduces the overall memory footprint of ruTorrent by nullifying some variables (which hold a lot of data) when they are no longer in use.

The usage of the "always" function for AJAX calls is removed because it's no longer convenient to use it. It would require too much type checking to find the jqXHR object for the response headers. The request object has to be nullified because it's leaking memory. I opted to update the time on the WebUI during "fail" and "done" instead, which accomplishes the same thing.