### PR TITLE
Reduce 'trafic' memory footprint

### DIFF
--- a/plugins/trafic/init.js
+++ b/plugins/trafic/init.js
@@ -361,9 +361,12 @@ if(plugin.canChangeColumns() && plugin.collectStatForTorrents)
 			var rStat = this.ratiosStat;
 			$.each(data.torrents, function(hash,torrent)
 			{
-				torrent.ratioday = rStat[hash][0]/torrent.size;
-				torrent.ratioweek = rStat[hash][1]/torrent.size;
-				torrent.ratiomonth = rStat[hash][2]/torrent.size;
+				if($type(rStat[hash]) && torrent.size)
+				{
+					torrent.ratioday = rStat[hash][0]/torrent.size;
+					torrent.ratioweek = rStat[hash][1]/torrent.size;
+					torrent.ratiomonth = rStat[hash][2]/torrent.size;
+				}
 			});
 			plugin.addTorrents.call(this, data);
 			rStat = null;

--- a/plugins/trafic/init.js
+++ b/plugins/trafic/init.js
@@ -280,6 +280,7 @@ if(plugin.canChangeTabs())
 
 if(plugin.canChangeColumns() && plugin.collectStatForTorrents)
 {
+	plugin.ratioChanged = false;	
 	plugin.config = theWebUI.config;
 	theWebUI.config = function()
 	{
@@ -298,15 +299,6 @@ if(plugin.canChangeColumns() && plugin.collectStatForTorrents)
 			return(plugin.trtFormat(table,arr));
 		}
 		plugin.config.call(this);
-		plugin.reqId = theRequestManager.addRequest("trt", null, function(hash,torrent,value)
-		{
-			if($type(theWebUI.ratiosStat[hash]) && torrent.size)
-			{
-				torrent.ratioday = theWebUI.ratiosStat[hash][0]/torrent.size;
-				torrent.ratioweek = theWebUI.ratiosStat[hash][1]/torrent.size;
-				torrent.ratiomonth = theWebUI.ratiosStat[hash][2]/torrent.size;
-			}
-		});
 		plugin.trtRenameColumn();
 	}
 
@@ -357,7 +349,28 @@ if(plugin.canChangeColumns() && plugin.collectStatForTorrents)
 
 	plugin.updateRatios = function( d )
 	{
+		plugin.ratioChanged = true;
 		window.setTimeout( plugin.startRatios, plugin.updateInterval*60000 );
+	}
+	
+	plugin.addTorrents = theWebUI.addTorrents;
+	theWebUI.addTorrents = function(data)
+	{
+		if(plugin.ratioChanged)
+		{
+			var rStat = this.ratiosStat;
+			$.each(data.torrents, function(hash,torrent)
+			{
+				torrent.ratioday = rStat[hash][0]/torrent.size;
+				torrent.ratioweek = rStat[hash][1]/torrent.size;
+				torrent.ratiomonth = rStat[hash][2]/torrent.size;
+			});
+			plugin.addTorrents.call(this, data);
+			rStat = null;
+			plugin.ratioChanged = false;
+		}
+		else
+			plugin.addTorrents.call(this, data);
 	}
 
 	rTorrentStub.prototype.getratios = function()

--- a/plugins/trafic/init.js
+++ b/plugins/trafic/init.js
@@ -358,18 +358,16 @@ if(plugin.canChangeColumns() && plugin.collectStatForTorrents)
 	{
 		if(plugin.ratioChanged)
 		{
-			var rStat = this.ratiosStat;
 			$.each(data.torrents, function(hash,torrent)
 			{
-				if($type(rStat[hash]) && torrent.size)
+				if($type(theWebUI.ratiosStat[hash]) && torrent.size)
 				{
-					torrent.ratioday = rStat[hash][0]/torrent.size;
-					torrent.ratioweek = rStat[hash][1]/torrent.size;
-					torrent.ratiomonth = rStat[hash][2]/torrent.size;
+					torrent.ratioday = theWebUI.ratiosStat[hash][0]/torrent.size;
+					torrent.ratioweek = theWebUI.ratiosStat[hash][1]/torrent.size;
+					torrent.ratiomonth = theWebUI.ratiosStat[hash][2]/torrent.size;
 				}
 			});
 			plugin.addTorrents.call(this, data);
-			rStat = null;
 			plugin.ratioChanged = false;
 		}
 		else


### PR DESCRIPTION
This pull request reduces the memory footprint of the 'trafic' plugin. It only updates the ratio stats columns on the WebUI once during startup and when they change. `theWebUI.ratiosStat` contains a lot of data that was being accessed unnecessarily.

theRequestManager is not a good option anymore. We would have an extra check plus function call overhead for every torrent.