### PR TITLE
truncate overflow of label text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -101,8 +101,12 @@ div#CatList .label-prefix div { margin-right: 0px; width: 12px; }
 #-_-_-iac-_-_- .label-icon {background-position: 0px -32px;}
 #-_-_-err-_-_- .label-icon {background-position: 0px -96px;}
 .label-count,.label-size { background-color: #F0F0F0; padding: 0.1em 0.3em 0.1em 0.3em; border-radius: 0.8em; }
-.label-size.rightalign {
+#CatList.rightalign-labelsize .label-size {
 	margin-left: auto;
+}
+#CatList.hide-textoverflow .label-text {
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 div#CatList ul li.RSS .label-icon { background-position: 0px -208px}
 div#CatList ul li.disRSS .label-icon { background-position: 0px -192px}

--- a/js/content.js
+++ b/js/content.js
@@ -497,6 +497,7 @@ function makeContent()
 							['webui.labelsize_rightalign', theUILang.labelSizeRightAlign],
 							['webui.show_label_path_tree', theUILang.showCustomLabelTree],
 							['webui.show_empty_path_labels', theUILang.showEmptyPathLabel],
+							['webui.show_label_text_overflow', theUILang.showLabelTextOverflow],
 							['webui.show_open_status', theUILang.showOpenStatus],
 						].map(([id, label]) =>
 						$('<div>').append(

--- a/js/webui.js
+++ b/js/webui.js
@@ -168,6 +168,7 @@ var theWebUI =
 		"webui.show_statelabelsize":	0,
 		"webui.show_label_path_tree":	1,
 		"webui.show_empty_path_labels":	0,
+		"webui.show_label_text_overflow": 0,
 		"webui.show_open_status":	1,
 		"webui.register_magnet":	0,
 		...(() => {
@@ -2314,15 +2315,10 @@ var theWebUI =
 			' ('+ count + ( showSize ? ' ; '+ lblSize : '') +')');
 		var sizeSpan = li.children('.label-size');
 		sizeSpan.text(lblSize);
-		if (size && showSize) {
-			if (theWebUI.settings['webui.labelsize_rightalign'])
-				sizeSpan.addClass('rightalign');
-			else
-				sizeSpan.removeClass('rightalign');
+		if (size && showSize)
 			sizeSpan.show();
-		} else {
+		else
 			sizeSpan.hide();
-		}
 	},
 
 	idToLbl: function(id) {
@@ -2331,6 +2327,15 @@ var theWebUI =
 
 	updateLabels: function(wasRemoved)
 	{
+		const catlist = $($$('CatList'));
+		if (theWebUI.settings['webui.labelsize_rightalign'])
+			catlist.addClass('rightalign-labelsize');
+		else
+			catlist.removeClass('rightalign-labelsize');
+		if (theWebUI.settings['webui.show_label_text_overflow'])
+			catlist.removeClass('hide-textoverflow');
+		else
+			catlist.addClass('hide-textoverflow');
 		this.updateAllFilterLabel('pstate_cont', this.settings["webui.show_statelabelsize"]);
 		this.updateAllFilterLabel('plabel_cont', this.settings["webui.show_labelsize"]);
 		this.updateAllFilterLabel('flabel_cont', this.settings["webui.show_searchlabelsize"]);

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP directive register_argc_argv is set to OFF. Change to ON, otherwise some plugins won't work correctly.",
  addTorrentFailedURL		: "Failed to add torrent. Can't retrieve URL.",

--- a/lang/da.js
+++ b/lang/da.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP directive register_argc_argv er sat til OFF. Skift til ON, ellers vil nogle plugins ikke virke korrekt.",
  addTorrentFailedURL		: "Kunne ikke tilføje torrent. Kan ikke forbine til URL.",

--- a/lang/de.js
+++ b/lang/de.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP Direktive register_argc_argv wurde auf OFF gesetzt. Ändere dies zu ON, andernfalls werden einige Plugins nicht richtig funktionieren.",
  addTorrentFailedURL		: "Fehler beim hinzufügen eines Torrent. URL kann nicht abgerufen werden.",

--- a/lang/el.js
+++ b/lang/el.js
@@ -256,6 +256,7 @@ var theUILang =
  showCustomLabelTree		: "Προβολή διαδρομής δένδρου ετικέτας",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Προβολή ετικετών χωρίς διαδρομή",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "Η οδηγία register_argc_argv της PHP είναι ορισμένη στο OFF. Αλλάξτε τη σε ON, αλλιώς κάποια πρόσθετα δεν θα λειτουργούν σωστά.",
  addTorrentFailedURL		: "Αποτυχία προσθήκης αρχείου torrent. Αδυναμία ανάκτησης URL.",

--- a/lang/en.js
+++ b/lang/en.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP directive register_argc_argv is set to OFF. Change to ON, otherwise some plugins won't work correctly.",
  addTorrentFailedURL		: "Failed to add torrent. Can't retrieve URL.",

--- a/lang/es.js
+++ b/lang/es.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "La directiva PHP register_argc_argv figura como OFF. Cámbiela a ON, de otra manera algunos plugins no funcionarán.",
  addTorrentFailedURL		: "Fallo al agregar torrent. No se encuentra la URL.",

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP directive register_argc_argv is set to OFF. Change to ON, otherwise some plugins won't work correctly.",
  addTorrentFailedURL		: "Failed to add torrent. Can't retrieve URL.",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "La directive PHP 'register_argc_argv' est désactivée. Veuillez l'activer sinon certains plugins ne fonctionneront pas correctement.",
  addTorrentFailedURL		: "Erreur: le torrent n'a pas pu être ajouté à rTorrent. Impossible de résoudre l'URL.",

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP directive register_argc_argv is set to OFF. Change to ON, otherwise some plugins won't work correctly.",
  addTorrentFailedURL		: "Failed to add torrent. Can't retrieve URL.",

--- a/lang/it.js
+++ b/lang/it.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "La direttiva PHP register_argc_argv è impostata su OFF. Cambia su ON, altrimenti alcuni plugin non funzioneranno correttamente.",
  addTorrentFailedURL		: "Aggiunta torrent fallita. Impossibile elaborare l'URL.",

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -256,6 +256,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP의 register_argc_argv directive가 OFF로 설정되어 있습니다. ON으로 바꾸지 않으면, 일부 플러그인이 올바르게 동작할 수 없습니다.",
  addTorrentFailedURL		: "토렌트를 추가하지 못했습니다. URL에 접근하지 못했습니다.",

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP directive register_argc_argv is set to OFF. Change to ON, otherwise some plugins won't work correctly.",
  addTorrentFailedURL		: "Failed to add torrent. Can't retrieve URL.",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP-instelling 'register_argc_argv' staat op OFF, waardoor sommige plugins niet kunnen functioneren. Wijzig de instelling naar ON.",
  addTorrentFailedURL		: "Fout bij toevoegen torrent: kan URL niet ophalen.",

--- a/lang/no.js
+++ b/lang/no.js
@@ -257,6 +257,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP innstillingen register_argc_argv er satt til OFF. Sett denne til ON, ellers vil enkelte tilleggsmoduler ikke fungere som de skal.",
  addTorrentFailedURL		: "Fikk ikke til å legge til torrent. Kan ikke hente lenke.",

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -259,6 +259,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "Ustawienie PHP register_argc_argv jest wyłączone. Włącz je, inaczej niektóre wtyczki nie będą działać poprawnie.",
  addTorrentFailedURL		: "Torrent nie został dodany. Nie można pobrać adresu.",

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "Diretiva PHP register_argc_argv está definida para OFF. Mude para ON, caso contrário, alguns plugins não irão funcionar corretamente.",
  addTorrentFailedURL		: "Falha ao adicionar torrent. Não foi possivel recuperar a URL.",

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "Директива php register_argc_argv выставлена в Off. Измените ее значение на On, иначе некоторые плагины будут работать некорректно.",
  addTorrentFailedURL		: "Ошибка добавления закачки. Невозможно получить файл по заданному URL.",

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP directive register_argc_argv is set to OFF. Change to ON, otherwise some plugins won't work correctly.",
  addTorrentFailedURL		: "Failed to add torrent. Can't retrieve URL.",

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -256,6 +256,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP directive register_argc_argv is set to OFF. Change to ON, otherwise some plugins won't work correctly.",
  addTorrentFailedURL		: "Failed to add torrent. Can't retrieve URL.",

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -256,6 +256,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP-direktivet register_argc_argv är inställt på OFF. Byt till ON, annars kommer några insticksprogram inte fungera korrekt.",
  addTorrentFailedURL		: "Det gick inte att lägga till torrent. Kan inte hämta webbadress.",

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -257,6 +257,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP yönergesi register_argc_argv OFF olarak ayarlandı. ON olarak değiştirin, aksi halde bazı eklentiler düzgün çalışmayacaktır.",
  addTorrentFailedURL : "Torrent eklenemedi. URL alınamıyor.",

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "Директиву інтерпретатора PHP register_argc_argv вимкнено (значення Off). Увімкніть її (значення On), інакше деякі плагіни не працюватимуть.",
  addTorrentFailedURL		: "Сталася помилка. Файл .torrent не передано до rTorrent. Не вдалося отримати URL-адресу.",

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -256,6 +256,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP directive register_argc_argv is set to OFF. Change to ON, otherwise some plugins won't work correctly.",
  addTorrentFailedURL		: "Không thêm torrent được. Không thể tải được URL.",

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -258,6 +258,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP 参数 register_argc_argv 被设为 OFF. 把它切换到 ON, 否则某些插件会无法正常工作.",
  addTorrentFailedURL		: "添加 torrent 失败. 无法取回 URL.",

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -256,6 +256,7 @@ var theUILang =
  showCustomLabelTree		: "Show label path tree",
  labelSizeRightAlign		: "Right align size in category list",
  showEmptyPathLabel		: "Show empty path labels",
+ showLabelTextOverflow	: "Allow overflow of label text",
  showOpenStatus		: "Show open status in status bar",
  phpParameterUnavailable	: "PHP directive register_argc_argv is set to OFF. Change to ON, otherwise some plugins won't work correctly.",
  addTorrentFailedURL		: "Failed to add torrent. Can't retrieve URL.",


### PR DESCRIPTION
Truncating the `label-text` overflow probably looks better in most cases

`hide-textoverflow` and `rightalign-labelsize` are now classes of `#CatList` 
such that style classes do not need to be repeated for all labels 