### PR TITLE
webui: Fix speed graph with removed tab

### DIFF
--- a/js/graph.js
+++ b/js/graph.js
@@ -128,6 +128,7 @@ class rGraph {
 
   draw(force = false) {
     if (
+      this.plot &&
       (force || !this.webuiView || theWebUI.activeView === this.webuiView) &&
       !this._animationRequestId
     ) {

--- a/js/webui.js
+++ b/js/webui.js
@@ -388,13 +388,14 @@ var theWebUI =
 			this.assignEvents();
 			this.resize();
 			this.update();
-			this.createSpeedGraph();
 		}
 	},
 	
 	createSpeedGraph: function()
 	{
-		this.speedGraph.create($("#Speed"));		
+		const speedTab = $("#Speed");
+		if (speedTab.length)
+			this.speedGraph.create(speedTab);
 	},
 
 	config: function()
@@ -461,6 +462,7 @@ var theWebUI =
 			}
 			return sorter;
 		}
+		this.createSpeedGraph();
 		const tab = theWebUI.settings['webui.selected_tab.keep'] ?
 					theWebUI.settings['webui.selected_tab.last'] : 'lcont';
 		theTabs.show(tab);


### PR DESCRIPTION
The speed graph did not expect the `#Speed` tab to be removed.

However, it is removed here: https://github.com/Novik/ruTorrent/blob/master/js/content.js#L731

Fixes: https://github.com/Novik/ruTorrent/issues/2492

https://github.com/Novik/ruTorrent/commit/0019e62b203f4f5b48e8306ede8cad67cd833d9a is not enough.