### PR TITLE
display custom label paths as tree

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -86,19 +86,24 @@ table#maincont {margin: 5px 0 0 0}
 table#maincont td.uicell {vertical-align: top; padding: 0 }
 
 div#CatList {width: 0px; border: 1px solid #A0A0A0; background-color: #FFFFFF; overflow-y: auto; overflow-x: hidden}
-div#CatList ul {padding: 0; margin: 0; list-style: none; white-space: nowrap}
-div#CatList ul li {padding: 2px 25px; margin: 0; line-height: 14px; font-size: 11px;  cursor: pointer; border: 1px solid #FFFFFF; background-repeat: no-repeat}
+div#CatList ul { margin: 0; padding: 0; list-style: none; white-space: nowrap}
+div#CatList ul li { display: flex; padding: 3px; flex-flow: row nowrap; align-items: center; height: 16px; font-size: 11px;  cursor: pointer; border: 0px solid #FFFFFF; overflow: hidden;}
 div#CatList ul li.sel {background-color: #CFDEEF; border-color: #CFDEEF }
-.-_-_-all-_-_-, #-_-_-all-_-_-, #-_-_-dls-_-_-, #-_-_-com-_-_-, #-_-_-act-_-_-, #-_-_-iac-_-_-, #-_-_-err-_-_- {background-image: url(../images/tstatus.png)}
-.-_-_-all-_-_-, #-_-_-all-_-_- {background-position: 4px -174px;}
-#-_-_-dls-_-_- {background-position: 4px 2px;}
-#-_-_-com-_-_- {background-position: 4px -14px;}
-#-_-_-act-_-_- {background-position: 4px -158px;}
-#-_-_-iac-_-_- {background-position: 4px -30px;}
-#-_-_-err-_-_- {background-position: 4px -94px;}
-span.label-count,span.label-size { background-color: #F0F0F0; padding: 0.1em 0.3em 0.1em 0.3em; margin-left: 0.3em; border-radius: 0.8em; }
-div#CatList ul li.RSS {background-image: url(../images/tstatus.png); background-position: 4px -206px}
-div#CatList ul li.disRSS {background-image: url(../images/tstatus.png); background-position: 4px -190px}
+div#CatList ul li div { margin-right: 0.5em; }
+div#CatList .label-prefix { flex: 0 0 auto; display: flex; flex-flow: row nowrap; opacity: 0.1; font-family: monospace; font-size: 19px; margin-left: -2px; margin-right: 2px; }
+div#CatList .label-prefix div { margin-right: 0px; width: 12px; }
+.label-icon { min-width: 16px; min-height: 16px; background-image: url(../images/tstatus.png); background-repeat: no-repeat; }
+.label-icon img { width: 16px; }
+.-_-_-all-_-_- .label-icon, #-_-_-all-_-_- .label-icon {background-position: 0px -176px;}
+#-_-_-dls-_-_- .label-icon {background-position: 0px 0px;}
+#-_-_-com-_-_- .label-icon {background-position: 0px -16px;}
+#-_-_-act-_-_- .label-icon {background-position: 0px -160px;}
+#-_-_-iac-_-_- .label-icon {background-position: 0px -32px;}
+#-_-_-err-_-_- .label-icon {background-position: 0px -96px;}
+.label-count,.label-size { background-color: #F0F0F0; padding: 0.1em 0.3em 0.1em 0.3em; border-radius: 0.8em; }
+div#CatList ul li.RSS .label-icon { background-position: 0px -208px}
+div#CatList ul li.disRSS .label-icon { background-position: 0px -192px}
+#flabel_cont li:not(.-_-_-all-_-_-) .label-icon { background-position: 0px -32px; }
 
 .stable-icon {background-image: url(../images/tstatus.png); background-repeat: no-repeat}
 .Status_Down {background-position: 0px 0px}

--- a/index.html
+++ b/index.html
@@ -96,32 +96,32 @@
 						<div class="catpanel" id="pstate" onclick="theWebUI.togglePanel(this); return(false);"><script type="text/javascript"> document.write(theUILang.pnlState); </script></div>
 						<ul id="pstate_cont" class="catpanel_cont">
 							<li class="-_-_-all-_-_- sel cat">
-								<span class="label-text"><script type="text/javascript"> document.write(theUILang.All); </script></span><span class="label-count">0</span><span class="label-size" style="display: none"></span>
+								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text"><script type="text/javascript"> document.write(theUILang.All); </script></div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
 							</li>
 							<li id="-_-_-dls-_-_-" class="cat">
-								<span class="label-text"><script type="text/javascript"> document.write(theUILang.Downloading); </script></span><span class="label-count">0</span><span class="label-size" style="display: none"></span>
+								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text"><script type="text/javascript"> document.write(theUILang.Downloading); </script></div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
 							</li>
 							<li id="-_-_-com-_-_-" class="cat">
-								<span class="label-text"><script type="text/javascript"> document.write(theUILang.Finished); </script></span><span class="label-count">0</span><span class="label-size" style="display: none"></span>
+								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text"><script type="text/javascript"> document.write(theUILang.Finished); </script></div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
 							</li>
 							<li id="-_-_-act-_-_-" class="cat">
-								<span class="label-text"><script type="text/javascript"> document.write(theUILang.Active); </script></span><span class="label-count">0</span><span class="label-size" style="display: none"></span>
+								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text"><script type="text/javascript"> document.write(theUILang.Active); </script></div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
 							</li>
 							<li id="-_-_-iac-_-_-" class="cat">
-								<span class="label-text"><script type="text/javascript"> document.write(theUILang.Inactive); </script></span><span class="label-count">0</span><span class="label-size" style="display: none"></span>
+								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text"><script type="text/javascript"> document.write(theUILang.Inactive); </script></div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
 							</li>
 							<li id="-_-_-err-_-_-" class="cat">
-								<span class="label-text"><script type="text/javascript"> document.write(theUILang.Error); </script></span><span class="label-count">0</span><span class="label-size" style="display: none"></span>
+								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text"><script type="text/javascript"> document.write(theUILang.Error); </script></div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
 							</li>
 						</ul>
 						<div class="catpanel" id="plabel" onclick="theWebUI.togglePanel(this); return(false);"><script type="text/javascript"> document.write(theUILang.Labels); </script></div>
 						<div class="catpanel_cont" id="plabel_cont">
 							<ul id="clabel_cont">
 								<li class="-_-_-all-_-_- sel cat">
-									<span class="label-text"><script type="text/javascript"> document.write(theUILang.All); </script></span><span class="label-count">0</span><span class="label-size" style="display: none"></span>
+									<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text"><script type="text/javascript"> document.write(theUILang.All); </script></div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
 								</li>
 								<li id="-_-_-nlb-_-_-" class="cat">
-									<span class="label-text"><script type="text/javascript"> document.write(theUILang.No_label); </script></span><span class="label-count">0</span><span class="label-size" style="display: none"></span>
+									<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text"><script type="text/javascript"> document.write(theUILang.No_label); </script></div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
 								</li>
 							</ul>
 							<ul id="lbll">
@@ -131,7 +131,7 @@
 						<div class="catpanel_cont" id="flabel_cont">
 							<ul id="lblf">
 								<li class="-_-_-all-_-_- sel cat">
-									<span class="label-text"><script type="text/javascript"> document.write(theUILang.All); </script></span><span class="label-count">0</span><span class="label-size" style="display: none"></span>
+									<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text"><script type="text/javascript"> document.write(theUILang.All); </script></div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
 								</li>
 							</ul>
 						</div>

--- a/js/common.js
+++ b/js/common.js
@@ -761,6 +761,16 @@ var theFormatter =
 	      		}
 	   	}
 		return(arr);
