### PR TITLE
Fix plugin diagnostics

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -52,6 +52,7 @@
 		"gzip"	=> '',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
 		"id"	=> '',			// Something like /usr/bin/id. If empty, will be found in PATH.
 		"stat"	=> '',			// Something like /usr/bin/stat. If empty, will be found in PATH.
+		"perl" 	=> '', 			// Something like /usr/bin/perl. If empty, will be found in PATH.
 	);
 
 	$localhosts = array( 			// list of local interfaces

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Show table contents while scrolling",
  idNotFound			: "rTorrent user can't access 'id' program. Some functionality will be unavailable.",
  gzipNotFound			: "Webserver user can't access 'gzip' program. ruTorrent will not work.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent cannot determine the UID of rTorrent user. Some functionality will be unavailable.",
  retryOnErrorTitle		: "If rTorrent is not available try again after",
  retryOnErrorList		: { 0: "Don't try again", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/da.js
+++ b/lang/da.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Vis tabelindhold imens der rulles",
  idNotFound			: "rTorrent brugeren kan ikke få adgang til 'id' programmet. Noget funktionalitet vil ikke være tilgængelig.",
  gzipNotFound			: "Webserverens bruger har ikke adgang til 'gzip' programmet. ruTorrent kan ikke virke uden.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent kan ikke finde UID af rTorrent brugeren. Noget funktionalitet vil ikke være tilgængelig.",
  retryOnErrorTitle		: "Hvis rTorrent ikke er tilgængelig, prøv igen efter",
  retryOnErrorList		: { 0: "Prøv ikke igen", 30: "30 sek", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/de.js
+++ b/lang/de.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Tabelleninhalt beim Scrollen anzeigen",
  idNotFound			: "rTorrent Benutzer kann nicht auf 'id' programm Zugreifen. Einige Funktionalitäten werde nicht zur Verfügung stehen.",
  gzipNotFound			: "Webserver kann nicht auf 'gzip' Programm zugreifen. ruTorrent wird nicht funktionieren.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent kann nicht die UID des rTorrent Benutzers herausfinden. Einige Funktionalitäten werde nicht zur Verfügung stehen.",
  retryOnErrorTitle		: "Falls rTorrent nicht erreichbar ist, erneut versuchen nach",
  retryOnErrorList		: { 0: "Nie", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/el.js
+++ b/lang/el.js
@@ -206,6 +206,8 @@ var theUILang =
  showScrollTables		: "Προβολή των περιεχομένων του πίνακα κατά την κύλιση",
  idNotFound			: "Ο χρήστης του rTorrent δεν έχει πρόσβαση στο πρόγραμμα 'id'. Ορισμένες λειτουργίες δεν θα είναι διαθέσιμες.",
  gzipNotFound			: "Ο χρήστης του διακομιστή Web δεν έχει πρόσβαση στο πρόγραμμα 'gzip'. Το ruTorrent δεν θα λειτουργήσει.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "Το ruTorrent δεν μπορεί να καθορίσει το UID του χρήστη rTorrent. Ορισμένες λειτουργίες δεν θα είναι διαθέσιμες.",
  retryOnErrorTitle		: "Αν το rTorrent δεν είναι διαθέσιμο, προσπάθεια πάλι σε",
  retryOnErrorList		: { 0: "Όχι ξανά", 30: "30 δευτ.", 60: "1 λεπτό", 120: "2 λεπτά", 300: "5 λεπτά", 900: "15 λεπτά" },

--- a/lang/en.js
+++ b/lang/en.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Show table contents while scrolling",
  idNotFound			: "rTorrent user can't access 'id' program. Some functionality will be unavailable.",
  gzipNotFound			: "Webserver user can't access 'gzip' program. ruTorrent will not work.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent cannot determine the UID of rTorrent user. Some functionality will be unavailable.",
  retryOnErrorTitle		: "If rTorrent is not available try again after",
  retryOnErrorList		: { 0: "Don't try again", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/es.js
+++ b/lang/es.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Mostrar contenidos mientras se desplaza",
  idNotFound			: "rTorrent no puede acceder al 'id' del programa. Algunas funcionalidades no estarán disponibles.",
  gzipNotFound			: "El Webserver no puede acceder al programa 'gzip'. ruTorrent no funcionará.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent cannot determine the UID of rTorrent user. Algunas funcionalidades no estarán disponibles.",
  retryOnErrorTitle		: "Si rTorrent no está disponible, reintentar en",
  retryOnErrorList		: { 0: "No reintentar", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Show table contents while scrolling",
  idNotFound			: "rTorrent user can't access 'id' program. Some functionality will be unavailable.",
  gzipNotFound			: "Webserver user can't access 'gzip' program. ruTorrent will not work.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent cannot determine the UID of rTorrent user. Some functionality will be unavailable.",
  retryOnErrorTitle		: "If rTorrent is not available try again after",
  retryOnErrorList		: { 0: "Don't try again", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Afficher la liste des torrents pendant le défilement",
  idNotFound			: "rTorrent ne peut pas accéder au programme 'id'. Certaines fonctionnalités ne seront pas disponibles.",
  gzipNotFound			: "Le serveur web n'a pas accès au programme 'gzip'. ruTorrent ne fonctionnera pas.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent ne détecte pas l'UID ou l'utilisateur de rTorrent. Certaines fonctionnalités ne seront pas disponibles.",
  retryOnErrorTitle		: "Si rTorrent n'est pas accessible, réessayer après",
  retryOnErrorList		: { 0: "Ne pas réessayer", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -209,6 +209,8 @@ var theUILang =
  idNotFound			: "rTorrent user can't access 'id' program. Some functionality will be unavailable.",
  gzipNotFound			: "Webserver user can't access 'gzip' program. ruTorrent will not work.",
  cantObtainUser			: "ruTorrent cannot determine the UID of rTorrent user. Some functionality will be unavailable.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  retryOnErrorTitle		: "Ha az rtorrent nem elérhető, próbálkozz később újra:",
  retryOnErrorList		: { 0: "Ne próbálja újra", 30: "30 másodperc", 60: "1 perc", 120: "2 perc", 300: "5 perc", 900: "15 perc" },
  statNotFound			: "rTorrent user can't access 'stat' program. Some functionality will be unavailable.",

--- a/lang/it.js
+++ b/lang/it.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Mostra contenuti della tabella durante lo scorrimento",
  idNotFound			: "L'utente che esegue rTorrent non può accedere all''id' del programma. Alcune funzioni non saranno disponibili.",
  gzipNotFound			: "L'utente che esegue il Webserver non può accedere al programma 'gzip'. ruTorrent non funzionerà.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent non può determinare l'UID dell'utente di rTorrent. Alcune funzioni non saranno disponibili.",
  retryOnErrorTitle		: "Se rTorrent non è disponibile prova nuovamente dopo",
  retryOnErrorList		: { 0: "Non provare ancora", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -206,6 +206,8 @@ var theUILang =
  showScrollTables		: "스크롤하는 동안 표 내용 표시",
  idNotFound			: "rTorrent 사용자가 'id' 프로그램에 접근할 수 없습니다. 일부 기능을 사용할 수 없습니다.",
  gzipNotFound			: "웹서버 사용자가 'gzip' 프로그램에 접근할 수 없습니다. ruTorrent가 동작할 수 없습니다.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent가 rTorrent 사용자의 UID를 얻을 수 없습니다. 일부 기능을 사용할 수 없습니다.",
  retryOnErrorTitle		: "rTorrent를 사용할 수 없을 때 다음 시간 이후 재시도",
  retryOnErrorList		: { 0: "재시도하지 않음", 30: "30 초", 60: "1 분", 120: "2 분", 300: "5 분", 900: "15 분" },

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Show table contents while scrolling",
  idNotFound			: "rTorrent user can't access 'id' program. Some functionality will be unavailable.",
  gzipNotFound			: "Webserver user can't access 'gzip' program. ruTorrent will not work.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent cannot determine the UID of rTorrent user. Some functionality will be unavailable.",
  retryOnErrorTitle		: "If rTorrent is not available try again after",
  retryOnErrorList		: { 0: "Don't try again", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Toon tabelinhoud tijdens scrollen",
  idNotFound			: "rTorrent-gebruiker heeft geen toegang tot het programma 'id'. Sommige functies zullen niet werken.",
  gzipNotFound			: "Web-server heeft geen toegang tot het programma 'gzip'. ruTorrent zal niet werken.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent kan de UID of rTorrent-gebruiker niet detecteren. Sommige functies zullen niet werken.",
  retryOnErrorTitle		: "Wanneer rTorrent niet beschikbaar is, probeer opnieuw na",
  retryOnErrorList		: { 0: "Probeer niet opnieuw", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/no.js
+++ b/lang/no.js
@@ -207,6 +207,8 @@ var theUILang =
  showScrollTables		: "Vis tabellinnhold under scrolling",
  idNotFound			: "rTorrent-bruker kan ikke kjøre 'id'. Noe funksjonalitet vil ikke være tilgjengelig.",
  gzipNotFound			: "Webserver-bruker kan ikke kjøre 'gzip'. ruTorrent vil ikke fungere.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent kan ikke fastslå UID av rTorrent-bruker. Noe funksjonalitet vil ikke være tilgjengelig.",
  retryOnErrorTitle		: "Hvis rTorrent ikke er tilgjengelig, prøv igjen etter",
  retryOnErrorList		: { 0: "Ikke prøv igjen", 30: "30 sekunder", 60: "1 minutt", 120: "2 minutter", 300: "5 minutter", 900: "15 minutter" },

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -209,6 +209,8 @@ var theUILang =
  showScrollTables		: "Pokaż zawartość tabeli przy przewijaniu",
  idNotFound			: "Użytkownik rTorrent nie ma dostępu do programu 'id'. Niektóre funkcje będą niedostępne.",
  gzipNotFound			: "Użytkownik serwera www nie ma dostępu do programu 'gzip'. ruTorrent nie będzie działać.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent nie może określić identyfikatora użytkownika rTorrent. Niektóre funkcje będą niedostępne.",
  retryOnErrorTitle		: "Jeśli rTorrent jest niedostępny spróbuj ponownie za",
  retryOnErrorList		: { 0: "Nie próbuj ponownie", 30: "30 sek", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Mostrar o conteúdo das tabelas durante a rolagem",
  idNotFound			: "Usuário do rTorrent não pode acessar a 'id' do programa. Algumas funcionalidades não estarão disponíveis.",
  gzipNotFound			: "Usuário do servidor não pode acessar o programa 'gzip'. uTorrent não vai funcionar.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent não pode determinar o UID do usuário rTorrent. Algumas funcionalidades não estarão disponíveis.",
  retryOnErrorTitle		: "Se Torrent não está disponível tente novamente depois",
  retryOnErrorList		: { 0: "Não tente novamente", 30: "30 seg", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Показывать содержимое таблиц при скроллировании",
  idNotFound			: "Пользователю rTorrent не доступна программа 'id'. Часть функциональности будет недоступна.",
  gzipNotFound			: "Веб сервер не имеет доступа к программе 'gzip'. ruTorrent не будет работать.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent не может определить UID пользователя rTorrent. Часть функциональности будет недоступна.",
  retryOnErrorTitle		: "При ошибке обновления GUI повторять запрос через",
  retryOnErrorList		: { 0: "Не повторять", 30: "30 секунд", 60: "1 минуту", 120: "2 минуты", 300: "5 минут", 900: "15 минут" },

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Show table contents while scrolling",
  idNotFound			: "rTorrent user can't access 'id' program. Some functionality will be unavailable.",
  gzipNotFound			: "Webserver user can't access 'gzip' program. ruTorrent will not work.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent cannot determine the UID of rTorrent user. Some functionality will be unavailable.",
  retryOnErrorTitle		: "If rTorrent is not available try again after",
  retryOnErrorList		: { 0: "Don't try again", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -206,6 +206,8 @@ var theUILang =
  showScrollTables		: "Прикажи садржај табеле приликом померања",
  idNotFound			: "rTorrent user can't access 'id' program. Some functionality will be unavailable.",
  gzipNotFound			: "Webserver user can't access 'gzip' program. ruTorrent will not work.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent cannot determine the UID of rTorrent user. Some functionality will be unavailable.",
  retryOnErrorTitle		: "If rTorrent is not available try again after",
  retryOnErrorList		: { 0: "Don't try again", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -206,6 +206,8 @@ var theUILang =
  showScrollTables		: "Visa tabellinnehåll under skrollning",
  idNotFound			: "rTorrent-användaren kan inte komma åt 'id'. Vissa funktioner kommer att vara otillgängliga.",
  gzipNotFound			: "Webbserveranvändaren kan inte komma åt 'gzip'. ruTorrent kommer inte att fungera.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent kan inte fastställa användar-id för rTorrent-användare. Vissa funktioner kommer att vara otillgängliga.",
  retryOnErrorTitle		: "Om rTorrent är inte tillgängligt försök igen efter",
  retryOnErrorList		: { 0: "Försök inte igen", 30: "30 sek", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -206,6 +206,8 @@ var theUILang =
  showScrollTables		: "Show table contents while scrolling",
  idNotFound			: "rTorrent user can't access 'id' program. Some functionality will be unavailable.",
  gzipNotFound			: "Webserver user can't access 'gzip' program. ruTorrent will not work.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent cannot determine the UID of rTorrent user. Some functionality will be unavailable.",
  retryOnErrorTitle		: "If rTorrent is not available try again after",
  retryOnErrorList		: { 0: "Don't try again", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "Показувати вміст таблиць під час прокручування",
  idNotFound			: "Програма «id» недоступна користувачу rTorrent. Деякі функції будуть недоступні.",
  gzipNotFound			: "Програма «gzip» недоступна веб-серверу. ruTorrent не працюватиме.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent не вдалося визначити ідентифікатор користувача rTorrent. Деякі функції будуть недоступні.",
  retryOnErrorTitle		: "У разі виникнення помилки оновлення GUI повторювати запит через",
  retryOnErrorList		: { 0: "Не повторювати", 30: "30 секунд", 60: "1 хвилину", 120: "2 хвилини", 300: "5 хвилин", 900: "15 хвилин" },

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -206,6 +206,8 @@ var theUILang =
  showScrollTables		: "Hiện nội dung bảng khi cuộn",
  idNotFound			: "rTorrent's không thể truy cập chương trình 'id'. Một số tính năng sẽ không hoạt động.",
  gzipNotFound			: "Máy chủ Web không thể truy cập chương trình 'gzip'. ruTorrent sẽ không hoạt động.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent không thể xác định UID hoặc người dùng rTorrent. Một số tính năng sẽ không hoạt động.",
  retryOnErrorTitle		: "Nếu không kết nối được rTorrent, tự động thử lại sau",
  retryOnErrorList		: { 0: "Không thử lại", 30: "30 giây", 60: "1 phút", 120: "2 phút", 300: "5 phút", 900: "15 phút" },

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -208,6 +208,8 @@ var theUILang =
  showScrollTables		: "滚动时显示表格内容",
  idNotFound			: "rTorrent 运行用户无法访问 'id' 程序. 某些功能将不可用.",
  gzipNotFound			: "网页服务器 执行用户无法访问 'gzip' 程序. ruTorrent 将不会工作.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent 不能确定 rTorrent 运行用户的 UID. 某些功能将不可用.",
  retryOnErrorTitle		: "如果 rTorrent 不可用则在这个时间后重试",
  retryOnErrorList		: { 0: "不重试", 30: "30 秒", 60: "1 分钟", 120: "2 分钟", 300: "5 分钟", 900: "15 分钟" },

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -206,6 +206,8 @@ var theUILang =
  showScrollTables		: "Show table contents while scrolling",
  idNotFound			: "rTorrent user can't access 'id' program. Some functionality will be unavailable.",
  gzipNotFound			: "Webserver user can't access 'gzip' program. ruTorrent will not work.",
+ perlNotFound			: "rTorrent user can't access 'perl' program. ruTorrent will not work.",
+ perlDependency			: "Please install 'perl' package first. It may resolve other plugin errors.",
  cantObtainUser			: "ruTorrent cannot determine the UID of rTorrent user. Some functionality will be unavailable.",
  retryOnErrorTitle		: "If rTorrent is not available try again after",
  retryOnErrorList		: { 0: "Don't try again", 30: "30 sec", 60: "1 min", 120: "2 min", 300: "5 min", 900: "15 min" },


### PR DESCRIPTION
This pull request fixes #2228. `tesh.sh` throws the error `"bash: ./test.sh: /bin/sh^M: bad interpreter"` when being run by plugin diagnostics. The cause is the `tesh.sh` file being modified by Windows with "dos" line endings. This prevents the bash script from being run on Linux. The solution is to change the line endings on the file back to "unix" (Linux) format.

The `perl` package dependency is required to safely modify the bash script. Other methods may accidently delete the file contents. It must be installed on the same server as rTorrent. The user is warned to install the `perl` package first. ruTorrent may disable other plugins and incorrectly show missing packages on the rTorrent server, until this problem is fixed. 

This feature is only enabled when `$do_diagnostic` in `config.php` is set to true. It is purely for diagnostic purposes only.