### PR TITLE
Reduce httprpc cache memory footprint by 60%

### DIFF
--- a/plugins/httprpc/rpccache.php
+++ b/plugins/httprpc/rpccache.php
@@ -1,6 +1,7 @@
 <?php
 
-@define("MAX_CACHE", 	16);
+@define("MIN_CACHE",	8);
+@define("MAX_CACHE", 	10);
 @define("SIZEOF_HASH", 	40);
 @define("SIZEOF_MD5", 	32);
 
@@ -91,7 +92,7 @@ class rpcCache
 		        	{	
 					@unlink( $file );
 					$i++;
-					if($i>MAX_CACHE/2)
+					if($i>(MAX_CACHE-MIN_CACHE))
 						break;
 				}
 			}


### PR DESCRIPTION
This pull request reduces the memory footprint of the httprpc cache by 60%. It also reduces the amount of delete operations performed at once. It will now only delete 2 files at once instead of 8 files.

It does not decrease the effectiveness of the cache in the worse case scenario. There will always be at least 8 caches saved in memory just like before. This almost negates the negative impact of having 10 caches instead 16 caches. The upper bound value was not being used very frequently anyways, as 50% of the caches were being deleted when it reached that value.

The goal here is to make httprpc a more scalable option for enterprise environments. This reduces the memory consumption on the host machine by gigabytes when running hundreds of instances of ruTorrent at once. 