### PR TITLE
add size of viewed torrents to status row

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -193,7 +193,7 @@ div.graph_tab {background-color: #FFFFFF; overflow: hidden; display: block; -moz
 }
 .graph_tab_grid { background-color: transparent; border: 2px solid #545454; }
 .graph_tab_legend { background-color: #F0F0F0; border: 0px none transparent; }
-.graph_tab_tooltip { border: 1px solid #fdd; padding: 2px; background-color: #fee; color: black; font-size: 11px; font-weight: bold; font-family: Tahoma, Arial, Helvetica, sans-serif; opacity: 0.80; }
+.graph_tab_tooltip { position: absolute; border: 1px solid #fdd; padding: 2px; background-color: #fee; color: black; font-size: 11px; font-weight: bold; font-family: Tahoma, Arial, Helvetica, sans-serif; opacity: 0.80; }
 
 div.table_tab {background-color: #FFFFFF; overflow: hidden; display: block; -moz-user-select: none; -moz-user-focus: normal; -moz-user-input: enabled; user-select: none; }
 div#List {border: 1px solid #A0A0A0;}

--- a/index.html
+++ b/index.html
@@ -263,6 +263,7 @@
 								<table id="st_system" class="statuscell" cellpadding="0" cellspacing="0">
 									<tr>
 										<td><div class="sthdr"><script type="text/javascript"> document.write(theUILang.Torrents); </script>:</div></td><td><div class="stval" id="viewrows"></div></td>
+										<td><div class="stval" id="viewrows_size"></div></td>
 									</tr>
 								</table>
 							</td>

--- a/js/graph.js
+++ b/js/graph.js
@@ -140,7 +140,6 @@ rSpeedGraph.prototype.draw = function()
 					.addClass('graph_tab_tooltip')
 					.text(contents)
 					.css( {
-						position: 'absolute',
 						display: 'none',
 						top: y + 5,
 						left: x + 5,

--- a/js/webui.js
+++ b/js/webui.js
@@ -1754,7 +1754,7 @@ var theWebUI =
 		this.loadTorrents();
 		this.getTotal();
 
-		$('#viewrows').text(table.viewRows + '/' + table.rows);
+		this.updateViewRows(table)
 
 		// Cleanup memory leaks
 		tArray = null;
@@ -1767,6 +1767,17 @@ var theWebUI =
 			'#' + labelType + ' .-_-_-all-_-_-',
 			Object.keys(this.torrents).length,
 			this.allLabelSize, showSize);
+	},
+
+	updateViewRows: function(table)
+	{
+		var viewSize = 0;
+		for (var sId in table.rowdata) {
+			var s = iv(this.torrents[sId].size);
+			viewSize += s * (table.rowdata[sId].enabled);
+		}
+		$('#viewrows').text(table.viewRows + '/' + table.rows);
+		$('#viewrows_size').text(theConverter.bytes(viewSize, 2));
 	},
 
 	setSpeedValues: function(tul,tdl)
@@ -2187,7 +2198,7 @@ var theWebUI =
 			}
 			table.refreshRows();
 
-			$('#viewrows').text(table.viewRows + '/' + table.rows);
+			this.updateViewRows(table);
 		}
 	},
 

--- a/plugins/trafic/init.js
+++ b/plugins/trafic/init.js
@@ -88,7 +88,6 @@ if(plugin.canChangeTabs())
 						.addClass('graph_tab_tooltip')
 						.text(contents)
 						.css( {
-							position: 'absolute',
 							display: 'none',
 							top: y + 5,
 							left: x + 5,


### PR DESCRIPTION
Show the size of the viewed torrents `#viewrows_size` next to `#viewrows` in the status bar
<pre>Torrents(s):     3/21     3.36 GiB</pre>

I also moved the tooltip position attribute like you suggested