### PR TITLE
fix positioning of and add vertical scroll to submenu of context menu

### DIFF
--- a/js/objects.js
+++ b/js/objects.js
@@ -381,7 +381,13 @@ var theContextMenu =
 					submenu.css( "top", -submenu.height()+20 );
 				if(submenu.offset().top<0)
 					submenu.css( "top", -submenu.height()+20-submenu.offset().top );
+				if ($(window).height() < submenu.offset().top + submenu.height())
+					submenu.css( { "padding-right": 12, "max-height": $(window).height() - submenu.offset().top, overflow: "visible scroll" } );
 			}
+		}, function () {
+			var submenu = $(this).children("ul");
+			if (submenu.length)
+				submenu.css( { "padding-right": 0, "max-height": "none", overflow: "visible" } );
 		});
                 obj.show(theDialogManager.divider, function() { obj.css( { overflow: "visible" } ); } );
 	},

--- a/js/objects.js
+++ b/js/objects.js
@@ -372,16 +372,17 @@ var theContextMenu =
 		if(y<0)
 			y = 0;
 		obj.css( { left: x, top: y, "z-index": ++theDialogManager.maxZ } );
-                $("ul.CMenu a.exp").on('hover', function()
-                { 
-                	var submenu = $(this).next();
-                	if(submenu.offset().left + submenu.width() > $(window).width()) 
-	                	submenu.css( "left", -150 );
-                	if(submenu.offset().top + submenu.height() > $(window).height()) 
-	                	submenu.css( "top", -submenu.height()+20 );
-	                if(submenu.offset().top<0)
-				submenu.css( "top", -submenu.height()+20-submenu.offset().top );
-                });
+		obj.children("li").hover( function() {
+			var submenu = $(this).children("ul");
+			if (submenu.length) {
+				if(submenu.offset().left + submenu.width() > $(window).width())
+					submenu.css( "left", -150 );
+				if(submenu.offset().top + submenu.height() > $(window).height())
+					submenu.css( "top", -submenu.height()+20 );
+				if(submenu.offset().top<0)
+					submenu.css( "top", -submenu.height()+20-submenu.offset().top );
+			}
+		});
                 obj.show(theDialogManager.divider, function() { obj.css( { overflow: "visible" } ); } );
 	},
 	hide: function()


### PR DESCRIPTION
The submenu of the context menu does not get repositioned correctly.

`$("ul.CMenu a.exp").on('hover', function()` does not trigger
it should be `$("ul.CMenu li a.exp").on('hover', function()` but somehow this also does not trigger.
`obj.children("li").hover( function() ` works fine.

Additionally, I added a vertical scrollbar if a submenu gets larger than the screen height. 
(the `Labels` selection submenu can get quite large)