### PR TITLE
add option to delay rss errors

### DIFF
--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -739,6 +739,12 @@ rTorrentStub.prototype.getXMLValue = function(values,i)
 	return((ret==null) ? "" : ret);
 }
 
+rTorrentStub.prototype.processAction = function(actionSuffix, data)
+{
+	const parseFunc = this.action+actionSuffix;
+	return parseFunc in this ? this[parseFunc](data) : data;
+}
+
 rTorrentStub.prototype.getResponse = function(data) 
 {
 	var ret = "";
@@ -764,17 +770,10 @@ rTorrentStub.prototype.getResponse = function(data)
 						this.faultString.push("XMLRPC Error: "+this.getXMLValue(values,0)+" ["+this.action+"]");
 					}
 		}
-		const parseFunc = this.action+'ParseXML';
-		if(parseFunc in this)
-			responseData = this[parseFunc](responseData);
+		responseData = this.processAction('ParseXML', responseData);
 	}
 	if(!this.isError())
-	{
-		if(this.action+'Response' in this)
-			ret = this[this.action+'Response'](responseData);
-		else
-			ret = responseData;
-	}
+		ret = this.processAction('Response', responseData);
 	return(ret);
 }
 

--- a/plugins/rss/action.php
+++ b/plugins/rss/action.php
@@ -9,17 +9,16 @@ $cmd = "get";
 if(isset($_REQUEST['mode']))
 	$cmd = $_REQUEST['mode'];
 $errorsReported = false;
-$dataType="application/json";
 $mngr = new rRSSManager();
 switch($cmd)
 {
-	case "setinterval":
+	case "setsettings":
 	{
-		$mngr->setInterval($_REQUEST['interval']);
+		$mngr->setSettings($_REQUEST['interval'], $_REQUEST['delayerrui']);
 	}
-	case "getintervals":
+	case "getsettings":
 	{
-		$val = $mngr->getIntervals();
+		$val = $mngr->getSettings();
 		break;
 	}
 	case "add":
@@ -273,9 +272,8 @@ switch($cmd)
 	}
 	case "getdesc":
 	{
-		$dataType="text/xml";
 		$val = '';
-	        if(isset($_REQUEST['rss']) && isset($_REQUEST['href']))
+		if(isset($_REQUEST['rss']) && isset($_REQUEST['href']))
 			$val = $mngr->getDescription($_REQUEST['rss'],$_REQUEST['href']);
 		break;
 	}
@@ -364,10 +362,7 @@ if($val===null)
 	$val = $mngr->get();
 	$errorsReported = true;
 }
-if($dataType=="text/xml")
-	CachedEcho::send('<?xml version="1.0" encoding="UTF-8"?><data><![CDATA['.$val.']]></data>',"text/xml",true,false);
-else
-	CachedEcho::send(JSON::safeEncode($val),$dataType,true,false);
+CachedEcho::send(JSON::safeEncode($val), "application/json",true,false);
 
 ob_flush();
 flush();

--- a/plugins/rss/lang/cs.js
+++ b/plugins/rss/lang/cs.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Do you really want to delete selected group with all contents?";
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/da.js
+++ b/plugins/rss/lang/da.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Do you really want to delete selected group with all contents?";
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/de.js
+++ b/plugins/rss/lang/de.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Ausgewählte Gruppe wirklich mit allen Inhalten löschen?";
  theUILang.rssAllFiters			= "Alle Filter";
  theUILang.rssUpdateInterval		= "Aktualisierungsintervall";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Verzeichnisse";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/el.js
+++ b/plugins/rss/lang/el.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Θέλετε πραγματικά να διαγράψετε την επιλεγμένη ομάδα με όλα τα περιεχόμενα;";
  theUILang.rssAllFiters			= "Όλα τα φίλτρα";
  theUILang.rssUpdateInterval		= "Μεσοδιάστημα ανανέωσης";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Φάκελοι";
  theUILang.Labels			= "Ετικέτες";
 

