### PR TITLE
Add option for RSS sanitization level

### DIFF
--- a/js/sanitize.config.js
+++ b/js/sanitize.config.js
@@ -2,6 +2,8 @@ if(!Sanitize.Config) {
   Sanitize.Config = {}
 }
 
+Sanitize.Config.Levels = ['RESTRICTED', 'BASIC', 'RELAXED'];
+
 Sanitize.Config.RESTRICTED = {
   elements: [
      'a', 'b', 'blockquote', 'br', 'cite', 'code', 'dd', 'dl', 'dt', 'em',
@@ -10,10 +12,7 @@ Sanitize.Config.RESTRICTED = {
 }
 
 Sanitize.Config.BASIC = {
-  elements: [
-     'a', 'b', 'blockquote', 'br', 'cite', 'code', 'dd', 'dl', 'dt', 'em',
-     'i', 'li', 'ol', 'p', 'pre', 'q', 'small', 'strike', 'strong', 'sub',
-     'sup', 'u', 'ul'],
+  ...Sanitize.Config.RESTRICTED,
 
    attributes: {
      'a'         : ['href'],
@@ -22,7 +21,7 @@ Sanitize.Config.BASIC = {
    },
 
    add_attributes: {
-     'a': {'rel': 'nofollow'}
+     'a': {'rel': 'noreferrer noopener', 'target': '_blank' }
    },
 
    protocols: {
@@ -33,31 +32,32 @@ Sanitize.Config.BASIC = {
 }
 
 Sanitize.Config.RELAXED = {
+  ...Sanitize.Config.BASIC,
   elements: [
-    'a', 'b', 'blockquote', 'br', 'caption', 'cite', 'code', 'col',
-    'colgroup', 'dd', 'dl', 'dt', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-    'i', 'img', 'li', 'ol', 'p', 'pre', 'q', 'small', 'strike', 'strong',
-    'sub', 'sup', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'u',
-    'ul'],
+    ...Sanitize.Config.BASIC.elements,
+    'caption', 'col', 'colgroup', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'img', 'table', 'tbody', 'td', 'tfoot', 'th', 'thead', 'tr', 'ul'],
 
   attributes: {
+    ...Sanitize.Config.BASIC.attributes,
     'a'         : ['href', 'title'],
-    'blockquote': ['cite'],
     'col'       : ['span', 'width'],
     'colgroup'  : ['span', 'width'],
     'img'       : ['align', 'alt', 'height', 'src', 'title', 'width'],
     'ol'        : ['start', 'type'],
-    'q'         : ['cite'],
     'table'     : ['summary', 'width'],
     'td'        : ['abbr', 'axis', 'colspan', 'rowspan', 'width'],
     'th'        : ['abbr', 'axis', 'colspan', 'rowspan', 'scope', 'width'],
     'ul'        : ['type']
   },
 
+   add_attributes: {
+    ...Sanitize.Config.BASIC.add_attributes,
+     'img': {'referrerpolicy': 'no-referrer' }
+   },
+
   protocols: {
-    'a'         : {'href': ['ftp', 'http', 'https', 'mailto', Sanitize.RELATIVE]},
-    'blockquote': {'cite': ['http', 'https', Sanitize.RELATIVE]},
+    ...Sanitize.Config.BASIC.protocols,
     'img'       : {'src' : ['http', 'https', Sanitize.RELATIVE]},
-    'q'         : {'cite': ['http', 'https', Sanitize.RELATIVE]}
   }
 }

--- a/plugins/rss/action.php
+++ b/plugins/rss/action.php
@@ -14,7 +14,7 @@ switch($cmd)
 {
 	case "setsettings":
 	{
-		$mngr->setSettings($_REQUEST['interval'], $_REQUEST['delayerrui']);
+		$mngr->setSettings($_REQUEST['interval'], $_REQUEST['delayerrui'], $_REQUEST['relaxsanitization']);
 	}
 	case "getsettings":
 	{

--- a/plugins/rss/lang/cs.js
+++ b/plugins/rss/lang/cs.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/da.js
+++ b/plugins/rss/lang/da.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/de.js
+++ b/plugins/rss/lang/de.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Alle Filter";
  theUILang.rssUpdateInterval		= "Aktualisierungsintervall";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Verzeichnisse";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/el.js
+++ b/plugins/rss/lang/el.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Όλα τα φίλτρα";
  theUILang.rssUpdateInterval		= "Μεσοδιάστημα ανανέωσης";
  theUILang.rssShowErrorsDelayed		= "Καθυστέρηση της ειδοποίησης για σφάλματα RSS μέχρι η καρτέλα καταγραφής σφαλμάτων ή η τροφοδοσία RSS να είναι ορατά";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Φάκελοι";
  theUILang.Labels			= "Ετικέτες";
 

--- a/plugins/rss/lang/en.js
+++ b/plugins/rss/lang/en.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/es.js
+++ b/plugins/rss/lang/es.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Todos los filtros";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/fi.js
+++ b/plugins/rss/lang/fi.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/fr.js
+++ b/plugins/rss/lang/fr.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Tous les filtres";
  theUILang.rssUpdateInterval		= "Intervalle de mise à jour";
  theUILang.rssShowErrorsDelayed		= "Retarder les notifications d'erreurs RSS jusqu'a ce que l'onglet journal ou le flux RSS soit visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Annuaires";
  theUILang.Labels			= "Étiquettes";
 

--- a/plugins/rss/lang/hu.js
+++ b/plugins/rss/lang/hu.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/it.js
+++ b/plugins/rss/lang/it.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Tutti i filtri";
  theUILang.rssUpdateInterval		= "Intervallo di aggiornamento";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Cartelle";
  theUILang.Labels			= "Etichette";
 

--- a/plugins/rss/lang/ko.js
+++ b/plugins/rss/lang/ko.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "모든 필터";
  theUILang.rssUpdateInterval		= "업데이트 주기";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "디렉토리";
  theUILang.Labels			= "라벨";
 

--- a/plugins/rss/lang/lv.js
+++ b/plugins/rss/lang/lv.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/nl.js
+++ b/plugins/rss/lang/nl.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Alle filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/no.js
+++ b/plugins/rss/lang/no.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Alle filtre";
  theUILang.rssUpdateInterval		= "Oppdateringsintervall";
  theUILang.rssShowErrorsDelayed		= "Utsett varsling om feil på RSS inntil logg eller RSS-feed er synlig";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Mapper";
  theUILang.Labels			= "Etiketter";
 

--- a/plugins/rss/lang/pl.js
+++ b/plugins/rss/lang/pl.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Wszystkie filtry";
  theUILang.rssUpdateInterval		= "Aktualizuj co";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Katalogi";
  theUILang.Labels			= "Etykiety";
 

--- a/plugins/rss/lang/pt.js
+++ b/plugins/rss/lang/pt.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/ru.js
+++ b/plugins/rss/lang/ru.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Все фильтры";
  theUILang.rssUpdateInterval		= "Интервал обновления";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Директории";
  theUILang.Labels			= "Метки";
 

--- a/plugins/rss/lang/sk.js
+++ b/plugins/rss/lang/sk.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/sr.js
+++ b/plugins/rss/lang/sr.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/sv.js
+++ b/plugins/rss/lang/sv.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Alla filter";
  theUILang.rssUpdateInterval		= "Uppdateringsintervall";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Mappar";
  theUILang.Labels			= "Etiketter";
 

--- a/plugins/rss/lang/tr.js
+++ b/plugins/rss/lang/tr.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/lang/uk.js
+++ b/plugins/rss/lang/uk.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Усі фільтри";
  theUILang.rssUpdateInterval		= "Інтервал оновлення";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Директорії";
  theUILang.Labels			= "Мітки";
 

--- a/plugins/rss/lang/vi.js
+++ b/plugins/rss/lang/vi.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "Tất cả bộ lọc";
  theUILang.rssUpdateInterval		= "Cập nhật sau mỗi";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Các thư mục";
  theUILang.Labels			= "Các nhãn";
 

--- a/plugins/rss/lang/zh-cn.js
+++ b/plugins/rss/lang/zh-cn.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "增加过滤器";
  theUILang.rssUpdateInterval		= "更新间隔";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "文件夹";
  theUILang.Labels			= "标签";
 

--- a/plugins/rss/lang/zh-tw.js
+++ b/plugins/rss/lang/zh-tw.js
@@ -74,6 +74,8 @@
  theUILang.rssAllFiters			= "All filters";
  theUILang.rssUpdateInterval		= "Update interval";
  theUILang.rssShowErrorsDelayed		= "Delay RSS error notification until the log tab or RSS feed is visible";
+ theUILang.rssSanitizationLevel		= "Show external RSS content";
+ theUILang.rssSanitizationLevels	= {RESTRICTED: "Restricted (no links or images)", BASIC: "Basic (no images)", RELAXED: "Relaxed"};
  theUILang.Directories			= "Directories";
  theUILang.Labels			= "Labels";
 

--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -728,6 +728,7 @@ class rRSSData
 	public $hash = "data";
 	public $interval = 30;
 	public $delayErrorsUI = true;
+	public $relaxSanitization = 0;
 }
 
 class rRSSManager
@@ -751,7 +752,7 @@ class rRSSManager
 		$this->data = new rRSSData();
 		$this->cache->get($this->data);
 	}
-	public function setSettings($interval, $delay_err_ui)
+	public function setSettings($interval, $delay_err_ui, $relax_sanitization)
 	{
 		// setInterval
 		global $minInterval;
@@ -762,6 +763,7 @@ class rRSSManager
 		$this->data->interval = $interval;
 		// set delay ui errors
 		$this->data->delayErrorsUI = (bool) $delay_err_ui;
+		$this->data->relaxSanitization = $relax_sanitization;
 		$this->cache->set($this->data);
 		$this->setHandlers();
 	}
@@ -1004,7 +1006,8 @@ class rRSSManager
 		return([
 			"next"=>$nextTouch,
 			"interval"=>$this->data->interval,
-			"delayerrui"=>$this->data->delayErrorsUI
+			"delayerrui"=>$this->data->delayErrorsUI,
+			"relaxsanitization"=>$this->data->relaxSanitization
 		]);
 	}
 	public function get()


### PR DESCRIPTION
@stickz Here you go. https://github.com/Novik/ruTorrent/pull/2428#issuecomment-1369376889

Additionally, I included Novik's `noreferrer` suggestion https://github.com/Novik/ruTorrent/issues/2426#issuecomment-1368454942. This problem is also addressed here: https://developer.mozilla.org/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns#how_can_we_fix_this

**Idea**: some users want to have a less restricted view as in #2426.
This PR makes the sanitization levels (`RESTRICTED`, `BASIC`, `RELAXED`) available to the user.

*WIP*: security requirements are unclear (possibly completely different sanitization profiles required)