### PR TITLE
Let table scrollbar start at first row instead of header row

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -93,7 +93,7 @@ div#CatList ul li div { margin-right: 0.5em; }
 div#CatList .label-prefix { flex: 0 0 auto; display: flex; flex-flow: row nowrap; opacity: 0.1; font-family: monospace; font-size: 19px; margin-left: -2px; margin-right: 2px; }
 div#CatList .label-prefix div { margin-right: 0px; width: 12px; }
 .label-icon { min-width: 16px; min-height: 16px; background-image: url(../images/tstatus.png); background-repeat: no-repeat; }
-.label-icon img { width: 16px; }
+.label-icon img { width: 16px; height: 16px; }
 .-_-_-all-_-_- .label-icon, #-_-_-all-_-_- .label-icon {background-position: 0px -176px;}
 #-_-_-dls-_-_- .label-icon {background-position: 0px 0px;}
 #-_-_-com-_-_- .label-icon {background-position: 0px -16px;}

--- a/js/stable.js
+++ b/js/stable.js
@@ -337,7 +337,7 @@ dxSTable.prototype.calcSize = function()
 	if(this.created && this.dCont.offsetWidth >= 4) 
 	{
 		this.dBody.style.width = this.dCont.offsetWidth - 2 + "px";
-		this.dBody.style.paddingTop = this.dHead.offsetHeight + "px";
+		this.dBody.style.marginTop = this.dHead.offsetHeight + "px";
 		this.tBody.style.width = this.tHead.offsetWidth + "px";
 		var h = this.dCont.clientHeight - this.dHead.offsetHeight;
 		if(h >= 0) 


### PR DESCRIPTION
- With `paddingTop` the table scrollbar intersects with table header row:
![before](https://user-images.githubusercontent.com/83290594/215334293-3698ae02-0b1f-44b2-97c3-037f24580c2d.png)
- With `marginTop` this is not the case and it is easier to tell when the top row is reached:
![after](https://user-images.githubusercontent.com/83290594/215334304-4db100ba-6a0d-48ea-8423-bd9df65888e9.png)
- Non-square label icons are stretched to fit `16x16 px`