--- a/plugins/rss/lang/en.js
+++ b/plugins/rss/lang/en.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Do you really want to delete selected group with all contents?";
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/es.js
+++ b/plugins/rss/lang/es.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Realmente desea borrar el grupo seleccionad con todo su contenido?";
  theUILang.rssAllFiters			= "Todos los filtros";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/fi.js
+++ b/plugins/rss/lang/fi.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Do you really want to delete selected group with all contents?";
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/fr.js
+++ b/plugins/rss/lang/fr.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Êtes-vous sûr de vouloir supprimer ce groupe ainsi que tout son contenu?";
  theUILang.rssAllFiters			= "Tous les filtres";
  theUILang.rssUpdateInterval		= "Intervalle de mise à jour";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Annuaires";
  theUILang.Labels			= "Étiquettes";
 

--- a/plugins/rss/lang/hu.js
+++ b/plugins/rss/lang/hu.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Do you really want to delete selected group with all contents?";
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/it.js
+++ b/plugins/rss/lang/it.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Vuoi veramente cancellare i gruppi selezionati con tutti i contenuti?";
  theUILang.rssAllFiters			= "Tutti i filtri";
  theUILang.rssUpdateInterval		= "Intervallo di aggiornamento";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Cartelle";
  theUILang.Labels			= "Etichette";
 

--- a/plugins/rss/lang/ko.js
+++ b/plugins/rss/lang/ko.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "정말 선택한 그룹 및 모든 항목을 제거할까요?";
  theUILang.rssAllFiters			= "모든 필터";
  theUILang.rssUpdateInterval		= "업데이트 주기";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "디렉토리";
  theUILang.Labels			= "라벨";
 

--- a/plugins/rss/lang/lv.js
+++ b/plugins/rss/lang/lv.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Do you really want to delete selected group with all contents?";
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/nl.js
+++ b/plugins/rss/lang/nl.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Weet u zeker dat u de geslecteerde groep + inhoud wilt verwijderen?";
  theUILang.rssAllFiters			= "Alle filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/no.js
+++ b/plugins/rss/lang/no.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Vil du virkelig slette valgt gruppe med all dens innhold?";
  theUILang.rssAllFiters			= "Alle filtre";
  theUILang.rssUpdateInterval		= "Oppdater intervall";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Mapper";
  theUILang.Labels			= "Etiketter";
 

--- a/plugins/rss/lang/pl.js
+++ b/plugins/rss/lang/pl.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Czy na pewno chcesz usunąć wybraną grupę wraz z całą zawartością?";
  theUILang.rssAllFiters			= "Wszystkie filtry";
  theUILang.rssUpdateInterval		= "Aktualizuj co";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Katalogi";
  theUILang.Labels			= "Etykiety";
 

--- a/plugins/rss/lang/pt.js
+++ b/plugins/rss/lang/pt.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Do you really want to delete selected group with all contents?";
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/ru.js
+++ b/plugins/rss/lang/ru.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Вы действительно хотите удалить выбранную группу со всем ее содержимым?";
  theUILang.rssAllFiters			= "Все фильтры";
  theUILang.rssUpdateInterval		= "Интервал обновления";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Директории";
  theUILang.Labels			= "Метки";
 

--- a/plugins/rss/lang/sk.js
+++ b/plugins/rss/lang/sk.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Do you really want to delete selected group with all contents?";
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/sr.js
+++ b/plugins/rss/lang/sr.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Do you really want to delete selected group with all contents?";
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/sv.js
+++ b/plugins/rss/lang/sv.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Vill du verkligen ta bort markerad grupp och radera allt innehåll?";
  theUILang.rssAllFiters			= "Alla filter";
  theUILang.rssUpdateInterval		= "Uppdateringsintervall";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Mappar";
  theUILang.Labels			= "Etiketter";
 

--- a/plugins/rss/lang/tr.js
+++ b/plugins/rss/lang/tr.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Do you really want to delete selected group with all contents?";
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/uk.js
+++ b/plugins/rss/lang/uk.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Справді видалити вибрану групу з усім її вмістом?";
  theUILang.rssAllFiters			= "Усі фільтри";
  theUILang.rssUpdateInterval		= "Інтервал оновлення";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Директорії";
  theUILang.Labels			= "Мітки";
 

