### PR TITLE
Use Discussions for ruTorrent questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Questions
+    url: "https://github.com/Novik/ruTorrent/discussions"
+    about: "Please ask questions related to ruTorrent in the Discussions section"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Questions
-    url: "https://github.com/Novik/ruTorrent/discussions"
+    url: "https://github.com/Novik/ruTorrent/discussions/categories/q-a"
     about: "Please ask questions related to ruTorrent in the Discussions section"


### PR DESCRIPTION
This pull request asks users to create a Discussion for ruTorrent questions. When they create an issue report, it will show a "Questions" item with a description of "Please ask questions related to ruTorrent in the Discussions section". There will be a button to the right that says "Open". When the user clicks "Open", it will send them to the Discussions to look at all the other questions asked. If their question is not already there, they will be able to create a new Discussion and ask their question. 

The problem with the current system is that it encourages users to file an Issue for questions. There are almost 1750 issues currently. It's virtually impossible to find if the question is already asked. Users are asking the same questions constantly.