### PR TITLE
Ratio improvements & fixes

### DIFF
--- a/php/utility/math.php
+++ b/php/utility/math.php
@@ -7,6 +7,9 @@ class Math
 	const XMLRPC_MIN_I4 = ~XMLRPC_MAX_I4;
 	const XMLRPC_MIN_I8 = -9.999999999999999E+15;
 	const XMLRPC_MAX_I8 = 9.999999999999999E+15;
+	const DEF_FLOAT_MIN = 0.01;
+	const DEF_FLOAT_MAX = 999999;
+	const DEF_FLOAT_PER = 2;
 	
 	public static function iclamp( $val, $min = 0, $max = self::XMLRPC_MAX_I8 )
 	{
@@ -16,5 +19,15 @@ class Math
 		if( $val > $max )
 			$val = $max;
 		return( ((PHP_INT_SIZE>4) || ( ($val>=self::PHP_INT_MIN) && ($val<=PHP_INT_MAX) )) ? intval($val) : $val );
+	}
+	
+	public static function fRoundClamp( $val, $per = self::DEF_FLOAT_PER, $min = self::DEF_FLOAT_MIN, $max = self::DEF_FLOAT_MAX)
+	{
+		$val = floatval($val);
+		if( $val < $min )
+			$val = $min;
+		if( $val > $max )
+			$val = $max;
+		return round($val, $per);
 	}
 }

