### PR TITLE
specify lang of document

### DIFF
--- a/lang/langs.js
+++ b/lang/langs.js
@@ -92,4 +92,8 @@ function SetActiveLanguage(lang)
 	document.cookie = "Language="+ lang + expires +"; path=/";
 }
 
-document.write("<script type=\"text/javascript\" src=\"./lang/"+GetActiveLanguage()+".js\"></script>");
+{
+	const lang = GetActiveLanguage();
+	document.documentElement.setAttribute('lang', lang);
+	document.write(`<script type="text/javascript" src="./lang/${lang}.js"></script>`);
+}


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform lists some language-specific rules that are not applied if the language is not specified.

This issue was pointed out by #2407

> In Greek (el), vowels lose their accent when the whole word is in uppercase (ά/Α), except for the disjunctive eta (ή/Ή). Also, diphthongs with an accent on the first vowel lose the accent and gain a diaeresis on the second vowel (άι/ΑΪ).

The language can be specified  

globally `<html lang="el">...` (with `document.documentElement.setAttribute('lang', lang);`) 

or locally `<span lang="el">...`.
