### PR TITLE
rss: Fix DOMDocument dependency check

### DIFF
--- a/plugins/rss/rss_reader.php
+++ b/plugins/rss/rss_reader.php
@@ -120,7 +120,7 @@ class RegexRSSReader
 
 function rssXpath($data)
 {
-	if (extension_loaded('libxml')) {
+	if (extension_loaded('dom') && extension_loaded('libxml')) {
 		$doc = new DOMDocument();
 		$doc->recover = true;
 		// note: as of php8 (libxml 2.9.0) entity substitution is disabled by default


### PR DESCRIPTION
Closes https://github.com/Novik/ruTorrent/issues/2496 Closes #2500.

@Frizlab You are probably missing the `dom` module which can be installed via the `php-xml` package.
Could you please confirm that this fix works for you?

1. Check `php -r 'echo extension_loaded("dom") ? "yes" : "no";'` says no and confirm that the feed updates correctly
2. Then install `php-xml`
3. Check that `php -r 'new DOMDocument();'` works and, again, confirm that the feed updates correctly 