### PR TITLE
Plugin: check_port fix for portchecker.co

### DIFF
--- a/plugins/check_port/action.php
+++ b/plugins/check_port/action.php
@@ -19,7 +19,7 @@ if($useWebsite=="portchecker")
 {
 	$url = "https://portchecker.co/";
 	$ipMatch = '/data-ip="(?P<ip>[^"]+)/';
-	$checker = $url;
+	$checker = "https://portchecker.co/checking";
 	$closed = ">closed<";
 	$open = ">open<";
 }


### PR DESCRIPTION
Extremely simple fix to make this option work again. Was not being submitted to the correct url.

My personal usecase requires portchecker over yougetsignal because yougetsignal is returning my machine's ipv6 address. However it does not support checking ports for ipv6 addresses at all, so it's completely broken. Despite the port being open for both ipv6 and ipv4.

Whereas portchecker only returns ipv4 addresses. Will try and work on a fix for yougetsignal with an option to prefer ipv4 addresses when making http request, which should be all that is needed.