+	},
+	treePrefix: function({hasNext, level})
+	{
+		const prefix = [];
+		for (let l = 1; l < level+1; l++) {
+			prefix.push(hasNext[l] ?
+				(l === level ? '├' : '│') :
+				(l === level ? '└' : ' '));
+		}
+		return prefix;
 	}
 };
 

--- a/js/content.js
+++ b/js/content.js
@@ -346,6 +346,12 @@ function makeContent()
 					"<div class=\"op100l\"><input type=\"checkbox\" id=\"webui.show_searchlabelsize\"/>"+
 						"<label for=\"webui.show_searchlabelsize\" id=\"lbl_webui.show_searchlabelsize\" >"+theUILang.showSearchLabelSize+"</label>"+
 					"</div>"+
+					"<div class=\"op100l\"><input type=\"checkbox\" id=\"webui.show_label_path_tree\"/>"+
+						"<label for=\"webui.show_label_path_tree\" id=\"lbl_webui.show_label_path_tree\" >"+theUILang.showCustomLabelTree+"</label>"+
+					"</div>"+
+					"<div class=\"op100l\"><input type=\"checkbox\" id=\"webui.show_empty_path_labels\"/>"+
+						"<label for=\"webui.show_empty_path_labels\" id=\"lbl_webui.show_empty_path_labels\" >"+theUILang.showEmptyPathLabel+"</label>"+
+					"</div>"+
 					"<div class=\"op100l\"><input type=\"checkbox\" id=\"webui.register_magnet\"/>"+
 						"<label for=\"webui.register_magnet\" id=\"lbl_webui.register_magnet\" >"+theUILang.registerMagnet+"</label>"+
 					"</div>"+

