### PR TITLE
Multi select labels

### DIFF
--- a/js/stable.js
+++ b/js/stable.js
@@ -47,7 +47,7 @@ var dxSTable = function()
 	this.viewRows = 0;
 	this.cols = 0;
 	this.colsdata = new Array();
-	this.stSel = null;
+	this.stSel = [];
 	this.format = function(r) { return r; };
 	this.sIndex =- 1;
 	this.reverse = 0;
@@ -1173,105 +1173,58 @@ dxSTable.prototype.selectRow = function(e, row)
 {
 	if(!$.support.touchable)
 		this.bindKeys();
-	var id = row.id;
-	if(!((e.which==3) && (this.rowSel[id] == true))) 
-	{
-		if(e.shiftKey) 
-		{
-			if(this.stSel == null) 
+
+	const targetId = row.id;
+	const rightClick = e.which === 3;
+	if (!(rightClick && this.rowSel[targetId])) {
+		const toggle = e.metaKey;
+		const range = e.shiftKey;
+		const oldSel = this.stSel ?? [];
+		const anchor = oldSel.length ? oldSel[oldSel.length-1] : null;
+		let selection = [];
+
+		if (range && anchor) {
+			// range selection
+			let behindAnchor = false;
+			let behindTarget = false;
+			for(let i = 0; i < this.rowIDs.length; i++)
 			{
-				this.stSel = id;
-				this.rowSel[id] = true;
-				this.selCount = 1;
-			}
-			else 
-			{
-				this.selCount = 0;
-				var _81 = false, passedCID = false, k = "";
-				for(var i = 0, l = this.rowIDs.length; i < l; i++) 
-				{
-					k = this.rowIDs[i];
-					this.rowSel[k] = false;
-					if((k == this.stSel) || _81) 
-					{
-						if(!passedCID) 
-						{
-							this.rowSel[k] = true;
-							this.selCount++;
-                     				}
-						else 
-						{
-							if((k == this.stSel) || (k == id)) 
-							{
-				                        	this.rowSel[k] = true;
-								this.selCount++;
-							}
-						}
-					}
-					else 
-					{
-						if((k == id) || passedCID) 
-						{
-							if(!_81) 
-							{
-								this.rowSel[k] = true;
-								this.selCount++;
-							}
-							else 
-							{
-								if((k == this.stSel) || (k == id)) 
-								{
-									this.rowSel[k] = true;
-									this.selCount++;
-                           					}
-                        				}
-                     				}
-                  			}
-					if(!this.rowdata[k].enabled && this.rowSel[k]) 
-					{
-						this.rowSel[k] = false;
-						this.selCount--;
-                  			}
-					if(k == this.stSel) 
-						_81 = true;
-					if(k == id) 
-						passedCID = true;
+				const id = this.rowIDs[i];
+				behindAnchor |= anchor === id;
+				behindTarget |= targetId === id;
+				if (
+					(behindAnchor || behindTarget)
+					&& !(toggle && this.rowSel[id])
+					&& this.rowdata[id].enabled
+				) {
+					selection.push(id);
+				}
+				if (behindAnchor && behindTarget) {
+					break;
 				}
 			}
+		} else {
+			selection = [targetId];
 		}
-		else 
-		{
-			if(e.metaKey) 
-			{
-				this.stSel = id;
-				this.rowSel[id] =!this.rowSel[id];
-				if(this.rowSel[id]) 
-					this.selCount++;
-				else 
-					this.selCount--;
-			}
-			else 
-			{
-				this.stSel = id;
-				this.selCount = 0;
-				for(var k in this.rowSel) 
-				{
-					if(k == id) 
-					{
-						this.rowSel[k] = true;
-						this.selCount++;
-					}
-					else 
-						this.rowSel[k] = false;
-				}
-			}
+
+		if (toggle) {
+			const selSet = new Set(selection);
+			// unselect ids if already selected
+			selection = oldSel.filter(id => !selSet.has(id)).concat(
+				selection.filter(id => !this.rowSel[id])
+			);
 		}
-		if(this.selCount == 0) 
-			this.stSel = null;
+		const fullSelSet = new Set(selection);
+		for (const id in this.rowSel) {
+			this.rowSel[id] = fullSelSet.has(id);
+		}
+		this.selCount = fullSelSet.size;
+		this.stSel = selection;
 		this.refreshSelection();
 	}
+
 	if($type(this.onselect) == "function") 
-		this.onselect(e, id);
+		this.onselect(e, targetId);
 	return(false);
 }
 
@@ -1542,6 +1495,7 @@ dxSTable.prototype.clearSelection = function()
 	for(var k in this.rowSel)
 		this.rowSel[k] = false;
 	this.selCount = 0;
+	this.stSel = [];
 	this.refreshSelection();
 }
 
@@ -1559,13 +1513,14 @@ dxSTable.prototype.correctSelection = function()
 
 dxSTable.prototype.fillSelection = function() 
 {
-	this.selCount = 0;
+	this.stSel = [];
 	for(var k in this.rowSel) 
 		if(this.rowdata[k].enabled)
 		{
 			this.rowSel[k] = true;
-			this.selCount++;
+			this.stSel.push(k);
 		}
+	this.selCount = this.stSel.length;
 	this.refreshSelection();
 }
 

--- a/js/stable.js
+++ b/js/stable.js
@@ -1180,24 +1180,31 @@ dxSTable.prototype.selectRow = function(e, row)
 		const toggle = e.metaKey;
 		const range = e.shiftKey;
 		const oldSel = this.stSel ?? [];
-		const anchor = oldSel.length ? oldSel[oldSel.length-1] : null;
+		const anchor = oldSel.length ? oldSel[toggle ? oldSel.length-1 : 0] : null;
 		let selection = [];
 
-		if (range && anchor) {
+		if (range && anchor && anchor !== targetId) {
 			// range selection
 			let behindAnchor = false;
 			let behindTarget = false;
+			let reverse = false;
 			for(let i = 0; i < this.rowIDs.length; i++)
 			{
 				const id = this.rowIDs[i];
 				behindAnchor |= anchor === id;
 				behindTarget |= targetId === id;
+				reverse |= behindTarget && !behindAnchor;
+
 				if (
 					(behindAnchor || behindTarget)
 					&& !(toggle && this.rowSel[id])
 					&& this.rowdata[id].enabled
 				) {
-					selection.push(id);
+					if (reverse) {
+						selection.unshift(id);
+					} else {
+						selection.push(id);
+					}
 				}
 				if (behindAnchor && behindTarget) {
 					break;

--- a/js/webui.js
+++ b/js/webui.js
@@ -2205,8 +2205,15 @@ var theWebUI =
 		});
 
 		const actLbls = theWebUI.actLbls['plabel_cont'] ?? [];
-		// filter out removed labels (no re-filtering required)
-		theWebUI.actLbls['plabel_cont'] = actLbls.filter(labelId => pLabels.includes(theWebUI.idToLbl(labelId)));
+		const residualActLbls = actLbls.filter(labelId => pLabels.includes(theWebUI.idToLbl(labelId)));
+		const actDeleted = actLbls.length !== residualActLbls.length;
+		if (actDeleted)
+		{
+			// filter out removed labels (no re-filtering required)
+			theWebUI.actLbls['plabel_cont'] = residualActLbls;
+			// no theWebUI.switchLabel: to avoid switching away from other table views (extsearch, rss)
+			this.refreshLabelSelection('plabel_cont');
+		}
 	},
 
 	/**

--- a/js/webui.js
+++ b/js/webui.js
@@ -225,7 +225,7 @@ var theWebUI =
 	},
 	actLbls:
 	{
-		"pstate_cont": ""
+		'pstate_cont': []
 	},
 	cLabels:	{},
 	stateLabels: {},
@@ -516,16 +516,14 @@ var theWebUI =
 		}
 		// switch to labels if keeping selected labels is enabled
 		if (theWebUI.settings["webui.selected_labels.keep"]) {
-			this.actLbls = this.settings['webui.selected_labels.last'];
-			for(const labelType in this.actLbls) {
-				if (labelType in this.actLbls) {
-					const ele = $$(this.actLbls[labelType]);
-					if (ele) {
-						$($$(labelType)).find(".sel").removeClass("sel");
-						$(ele).addClass("sel");
-					}
-				}
+			const actLbls = this.settings['webui.selected_labels.last'];
+			for(const [labelType, lbls] of Object.entries(actLbls)) {
+				// consider legacy single-label selection
+				this.actLbls[labelType] = Array.isArray(lbls) ? lbls : lbls ? [lbls] : [];
 			}
+		}
+		for (const labelType of ['pstate_cont', 'plabel_cont', 'flabel_cont']) {
+			this.refreshLabelSelection(labelType);
 		}
 
 		// user must be able add peer when peers are empty
@@ -1973,9 +1971,9 @@ var theWebUI =
 //
 
 	createTeg: function(str) {
-			var tegId = "teg_"+this.lastTeg;
+			const tegId = "teg_"+this.lastTeg;
 			this.lastTeg++;
-			var el = this.createSelectableLabelElement(tegId, str, theWebUI.tegContextMenu).addClass('teg');
+			const el = this.createSelectableLabelElement(tegId, str, theWebUI.labelContextMenu).addClass('teg');
 			$("#lblf").append( el );
 			this.tegs[tegId] = { val: str };
 			this.updateTegs([this.tegs[tegId]]);
@@ -1986,21 +1984,18 @@ var theWebUI =
 	setTeg: function(str)
 	{
 		str = str.trim();
-		if(str!="")
-		{
-			for( var id in this.tegs )
-				if(this.tegs[id].val==str)
-				{
-					this.switchLabel($$(id));
-					return;
-				}
-			const el = this.createTeg(str);
+		const validTeg = str !== '';
+		let teg_entry = validTeg && Object.entries(this.tegs)
+			.find(([_,teg]) => teg.val == str);
+		if (!teg_entry) {
 			this.resetLabels();
-			this.switchLabel(el[0]);
+			if (validTeg) {
+				const teg = this.createTeg(str);
+				teg_entry = [teg.id, teg];
+			}
 		}
-		else
-		{
-			this.resetLabels();
+		if (teg_entry) {
+			this.switchLabel('flabel_cont', teg_entry[0]);
 		}
 	},
 
@@ -2036,10 +2031,13 @@ var theWebUI =
 		}
 	},
 
-	removeTeg: function(id)
+	removeActiveTegs: function()
 	{
-		delete this.tegs[id];
-		$($$(id)).remove();
+		const tegIds = this.actLbls['flabel_cont'] ?? [];
+		for (const tegId of tegIds) {
+			delete this.tegs[tegId];
+			$($$(tegId)).remove();
+		}
 		this.resetLabels();
 	},
 
@@ -2052,51 +2050,61 @@ var theWebUI =
 		this.resetLabels();
 	},
 
-	tegContextMenu: function(e)
+	labelContextMenu: function(e)
 	{
-	        if(e.which==3)
-	        {
-		        var table = theWebUI.getTable("trt");
+		const el = e.delegateTarget;
+		const labelType = $(el).parents('.catpanel_cont')[0].id;
+		const table = theWebUI.contextMenuTable(labelType, el);
+		const rightClick = e.which===3;
+		if (rightClick)
+		{
 			table.clearSelection();
-			theWebUI.switchLabel(this);
+		}
+		if (!(rightClick && (theWebUI.actLbls[labelType] ?? []).includes(el.id))) {
+			theWebUI.switchLabel(labelType, el.id, e.metaKey, e.shiftKey);
+		}
+		if (rightClick)
+		{
 			table.fillSelection();
-			var id = table.getFirstSelected();
-			if(id)
+			const id = table.getFirstSelected();
+			const entries = theWebUI.contextMenuEntries(labelType, el);
+			if (!(entries && (id || entries.length)))
 			{
-				theWebUI.createMenu(null, id);
-		   		theContextMenu.add([CMENU_SEP]);
+				theContextMenu.hide();
+				return false;
 			}
-			else
+			// show a context menu
+			if (id) {
+				theWebUI.createMenu(null, id);
+				if (entries.length) {
+					theContextMenu.add([CMENU_SEP]);
+				}
+			} else {
 				theContextMenu.clear();
-			theContextMenu.add([theUILang.removeTeg, "theWebUI.removeTeg('"+this.id+"');"]);
-			theContextMenu.add([theUILang.removeAllTegs, "theWebUI.removeAllTegs();"]);
+			}
+			for (const entry of entries) {
+				theContextMenu.add(entry);
+			}
 			theContextMenu.show(e.clientX,e.clientY);
 		}
-		else
-			theWebUI.switchLabel(this);
 		return(false);
 	},
 
-	labelContextMenu: function(e)
-	{
-	        if(e.which==3)
-	        {
-		        var table = theWebUI.getTable("trt");
-			table.clearSelection();
-			theWebUI.switchLabel(this);
-			table.fillSelection();
-			var id = table.getFirstSelected();
-			if(id)
-			{
-				theWebUI.createMenu(null, id);
-				theContextMenu.show(e.clientX,e.clientY);
-			}
-			else
-				theContextMenu.hide();
+	contextMenuTable: function(labelType, el) {
+		return theWebUI.getTable('trt');
+	},
+
+	contextMenuEntries: function(labelType, el) {
+		if (labelType === 'flabel_cont') {
+			return (
+				(this.actLbls['flabel_cont'] ?? []).length ? [
+					[theUILang.removeTeg, "theWebUI.removeActiveTegs();"]
+				] : []
+			).concat([
+				[theUILang.removeAllTegs, "theWebUI.removeAllTegs();"]
+			]);
 		}
-		else
-			theWebUI.switchLabel(this);
-		return(false);
+		return [];
 	},
 
 	cLabelText: function(lbl) {
@@ -2150,8 +2158,8 @@ var theWebUI =
 						let ele = $$(cid);
 						if(!ele) {
 							ele = this.createSelectableLabelElement(cid, clbl, theWebUI.labelContextMenu);
-							if (cid === this.actLbls['plabel_cont']) {
-								$('#plabel_cont').find('.sel').removeClass('sel');
+							if (this.actLbls['plabel_cont'].includes(cid)) {
+								$('#plabel_cont .-_-_-all-_-_-').removeClass('sel');
 								ele.addClass('sel');
 							}
 							if (prevCustomEle) {
@@ -2186,22 +2194,19 @@ var theWebUI =
 			label.hasNext = [...hasNext];
 			hasNext[label.level] = true;
 		}
-		var actDeleted = false;
-		var pLabels = ['nlb'].concat(Object.keys(this.cLabels));
+		const pLabels = ['nlb'].concat(Object.keys(this.cLabels));
 		p.children().each(function(ndx,val)
 		{
 			var id = val.id;
 			var lbl = (id&&theWebUI.idToLbl(id))||'nlb';
 			if (!pLabels.includes(lbl)) {
 				$(val).remove();
-				if(theWebUI.actLbls["plabel_cont"] == id)
-					actDeleted = true;
 			}
 		});
-		if(actDeleted)
-		{
-			this.switchLabel($("#plabel_cont .-_-_-all-_-_-").get(0))
-		}
+
+		const actLbls = theWebUI.actLbls['plabel_cont'] ?? [];
+		// filter out removed labels (no re-filtering required)
+		theWebUI.actLbls['plabel_cont'] = actLbls.filter(labelId => pLabels.includes(theWebUI.idToLbl(labelId)));
 	},
 
 	/**
@@ -2360,28 +2365,74 @@ var theWebUI =
 	},
 
 	resetLabels: function() {
-		var allLbls = $('.-_-_-all-_-_-');
-		for(var i = 0; i < allLbls.length; i++)
-			this.switchLabel(allLbls.get(i));
+		for (const labelType of Object.keys(this.actLbls)) {
+			this.actLbls[labelType] = [];
+			this.refreshLabelSelection(labelType);
+		}
+		this.filterTorrentTable();
 	},
 
-	switchLabel: function(obj)
+	switchLabel: function(labelType, targetId, toggle=false, range=false)
 	{
-		var panelCont = $(obj).closest(".catpanel_cont");
-		var labelType = panelCont.attr('id')
+		const oldLabelIds = this.actLbls[labelType] ?? [];
+		const oldSelSet = new Set(oldLabelIds);
+		let labelIds = targetId ? [targetId] : [];
 
-		if(this.actLbls[labelType] != obj.id)
-		{
-			panelCont.find(".sel").removeClass("sel");
-			$(obj).addClass("sel");
+		if (range && targetId) {
+			// range selection
+			const anchor = oldLabelIds.length ? oldLabelIds[toggle ? oldLabelIds.length-1 : 0] : 'all';
+			if (targetId !== anchor && !(toggle && oldLabelIds.includes(targetId))) {
+				// select labelIds between anchor and target
+				const allTypeLabelIds = $($$(labelType)).find('.cat').map((_,e) => e.id || 'all');
+				const indexOfLabel = lid => Number(Object.entries(allTypeLabelIds).find(([_,l]) => l === lid)[0]);
+				const a = indexOfLabel(anchor);
+				const t = indexOfLabel(targetId);
 
-			this.actLbls[labelType] = obj.id;
+				const rangeIndices = [];
+				const step = a <= t ? 1 : -1;
+				for (let i = a; i != t; i += step) {
+					rangeIndices.push(i);
+				}
+				rangeIndices.push(t);
+
+				labelIds = rangeIndices
+					.map(i => allTypeLabelIds[i])
+					.filter(lid => lid !== 'all' && !(toggle && oldSelSet.has(lid)));
+			}
+		}
+
+		if (toggle) {
+			const selSet = new Set(labelIds);
+			// unselect ids if already selected
+			labelIds = oldLabelIds.filter(id => !selSet.has(id)).concat(
+				labelIds.filter(id => !oldSelSet.has(id))
+			);
+		}
+
+		if (labelIds.some(lid => !oldLabelIds.includes(lid)) || oldLabelIds.some(lid => !labelIds.includes(lid))) {
+			// change in label selection
+			this.actLbls[labelType] = labelIds;
+
+			this.refreshLabelSelection(labelType);
 
 			this.filterTorrentTable();
 
 			if (this.settings['webui.open_tegs.keep']
 				||this.settings['webui.selected_labels.keep'])
 				this.save();
+		}
+	},
+
+	refreshLabelSelection: function(labelType) {
+		const container = $($$(labelType));
+		container.find('.sel').removeClass('sel');
+		const labelIds = this.actLbls[labelType] ?? [];
+		if (labelIds.length) {
+			for (const labelId of labelIds) {
+				$($$(labelId)).addClass('sel');
+			}
+		} else {
+				container.find('.-_-_-all-_-_-').addClass('sel');
 		}
 	},
 
@@ -2403,33 +2454,25 @@ var theWebUI =
 
 	filterByLabel: function(sId)
 	{
-		var table = this.getTable("trt");
-
-		var showRow = true;
-		for(var lblType in this.actLbls)
-		{
-			if (lblType != "plabel_cont" && lblType != "pstate_cont" && lblType != "flabel_cont")
-				continue;
-
-			var actLbl = this.actLbls[lblType];
-
-			if($($$(actLbl)).hasClass("teg"))
-			{
-				var teg = this.tegs[actLbl];
-				if(teg)
-				{
-					if(!this.matchTeg(teg, table.getValueById(sId, "name")))
-						showRow = false;
-				}
-			}
-			else if(table.getAttr(sId, "label").indexOf(actLbl) == -1)
-				showRow = false;
-		}
-
-		if(showRow)
+		const table = this.getTable('trt');
+		if(this.isTorrentRowShown(table, sId))
 			table.unhideRow(sId);
 		else
 			table.hideRow(sId);
+	},
+
+	isTorrentRowShown: function(table, sId)
+	{
+		const title = table.getValueById(sId, 'name');
+		const label = table.getAttr(sId, 'label');
+		return Object.entries(this.actLbls).filter(
+			([labelType, _]) => ['plabel_cont', 'pstate_cont', 'flabel_cont'].includes(labelType)
+		).every(([labelType, actLbls]) => !actLbls.length || (
+			// filter by torrent label
+			labelType !== 'flabel_cont' ? actLbls.some(labelId => label.includes(labelId))
+			// filter by title search teg
+			: actLbls.some(labelId => !(labelId in this.tegs) || this.matchTeg(this.tegs[labelId], title))
+		));
 	},
 
 //

--- a/plugins/rss/init.js
+++ b/plugins/rss/init.js
@@ -39,29 +39,32 @@ if(plugin.canChangeOptions())
 }
 
 plugin.switchLabel = theWebUI.switchLabel;
-theWebUI.switchLabel = function(el)
+theWebUI.switchLabel = function(labelType, targetId, toggle=false, range=false)
 {
-        var lst = $("#RSSList");
-	if(lst.is(":visible"))
-	{
-		theWebUI.getTable("trt").clearSelection();
-		theWebUI.dID = "";
-		theWebUI.clearDetails();
-		theWebUI.getTable("rss").clearSelection();
-		if(theWebUI.actRSSLbl)
-			$($$(theWebUI.actRSSLbl)).removeClass('sel');
-		theWebUI.actRSSLbl = null;
-		$("#List").show();
-		lst.hide();
-		theWebUI.switchLayout(false);
+	const rssList = $("#RSSList");
+	const list = $("#List");
+	if(labelType === 'prss_cont') {
+		theWebUI.switchRSSLabel($$(targetId));
+	} else {
+		list.show();
+		if(rssList.is(":visible"))
+		{
+			theWebUI.getTable("trt").clearSelection();
+			theWebUI.dID = "";
+			theWebUI.clearDetails();
+			theWebUI.getTable("rss").clearSelection();
+			if(theWebUI.actRSSLbl)
+				$($$(theWebUI.actRSSLbl)).removeClass('sel');
+			theWebUI.actRSSLbl = null;
+			rssList.hide();
+			theWebUI.switchLayout(false);
+		}
+		plugin.switchLabel.call(theWebUI, labelType, targetId, toggle, range);
 	}
-
-	if( $(el).hasClass('RSS') ||
-		$(el).hasClass('disRSS') ||
-		$(el).hasClass('RSSGroup'))
-		theWebUI.switchRSSLabel(el);
-
-	plugin.switchLabel.call(theWebUI,el);
+	// finally hide list if rsslist shown
+	if(rssList.is(":visible")) {
+		list.hide();
+	}
 }
 
 theWebUI.isActiveRSSEnabled = function()
@@ -309,28 +312,18 @@ theWebUI.RSSManager = function()
 	theWebUI.request("?action=getfilters",[this.loadFilters, this]);
 }
 
-theWebUI.rssLabelContextMenu = function(e)
-{
-        if(e.which==3)
-        {
-		if(plugin.canChangeMenu())
-		{
-			theWebUI.getTable("trt").clearSelection();
-			theWebUI.getTable("rss").clearSelection();
-			theWebUI.switchLabel(this);
-			theWebUI.getTable("rss").fillSelection();
-			theWebUI.createRSSMenu(null, null);
-			theContextMenu.show();
-		}
-		else
-		{
-			theContextMenu.hide();
-			theWebUI.switchLabel(this);
-		}
-	}
-	else
-		theWebUI.switchLabel(this);
-	return(false);
+plugin.contextMenuTable = theWebUI.contextMenuTable;
+theWebUI.contextMenuTable = function(labelType, el) {
+	return labelType === 'prss_cont' ? 
+		theWebUI.getTable('rss') 
+		: plugin.contextMenuTable.call(theWebUI, labelType, el);
+},
+
+plugin.contextMenuEntries = theWebUI.contextMenuEntries;
+theWebUI.contextMenuEntries = function(labelType, el) {
+	return labelType === 'prss_cont' ?
+		theWebUI.createRSSMenuPrim()
+		: plugin.contextMenuEntries.call(theWebUI, labelType, el);
 }
 
 theWebUI.fillRSSGroups = function()
@@ -408,62 +401,63 @@ theWebUI.RSSGroupDeleteContents = function()
 
 theWebUI.createRSSMenuPrim = function()
 {
-        if(plugin.canChangeMenu())
-        {
-		theContextMenu.add([ theUILang.rssMenuClearHistory, "theWebUI.RSSClearHistory()"]);
-		theContextMenu.add([ theUILang.addRSS, "theDialogManager.toggle('dlgAddRSS')"]);
-		theContextMenu.add([ theUILang.addRSSGroup, "theWebUI.RSSAddGroup()"]);
-		theContextMenu.add([ theUILang.rssMenuManager, "theWebUI.RSSManager()"]);
-		if(theWebUI.actRSSLbl) 
+	theWebUI.getTable('trt').clearSelection();
+	theWebUI.dID = "";
+	theWebUI.clearDetails();
+	if(!plugin.canChangeMenu()) {
+		return false;
+	}
+	let entries = [];
+	entries = [
+		[ theUILang.rssMenuClearHistory, "theWebUI.RSSClearHistory()"],
+		[ theUILang.addRSS, "theDialogManager.toggle('dlgAddRSS')"],
+		[ theUILang.addRSSGroup, "theWebUI.RSSAddGroup()"],
+		[ theUILang.rssMenuManager, "theWebUI.RSSManager()"]
+	];
+	if(theWebUI.actRSSLbl)
+	{
+		entries.push([CMENU_SEP]);
+		if(this.actRSSLbl == "_rssAll_")
 		{
-			theContextMenu.add([CMENU_SEP]);			
-			if(this.actRSSLbl == "_rssAll_")
+			entries = entries.concat([
+				[ theUILang.rssMenuDisable ],
+				[ theUILang.rssMenuEdit ],
+				[ theUILang.rssMenuRefresh, "theWebUI.RSSRefresh()"],
+				[ theUILang.rssMenuDelete ]
+			]);
+		}
+		else
+		{
+			if(this.isGroupSelected())
 			{
-				theContextMenu.add([ theUILang.rssMenuDisable ]);
-				theContextMenu.add([ theUILang.rssMenuEdit ]);
-				theContextMenu.add([ theUILang.rssMenuRefresh, "theWebUI.RSSRefresh()"]);
-				theContextMenu.add([ theUILang.rssMenuDelete ]);
+				entries = entries.concat(this.rssGroups[this.actRSSLbl].enabled==1 ? [
+					[ theUILang.rssMenuGroupDisable, "theWebUI.RSSGroupSetStatus(0)"],
+					[ theUILang.rssMenuGroupRefresh, "theWebUI.RSSGroupRefresh()"]
+				] : [
+					[ theUILang.rssMenuGroupEnable, (this.rssGroups[this.actRSSLbl].cnt==0) ? null : "theWebUI.RSSGroupSetStatus(1)"],
+					[ theUILang.rssMenuGroupRefresh ]
+				]).concat([
+					[ theUILang.rssMenuGroupEdit, "theWebUI.RSSEditGroup()"],
+					[ theUILang.rssMenuGroupDelete, "theWebUI.RSSGroupDelete()"],
+					[ theUILang.rssMenuGroupContentsDelete, "theWebUI.RSSGroupDeleteContents()"]
+				]);
 			}
 			else
 			{
-				if(this.isGroupSelected())
-				{
-					if(this.rssGroups[this.actRSSLbl].enabled==1)
-					{
-						theContextMenu.add([ theUILang.rssMenuGroupDisable, "theWebUI.RSSGroupSetStatus(0)"]);
-						theContextMenu.add([ theUILang.rssMenuGroupRefresh, "theWebUI.RSSGroupRefresh()"]);
-					}
-					else
-					{
-						theContextMenu.add([ theUILang.rssMenuGroupEnable, (this.rssGroups[this.actRSSLbl].cnt==0) ? null : "theWebUI.RSSGroupSetStatus(1)"]);
-						theContextMenu.add([ theUILang.rssMenuGroupRefresh ]);
-					}
-					theContextMenu.add([ theUILang.rssMenuGroupEdit, "theWebUI.RSSEditGroup()"]);
-					theContextMenu.add([ theUILang.rssMenuGroupDelete, "theWebUI.RSSGroupDelete()"]);
-					theContextMenu.add([ theUILang.rssMenuGroupContentsDelete, "theWebUI.RSSGroupDeleteContents()"]);
-				}
-				else
-				{
-					if(this.rssLabels[this.actRSSLbl].enabled==1)
-					{
-						theContextMenu.add([ theUILang.rssMenuDisable, "theWebUI.RSSToggleStatus()"]);
-						theContextMenu.add([ theUILang.rssMenuRefresh, "theWebUI.RSSRefresh()"]);
-					}
-					else
-					{
-						theContextMenu.add([ theUILang.rssMenuEnable, "theWebUI.RSSToggleStatus()"]);
-						theContextMenu.add([ theUILang.rssMenuRefresh ]);
-					}
-					theContextMenu.add([ theUILang.rssMenuEdit, "theWebUI.RSSEdit()"]);
-					theContextMenu.add([ theUILang.rssMenuDelete, "theWebUI.RSSDelete()"]);
-				}
+				entries = entries.concat(this.rssLabels[this.actRSSLbl].enabled==1 ? [
+					[ theUILang.rssMenuDisable, "theWebUI.RSSToggleStatus()"],
+					[ theUILang.rssMenuRefresh, "theWebUI.RSSRefresh()"]
+				] : [
+					[ theUILang.rssMenuEnable, "theWebUI.RSSToggleStatus()"],
+					[ theUILang.rssMenuRefresh ]
+				]).concat([
+					[ theUILang.rssMenuEdit, "theWebUI.RSSEdit()"],
+					[ theUILang.rssMenuDelete, "theWebUI.RSSDelete()"]
+				]);
 			}
 		}
 	}
-	else
-		theContextMenu.hide();
-	theWebUI.dID = "";
-	theWebUI.clearDetails();
+	return entries;
 }
 
 theWebUI.RSSAddToFilter = function()
@@ -471,33 +465,40 @@ theWebUI.RSSAddToFilter = function()
 	theWebUI.request("?action=getfilters",[this.loadFiltersWithAdditions, this]);
 }
 
-theWebUI.createRSSMenu = function(e, id) 
+plugin.createMenu = theWebUI.createMenu;
+theWebUI.createMenu = function(e, id)
 {
-	var trtArray = [];
-	this.rssArray = [];
-	var sr = this.getTable("rss").rowSel;
-	for(var k in sr) 
-	{
-		if(sr[k] == true)
-		{
-			var hash = this.rssItems[k].hash;
-			if(hash && $type(theWebUI.torrents[hash]))
-				trtArray.push(hash);
-			else
-				this.rssArray.push(k);
-		}
+	if (id in this.rssItems) {
+		// context menu for rss item
+		theWebUI.createRSSMenu(e, id);
+	} else {
+		plugin.createMenu.call(theWebUI, e, id);
 	}
+}
+
+theWebUI.createRSSMenu = function(e, id)
+{
+	const selectedHashes = Object.entries(this.getTable("rss").rowSel)
+	.filter(([_, sel]) => sel)
+	.map(([link,_]) => this.rssItems[link].hash);
+
+	const partition2 = (values, pred) => values.reduce((p0_p1, v) => {
+		p0_p1[pred(v) ? 0 : 1].push(v);
+		return p0_p1;
+	}, [[],[]]);
+
+	const [rssArray, trtArray] = partition2(selectedHashes, h => h && h in theWebUI.torrents);
+	this.rssArray = rssArray;
+
 	theContextMenu.clear();
 	if(this.rssArray.length)
 	{
-	        if(plugin.canChangeMenu())
-	        {
+		if(plugin.canChangeMenu())
+		{
 			theContextMenu.add([ theUILang.rssMenuLoad, "theWebUI.RSSLoad()"]);
 			theContextMenu.add([ theUILang.rssMenuOpen, "theWebUI.RSSOpen()"]);
 			theContextMenu.add([ theUILang.rssMenuAddToFilter, "theWebUI.RSSAddToFilter()"]);
 			theContextMenu.add([CMENU_CHILD, theUILang.rssMarkAs, [ [ theUILang.rssAsLoaded, "theWebUI.RSSMarkState(1)"], [ theUILang.rssAsUnloaded, "theWebUI.RSSMarkState(0)"] ]]);
-			theContextMenu.add([CMENU_SEP]);
-			theWebUI.createRSSMenuPrim();
 		}
 		else
 			theContextMenu.hide();
@@ -505,7 +506,7 @@ theWebUI.createRSSMenu = function(e, id)
 	else
 	if(trtArray.length)
 	{
-	        var table = this.getTable("trt");
+		var table = this.getTable("trt");
 		for(var k in table.rowSel)
 			table.rowSel[k] = false;
 		table.selCount = trtArray.length;
@@ -514,11 +515,7 @@ theWebUI.createRSSMenu = function(e, id)
 		table.refreshSelection();
 		this.dID = trtArray[0];
 		theWebUI.createMenu(e, trtArray[0]);
-		theContextMenu.add([CMENU_SEP]);
-		theWebUI.createRSSMenuPrim();
 	}
-	else
-		theWebUI.createRSSMenuPrim();
 }
 
 theWebUI.rssSelect = function(e, id)
@@ -683,7 +680,7 @@ theWebUI.updateRSSLabels = function(rssLabels,rssGroups)
 		for( const [lbl, category] of labels ) {
 			let li = $($$(lbl));
 			if(li.length === 0) {
-				li = theWebUI.createSelectableLabelElement(lbl, category.name, theWebUI.rssLabelContextMenu);
+				li = theWebUI.createSelectableLabelElement(lbl, category.name, theWebUI.labelContextMenu);
 			}
 			li.addClass([rssClass, 'disRSS']);
 			li.removeClass(category.enabled == 1 ? 'disRSS' : rssClass);
@@ -700,9 +697,9 @@ theWebUI.updateRSSLabels = function(rssLabels,rssGroups)
 	const curRSSLbl = theWebUI.actRSSLbl;
 	theWebUI.actRSSLbl = null;
 	if (removedLbls.includes(curRSSLbl)) {
-		this.switchLabel($$("_rssAll_"));
+		this.switchLabel('prss_cont', '_rssAll_');
 	} else if(curRSSLbl) {
-		this.switchLabel($$(curRSSLbl));
+		this.switchLabel('prss_cont', curRSSLbl);
 	}
 }
 
@@ -1040,9 +1037,9 @@ theWebUI.showFilterResults = function( d )
 {
 	this.showErrors(d.errors);
 	if(d.rss && d.rss.length)
-		this.switchLabel($$(d.rss));
+		this.switchLabel('prss_cont', d.rss);
 	else
-		this.switchLabel($$('_rssAll_'));
+		this.switchLabel('prss_cont', '_rssAll_');
 	var table = this.getTable("rss");
 	for(var k in table.rowSel)
 		table.rowSel[k] = false;
@@ -1418,7 +1415,7 @@ plugin.onLangLoaded = function()
 				theWebUI.createSelectableLabelElement(
 					'_rssAll_',
 					theUILang.allFeeds,
-					theWebUI.rssLabelContextMenu
+					theWebUI.labelContextMenu
 				).addClass('RSS')
 		));
 	$("#prss").append( $("<span></span>").attr("id", "rsstimer") );

--- a/plugins/rss/init.js
+++ b/plugins/rss/init.js
@@ -478,16 +478,15 @@ theWebUI.createMenu = function(e, id)
 
 theWebUI.createRSSMenu = function(e, id)
 {
-	const selectedHashes = Object.entries(this.getTable("rss").rowSel)
+	const [rssArray, trtArray] = Object.entries(this.getTable("rss").rowSel)
 	.filter(([_, sel]) => sel)
-	.map(([link,_]) => this.rssItems[link].hash);
-
-	const partition2 = (values, pred) => values.reduce((p0_p1, v) => {
-		p0_p1[pred(v) ? 0 : 1].push(v);
-		return p0_p1;
+	.map(([link,_]) => [link, this.rssItems[link].hash])
+	.reduce((rss_trt, [l,h]) => {
+		const isTorrent = h && h in theWebUI.torrents;
+		rss_trt[isTorrent ? 1 : 0].push(isTorrent ? h : l);
+		return rss_trt;
 	}, [[],[]]);
 
-	const [rssArray, trtArray] = partition2(selectedHashes, h => h && h in theWebUI.torrents);
 	this.rssArray = rssArray;
 
 	theContextMenu.clear();


### PR DESCRIPTION
The labels in the category list should be multi-selectable like rows in the tables.

Intended behavior:
As before a torrent has to match every category. Now, some of the selected labels have to match to match a category.
`meta/Ctrl`: toggle single label
`shift`: select range of labels
`meta/Ctrl + shift`: extend range selection (from last anchor)

Multi-select containers:
container ids: `[pstate_cont, plabel_cont, flabel_cont, ptrackers_cont]`. 
Search condition is always true for a container/category if  `All` is selected: `actLbls[cont] = []`.

(`rss` (`prss_cont`) and `extsearch` are still single-select)

## Additional Changes 
- `theWebUI.switchLabel` gets additional parameters `labelType, toggle, range` 
  - for instance `theWebUI.switchLabel('plabel_cont')` selects `All` labels
- Label context menu behavior for different containers is moved to `labelContextMenu`.
- Improve mutli-select behavior of tables (previously selecting multiple small ranges did not work)
