### PR TITLE
Add tracklabels icon upload

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -79,6 +79,7 @@ Input.TextboxMid {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; wid
 Input.TextboxLarge {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 220px}
 Input.TextboxVShort {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 30px}
 input.Button {padding: 1px 10px; background: #F0F0F0 url(../images/h.gif) repeat-x center bottom; width: 80px; height: 19px; border: 1px solid #A0A0A0; cursor: pointer }
+input.Button[disabled] { opacity: 0.3; cursor: default }
 
 select {margin-top: 5px}
 a {font-size: 11px;  color: #686868}

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -398,13 +398,23 @@ rPlugin.prototype.removePaneFromStatusbar = function(id)
 	return(this);
 }
 
-rPlugin.prototype.addPaneToCategory = function(id,name)
+rPlugin.prototype.addPaneToCategory = function(id,name, afterId)
 {
-        if(this.canChangeCategory())
-        {
-		$('#CatList').append(
-			$("<div>").addClass("catpanel").attr("id",id).text(name).on('click', function() { theWebUI.togglePanel(this); })).
-				append($("<div>").attr("id",id+"_cont").addClass("catpanel_cont"));
+	if(this.canChangeCategory())
+	{
+		const catpanel = $("<div>")
+			.addClass("catpanel")
+			.attr("id",id)
+			.text(name)
+			.on('click', function() { theWebUI.togglePanel(this); });
+		const catcont = $("<div>")
+			.attr("id",id+"_cont")
+			.addClass("catpanel_cont");
+		if (afterId) {
+			$(`#${afterId}`).after(catpanel, catcont);
+		} else {
+			$('#CatList').append(catpanel, catcont);
+		}
 		theWebUI.showPanel($$(id),!theWebUI.settings["webui.closed_panels"][id]);
 	}
 	return($("#"+id+"_cont"));

--- a/js/stable.js
+++ b/js/stable.js
@@ -211,7 +211,12 @@ dxSTable.prototype.create = function(ele, styles, aName)
 	this.dBody.appendChild(this.tBody);
 	this.bpad = $("<div>").addClass("stable-virtpad").get(0);
 	this.dBody.appendChild(this.bpad);
-	this.tBody.tb = $("<tbody>").get(0);
+	const tb = $("<tbody>");
+	tb.mouseclick(this.handleClick.bind(this));
+	if(typeof this.ondblclick === 'function') {
+		tb.dblclick(this.handleClick.bind(this));
+	}
+	this.tBody.tb = tb[0];
 	this.tBody.appendChild(this.tBody.tb);
 
 	cg = $("<colgroup>");
@@ -237,6 +242,17 @@ dxSTable.prototype.create = function(ele, styles, aName)
 	this.rowCover = $("<div>").addClass("rowcover").get(0);
 	this.dHead.appendChild(this.rowCover);
 	this.created = true;
+}
+
+dxSTable.prototype.handleClick = function(e)
+{
+	const row = $(e.target).parents('tr')[0];
+	if (e.type == 'dblclick') {
+		this.ondblclick(row);
+	} else if (e.which === 3 || e.which === 1) {
+		// only select rows with left or right click
+		this.selectRow(e, row);
+	}
 }
 
 dxSTable.prototype.toggleColumn = function(i)
@@ -1215,57 +1231,54 @@ dxSTable.prototype.addRow = function(cols, sId, icon, attr, fast = false)
 	}
 }
 
-dxSTable.prototype.createRow = function(cols, sId, icon, attr) 
+dxSTable.prototype.createIconHTML = function(icon)
 {
-	if(!$type(attr)) 
-		attr = [];
-	var tr = $("<tr>").attr( { index: this.rows, title: cols[0] });
-	if(sId != null) 
-		tr.attr("id",sId);
-	var self = this;
-	if(this.colorEvenRows) 
-		tr.addClass( (this.rows & 1) ? "odd" : "even" );
+	return icon == null ? '' : (typeof icon === 'object'
+		? $('<img>').attr({src: icon.src, width: 16, height: 16}).css('background-image', 'none').addClass('stable-icon')
+		: $('<span>').addClass(['stable-icon', icon]))[0].outerHTML;
+}
 
-	tr.mouseclick(function(e) { return(self.selectRow(e, this)); });
-
-	if($type(this.ondblclick) == "function") 
-		tr.on('dblclick', function(e) { return(self.ondblclick(this)); } );
-
-	for(var k in attr) 
-		tr.attr(k, attr[k]);
-	var data = this.rowdata[sId].fmtdata;
-	var s = "";
-	var div;
-	var ret;
-	for(var i = 0; i < this.cols; i++) 
-	{
-		var ind = this.colOrder[i];
-		s+="<td class='stable-"+this.dCont.id+"-col-"+ind+"'";
-		var span1 = "";
-		var span2 = "";
-		if(this.colsdata[i].type==TYPE_PROGRESS)
-		{
-			s+=" rawvalue='"+($type(cols[ind]) ? cols[ind] : "")+"'";
-		        span1 = "<span class='meter-text' style='overflow: visible'>"+escapeHTML(data[ind])+"</span>";
-			div = "<div class='meter-value' style='float: left; background-color: "+
-		 		(new RGBackground()).setGradient(this.prgStartColor,this.prgEndColor,parseFloat(data[ind])).getColor()+
-				"; width: "+iv(data[ind])+"%"+
-				"; visibility: "+(iv(data[ind]) ? "visible" : "hidden")+
-				"'>&nbsp;</div>";
-		}
-		else
-			div = "<div>"+((String(data[ind]) == "") ? "&nbsp;" : escapeHTML(data[ind]))+"</div>";
-		if((ind == 0) && (icon != null)) 
-			span2 = "<span class='stable-icon "+icon+"'></span>";
-		if(!this.colsdata[i].enabled && !browser.isIE7x)
-			s+=" style='display: none'";
-		s+=">";
-		s+=span1;
-		s+=span2;
-		s+=div;
-		s+="</td>";
+dxSTable.prototype.createRow = function(cols, sId, icon, attr)
+{
+	const attrs = { id: sId, index: this.rows, title: cols[0] };
+	if (sId == null) {
+		delete attrs['id'];
 	}
-	ret = tr.append(s).get(0);
+	Object.assign(attrs, attr || {});
+	const data = this.rowdata[sId]?.fmtdata || {};
+
+	const ret = document.createElement('tr');
+	ret.className = this.colorEvenRows ? ((this.rows & 1) ? "odd" : "even") : "";
+	for(const [a,v] of Object.entries(attrs)) {
+		const attr_node = document.createAttribute(a);
+		attr_node.value = v;
+		ret.setAttributeNode(attr_node);
+	}
+	ret.innerHTML = [...Array(this.cols).keys()]
+			.map((_,i) => [this.colOrder[i], this.colsdata[i]])
+			.map(([ind, cdat]) => ({
+				td: [
+					`<td class="stable-${this.dCont.id}-col-${ind}"`,
+					Boolean(cdat.enabled || browser.isIE7x) ?	'>' : ' style="display: none">',
+					ind === 0 ? this.createIconHTML(icon) : ''
+				],
+				celldata: data[ind] || '',
+				rawvalue: cols[ind] || '',
+				progress: cdat.type == TYPE_PROGRESS,
+			}))
+			.flatMap(({td, celldata, rawvalue, progress}) => progress
+				? [
+					td[0], ` rawvalue="${rawvalue}"`, ...td.slice(1),
+					'<span class="meter-text" style="overflow: visible">', escapeHTML(celldata), '</span>',
+					'<div class="meter-value" style="', Object.entries(this.progressStyle(celldata)).map(pair => pair.join(': ')).join(';'), '">&nbsp;</div>',
+					'</td>'
+				]
+				: [
+					...td,
+					'<div>', escapeHTML(celldata) || '&nbsp;', '</div>',
+					'</td>'
+				]
+			).join('');
 	if(!browser.isIE7x)
 	{
 		var _e = this.tBody.getElementsByTagName("colgroup")[0].getElementsByTagName("col");
@@ -1544,6 +1557,19 @@ dxSTable.prototype.setValueById = function(row, id, val)
 	return(this.setValue(row, this.getColById(id), val));
 }
 
+dxSTable.prototype.progressStyle = function(val)
+{
+  const nval = iv(val);
+  return {
+    float: 'left',
+    width: `${nval}%`,
+    backgroundColor: new RGBackground()
+      .setGradient(this.prgStartColor, this.prgEndColor, parseFloat(val))
+      .getColor(),
+    visibility: nval ? 'visible' : 'hidden',
+  };
+}
+
 dxSTable.prototype.setValue = function(row, col, val)
 {
 	const rdata = this.rowdata[row];
@@ -1569,15 +1595,9 @@ dxSTable.prototype.setValue = function(row, col, val)
 					let textEl = td.lastChild;
 					if(this.colsdata[c].type==TYPE_PROGRESS)
 					{
-						const nval = iv(fmtVal);
 						$(td).attr('rawvalue', val)
-						.children().last().css({
-							width: `${nval}%`,
-							backgroundColor: new RGBackground()
-								.setGradient(this.prgStartColor,this.prgEndColor,parseFloat(fmtVal))
-								.getColor(),
-							visibility: nval ? 'visible' : 'hidden'
-						});
+							.children('.meter-value')
+							.css(this.progressStyle(fmtVal));
 						textEl = td.firstChild;
 					}
 					$(textEl).text(fmtVal);
@@ -1596,15 +1616,24 @@ dxSTable.prototype.getIcon = function(row)
 
 dxSTable.prototype.setIcon = function(row, icon) 
 {
-	if(this.rowdata[row].icon != icon)
+	const dataRow = this.rowdata[row];
+	const oldIconIsImg = Boolean(dataRow.icon?.src);
+	const newIconIsImg = Boolean(icon?.src);
+	if(newIconIsImg != oldIconIsImg ||
+		(newIconIsImg && dataRow.icon.src !== icon.src) ||
+		(!oldIconIsImg && dataRow.icon !== icon))
 	{
-		this.rowdata[row].icon = icon;
-		var r = $$(row);
+		dataRow.icon = icon;
+		const r = $$(row);
 		if(r == null) 
 			return(false);
-		var td = r.cells[this.getColOrder(0)];
-
-		td.firstChild.className = (icon) ? "stable-icon " + icon : "";
+		const td = r.cells[this.getColOrder(0)];
+		if (dataRow.icon !== null) {
+			td.firstChild.remove();
+		}
+		if (icon !== null) {
+			td.innerHTML = this.createIconHTML(icon) + td.innerHTML;
+		}
 		return(true);
 	}
 	return(false);

--- a/js/stable.js
+++ b/js/stable.js
@@ -1546,40 +1546,43 @@ dxSTable.prototype.setValueById = function(row, id, val)
 
 dxSTable.prototype.setValue = function(row, col, val)
 {
-	if((col>=0) && this.rowdata[row])
+	const rdata = this.rowdata[row];
+	if((col>=0) && rdata)
 	{
-		this.rowdata[row].data[col] = val;
-		var r = $$(row);
-		var rawvalue = val;
-		var arr = [];
+		rdata.data[col] = val;
+		let arr = [];
 		arr[col] = val;
-		val = this.format(this,arr)[col];
+		const fmtVal = this.format(this,arr)[col];
+		const fmtdata = rdata.fmtdata;
 
-		if(this.rowdata[row].fmtdata[col] != val)
+		if(fmtdata[col] != fmtVal)
 		{
-			this.rowdata[row].fmtdata[col] = val;
-        		if(r)
-        		{
-	        		var c = this.getColOrder(col);
-				var td = r.cells[c];
+			fmtdata[col] = fmtVal;
+			const tr = $$(row);
+			if(tr)
+			{
+				const c = this.getColOrder(col);
+				const td = tr.cells[c];
 			
-			        if(td)
-			        {
+				if(td)
+				{
+					let textEl = td.lastChild;
 					if(this.colsdata[c].type==TYPE_PROGRESS)
 					{
-						$(td).attr("rawvalue",rawvalue);
-						td.lastChild.style.width = iv(val)+"%";
-						td.lastChild.style.backgroundColor = (new RGBackground()).setGradient(this.prgStartColor,this.prgEndColor,parseFloat(val)).getColor();
-						if(!iv(val))
-							$(td.lastChild).css({visibility: "hidden"});
-						else
-							$(td.lastChild).css({visibility: "visible"});
-						td.firstChild.innerHTML = escapeHTML(val);
+						const nval = iv(fmtVal);
+						$(td).attr('rawvalue', val)
+						.children().last().css({
+							width: `${nval}%`,
+							backgroundColor: new RGBackground()
+								.setGradient(this.prgStartColor,this.prgEndColor,parseFloat(fmtVal))
+								.getColor(),
+							visibility: nval ? 'visible' : 'hidden'
+						});
+						textEl = td.firstChild;
 					}
-					else
-						td.lastChild.innerHTML = escapeHTML(val);
+					$(textEl).text(fmtVal);
 				}
-			}					
+			}
 			return(true);
 		}
 	}

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -810,7 +810,6 @@ input.Button
 	border-radius:2px;
 	border:none;
 	color:#FFF;
-	cursor:pointer;
 	display:inline;
 	font-weight:700;
 	text-transform:uppercase;
@@ -821,7 +820,7 @@ input.Button
 	text-shadow:none
 }
 
-input.Button:hover,input.Button:focus
+input.Button:not([disabled]):hover,input.Button:not([disabled]):focus
 {
 	background:#1a77c9 none repeat scroll 0 0
 }

--- a/plugins/tracklabels/action.php
+++ b/plugins/tracklabels/action.php
@@ -3,63 +3,93 @@
 require_once( dirname(__FILE__)."/../../php/util.php" );
 require_once( dirname(__FILE__)."/../../php/Snoopy.class.inc" );
 
-ignore_user_abort(true);
-set_time_limit(0);
-
-if(isset($_REQUEST["label"]))
+function try_send_image($image_name, $mime = 'image/png')
 {
-	$label = function_exists('mb_strtolower')
-		? mb_strtolower(rawurldecode($_REQUEST["label"]), 'utf-8')
-		: strtolower(rawurldecode($_REQUEST["label"]));
-	$name = FileUtil::getSettingsPath().'/labels';
-	if(!is_dir($name))
-		FileUtil::makeDirectory($name);
-	$name.=('/'.$label.".png");
-	if(is_readable($name))
-	{
-		SendFile::send( $name, "image/png" );
-		exit;
-	}
-	$name = dirname(__FILE__)."/labels/".$label.".png";
-	if(is_readable($name))
-	{
-		SendFile::send( $name, "image/png" );
+	if (is_readable($image_name)) {
+		SendFile::send($image_name, $mime);
 		exit;
 	}
 }
 
-if(isset($_REQUEST["tracker"]))
+function bad($message) {
+	http_response_code(400);
+	echo $message;
+	exit;
+}
+
+$basepath = realpath(FileUtil::getSettingsPath());
+
+function image_name($prefix, $req_field)
 {
-	$tracker = rawurldecode($_REQUEST["tracker"]);
-	$name = dirname(__FILE__)."/trackers/".$tracker.".png";
-	if(is_readable($name))
-	{
-		SendFile::send( $name, "image/png" );
-		exit;
+	global $basepath;
+	$res = null;
+	if (isset($_REQUEST[$req_field])) {
+		$dir = $basepath . '/' . $prefix;
+		if (!is_dir($dir))
+			FileUtil::makeDirectory($dir);
+		$name = function_exists('mb_strtolower')
+			? mb_strtolower(rawurldecode($_REQUEST[$req_field]), 'utf-8')
+			: strtolower(rawurldecode($_REQUEST[$req_field]));
+		$res = $dir . '/' . $name . '.png';
+		if (!strlen($name)
+			|| strlen($name) > 200
+			|| strpos($res, '/./') !== false
+			|| strpos($res, '/../') !== false
+			|| strpos($res, '//') !== false)
+			// restrict to sane sub-directory paths
+			bad('Invalid ' . $req_field . ': '.$name);
 	}
-	$name = FileUtil::getSettingsPath().'/trackers';
-	if(!is_dir($name))
-		FileUtil::makeDirectory($name);
-	$name.='/';
-	if(strlen($tracker))
-	{
-		$name.=$tracker;
-		$name.='.ico';
-		if(!is_readable($name))
-		{
+	return $res;
+}
+
+$png_name = image_name('labels', 'label');
+if ($png_name === null)
+	$png_name = image_name('trackers', 'tracker');
+
+if ($png_name !== null) {
+	$targetdir = dirname($png_name);
+	if (isset($_POST['delete'])) {
+		@unlink($png_name);
+		// delete empty sub-directories
+		while (Utility::str_starts_with(dirname($targetdir), $basepath.'/') && @rmdir($targetdir)) {
+			$targetdir = dirname($targetdir);
+		}
+		exit;
+	} else if (isset($_POST['upload'])) {
+		$filename = $_FILES['uploadfile']["name"];
+		$tempname = $_FILES['uploadfile']["tmp_name"];
+
+		if (!is_dir($targetdir))
+			FileUtil::makeDirectory($targetdir);
+		if (!is_dir($targetdir))
+			bad('Failed to create dir: ' . $targetdir);
+		if (mime_content_type($tempname) !== 'image/png')
+			bad('Only image/png supported!');
+		if (!move_uploaded_file($tempname, $png_name))
+			bad('Image upload failed!');
+		exit;
+	} else {
+		try_send_image($png_name);
+		try_send_image(dirname(__FILE__).substr($png_name, strlen($basepath)));
+
+
+		if (!isset($_REQUEST["label"]) && isset($_REQUEST["tracker"])) {
+			$tracker = basename($png_name, '.png');
+			$ico_name = $targetdir . '/' . $tracker . '.ico';
+			try_send_image($ico_name, 'image/x-icon');
+			try_send_image(dirname(__FILE__).substr($ico_name, strlen($basepath)), 'image/x-icon');
+
+			ignore_user_abort(true);
+			set_time_limit(0);
+
 			$url = Snoopy::linkencode("http://".$tracker."/favicon.ico");
 			$client = new Snoopy();
 			@$client->fetchComplex($url);
-			if($client->status==200)
-				file_put_contents($name,$client->results);
-		}
-		if(is_readable($name))
-		{
-			SendFile::send( $name, "image/x-icon" );
-			exit;
+			if ($client->status == 200)
+				file_put_contents($ico_name, $client->results);
+			try_send_image($ico_name, 'image/x-icon');
 		}
 	}
 }
 
-// If we can't find an image, send a generic unknown image and cache for 30 days
-SendFile::sendCachedImage("./trackers/unknown.png", "image/png", "2592000");
+SendFile::send('./trackers/unknown.png', 'image/png');

--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -12,13 +12,8 @@ theWebUI.config = function()
 		plugin.config.call(this);
 		plugin.reqId = theRequestManager.addRequest("trk", null, function(hash,tracker,value)
 		{
-			var domain = theWebUI.getTrackerName( tracker.name );
-			tracker.icon = "trk"+domain.replace(/\./g, "_");
-			if(!plugin.injectedStyles[tracker.icon])
-			{
-				plugin.injectedStyles[tracker.icon] = true;
-				injectCSSText( "."+tracker.icon+" {background-image: url(./plugins/tracklabels/action.php?tracker="+domain+"); background-repeat: no-repeat; background-size: 16px 16px; }\n" );
-			}
+			const domain = theWebUI.getTrackerName( tracker.name );
+			tracker.icon = domain ? {src: plugin.imageURI('tracker', domain)} : 'Status_Checking';
 		});
 	}
 }

--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -1,6 +1,7 @@
 
 theWebUI.trackersLabels = {};
 plugin.injectedStyles = {};
+plugin.loadLang();
 
 plugin.config = theWebUI.config;
 theWebUI.config = function()
@@ -81,11 +82,24 @@ if(!$type(theWebUI.getTrackerName))
 
 plugin.contextMenuEntries = theWebUI.contextMenuEntries;
 theWebUI.contextMenuEntries = function(labelType, el) {
-	if (labelType === 'ptrackers_cont') {
-		return plugin.canChangeMenu() ? [] : false;
+	const entries = plugin.contextMenuEntries.call(theWebUI, labelType, el);
+	if (plugin.canChangeMenu() && ['ptrackers_cont', 'plabel_cont'].includes(labelType)) {
+		const lbl = 'ptrackers_cont' === labelType ? el.id.substr(1) : theWebUI.idToLbl(el.id);
+		if (lbl)
+			return entries.concat([
+				[theUILang.EditIcon, `theWebUI.showTracklabelsDialog('${lbl}');`]
+			]);
 	}
-	return plugin.contextMenuEntries.call(theWebUI, labelType, el);
+	return entries;
 }
+
+
+theWebUI.showTracklabelsDialog = function(lbl) {
+	$(`#${plugin.dialogId} input[type=text]`).val(lbl);
+	theDialogManager.show(plugin.dialogId);
+}
+
+
 
 plugin.updateLabel = theWebUI.updateLabel;
 theWebUI.updateLabel = function(label, ...args)
@@ -97,7 +111,7 @@ theWebUI.updateLabel = function(label, ...args)
 	{
 		var lbl = theWebUI.idToLbl(id);
 		icon.append($("<img>")
-			.attr({ id: 'lbl_'+lbl, src: 'plugins/tracklabels/action.php?label='+lbl}))
+			.attr({ id: 'lbl_'+lbl, src: plugin.imageURI('label', lbl)}))
 			.css({ background: 'none' });
 	}
 }
@@ -117,95 +131,81 @@ theWebUI.updateLabels = function(wasRemoved)
 theWebUI.rebuildTrackersLabels = function()
 {
 	if(!plugin.allStuffLoaded)
-		setTimeout('theWebUI.rebuildTrackersLabels()',1000);
-	else
 	{
-		var table = this.getTable('trt');
-		var trackersLabels = new Object();
-		var trackersSizes = new Object();
-		var counted = new Object();
-		for(var hash in this.trackers)
-		{
-			if($type(this.torrents[hash]))
-			{
-			        this.torrents[hash].tracker = null;
-				counted[hash] = new Array();
-				for( var i=0; i<this.trackers[hash].length; i++)
-				{
-					if(this.trackers[hash][i].group==0)
-					{
-						var tracker = theWebUI.getTrackerName( this.trackers[hash][i].name );
-						if(tracker)
-						{
-							if(!this.torrents[hash].tracker)
-							{
-								this.torrents[hash].tracker = tracker;
-								if(plugin.canChangeColumns())
-									table.setValueById(hash, 'tracker', tracker);
-							}
-							if($.inArray(tracker, counted[hash]) == -1)
-							{
-								if($type(trackersLabels[tracker]))
-									trackersLabels[tracker]++;
-								else
-									trackersLabels[tracker] = 1;
-
-								if(!$type(trackersSizes[tracker]))
-									trackersSizes[tracker] = 0;
-								trackersSizes[tracker] += parseInt(this.torrents[hash].size);
-
-								counted[hash].push(tracker);
-							}
-						}
-					}
-				}
-			}
-		}
-		var ul = $("#torrl");
-
-		var lbls = Object.keys(trackersLabels);
-		lbls.sort();
-
-		let needTableFilter = false;
-		for(var lbl of lbls)
-		{
-			if(!(lbl in this.trackersLabels))
-			{
-				ul.append(theWebUI.createSelectableLabelElement('i'+lbl, lbl, theWebUI.labelContextMenu)
-					.addClass("tracker"));
-				$($$('i'+lbl)).children('.label-icon')
-					.append($("<img>").attr("src","plugins/tracklabels/action.php?tracker="+lbl))
-					.css({ background: 'none' });
-			}
-			theWebUI.updateLabel($$('i'+lbl), trackersLabels[lbl], trackersSizes[lbl], theWebUI.settings["webui.show_labelsize"]);
-			if(plugin.isActiveLabel(lbl)) {
-				const actLabel = $($$('i'+lbl));
-				if (!actLabel.hasClass('sel')) {
-					needTableFilter = true;
-					$('#ptrackers_cont').find('.sel').removeClass('sel');
-					$(actLabel).addClass("sel");
-				}
-			}
-		}
-		if (needTableFilter)
-			theWebUI.filterTorrentTable();
-		var needSwitch = false;
-		for(var lbl in this.trackersLabels)
-			if(!(lbl in trackersLabels))
-			{
-				$($$('i'+lbl)).remove();
-				if(plugin.isActiveLabel(lbl))
-					needSwitch = true;
-			}
-		this.trackersLabels = trackersLabels;
-		if(needSwitch)
-			theWebUI.resetLabels();
-		
-		setTimeout(plugin.refreshTrackerRows, 0);
+		setTimeout('theWebUI.rebuildTrackersLabels()',1000);
+		return;
 	}
+
+	const table = this.getTable('trt');
+	const colId = table.getColById('tracker');
+	const setTracker = plugin.canChangeColumns()
+		? ((hash, trk) => table.setValue(hash, colId, trk))
+		: () => {};
+	const countByTracker = {};
+	const sizeByTracker = {};
+	for(const [hash, torrent] of Object.entries(this.torrents))
+	{
+		const trackerNames = (this.trackers[hash] ?? [])
+			.filter(t => t.group == 0)
+			.map(t => theWebUI.getTrackerName(t.name))
+			.filter(name => Boolean(name));
+
+		const firstName = trackerNames[0] ?? null;
+		torrent.tracker = firstName;
+		if (firstName)
+		{
+			setTracker(hash, firstName);
+			const size = parseInt(torrent.size);
+			new Set(trackerNames).forEach( name => {
+				countByTracker[name] = (countByTracker[name] ?? 0) + 1;
+				sizeByTracker[name] = (sizeByTracker[name] ?? 0) + size;
+			});
+		}
+	}
+	const ul = $("#torrl");
+	const lbls = Object.keys(countByTracker);
+	lbls.sort();
+
+	let needTableFilter = false;
+	for(const lbl of lbls)
+	{
+		if(!(lbl in this.trackersLabels))
+		{
+			const labelEl = theWebUI.createSelectableLabelElement('i'+lbl, lbl, theWebUI.labelContextMenu)
+				.addClass('tracker');
+			labelEl.children('.label-icon')
+				.append($('<img>').attr('src', plugin.imageURI('tracker', lbl)))
+				.css({ background: 'none' });
+			ul.append(labelEl);
+		}
+		theWebUI.updateLabel($$('i'+lbl), countByTracker[lbl], sizeByTracker[lbl], theWebUI.settings["webui.show_labelsize"]);
+		if(plugin.isActiveLabel(lbl)) {
+			const actLabel = $($$('i'+lbl));
+			if (!actLabel.hasClass('sel')) {
+				needTableFilter = true;
+				$('#ptrackers_cont').find('.sel').removeClass('sel');
+				$(actLabel).addClass("sel");
+			}
+		}
+	}
+	if (needTableFilter)
+		theWebUI.filterTorrentTable();
+	let needSwitch = false;
+	for(const lbl in this.trackersLabels)
+		if(!(lbl in countByTracker))
+		{
+			$($$('i'+lbl)).remove();
+			if(plugin.isActiveLabel(lbl))
+				needSwitch = true;
+		}
+	this.trackersLabels = countByTracker;
+	if(needSwitch)
+		theWebUI.resetLabels();
+
+	setTimeout(plugin.refreshTrackerRows, 0);
 }
 
-plugin.refreshTrackerRows = async function()
+plugin.refreshTrackerRows = function()
 {
 	if(plugin.canChangeColumns())
 	{
@@ -216,19 +216,124 @@ plugin.refreshTrackerRows = async function()
 	}
 }
 
-theWebUI.initTrackersLabels = function()
+plugin.imageURI = function (target, label) {
+	return `plugins/tracklabels/action.php?${target}=${encodeURIComponent(label)}`;
+}
+
+plugin.onLangLoaded = function()
 {
-	plugin.addPaneToCategory("ptrackers",theUILang.Trackers).
-		append($("<ul></ul>").attr("id","torrl"));
+	if ('dialogId' in plugin)
+		return;
+	const eid = 'tracklabels-dialog'
+	plugin.dialogId = eid;
+	theDialogManager.make(plugin.dialogId, theUILang.Tracklabels_dialog,
+		$('<div>').addClass('cont').append(
+		$('<form>').addClass('optionColumn')
+		.attr({ enctype: 'multipart/form-data', method: 'post', action: 'javascript:;' })
+		.append(...[
+			[theUILang.FileUserIcon, 'uploadfile', 'file', { value: '', accept: '.png' }],
+			[theUILang.Label, 'label', 'text', { value: '', list: `${eid}-datalist`, class: 'TextboxLarge' }],
+		].map(([text, name, type, attribs]) => $('<div>').append(
+			$('<label>').attr('for', `${eid}-${name}`).text(text),
+			$('<input>').attr({ name, type, id: `${eid}-${name}`, ...attribs })
+		)),
+			$('<datalist>').attr('id', `${eid}-datalist`),
+			$('<div>').addClass('aright buttons-list').attr('style', 'margin-top: 10px')
+			.append(...[
+				[theUILang.UploadUserIcon, 'submit', 'OK Button', {}],
+				[theUILang.DeleteUserIcon, 'button', 'Button', {name: 'delete'}],
+				[theUILang.Cancel, 'button', 'Cancel Button', {}],
+			].map(([value, type, cls, attribs]) => $('<input>')
+				.attr({value, type, class: cls, ...attribs})
+			))))[0].outerHTML
+	);
+	const submitBtn = $(`#${eid} input[type=submit]`);
+	const delBtn = $(`#${eid} input[name=delete]`);
+	const labelTxt = $(`#${eid}-label`);
+	const formEl = $(`#${eid} form`)[0];
 
-	var ul = $("#torrl");
-	ul.append(theWebUI.createSelectableLabelElement(undefined, theUILang.All, theWebUI.labelContextMenu).addClass('-_-_-all-_-_- sel'));
+	const validFormData = (del) => {
+		const label = labelTxt.val();
+		const formData = new FormData(formEl);
+		const valid = label && (del || formData.get('uploadfile')?.size);
+		const trackerTarget = label.includes('.') && !label.includes('/');
+		if (valid) {
+			if (trackerTarget) {
+				formData.delete('label');
+				formData.set('tracker', label);
+			}
+			if (del) {
+				formData.delete('uploadfile');
+				formData.set('delete', 'on');
+			} else {
+				formData.set('upload', 'on');
+			}
+		}
+		return valid ? formData : null;
+	};
 
-	plugin.markLoaded();
+	const updateButtons = () => {
+		submitBtn.prop('disabled', !validFormData(false));
+		delBtn.prop('disabled', !validFormData(true));
+	};
+	labelTxt.keyup(updateButtons).change(updateButtons);
+	$(`#${eid} input[name=uploadfile]`).change(updateButtons);
+
+	const sendForm = (del) => {
+		const formData = validFormData(del);
+		const valid = Boolean(formData);
+		if (valid) {
+			submitBtn.prop('disabled', true);
+			const trkTarget = formData.has('tracker');
+			const target = trkTarget ? 'tracker' : 'label';
+			const label = formData.get(target);
+			const uri = plugin.imageURI(target, label);
+			formData.delete(target);
+			const request = new XMLHttpRequest();
+			request.onloadend = () => {
+				if (request.status === 200) {
+					// hide dialog if upload successful
+					theDialogManager.hide(plugin.dialogId);
+					// show uploaded image
+					const el = $($$((trkTarget ? 'i' : 'lbl_')+label));
+					const img = trkTarget ? el.find('img') : el;
+					img.attr('src', `${uri}&t=${new Date().getTime()}`);
+				} else {
+					noty(`Icon edit failed! ${request.response}`, 'error');
+				}
+				submitBtn.prop('disabled', false);
+			};
+			// successful POST invalidates cache for URI: see https://www.rfc-editor.org/rfc/rfc7234#section-4.4
+			request.open('POST', uri);
+			request.send(formData);
+		}
+		return valid;
+	};
+	$(`#${eid} form`).submit(() => sendForm(false));
+	delBtn.click(() => sendForm(true))
+
+	theDialogManager.setHandler(plugin.dialogId, 'beforeShow', function()
+	{
+		$(`#${eid}-datalist`).empty().append(
+			...Object.keys(theWebUI.cLabels).concat(Object.keys(theWebUI.trackersLabels))
+			.map(lbl => $('<option>').attr('value', lbl))
+		);
+		updateButtons();
+	});
+
+	plugin.addPaneToCategory("ptrackers",theUILang.Trackers, 'flabel_cont')
+		.append(
+			$('<ul>').attr('id', 'torrl')
+			.append(theWebUI.createSelectableLabelElement(undefined, theUILang.All, theWebUI.labelContextMenu).addClass('-_-_-all-_-_- sel'))
+		);
 };
 
 plugin.onRemove = function()
 {
+	if ('dialogId' in plugin) {
+		$(`#${plugin.dialogId}`).remove();
+		plugin.dialogId = undefined;
+	}
 	plugin.removePaneFromCategory('ptrackers');
 	theWebUI.resetLabels();
 	if(plugin.canChangeColumns())
@@ -236,8 +341,6 @@ plugin.onRemove = function()
 		theWebUI.getTable("trt").removeColumnById("tracker");
 		if(thePlugins.isInstalled("rss"))
 			theWebUI.getTable("rss").removeColumnById("tracker");
-		theRequestManager.removeRequest('trk',plugin.reqId);
 	}
 }
 
-theWebUI.initTrackersLabels();

--- a/plugins/tracklabels/lang/cs.js
+++ b/plugins/tracklabels/lang/cs.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/da.js
+++ b/plugins/tracklabels/lang/da.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/de.js
+++ b/plugins/tracklabels/lang/de.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/el.js
+++ b/plugins/tracklabels/lang/el.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/en.js
+++ b/plugins/tracklabels/lang/en.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/es.js
+++ b/plugins/tracklabels/lang/es.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/fi.js
+++ b/plugins/tracklabels/lang/fi.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/fr.js
+++ b/plugins/tracklabels/lang/fr.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/hu.js
+++ b/plugins/tracklabels/lang/hu.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/it.js
+++ b/plugins/tracklabels/lang/it.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/ko.js
+++ b/plugins/tracklabels/lang/ko.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/lv.js
+++ b/plugins/tracklabels/lang/lv.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/nl.js
+++ b/plugins/tracklabels/lang/nl.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/no.js
+++ b/plugins/tracklabels/lang/no.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/pl.js
+++ b/plugins/tracklabels/lang/pl.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/pt.js
+++ b/plugins/tracklabels/lang/pt.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/ru.js
+++ b/plugins/tracklabels/lang/ru.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/sk.js
+++ b/plugins/tracklabels/lang/sk.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/sr.js
+++ b/plugins/tracklabels/lang/sr.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/sv.js
+++ b/plugins/tracklabels/lang/sv.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/tr.js
+++ b/plugins/tracklabels/lang/tr.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/uk.js
+++ b/plugins/tracklabels/lang/uk.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/vi.js
+++ b/plugins/tracklabels/lang/vi.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/zh-cn.js
+++ b/plugins/tracklabels/lang/zh-cn.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();

--- a/plugins/tracklabels/lang/zh-tw.js
+++ b/plugins/tracklabels/lang/zh-tw.js
@@ -1,0 +1,8 @@
+
+ theUILang.Tracklabels_dialog = "Upload icon for tracker or label";
+ theUILang.DeleteUserIcon = "Delete";
+ theUILang.FileUserIcon = "PNG file";
+ theUILang.UploadUserIcon = "Upload";
+ theUILang.EditIcon = "Edit icon";
+
+thePlugins.get("tracklabels").langLoaded();


### PR DESCRIPTION
Add an `Edit icon` entry to the context menu of labels in `ptrackers_cont` (also in `plabel_cont` with https://github.com/Novik/ruTorrent/pull/2393) which opens up an upload dialog:
![tracklabels-icon-upload](https://user-images.githubusercontent.com/83290594/215333331-110831df-f785-4d68-b403-4d31d2cc3eb0.png)


`plugins/tracklabels/action.php` first looks for `share/users/${USR}/settings/{labels,trackers}/${LABEL}.png` then for `plugins/tracklabels/{labels,trackers}/${LABEL}.png` (for trackers: looks also for `.ico`)
Sub-directories for labels are automatically created and deleted.
- `addPaneToCategory` is adjusted to ensure that `ptrackers_cont` is inserted after `flabels_cont` 
- to see updated icon, caching with `sendCachedImage` for 30 days is removed