### PR TITLE
fix merging of fragmented responseText

### DIFF
--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -1221,12 +1221,12 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout, partialD
 	    {
 			var responseText = stub.getResponse(data);
 			if (partialData) {
-				if (responseText instanceof Array) {
-					responseText = partialData.concat(responseText);
-				} else if (responseText instanceof Object) {
+				if (responseText instanceof Object && !(responseText instanceof XMLDocument)) {
+					// merge responses for this.hashes with previous partialData
 					Object.assign(responseText, partialData);
-				} else {
-					responseText = partialData + responseText;
+				} else if (responseText instanceof String) {
+					// keep responseText = this.allHashes[0]
+					responseText = partialData;
 				}
 			}
 			if (pending) {


### PR DESCRIPTION
Sorry, I overlooked something.
`responseText` is never an `Array` and a `String` response i.e. `setprioResponse` should keep the initial `responseText` value to achieve the behaviour as before of `return(this.hashes[0])`.
`XMLDocument` responses should be ignored

Btw, thank you for maintaining ruTorrent :slightly_smiling_face: 