### PR TITLE
Optimize WebUI.addTorrents

### DIFF
--- a/js/webui.js
+++ b/js/webui.js
@@ -2673,7 +2673,7 @@ var theWebUI =
    		if($("#cover").is(":visible"))
 		{
 			$("#cover").hide();
-			theWebUI.resize();
+			setTimeout(theWebUI.resize, 0);
 			theTabs.show("lcont");
 		}
    	},


### PR DESCRIPTION
This pull request optimizes the `WebUI.addTorrent()` function. It allows us to start rendering the WebUI, without having to wait for the torrent rows to refresh. In most cases, this reduces the [TBT](https://web.dev/tbt/) of the main thread by at least 50ms.

The torrent rows now refresh asynchronously, so it doesn't slow down the adding of torrents into the WebUI. The function chain which invokes `dxSTable.refreshRows()` can be done any time, as the objects are stored in the WebUI.

With this pull request, `WebUI.loadTorrents()` which invokes `WebUI.show()` now completes within 3ms instead of 60ms. The torrent rows will refresh when the main thread is no longer blocked and the WebUI has been shown.