### PR TITLE
Fix the typo/syntax error in the static method call

### DIFF
--- a/php/initplugins.php
+++ b/php/initplugins.php
@@ -124,7 +124,7 @@ if( count( $argv ) > 1 )
 require_once( "which.php" );
 require_once( "settings.php" );
 
-$tmp = FileUtil:getTempDirectory();
+$tmp = FileUtil::getTempDirectory();
 if($tmp!='/tmp/')
 	FileUtil::makeDirectory($tmp);
 


### PR DESCRIPTION
Fixes the small syntax error created by #2247.