### PR TITLE
MaterialDesign: Add row hover and move cpuload icon

### DIFF
--- a/plugins/cpuload/cpuload.css
+++ b/plugins/cpuload/cpuload.css
@@ -1,3 +1,3 @@
 #meter-cpu-text { position: absolute; left: 40px; top: 0px; font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif }
-#meter-cpu-holder { width: 100px; height: 19px; line-height: 19px; margin-left: 25px; }
-#meter-cpu-td { background: url(./images/cpu.png) 5px no-repeat; }
+#meter-cpu-holder { width: 100px; height: 19px; line-height: 19px; }
+#meter-cpu-td { display: block; width: 16px; height: 16px; background: url(./images/cpu.png) 0px no-repeat; }

--- a/plugins/cpuload/init.js
+++ b/plugins/cpuload/init.js
@@ -94,9 +94,7 @@ class rLoadGraph {
     const startSeconds = this.seconds - this.maxSeconds;
     this.load.data.splice(
       0,
-      this.load.data.findIndex(
-        ([_, sec]) => sec >= startSeconds
-      )
+      this.load.data.findIndex(([_, sec]) => sec >= startSeconds)
     );
     this.draw();
   }
@@ -121,8 +119,17 @@ plugin.init = function () {
     plugin.prgStartColor = new RGBackground("#99D699");
     plugin.prgEndColor = new RGBackground("#E69999");
     plugin.addPaneToStatusbar(
-      "meter-cpu-td",
-      $("<div>").attr("id", "meter-cpu-holder").get(0)
+      "meter-cpu-pane",
+      $("<table>")
+        .append(
+          $("<tbody>").append(
+            $("<tr>").append(
+              $("<td>").attr("id", "meter-cpu-td"),
+              $("<td>").append($("<div>").attr("id", "meter-cpu-holder"))
+            )
+          )
+        )
+        .get(0)
     );
     plugin.graph = new rLoadGraph();
     plugin.graph.create($("#meter-cpu-holder"));
@@ -133,7 +140,7 @@ plugin.init = function () {
 };
 
 plugin.onRemove = function () {
-  plugin.removePaneFromStatusbar("meter-cpu-td");
+  plugin.removePaneFromStatusbar("meter-cpu-pane");
   theRequestManager.removeRequest("ttl", plugin.reqId);
 };
 

--- a/plugins/theme/themes/DarkBetter/plugins.css
+++ b/plugins/theme/themes/DarkBetter/plugins.css
@@ -7,7 +7,7 @@
 .Cell0 {border: 1px dotted #888888}
 
 #meter-disk-td {background: url(./images/disk.svg) no-repeat !important; background-size: 22px !important}
-#meter-cpu-td {background: url(./images/cpu.svg) no-repeat !important; background-size: 22px !important}
+#meter-cpu-td {width: 22px; height: 22px; background: url(./images/cpu.svg) no-repeat !important; background-size: 22px !important}
 
 div#dlg_unpack div.dlg-header, div#cadd div.dlg-header { background: transparent url(./images/edit.svg) no-repeat 2px center !important; background-size: 20px !important}
 

--- a/plugins/theme/themes/MaterialDesign/plugins.css
+++ b/plugins/theme/themes/MaterialDesign/plugins.css
@@ -20,9 +20,9 @@
 #meter-disk-text, #qmeter-disk-text, #meter-band-text { color: #fff; text-shadow: 0px 0px 2px #000; position: relative; text-align: left; float: left; width: 0px; height: 0px; overflow: visible; left: 40%; font-size: 11px; font-family: Ubuntu; z-index: 1; }
 #meter-disk-holder, #qmeter-disk-holder, #meter-band-holder { width: 100px; height: 16px; line-height: 16px; border-right: none; padding-left: 25px; margin-left: 0px; background: url(./images/status_icons.png) no-repeat 3px -336px; }
 
-#meter-cpu-text { position: absolute; left: 65px; top: 0px; color: #fff; text-shadow: 0px 0px 2px #000; font-size: 11px; font-family: Ubuntu; }
-#meter-cpu-holder { width: 100px; height: 16px; line-height: 16px; border-right: none; margin-left: 0px; padding-left: 25px; background: url(./images/status_icons.png) no-repeat 3px -320px; }
-#meter-cpu-td {}
+#meter-cpu-text { color: #fff; text-shadow: 0px 0px 2px #000; font-family: Ubuntu; }
+#meter-cpu-holder { height: 22px; }
+#meter-cpu-td { padding-right: 0px; margin-top: 4px; background: url(./images/status_icons.png) no-repeat 0px -320px !important; }
 
 div#tcreate div.dlg-header { background: #181818 url(./images/dlg-toolbars.gif) no-repeat 0px -24px; border-bottom: 1px solid #333333; text-shadow: 0px -1px 0px #000; }
 div#dlgAddRSS { background-color: #222222; border-top: 1px solid #333; border-right: 1px solid #1b1b1b; border-left: 1px solid #1b1b1b; border-bottom: 1px solid #000000; }

--- a/plugins/theme/themes/MaterialDesign/stable.css
+++ b/plugins/theme/themes/MaterialDesign/stable.css
@@ -15,16 +15,17 @@ div#tdcont .stable { border: none; }
 .stable-head table tr td { border: none; font-family: Ubuntu; height: 18px; line-height: 18px; cursor: pointer; }
 .stable-head div.resz { border: 1px solid #FF0000; background: transparent url(./images/s.gif) no-repeat scroll left center; }
 .stable-body { background: window; text-shadow: 0px 1px 0px #000; color: #CACCCC; }
-.stable-body td { border-bottom: 1px solid #333333; }
+.stable-body td { border-bottom: 1px solid #252525; }
 .stable-body td div { font-family: Ubuntu, Verdana, Arial, Helvetica, sans-serif; height: 16px !important; }
-.stable-body tr.odd td { background: #333333 }
-.stable-body tr.even td { background: #191919 }
+.stable-body tr.odd td { background-color: #2A2A2A; }
+.stable-body tr.even td { background-color: #252525; }
+.stable-body tr.odd:hover td { background-color: #222222; }
+.stable-body tr.even:hover td { background-color: #1D1D1D; }
 .stable-body tr { height: 22px; }
 .stable-body { background: #181818 }
-.stable-body tr.selected td{ background: #000 url(./images/headers.png) repeat-x 0px 0px; color: #009DDD; text-shadow: 0px -1px 0px #000; }
-div.stable-body table tbody tr.even td { background: #181818 url(./images/headers.png) repeat-x 0px -37px; }
+.stable-body tr.selected td{ background-color: #191919; color: #009DDD; text-shadow: 0px -1px 0px #000; }
+.stable-body tr.selected:hover td{ background-color: #111111; }
 div.stable-body table tbody tr.even td:nth-child(2n+1) { color: #ffffff; }
-div.stable-body table tbody tr.even:nth-child(2n+1) td { background: #181818 url(./images/headers.png) repeat-x 0px -64px; }
 .stable-move-header { background: transparent url(./images/header_move.gif) repeat-x scroll center top; border: 1px solid #0099FF; }
 
 .stable-move-header { background: transparent url(./images/header_move.gif) repeat-x scroll center top rgba(128,128,128,0.7); border: 1px solid #0099FF; }
@@ -37,7 +38,7 @@ div.stable-body table tbody tr.even:nth-child(2n+1) td { background: #181818 url
 .stable-scrollpos { background: #181818 url(./images/headers.png) repeat-x 0px -37px; height: 17px; line-height: 17px; border-bottom: 1px solid #333333; }
 .stable-scrollpos:nth-child(2n+1) { background: #181818 url(./images/headers.png) repeat-x 0px -64px; }
 
-.meter-value { float: left; border: 1px inset #1b1b1b; border-bottom: none; background: #96CE00 url(./images/headers.png) repeat-x 0px -138px; }
+.meter-value { border: 0px; border-radius: 0.8em; }
 .stable-body tr.selected span.meter-value { color: #fff; }
 .meter-text { line-height: 16px; position: relative; text-align: left; float: left; width: 0px; height: 0px; overflow: visible; left: 40%; font-size: 11px; font-family: Ubuntu; z-index: 1; text-shadow: 0px 0px 2px #000; }
 

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -430,9 +430,6 @@ div#CatList
 	border-left:none
 }
 
-
-
-
 div#CatList ul li
 {
 	color:#FFF;
@@ -1146,22 +1143,10 @@ div#lcont div.std:nth-child(2n+1)
 	font-family:Roboto
 }
 
-#StatusBar table tr td
-{
-	padding-right:5px;
-	border:none;
-	background:transparent url(./images/headers.png) no-repeat right -208px
+.statuscell td:not(:last-child) {
+	padding-right: 5px;
 }
 
-#StatusBar table tr td td
-{
-	background:none
-}
-
-#StatusBar table tr td:last-child
-{
-	border-top:red
-}
 
 #st_up
 {

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -177,21 +177,6 @@ ul.CMenu li ul li a.dis:hover
 	color:#333
 }
 
-div.stable-body table tbody tr.even:nth-child(2n+1) td
-{
-	background:#252525!important
-}
-
-.stable-body td
-{
-	border-bottom:1px solid #252525!important
-}
-
-.stable-body tr.odd td
-{
-	background:#2A2A2A!important
-}
-
 #tdetails
 {
 	overflow:hidden
@@ -435,7 +420,13 @@ div#CatList ul li
 	color:#FFF;
 	border:none;
 	padding: 4px;
-	font-family:'Roboto'
+	font-family:'Roboto';
+	background-color: #1A2329;
+}
+
+div#CatList ul li:hover
+{
+	background-color: #161F25;
 }
 
 div#CatList .label-prefix
@@ -446,12 +437,17 @@ div#CatList .label-prefix
 
 div#CatList ul li.sel
 {
-	background-color:transparent;
+	background-color: #1A2329;
 	color:#009DDD;
 	text-shadow:0 -1px 0 #000;
 	border:none
 }
 
+
+div#CatList ul li.sel:hover
+{
+	background-color: #161F25;
+}
 div#CatList li.sel .label-prefix
 {
 	color:#FFF;

--- a/plugins/theme/themes/Oblivion/plugins.css
+++ b/plugins/theme/themes/Oblivion/plugins.css
@@ -6,7 +6,7 @@
 }
 
 #meter-cpu-text { color:#fff; text-shadow:0px 0px 2px #000; }
-#StatusBar table tr td#meter-cpu-td { background: url(./images/status_icons.png) no-repeat 3px -418px / 21px; }
+#StatusBar table tr td#meter-cpu-td { background: url(./images/status_icons.png) no-repeat 0px -418px / 21px; }
 
 div.graph_tab {color:#FFF;border-color: #000;}
 div#tcreate div.dlg-header {background: #181818 url(./images/dlg-toolbars.gif) no-repeat 0px -24px; border-bottom: 1px solid #333333;text-shadow:0px -1px 0px #000;}


### PR DESCRIPTION
Unlike the other StatusBar entries, the cpuload plugin used a `div` instead of a `table` element. This is an old issue which resulted in the material design theme looking like this:
![rutorrent_cpuload_before](https://user-images.githubusercontent.com/83290594/230212431-e2ae7969-0fc4-4f39-abdd-698a6e1f9fd1.png)

Now, it looks like this:
![rutorrent_cpuload_now](https://user-images.githubusercontent.com/83290594/230212457-aa2d531c-59df-4545-8e4a-3c6a0ae06d1c.png)

Additionally, I rounded the progress-bar and added a hover styling, inspired by the [club-QuickBox theme](https://github.com/TrimmingFool/club-QuickBox).