### PR TITLE
Optimize 'tracklabels' plugin

### DIFF
--- a/php/utility/sendfile.php
+++ b/php/utility/sendfile.php
@@ -105,4 +105,13 @@ class SendFile
 		}
 		return(false);
 	}
+	
+	public static function sendCachedImage($location, $type, $duration)
+	{
+		header('Content-Type: '.$type);
+		header('Cache-Control: max-age='.$duration);
+		header('HTTP/1.0 200 OK');
+		readfile($location);
+		exit;
+	}
 }

--- a/plugins/tracklabels/action.php
+++ b/plugins/tracklabels/action.php
@@ -61,6 +61,5 @@ if(isset($_REQUEST["tracker"]))
 	}
 }
 
-header("HTTP/1.0 302 Moved Temporarily");
-header("Location: ./trackers/unknown.png");
-exit();
+// If we can't find an image, send a generic unknown image and cache for 30 days
+SendFile::sendCachedImage("./trackers/unknown.png", "image/png", "2592000");

--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -139,7 +139,7 @@ theWebUI.updateLabels = function(wasRemoved)
 	plugin.updateLabels.call(theWebUI,wasRemoved);
 	if(plugin.enabled)
 	{
-		if(wasRemoved && !theWebUI.firstLoad)
+		if(wasRemoved)
 			theWebUI.rebuildTrackersLabels();
 		plugin.updateLabelsImages();
 	}
@@ -192,12 +192,6 @@ theWebUI.rebuildTrackersLabels = function()
 				}
 			}
 		}
-		if(plugin.canChangeColumns())
-		{
-			table.refreshRows();
-			if(table.sIndex !=- 1)
-				table.Sort();		
-		}
 		var ul = $("#torrl");
 
 		var keys = new Array();
@@ -237,6 +231,19 @@ theWebUI.rebuildTrackersLabels = function()
 		this.trackersLabels = trackersLabels;
 		if(needSwitch)
 			theWebUI.resetLabels();
+		
+		setTimeout(plugin.refreshTrackerRows, 0);
+	}
+}
+
+plugin.refreshTrackerRows = async function()
+{
+	if(plugin.canChangeColumns())
+	{
+		var table = theWebUI.getTable('trt');
+		table.refreshRows();
+		if(table.sIndex !=- 1)
+			table.Sort();
 	}
 }
 

--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -123,7 +123,7 @@ theWebUI.trackersLabelContextMenu = function(e)
 	return(false);
 }
 
-plugin.updateLabelsImages = async function()
+plugin.updateLabelsImages = function()
 {
 	$('#plabel_cont ul li').each( function()
 	{
@@ -141,7 +141,7 @@ theWebUI.updateLabels = function(wasRemoved)
 	{
 		if(wasRemoved)
 			theWebUI.rebuildTrackersLabels();
-		setTimeout(plugin.updateLabelsImages, 0);
+		plugin.updateLabelsImages();
 	}
 }
 

--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -141,7 +141,7 @@ theWebUI.updateLabels = function(wasRemoved)
 	{
 		if(wasRemoved)
 			theWebUI.rebuildTrackersLabels();
-		plugin.updateLabelsImages();
+		setTimeout(plugin.updateLabelsImages, 0);
 	}
 }
 

--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -123,7 +123,7 @@ theWebUI.trackersLabelContextMenu = function(e)
 	return(false);
 }
 
-plugin.updateLabelsImages = function()
+plugin.updateLabelsImages = async function()
 {
 	$('#plabel_cont ul li').each( function()
 	{
@@ -139,7 +139,7 @@ theWebUI.updateLabels = function(wasRemoved)
 	plugin.updateLabels.call(theWebUI,wasRemoved);
 	if(plugin.enabled)
 	{
-		if(wasRemoved)
+		if(wasRemoved && !theWebUI.firstLoad)
 			theWebUI.rebuildTrackersLabels();
 		plugin.updateLabelsImages();
 	}


### PR DESCRIPTION
This pull request optimizes the tracklabels plugin and improves overall loading times of ruTorrent. It contains two changes:

1. When an image is not found for tracker/torrent labels, it will remember this for 30 days. `unknown.png` will be loaded from the local computer. This saves us from having to make anther web server request and wait for script execution.

2. The tracker rows now refresh asynchronously, so it doesn't slow down the adding of tracker data into the WebUI. Calling `dxSTable.refreshRows` and `dxSTable.sort` can be done any time, as the object reference to the table is stored in the WebUI.