### PR TITLE
MaterialDesign: Fix TR_HEIGHT

### DIFF
--- a/plugins/theme/themes/MaterialDesign/init.js
+++ b/plugins/theme/themes/MaterialDesign/init.js
@@ -5,6 +5,8 @@
  *  Author: Phlo
  */ 
 
+TR_HEIGHT = 22
+
 plugin.materialdesignAllDone = plugin.allDone;
 plugin.allDone = function()
 {


### PR DESCRIPTION
`stable.js` uses the table row height `TR_HEIGHT` to determine the padding height when scrolling. Since the material design uses a row height of `22px`, the scrolling was slightly unstable. 