### PR TITLE
hooks support for plugins containing '-' in their name

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -157,7 +157,7 @@ class rTorrentSettings
 				if(is_file($file))
 				{
 					require_once( $file );
-					$func = $hook['name'].'Hooks::On'.$ename;
+					$func = str_replace('-', '_', $hook['name']).'Hooks::On'.$ename;
 					if(is_callable( $func ) && 
 						(call_user_func_array($func,$prm)==true))
 					{


### PR DESCRIPTION
Since its not possible to have class names containing '-' in their name, lets normalize the class name by replacing '-' with '_'

Ex: 
```
class filemanager_shareHooks
{
```