--- a/plugins/rss/lang/vi.js
+++ b/plugins/rss/lang/vi.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Bạn có thực sự muốn xóa các nhóm đã chọn và toạn bộ nội dung bên trong?";
  theUILang.rssAllFiters			= "Tất cả bộ lọc";
  theUILang.rssUpdateInterval		= "Cập nhật sau mỗi";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Các thư mục";
  theUILang.Labels			= "Các nhãn";
 

--- a/plugins/rss/lang/zh-cn.js
+++ b/plugins/rss/lang/zh-cn.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "你真的确定要删除选择组的所有内容吗?";
  theUILang.rssAllFiters			= "增加过滤器";
  theUILang.rssUpdateInterval		= "更新间隔";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "文件夹";
  theUILang.Labels			= "标签";
 

--- a/plugins/rss/lang/zh-tw.js
+++ b/plugins/rss/lang/zh-tw.js
@@ -73,6 +73,7 @@
  theUILang.rssDeleteGroupContentsPrompt	= "Do you really want to delete selected group with all contents?";
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
+ theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/rss.css
+++ b/plugins/rss/rss.css
@@ -52,7 +52,7 @@ div#FLT_buttons {clear: both}
 #FLT_interval {width: 185px}
 #FLTBtn {width: 30px}
 
-#rsslayout { border: 0; display: none; margin: 5px; }
+#rsslayout { border: 0; display: none; margin: 5px; white-space: pre-line; }
 
 #dlgAddRSSGroup {width: 320px; height: 300px}
 #dlgAddRSSGroup div.dlg-header {background-image: url(./images/rss.gif)}
@@ -62,5 +62,8 @@ div#dlgAddRSSGroup div.content {width: 302px; margin: 5px; padding: 5px; line-he
 .RSS .label-icon { background-position: 0px -208px; }
 .disRSS .label-icon { background-position: 0px -192px; }
 .RSSGroup .label-icon { background-position: 0px -240px; }
+
+#prss_cont .notification::after { color: red; content: " ⚠"; }
+#tab_lcont.notification > a::after { color: gray; content: " ⚠"; }
 
 #rsstimer { float: right; font-weight: normal; margin-right: -18px; }

--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -17,6 +17,7 @@ class rRSS
 	public $etag = null;
 	public $encoding = null;
 	public $version = 0;
+	public $lastErrorMsgs = [];
 	private $isValid=false;
 	private $channeltags = array('title', 'link', 'lastBuildDate');
 	private $itemtags = array('title', 'link', 'pubDate', 'enclosure', 'guid', 'source', 'description', 'dc:date');
@@ -125,13 +126,20 @@ class rRSS
 	public function fetch( $history )
 	{
 		$headers = array();
+		$this->lastErrorMsgs = [];
 		if($this->etag) 
 			$headers['If-None-Match'] = trim($this->etag);
 		if($this->lastModified)
 	                $headers['If-Last-Modified'] = trim($this->lastModified);
 		$cli = self::fetchURL($this->url,$this->cookies,$headers);
-		if($cli->status==304)
-			return(true);
+		if($cli->status<200 || $cli->status>=300) {
+			if ($cli->status!==304) {
+				$this->lastErrorMsgs[] = $cli->status == -100 ? '[RSS-Timeout]' :
+					($cli->status < 100 ? '[RSS-Connection-Error] '.$cli->error : '[RSS-HTTP-Error] Status: '.$cli->status);
+			}
+			// true if feed not modified
+			return($cli->status===304);
+		}
 		$this->etag = null;
 		$this->lastModified = null;
 		if($cli->status>=200 && $cli->status<300)
@@ -835,6 +843,7 @@ class rRSSData
 {
 	public $hash = "data";
 	public $interval = 30;
+	public $delayErrorsUI = true;
 }
 
 class rRSSManager
@@ -858,14 +867,17 @@ class rRSSManager
 		$this->data = new rRSSData();
 		$this->cache->get($this->data);
 	}
