### PR TITLE
Fix support for PHP 8.1.2

### DIFF
--- a/plugins/geoip/sqlite.php
+++ b/plugins/geoip/sqlite.php
@@ -5,7 +5,7 @@ function sqlite_exists()
 	return( (PHP_VERSION_ID < 50400) ? function_exists("sqlite_open") : class_exists("SQLite3", false) );
 }
 
-function sqlite_open1($filename, $mode = 0666, &$error_msg)
+function sqlite_open1($filename, $mode, &$error_msg)
 {
 	if (PHP_VERSION_ID < 50400)
 	{


### PR DESCRIPTION
Fix: Optional parameter $mode declared before required parameter $error_msg is implicitly treated as a required parameter