### PR TITLE
Fix loading utility classes from namespaces

### DIFF
--- a/php/util.php
+++ b/php/util.php
@@ -9,7 +9,8 @@ spl_autoload_register(function ($class)
 {
 	// Remove namespaces from the classname string
 	// Important for compatibility with 3rd party plugins
-	$class = end(explode('\\',$class));
+	$arr = explode('\\',$class);
+	$class = end($arr);
 	
 	require_once 'utility/'. strtolower($class). '.php';
 });

--- a/php/util.php
+++ b/php/util.php
@@ -9,9 +9,7 @@ spl_autoload_register(function ($class)
 {
 	// Remove namespaces from the classname string
 	// Important for compatibility with 3rd party plugins
-	if (preg_match('@\\\\([\w]+)$@', $class, $matches)) {
-		$class = $matches[1];
-	}
+	$class = end(explode('\\',$class));
 	
 	require_once 'utility/'. strtolower($class). '.php';
 });

--- a/php/util.php
+++ b/php/util.php
@@ -5,8 +5,15 @@ $rootPath = realpath(dirname(__FILE__)."/..");
 require_once( $rootPath.'/conf/config.php' );
 
 // Automatically include only the used utility classes
-spl_autoload_register(function ($class) {
-    require_once 'utility/'. strtolower($class). '.php';
+spl_autoload_register(function ($class) 
+{
+	// Remove namespaces from the classname string
+	// Important for compatibility with 3rd party plugins
+	if (preg_match('@\\\\([\w]+)$@', $class, $matches)) {
+		$class = $matches[1];
+	}
+	
+	require_once 'utility/'. strtolower($class). '.php';
 });
 
 // Fixes quotations if php verison is less than 5.4


### PR DESCRIPTION
This pull request fixes compatibility with 3rd party plugins which use namespaces. An autoloader was introduced in PR #2247. When we get the classname string from `spl_autoload_register`, we need to remove any namespaces from it. Otherwise, 3rd party plugins with namespaces will not load utility classes properly.