### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+*A clear and concise description of what the bug is.*
+
+**To Reproduce**
+*Steps to reproduce the behavior:*
+1. *Go to '...'*
+2. *Click on '....'*
+3. *Scroll down to '....'*
+4. *See error*
+
+**Expected behavior**
+*A clear and concise description of what you expected to happen.*
+
+**Screenshots**
+*If applicable, add screenshots to help explain your problem.*
+
+**Tell us which release or master commit**
+*Release: v4.0-beta.1*
+*Master: fc9d1f0*
+
+**Additional context**
+*Add any other context about the problem here.*

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,9 +23,20 @@ assignees: ''
 **Screenshots**
 *If applicable, add screenshots to help explain your problem.*
 
-**Tell us which release or master commit**
-*Release: v4.0-beta.1*
-*Master: fc9d1f0*
+**Tell us about your environment**
+*Which ruTorrent release or master commit?*
+*Release: v4.0-beta.1 OR Master: fc9d1f0*
+
+*Which web browser? What is the version?*
+*Example: Google Chrome version 97.0.4692.71*
+
+*What is the PHP version?*
+*Example: PHP 7.4.3 (cli) (built: Nov 25 2021 23:16:22) ( NTS )*
+
+*Which operating system and release version? How did the packages get installed?*
+*Example1: I am using Ubuntu 20.04.3 LTS. I used 'apt get install' for all my packages.*
+*Example2: I am using seedbox provider xyz. I don't know the OS or package configuration.*
+*Example3: I am using Ubuntu 21.10 with install script xyz. Please see the provided script link.*
 
 **Additional context**
 *Add any other context about the problem here.*

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/javascript-errors.md
+++ b/.github/ISSUE_TEMPLATE/javascript-errors.md
@@ -1,0 +1,34 @@
+---
+name: JavaScript Errors
+about: Report JavaScript errors here
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Perform a few basic tasks**
+*Let us know you've cleared your web browser cache, and refreshed the page.*
+*If upgrading to v4.0 or master, let us know you've copied everything except for the share folder.*
+
+**What were you trying to do?**
+*I was trying to change my theme to oblivion.*
+
+**Tell us which release or master commit**
+*Release: v4.0-beta.1*
+*Master: fc9d1f0*
+
+**Tell us the error message**
+*JS error: [https://www.example.com/rutorrent/ : 1118] Uncaught ReferenceError: bobo is not defined*
+
+**Give us the stack trace**
+*In Google Chrome go to Options -> More tools -> Developer tools.*
+*Select the console tab at the top. Then click the "info" tab on the left.*
+
+*Uncaught ReferenceError: bobo is not defined from ReferenceError: bobo is not defined
+    at String.<anonymous> (<anonymous>:1118:4)
+    at Function.each (rutorrent/js/jquery.js:2:3003)
+    at rPlugin.plugin.allDone (<anonymous>:1111:4)
+    at eval (eval at waitLoad (rutorrent/js/plugins.js:94:4), <anonymous>:1:25)
+    at Object.waitLoad (rutorrent/js/plugins.js:94:4)
+    at <anonymous>:1:12*

--- a/.github/ISSUE_TEMPLATE/javascript-errors.md
+++ b/.github/ISSUE_TEMPLATE/javascript-errors.md
@@ -22,8 +22,10 @@ assignees: ''
 *JS error: [https://www.example.com/rutorrent/ : 1118] Uncaught ReferenceError: bobo is not defined*
 
 **Give us the stack trace**
+*Please note this feature is currently only supported on the master branch.*
+
 *In Google Chrome go to Options -> More tools -> Developer tools.*
-*Select the console tab at the top. Then click the "info" tab on the left.*
+*Select the "console" tab at the top. Then click the "info" tab on the left.*
 
 *Uncaught ReferenceError: bobo is not defined from ReferenceError: bobo is not defined
     at String.<anonymous> (<anonymous>:1118:4)

--- a/.github/ISSUE_TEMPLATE/javascript-errors.md
+++ b/.github/ISSUE_TEMPLATE/javascript-errors.md
@@ -14,9 +14,12 @@ assignees: ''
 **What were you trying to do?**
 *I was trying to change my theme to oblivion.*
 
-**Tell us which release or master commit**
-*Release: v4.0-beta.1*
-*Master: fc9d1f0*
+**Tell us about your environment**
+*Which ruTorrent release or master commit?*
+*Release: v4.0-beta.1 OR Master: fc9d1f0*
+
+*Which web browser? What is the version?*
+*Example: Google Chrome version 97.0.4692.71*
 
 **Tell us the error message**
 *JS error: [https://www.example.com/rutorrent/ : 1118] Uncaught ReferenceError: bobo is not defined*
@@ -27,10 +30,10 @@ assignees: ''
 *In Google Chrome go to Options -> More tools -> Developer tools.*
 *Select the "console" tab at the top. Then click the "info" tab on the left.*
 
-*Uncaught ReferenceError: bobo is not defined from ReferenceError: bobo is not defined
-    at String.<anonymous> (<anonymous>:1118:4)
-    at Function.each (rutorrent/js/jquery.js:2:3003)
-    at rPlugin.plugin.allDone (<anonymous>:1111:4)
-    at eval (eval at waitLoad (rutorrent/js/plugins.js:94:4), <anonymous>:1:25)
-    at Object.waitLoad (rutorrent/js/plugins.js:94:4)
-    at <anonymous>:1:12*
+*Uncaught ReferenceError: bobo is not defined from ReferenceError: bobo is not defined*
+    *at String.<anonymous> (<anonymous>:1118:4)*
+    *at Function.each (rutorrent/js/jquery.js:2:3003)*
+    *at rPlugin.plugin.allDone (<anonymous>:1111:4)*
+    *at eval (eval at waitLoad (rutorrent/js/plugins.js:94:4), <anonymous>:1:25)*
+    *at Object.waitLoad (rutorrent/js/plugins.js:94:4)*
+    *at <anonymous>:1:12*

--- a/.github/ISSUE_TEMPLATE/other-errors.md
+++ b/.github/ISSUE_TEMPLATE/other-errors.md
@@ -1,0 +1,25 @@
+---
+name: Other Errors
+about: Report all other errors here
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Perform a few basic tasks**
+*Provide us with a list of all third party plugins you have installed.*
+*If upgrading to v4.0 or master, let us know you've copied everything except for the share folder.*
+
+**Give us detailed steps to reproduce the error**
+*If the error happens when you first load the page, tell us that.*
+
+**Tell us which release or master commit**
+*Release: v4.0-beta.1*
+*Master: fc9d1f0*
+
+**Tell us the error message**
+*Bad response from server: (500 [error,getplugins]) Internal Server Error*
+
+**Provide the php error log contents** (if applicable)
+*[20-Jan-2022 00:44:39 Europe/Berlin] PHP Parse error:  syntax error, unexpected end of file in /var/www/rutorrent/plugins/theme/init.php on line 26*

--- a/.github/ISSUE_TEMPLATE/other-errors.md
+++ b/.github/ISSUE_TEMPLATE/other-errors.md
@@ -14,12 +14,18 @@ assignees: ''
 **Give us detailed steps to reproduce the error**
 *If the error happens when you first load the page, tell us that.*
 
-**Tell us which release or master commit**
-*Release: v4.0-beta.1*
-*Master: fc9d1f0*
+**Tell us about your environment**
+*Which ruTorrent release or master commit?*
+*Release: v4.0-beta.1 OR Master: fc9d1f0*
+
+*Which web browser? What is the version?*
+*Example: Google Chrome version 97.0.4692.71*
+
+*What is the PHP version?*
+*Example: PHP 7.4.3 (cli) (built: Nov 25 2021 23:16:22) ( NTS )*
 
 **Tell us the error message**
 *Bad response from server: (500 [error,getplugins]) Internal Server Error*
 
-**Provide the php error log contents** (if applicable)
+**Provide the php error log contents** *(if applicable)*
 *[20-Jan-2022 00:44:39 Europe/Berlin] PHP Parse error:  syntax error, unexpected end of file in /var/www/rutorrent/plugins/theme/init.php on line 26*


### PR DESCRIPTION
This pull request adds 4 issue templates to GitHub to help people create better issue reports. Many of the issue reports people are creating on GitHub lack detailed information. People are skipping steps such as clearing their web browser cache when upgrading. They are also not copying all the required files when performing a version upgrade.

1) **Bug Report:** This is for all generic bug reports.
2) **Feature Requests:** This is for all feature requests.
3) **JavaScript Errors:** This is for all JavaScript errors. See #2271 for creating stack traces.
4) **Other Errors:** This is for all other errors including but not limited to PHP errors.