-	public function setInterval($interval)
+	public function setSettings($interval, $delay_err_ui)
 	{
+		// setInterval
 		global $minInterval;
 		if(!isset($minInterval))
 			$minInterval = 2;
 		if($interval<$minInterval)
 			$interval = $minInterval;
 		$this->data->interval = $interval;
+		// set delay ui errors
+		$this->data->delayErrorsUI = (bool) $delay_err_ui;
 		$this->cache->set($this->data);
 		$this->setHandlers();
 	}
@@ -1040,6 +1052,14 @@ class rRSSManager
 		if($grp)
 			$this->updateRSS($grp->lst);
 	}
+	private function tryFetch($rss) {
+		$success = $rss->fetch($this->history) && $this->cache->set($rss);
+		if (!$success) {
+			$this->rssList->addError( "theUILang.cantFetchRSS + ' - ".join("; ", $rss->lastErrorMsgs)."'", $rss->getMaskedURL() );
+		}
+		return($success);
+	}
+
 	public function updateRSS($hash)
 	{
 		$filters = $this->loadFilters();
@@ -1054,13 +1074,11 @@ class rRSSManager
 				$info = $this->rssList->lst[$item];
 	                        if($this->cache->get($rss) && $info['enabled'])
 				{
-					if($rss->fetch($this->history) && $this->cache->set($rss))
+					if($this->tryFetch($rss))
 					{
 						$this->checkFilters($rss,$filters);
 						$this->saveHistory();
 					}
-					else
-						$this->rssList->addError( "theUILang.cantFetchRSS", $rss->getMaskedURL() );
 				}
 			}
 			else
@@ -1081,10 +1099,10 @@ class rRSSManager
 			$rss->hash = $hash;
 			if($this->cache->get($rss) && $info['enabled'])
 			{
-				if($rss->fetch($this->history) && $this->cache->set($rss))
+				if($this->tryFetch($rss))
+				{
 					$this->checkFilters($rss,$filters);
-				else
-					$this->rssList->addError( "theUILang.cantFetchRSS", $rss->getMaskedURL() );
+				}
 			}
 		}
 		if(!$manual)
@@ -1094,12 +1112,16 @@ class rRSSManager
 		}
 		$this->saveHistory();
 	}
-	public function getIntervals()
+	public function getSettings()
 	{
 		$nextTouch = $this->data->interval*60;
 		if($this->rssList->updatedAt)
 			$nextTouch = $nextTouch-(time()-$this->rssList->updatedAt)+45;
-		return(array( "next"=>$nextTouch, "interval"=>$this->data->interval ));
+		return([
+			"next"=>$nextTouch,
+			"interval"=>$this->data->interval,
+			"delayerrui"=>$this->data->delayErrorsUI
+		]);
 	}
 	public function get()
 	{
@@ -1249,7 +1271,7 @@ class rRSSManager
 		$rss = new rRSS($rssURL);
 		if(!$this->rssList->isExist($rss))
 		{
-			if($rss->fetch($this->history) && $this->cache->set($rss))
+			if($this->tryFetch($rss))
 			{
 			        if($rssLabel)
 			        	$rssLabel = trim($rssLabel);
@@ -1265,8 +1287,6 @@ class rRSSManager
 				$this->checkFilters($rss);
 				$this->saveHistory();
 			}
-			else
-				$this->rssList->addError( "theUILang.cantFetchRSS", $rss->getMaskedURL() );
 		}
 		else
 			$this->rssList->addError( "theUILang.rssAlreadyExist", $rss->getMaskedURL() );


### PR DESCRIPTION
Since some RSS feeds sometimes time out, the UI will switch to the console tab (with the `Autoswitch to Log tab` option).
If this happens frequently, this can become distracting/annoying.

Now RSS error messages will be delayed until the user switches to rss feeds or the console tab, if the option `Delay RSS error notification...` is enabled.
When delayed messages are pending `Log ⚠`  is shown.

Changes to the RSS log message:
- add `cli->error` info to  (for instance `curl error 28` indicates connection timeout)
- add a `rssLabel` prefix instead of url

(+ refactoring: extract processAction function, extract rssCommon function)