### PR TITLE
Fix syntax error in langs.js

### DIFF
--- a/lang/langs.js
+++ b/lang/langs.js
@@ -47,7 +47,7 @@ var AvailableLanguages =
 	no:'Norsk',
 	pl:'Polski',
 	"pt-br":'Português (Brasil)',
-	"pt-pt":'Português (Portugal)'
+	"pt-pt":'Português (Portugal)',
 	ru:'Русский',
 	sk:'Slovenský',
 	sr:'Српски',


### PR DESCRIPTION
Fixed missing comma in `langs.js` preventing ruTorrent from loading in latest master.