### PR TITLE
Log error stack traces

### DIFF
--- a/js/webui.js
+++ b/js/webui.js
@@ -2686,19 +2686,27 @@ var theWebUI =
 
    	catchErrors: function(toLog)
    	{
-   	        if(toLog)
-	   		window.onerror = function(msg, url, line)
+		if(toLog)
+	   		window.onerror = function(msg, url, line, col, error)
 			{
-			        theWebUI.show();
+				theWebUI.show();
 				noty("JS error: [" + url + " : " + line + "] " + msg,"error");
+
+				if (error != null)
+					console.log(msg, "from", error.stack);
+
 				return true;
 			}
 		else
-			window.onerror = function(msg, url, line)
+			window.onerror = function(msg, url, line, col, error)
 			{
 				msg = "JS error: [" + url + " : " + line + "] " + msg;
 				theWebUI.msg(msg);
 				log(msg);
+				
+				if (error != null)
+					console.log(msg, "from", error.stack);
+				
 				return true;
 			}
    	},


### PR DESCRIPTION
This pull request logs error stack traces to the web browser console when a JavaScript error occurs. Most modern web browsers pass an error object to window.onerror now. It's extremely useful for debugging. We can ask for this in issue reports on GitHub.