--- a/plugins/ratio/init.js
+++ b/plugins/ratio/init.js
@@ -128,7 +128,7 @@ if(plugin.canChangeOptions())
 
 	rTorrentStub.prototype.setratioprm = function()
 	{
-		this.content = "default="+$('#ratDefault').val();
+		this.content = "default="+iv($('#ratDefault').val());
 		for(var i=0; i<theWebUI.maxRatio; i++)
 		{
 			var name = $('#rat_name'+i).val().trim();

--- a/plugins/ratio/init.js
+++ b/plugins/ratio/init.js
@@ -128,11 +128,11 @@ if(plugin.canChangeOptions())
 
 	rTorrentStub.prototype.setratioprm = function()
 	{
-		this.content = "default="+iv($('#ratDefault').val());
+		this.content = "default="+$('#ratDefault').val();
 		for(var i=0; i<theWebUI.maxRatio; i++)
 		{
 			var name = $('#rat_name'+i).val().trim();
-			var upload = iv($('#rat_upload'+i).val());
+			var upload = $('#rat_upload'+i).val();
 			var min = $('#rat_min'+i).val();
 			var time = $('#rat_time'+i).val();
 			var max = $('#rat_max'+i).val();
@@ -246,7 +246,7 @@ plugin.onLangLoaded = function()
 					"<td align=center><b>"+theUILang.ratioName+"</b></td>"+
 					"<td align=center><b>"+theUILang.minRatio+",%</b></td>"+
 					"<td align=center><b>"+theUILang.maxRatio+",%</b></td>"+
-					"<td align=center><b>"+theUILang.ratioUpload+","+theUILang.MB+"</b></td>"+
+					"<td align=center><b>"+theUILang.ratioUpload+","+theUILang.GB+"</b></td>"+
 					"<td class='ratio_time' align=center><b>"+theUILang.maxTime+","+theUILang.time_h.substr(0,theUILang.time_h.length-1)+"</b></td>"+
 					"<td align=center><b>"+theUILang.ratioAction+"</b></td>"+
 				"</tr>";
@@ -261,11 +261,19 @@ plugin.onLangLoaded = function()
 				"<td class='ratio_time'><input type='text' id='rat_time"+i+"' class='Textbox num1' maxlength='6'/></td>"+
 				"<td><select id='rat_action"+i+"'><option value='0'>"+theUILang.ratioStop+"</option><option value='1'>"+theUILang.ratioStopAndRemove+"</option><option value='2'>"+theUILang.ratioErase+"</option><option value='3'>"+theUILang.ratioEraseData+"</option><option value='4'>"+theUILang.ratioEraseData+" ("+theUILang.All+")</option></select></td>"+
 			"</tr>";
-	s+="</table></div></fieldset>";
-	s+="<div class='aright'><label>"+theUILang.ratioDefault+":</label><select id='ratDefault'><option value='0'>"+theUILang.dontSet+"</option>";
+	s+="</table></div></fieldset>";	
+	// Table to put the default ratio group selector beside the UL Legend
+	s+="<table><tr><td>";	
+	// Legend explaining how UL column works
+	s+="<div id='st_legend'><fieldset><legend>"+theUILang.ratioUpload+","+theUILang.GB+"</legend><table>";
+	s+="<tr><label>"+theUILang.minRatio+": 0.01"+theUILang.GB+" = 10"+theUILang.MB+"</label><br></tr>";
+	s+="<tr><label>"+theUILang.maxRatio+": 999999"+theUILang.GB+" = 1"+theUILang.PB+"</label></tr>";
+	s+="</table></fieldset></div></td>";
+	// Default ratio group selector
+	s+="<td><div class='aright'><label>"+theUILang.ratioDefault+":</label><select id='ratDefault'><option value='0'>"+theUILang.dontSet+"</option>";
 	for(var i=1; i<=theWebUI.maxRatio; i++)
 		s+="<option value='"+i+"'>"+i+"</option>";
-	s+="</select></div>";
+	s+="</select></div></td></tr></table>";
 	this.attachPageToOptions($("<div>").attr("id","st_ratio").html(s).get(0),theUILang.ratios);
 }
 

--- a/plugins/ratio/ratio.css
+++ b/plugins/ratio/ratio.css
@@ -1,5 +1,6 @@
 #st_ratio {display: none;}
 #st_ratio_h table {width: 400px; border-collapse: collapse;}
 #st_ratio_h table tr td {padding: 0px;}
-#st_ratio_h {width: 420px; overflow: auto; height: 260px }
-input.num1 {text-align: right; width: 33px}
+#st_ratio_h {width: 420px; overflow: auto; height: 260px; }
+#st_legend fieldset { width: 200px; }
+input.num1 {text-align: right; width: 33px;}

--- a/plugins/ratio/ratio.php
+++ b/plugins/ratio/ratio.php
@@ -16,17 +16,34 @@ class rRatio
 {
 	public $hash = "ratio.dat";
 	public $rat = array();
-	public $default = 0.1;
+	public $default = 0;
+	private $version = 3.10;
 
 	static public function load()
 	{
 		$cache = new rCache();
 		$rt = new rRatio();
 		if(!$cache->get($rt))
+		{
 			$rt->fillArray();
+			$rt->version = 3.11;
+		}
+		elseif ($rt->version != 3.11)
+		{
+			$rt->migrate();
+			$rt->pad();
+			$rt->version = 3.11;
+		}
 		else
 			$rt->pad();
 		return($rt);
+	}
+	private function migrate()
+	{
+		for($i=0; $i<count($this->rat); $i++)
+		{
+			$this->rat[$i]["upload"] /= 1000;
+		}		
 	}
 	public function pad()
 	{
@@ -44,7 +61,7 @@ class rRatio
 	{
 		$this->rat = array();
 		$this->pad();
-		$this->default = 0.1;
+		$this->default = 0;
 	}
 	public function getTimes()
 	{
@@ -222,7 +239,7 @@ class rRatio
 	public function set()
 	{
 		$this->rat = array();
-		$this->default = 0.1;
+		$this->default = 0;
 		for($i = 0; $i<MAX_RATIO; $i++)
 		{
 			$arr = array( "action"=>RAT_STOP, "min"=>100, "max"=>300, "upload"=>0.1, "name"=>"", "time"=>-1 );

--- a/plugins/ratio/ratio.php
+++ b/plugins/ratio/ratio.php
@@ -16,7 +16,7 @@ class rRatio
 {
 	public $hash = "ratio.dat";
 	public $rat = array();
-	public $default = 0;
+	public $default = 0.1;
 
 	static public function load()
 	{
@@ -35,16 +35,16 @@ class rRatio
 	        	$rat = &$this->rat[$i];
 	        	$rat["min"] = Math::iclamp($rat["min"]);
 	        	$rat["max"] = Math::iclamp($rat["max"]);
-	        	$rat["upload"] = Math::iclamp($rat["upload"],0,8796093022207);
+	        	$rat["upload"] = Math::fRoundClamp($rat["upload"]);
 	        }
 		for($i=count($this->rat); $i<MAX_RATIO; $i++)
-			$this->rat[] = array( "action"=>RAT_STOP, "min"=>100, "max"=>300, "upload"=>20, "name"=>"ratio".$i, "time"=>-1 );
+			$this->rat[] = array( "action"=>RAT_STOP, "min"=>100, "max"=>300, "upload"=>0.1, "name"=>"ratio".$i, "time"=>-1 );
 	}
 	public function fillArray()
 	{
 		$this->rat = array();
 		$this->pad();
-		$this->default = 0;
+		$this->default = 0.1;
 	}
 	public function getTimes()
 	{
@@ -159,7 +159,7 @@ class rRatio
 					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.enable',array("")) );
 					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.min.set',$rat["min"]) );
 					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.max.set',$rat["max"]) );
-					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.upload.set',floatval($rat["upload"]*1024*1024)) );
+					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.upload.set',floatval($rat["upload"]*1024*1024*1024)) );
 					switch($rat["action"])
 					{
 						case RAT_STOP:
@@ -222,18 +222,18 @@ class rRatio
 	public function set()
 	{
 		$this->rat = array();
-		$this->default = 0;
+		$this->default = 0.1;
 		for($i = 0; $i<MAX_RATIO; $i++)
 		{
-			$arr = array( "action"=>RAT_STOP, "min"=>100, "max"=>300, "upload"=>20, "name"=>"", "time"=>-1 );
+			$arr = array( "action"=>RAT_STOP, "min"=>100, "max"=>300, "upload"=>0.1, "name"=>"", "time"=>-1 );
 			if(isset($_REQUEST['rat_action'.$i]))
 				$arr["action"] = intval($_REQUEST['rat_action'.$i]);
 			if(isset($_REQUEST['rat_min'.$i]))
-			        $arr["min"] = iclamp($_REQUEST['rat_min'.$i]);
+			        $arr["min"] = Math::iclamp($_REQUEST['rat_min'.$i]);
 			if(isset($_REQUEST['rat_max'.$i]))
-			        $arr["max"] = iclamp($_REQUEST['rat_max'.$i]);
+			        $arr["max"] = Math::iclamp($_REQUEST['rat_max'.$i]);
 			if(isset($_REQUEST['rat_upload'.$i]))
-			        $arr["upload"] = iclamp($_REQUEST['rat_upload'.$i],0,8796093022207);
+			        $arr["upload"] = Math::fRoundClamp($_REQUEST['rat_upload'.$i]);
 			if(isset($_REQUEST['rat_time'.$i]))
 			        $arr["time"] = (is_numeric($_REQUEST['rat_time'.$i]) ? floatval($_REQUEST['rat_time'.$i]) : -1);
 			if(isset($_REQUEST['rat_name'.$i]))
@@ -245,7 +245,7 @@ class rRatio
 			$this->rat[] = $arr;
 		}
 		if(isset($_REQUEST['default']))
-			$this->default = intval($_REQUEST['default']);
+			$this->default = floatval($_REQUEST['default']);
                 $this->store();
 		$this->flush();
 		$this->setHandlers();

--- a/plugins/ratio/ratio.php
+++ b/plugins/ratio/ratio.php
@@ -42,7 +42,7 @@ class rRatio
 	{
 		for($i=0; $i<count($this->rat); $i++)
 		{
-			$this->rat[$i]["upload"] /= 1000;
+			$this->rat[$i]["upload"] /= 1024;
 		}		
 	}
 	public function pad()


### PR DESCRIPTION
This pull request improves the ratio group tab (for the ratio plugin) in the ruTorrent settings menu.

**The following changes are made by this pull request:**
1. The UL value is now measured in gigabytes instead of megabytes.
2. The default UL value is increased from 20MB to 100MB.
3. The min UL value is increased from 1MB to 10MB.
4. The max UL value is increased from 1TB to 1PB.
5. The UL value now accepts 2 decimal places.

6. A regression from #2247 is fixed when setting the ratio group UL Targets. The Math class was not referenced properly
7. A new translated legend is added beside the default ratio group selector. This explains to the user how the UL value works. It also makes it easier for the user to do terabyte and megabyte conversations, without having to look up the values.

**Here is a screenshot of how the ratio group tab looks now:**
![ratio_group](https://user-images.githubusercontent.com/9171157/149677420-cdb26cd6-f612-42a9-af97-02cc4f44d379.PNG)

**What is the motivation behind these changes?**
I wanted to set a 3 terabyte UL value for my torrent. I was not able to do that. 999999 megabytes which equals 1 terabyte was the max value. Also, it was difficult to set gigabyte UL values because the measurement unit was megabytes. Bandwidth has increased significantly since ruTorrent was first released. Setting megabyte UL values is no longer applicable for many people.