### PR TITLE
Friendly support for other autoloaders

### DIFF
--- a/php/util.php
+++ b/php/util.php
@@ -11,8 +11,12 @@ spl_autoload_register(function ($class)
 	// Important for compatibility with 3rd party plugins
 	$arr = explode('\\',$class);
 	$class = end($arr);
-	
-	require_once 'utility/'. strtolower($class). '.php';
+	$file = __DIR__.'/utility/'. strtolower($class). '.php';
+
+	if(file_exists($file))
+    {
+        require_once $file;
+    }
 });
 
 // Fixes quotations if php verison is less than 5.4


### PR DESCRIPTION
Regarding https://github.com/Novik/ruTorrent/pull/2253

`A file check must be done first, or restrict the namespace, or suppress error with @require_once , since this is the first autoloader registered when getplugins.php is called, a single plugin cannot register its autoloader when used in plugindir init.php, because this one tries to include a php file from php/utility, which will throw an error`