--- a/lang/en.js
+++ b/lang/en.js
@@ -244,6 +244,8 @@ var theUILang =
  showStateLabelSize		: "Show state size",
  showLabelSize			: "Show label size",
  showSearchLabelSize		: "Show search size",
+ showCustomLabelTree		: "Show label path tree",
+ showEmptyPathLabel		: "Show empty path labels",
  phpParameterUnavailable	: "PHP directive register_argc_argv is set to OFF. Change to ON, otherwise some plugins won't work correctly.",
  addTorrentFailedURL		: "Failed to add torrent. Can't retrieve URL.",
  addTorrentFailedFile		: "Failed to add torrent. The retrieved content is not a valid torrent file.",

--- a/plugins/theme/themes/Acid/style.css
+++ b/plugins/theme/themes/Acid/style.css
@@ -44,15 +44,6 @@ input.Button { background: #D7D7D7 url(./images/h.gif) repeat-x center bottom; }
 div#CatList { background-color: #272E36; color: #BDDBDB;}
 div#CatList ul li { border: 1px solid #272E36; font-weight: bold; }
 div#CatList ul li.sel {background-color: #BDDBDB; border-color: #BDDBDB; color: #272E36;}
-.-_-_-all-_-_-, #-_-_-all-_-_-, #-_-_-dls-_-_-, #-_-_-com-_-_-, #-_-_-act-_-_-, #-_-_-iac-_-_-, #-_-_-err-_-_- {background-image: url(./images/tstatus.png)}
-.-_-_-all-_-_-, #-_-_-all-_-_- {background-position: 4px -174px;}
-#-_-_-dls-_-_- {background-position: 4px 2px;}
-#-_-_-com-_-_- {background-position: 4px -14px;}
-#-_-_-act-_-_- {background-position: 4px -158px;}
-#-_-_-iac-_-_- {background-position: 4px -30px;}
-#-_-_-err-_-_- {background-position: 4px -94px;}
-div#CatList ul li.RSS {background-image: url(./images/tstatus.png); }
-div#CatList ul li.disRSS {background-image: url(./images/tstatus.png); }
 
 .stable-icon {background-image: url(./images/tstatus.png); }
 
@@ -106,8 +97,8 @@ span#loadimg { background: transparent url(./images/ajax-loader.gif) no-repeat c
 .Icon_Share {background: transparent url(./images/dir.gif) no-repeat left center}
 
 .catpanel { background: url(./images/pnl_open.gif) 2px no-repeat; background-color: #1e2124; color: #00ff00; font-weight: bold;}
-span.label-count,span.label-size { background-color: #1e2124; }
-li.sel span.label-count,li.sel span.label-size { background-color: #909090; }
+.label-count,.label-size { background-color: #1e2124; }
+li.sel .label-count,li.sel .label-size { background-color: #909090; }
 
 div#tadd-header {background-image: url(./images/world.gif); }
 div#tadd { background-color: #1e2124; border: 2px solid #909090; color: #BDDBDB;}

--- a/plugins/theme/themes/Blue/style.css
+++ b/plugins/theme/themes/Blue/style.css
@@ -34,8 +34,8 @@ input[type="text"], input[type="password"], input[type="file"], select, textarea
 input[type="text"][disabled],input[type="password"][disabled],input[type="file"][disabled], select[disabled], textarea[disabled] { border: 1px solid #C0C0C0; background: #F0F0F0; color: #C0C0C0}
 
 .catpanel {background-color: #D9E8FB; color: #15428B; font-weight: bold; border: 1px solid #8DB2E3; background-image: url(./images/pnl_open.gif) }
-span.label-count,span.label-size { background-color: #D9E8FB; border-radius: 0.5em 0.5em 0 0; }
-li.sel span.label-count,li.sel span.label-size { background-color: #FFFFFF; }
+.label-count,.label-size { background-color: #D9E8FB; border-radius: 0.5em 0.5em 0 0; }
+li.sel .label-count,li.sel .label-size { background-color: #FFFFFF; }
 
 div#tdcont { background: #FFFFFF; border: 1px solid #99BBE8; }
 

--- a/plugins/theme/themes/Dark/style.css
+++ b/plugins/theme/themes/Dark/style.css
@@ -51,9 +51,8 @@ a {color: #686868}
 div#CatList {border: 1px solid #333333; background-color: #181818}
 div#CatList ul li {border-color: #181818}
 div#CatList ul li.sel {background-color: #888888; color:#111111; border-color: #888888 }
-.-_-_-all-_-_-, #-_-_-all-_-_-, #-_-_-dls-_-_-, #-_-_-com-_-_-, #-_-_-act-_-_-, #-_-_-iac-_-_-, #-_-_-err-_-_- {background-image: url(./images/tstatus.png)}
-div#CatList ul li.RSS {background-image: url(./images/tstatus.png); }
-div#CatList ul li.disRSS {background-image: url(./images/tstatus.png); }
+div#CatList ul li.RSS .label-icon {background-image: url(./images/tstatus.png); }
+div#CatList ul li.disRSS .label-icon {background-image: url(./images/tstatus.png); }
 .stable-icon {background-image: url(./images/tstatus.png); }
 .Icon_File {background: transparent url(./images/file.gif) no-repeat left center}
 .Icon_Dir {background: transparent url(./images/dir.gif) no-repeat left center}
@@ -111,8 +110,8 @@ div#t div#ind {background: transparent url(./images/ajax-loader.gif) no-repeat 0
 span#loadimg {background: transparent url(./images/ajax-loader.gif) no-repeat center center; }
 
 .catpanel { background: url(./images/pnl_open.gif) 2px no-repeat; background-color: #111111; border-bottom: 1px solid #333333; border-top: 1px solid #333333;  }
-span.label-count,span.label-size { background-color: #111111; }
-li.sel span.label-count,li.sel span.label-size { background-color: #999999; }
+.label-count,.label-size { background-color: #111111; }
+li.sel .label-count,li.sel .label-size { background-color: #999999; }
 
 #StatusBar { border-top: 1px solid #333333; background-color: #181818; color: #888888 }
 #st_up { background:url(./images/status_up.gif) 6px no-repeat; }

--- a/plugins/theme/themes/Excel/style.css
+++ b/plugins/theme/themes/Excel/style.css
@@ -2,10 +2,10 @@ html, body { background-color: #DFE8F6; scrollbar-arrow-color: #586585; scrollba
 div#HDivider { width: 5px }
 div#CatList { border-top-style: none; border-color: #9EB6CE; background: scroll transparent url(./images/cbg.png) repeat-y 0 0 }
 div#CatList ul { background: scroll transparent url(./images/cbg.png) repeat-y 0 0 }
-div#CatList ul li { border-top: 1px solid #d0d7e5; border-bottom: 1px solid transparent; padding-left: 46px }
+div#CatList ul li { border-top: 1px solid #d0d7e5; border-bottom: 1px solid transparent; padding: 2px 0px 0px 46px; }
 .catpanel { border: none; background: transparent url(./images/pbg.png) repeat-x 0 0; padding: 0px 32px; height: 20px }
-span.label-count,span.label-size { background-color: #d2e0f0; border-radius: 0.5em 0 0 0; }
-li.sel span.label-count,li.sel span.label-size { background-color: #FFFFFF; }
+.label-count,.label-size { background-color: #d2e0f0; border-radius: 0.5em 0 0 0; }
+li.sel .label-count,li.sel .label-size { background-color: #FFFFFF; }
 
 div.table_tab { border: none }
 

--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -74,28 +74,19 @@ input[type="text"][disabled], input[type="password"][disabled], input[type="file
 input.Button {border: 1px solid #000;background: #000 url(./images/headers.png) repeat-x 0px 0px;color:#AACF27;cursor: pointer;font-weight: bold;text-shadow:0px -1px 0px #000;-moz-border-radius: 5px; -webkit-border-radius: 5px;border-radius: 5px;}
 
 div#CatList {border:none;background-color: #212121;border-right: 1px solid #1b1b1b;border-left: 1px solid #070707;}
-div#CatList ul {}
-div#CatList ul li span {color:#D4D6C9}
-div#CatList ul li.sel span {color:#AACF27}
+div#CatList ul li {color:#D4D6C9}
+div#CatList ul li.sel {color:#AACF27}
 div#CatList ul li {border-color: #212121;font-family: inherit;}
 div#CatList ul li.sel {background-color: transparent; color:#009DDD;text-shadow:0px -1px 0px #000;border:1px solid #212121; }
-.-_-_-all-_-_-, #-_-_-all-_-_-, #-_-_-dls-_-_-, #-_-_-com-_-_-, #-_-_-act-_-_-, #-_-_-iac-_-_-, #-_-_-err-_-_- {background-image: url(./images/status_icons.png)}
 .catpanel { font-size:12px;font-family:inherit;padding: 2px 24px; height:25px; line-height:25px;background: url(./images/pnl_open.gif) 0px 0px no-repeat; background-color: #232323;   font-weight: bold;color:#DCDCDC;text-shadow: 0px -1px 0px #000;border-top:1px solid #333;   border-bottom: none;border-right: none;}
-span.label-count,span.label-size { background-color: #181818; }
-.-_-_-all-_-_-, #-_-_-all-_-_- {background-position: 4px -175px;}
-#-_-_-dls-_-_- {background-position: 4px 2px;}
-#-_-_-com-_-_- {background-position: 4px -15px;}
-#-_-_-act-_-_- {background-position: 4px -159px;}
-#-_-_-iac-_-_- {background-position: 4px -31px;}
-#-_-_-err-_-_- {background-position: 4px -95px;}
-div#CatList ul li.RSS {background-image: url(./images/status_icons.png);background-position: 4px -207px; }
-div#CatList ul li.disRSS {background-image: url(./images/status_icons.png); }
+.label-icon { background-image: url(./images/status_icons.png); }
+.label-count,.label-size { background-color: #181818; }
 .stable-icon {background-image: url(./images/status_icons.png); }
 .Icon_File {background: transparent url(./images/file.gif) no-repeat left center}
 .Icon_Dir {background: transparent url(./images/dir.gif) no-repeat left center}
 .Icon_Share {background: transparent url(./images/dir.gif) no-repeat left center}
 
-div#flabel_cont ul li {background-image: url(./images/status_icons.png);background-position: 4px -352px;}
+div#flabel_cont li:not(.-_-_-all-_-_-) .label-icon { background-position: 0px -352px;}
 
 div.tab {background: #181818;font-family: inherit;}
 div#lcont {background: #181818;font-family: inherit;}

--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -1,4 +1,3 @@
-plugin.loadMainCSS();
 
 theWebUI.trackersLabels = {};
 plugin.injectedStyles = {};
@@ -123,27 +122,31 @@ theWebUI.trackersLabelContextMenu = function(e)
 	return(false);
 }
 
-plugin.updateLabelsImages = function()
+plugin.updateLabel = theWebUI.updateLabel;
+theWebUI.updateLabel = function(label, ...args)
 {
-	$('#plabel_cont ul li').each( function()
+	plugin.updateLabel.call(this, label, ...args);
+	var icon = $(label).children('.label-icon');
+	var id = icon.parent().attr('id');
+	if (id && icon.parents('#plabel_cont')[0] && !icon.children('img')[0])
 	{
-		var lbl = this.id.substr(5,this.id.length-10);
-		if(!$$("lbl_"+lbl))
-			$(this).prepend( $("<img>").attr("id","lbl_"+lbl).attr("src","plugins/tracklabels/action.php?label="+lbl).addClass("tfavicon") ).css({ padding: "2px 4px" });
-	});
+		var lbl = theWebUI.idToLbl(id);
+		icon.append($("<img>")
+			.attr({ id: 'lbl_'+lbl, src: 'plugins/tracklabels/action.php?label='+lbl}))
+			.css({ background: 'none' });
+	}
 }
 
 plugin.updateLabels = theWebUI.updateLabels;
 theWebUI.updateLabels = function(wasRemoved)
 {
-	plugin.updateLabels.call(theWebUI,wasRemoved);
 	if(plugin.enabled)
 	{
 		if(wasRemoved)
 			theWebUI.rebuildTrackersLabels();
 		theWebUI.updateAllFilterLabel('torrl', this.settings["webui.show_labelsize"]);
-		plugin.updateLabelsImages();
 	}
+	plugin.updateLabels.call(theWebUI,wasRemoved);
 }
 
 theWebUI.rebuildTrackersLabels = function()
@@ -202,10 +205,11 @@ theWebUI.rebuildTrackersLabels = function()
 		{
 			if(!(lbl in this.trackersLabels))
 			{
-				ul.append( theWebUI.createSelectableLabelElement('i'+lbl, lbl, theWebUI.trackersLabelContextMenu)
-					.addClass("tracker")
-					.prepend( $("<img>").attr("src","plugins/tracklabels/action.php?tracker="+lbl).addClass("tfavicon") )
-					.css({ padding: "2px 4px" }));
+				ul.append(theWebUI.createSelectableLabelElement('i'+lbl, lbl, theWebUI.trackersLabelContextMenu)
+					.addClass("tracker"));
+				$($$('i'+lbl)).children('.label-icon')
+					.append($("<img>").attr("src","plugins/tracklabels/action.php?tracker="+lbl))
+					.css({ background: 'none' });
 			}
 			theWebUI.updateLabel($$('i'+lbl), trackersLabels[lbl], trackersSizes[lbl], theWebUI.settings["webui.show_labelsize"]);
 			if(plugin.isActualLabel(lbl))

--- a/plugins/tracklabels/tracklabels.css
+++ b/plugins/tracklabels/tracklabels.css
@@ -1,1 +1,0 @@
-.tfavicon { width: 16px; height: 16px; margin-right: 5px; float: left }


### PR DESCRIPTION
Inspired by the old `lbll-suite` plugin I came up with a tree display for the custom label paths:

<p float="left"><img src="https://user-images.githubusercontent.com/83290594/153900541-917f286e-7828-49c2-9e15-b824bd4b38ee.png" alt="rutorrent_notree_short_display" height=500/>
<img src="https://user-images.githubusercontent.com/83290594/153900543-07012cd7-f2bb-44a4-9702-79c37af02c9a.png" alt="rutorrent_tree_short_display" height=500/></p>

I also added an option to show empty labels along the path to display the complete tree:

<p float="left"><img src="https://user-images.githubusercontent.com/83290594/153900534-4825dcaa-abad-4ae4-a20b-babb718eb4f8.png" alt="rutorrent_notree_display" height=635/>
<img src="https://user-images.githubusercontent.com/83290594/153900542-355cc166-3e72-4078-a6e8-694fbc004b57.png" alt="rutorrent_tree_display" height=635/>
</p>

The shortened labels are also displayed for `Labels >` in the context menu:
<pre>
...
Books
│Cat A
│Cat B
││Cat 1
││Cat 2
Image
...
</pre>

`label-size` is not displayed if `count == 0`

Instead of `span`s I use a flex container with `div`s 
to avoid the `float: left` of the tracklabel icons which conflicts with the `label-prefix`

updated all themes