### PR TITLE
Fix timeouts on AJAX requests

### DIFF
--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -1228,7 +1228,7 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout)
 	
 	// Nullify ajax request varriables to cleanup up memory leaks
 	request.onreadystatechange = null;
-	if (onTimeout == null)
+	if (reqTimeout==-1)
 		request.abort = null;
 	request = null;
 }

--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -1228,7 +1228,8 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout)
 	
 	// Nullify ajax request varriables to cleanup up memory leaks
 	request.onreadystatechange = null;
-	request.abort = null;
+	if (onTimeout == null)
+		request.abort = null;
 	request = null;
 }
 

--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -1228,8 +1228,6 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout)
 	
 	// Nullify ajax request varriables to cleanup up memory leaks
 	request.onreadystatechange = null;
-	if (reqTimeout==-1)
-		request.abort = null;
 	request = null;
 }
 


### PR DESCRIPTION
Resolves #2256 by fixing a regression with #2241. We can't nullify the abort component of the AJAX request object. jQuery needs to be able to call this function internally, to submit the timeout back to theWebUI.