### PR TITLE
Material design fixes

### DIFF
--- a/plugins/theme/themes/MaterialDesign/stable.css
+++ b/plugins/theme/themes/MaterialDesign/stable.css
@@ -8,13 +8,14 @@
 
 .stable { border: 1px solid; border-color: #333333 #181818 #181818 #333333; }
 .stable td { padding: 2px; }
+
 .stable-head { color: #626262; background: #181818 url(./images/headers.png) repeat-x 0px -91px; border: none; text-shadow: 0px 1px 0px #000; font-family: Ubuntu; }
 div#tdcont .stable-head { border: none; }
 div#tdcont .stable { border: none; }
 .stable-head table tr { background: transparent; border: none; }
 .stable-head table tr td { border: none; font-family: Ubuntu; height: 18px; line-height: 18px; cursor: pointer; }
 .stable-head div.resz { border: 1px solid #FF0000; background: transparent url(./images/s.gif) no-repeat scroll left center; }
-.stable-body { background: window; text-shadow: 0px 1px 0px #000; color: #CACCCC; }
+.stable-body { background: #181818; text-shadow: 0px 1px 0px #000; color: #CACCCC; }
 .stable-body td { border-bottom: 1px solid #252525; }
 .stable-body td div { font-family: Ubuntu, Verdana, Arial, Helvetica, sans-serif; height: 16px !important; }
 .stable-body tr.odd td { background-color: #2A2A2A; }
@@ -22,7 +23,6 @@ div#tdcont .stable { border: none; }
 .stable-body tr.odd:hover td { background-color: #222222; }
 .stable-body tr.even:hover td { background-color: #1D1D1D; }
 .stable-body tr { height: 22px; }
-.stable-body { background: #181818 }
 .stable-body tr.selected td{ background-color: #191919; color: #009DDD; text-shadow: 0px -1px 0px #000; }
 .stable-body tr.selected:hover td{ background-color: #111111; }
 div.stable-body table tbody tr.even td:nth-child(2n+1) { color: #ffffff; }
@@ -38,7 +38,12 @@ div.stable-body table tbody tr.even td:nth-child(2n+1) { color: #ffffff; }
 .stable-scrollpos { background: #181818 url(./images/headers.png) repeat-x 0px -37px; height: 17px; line-height: 17px; border-bottom: 1px solid #333333; }
 .stable-scrollpos:nth-child(2n+1) { background: #181818 url(./images/headers.png) repeat-x 0px -64px; }
 
-.meter-value { border: 0px; border-radius: 0.8em; }
+/* Workaround div.meter-value overflowing (due to `width: 100%`).
+ * Note for Firefox 103: `:has` selector needs `layout.css.has-selector.enabled` set to `true`. */
+.stable td:has(> .meter-value) { padding-right: 4px; }
+.stable-body td div.meter-value { margin: 0px !important; }
+
+.meter-value { border-width: 0px; border-radius: 0.8em; }
 .stable-body tr.selected span.meter-value { color: #fff; }
-.meter-text { line-height: 16px; position: relative; text-align: left; float: left; width: 0px; height: 0px; overflow: visible; left: 40%; font-size: 11px; font-family: Ubuntu; z-index: 1; text-shadow: 0px 0px 2px #000; }
+.meter-text { text-shadow: 0px 0px 2px #000; }
 

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -199,7 +199,7 @@ div#t
 	background-color:#273238;
 	background-image:none;
 	border-bottom:none;
-	padding:4px 0 2px 0;
+	padding:4px 0 2px 5px;
 	height: 40px;
 }
 
@@ -227,7 +227,7 @@ div#t div.TB_Separator
 
 div#t div#add
 {
-	background:transparent url(./images/toolbar.png) no-repeat 0 0
+	background:transparent url(./images/toolbar.png) no-repeat 0 1px;
 }
 
 div#t div#add:hover

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -737,6 +737,12 @@ div#tdcont
 	padding:0
 }
 
+table#maincont td.uicell {
+  overflow: hidden;
+  padding: 0;
+  vertical-align: top;
+}
+
 div#HDivider
 {
 	background:#141414;


### PR DESCRIPTION
The alignment of the `add` button is improved: 
![Fix-add-button-alignment](https://github.com/Novik/ruTorrent/assets/83290594/0912b385-7bdb-40bb-8f72-9bbafb31bdae)
and the percentage meter does not flow out of the cell, anymore:  
![Fix-meter-overflow](https://github.com/Novik/ruTorrent/assets/83290594/186820e9-1d4e-4525-a249-28b415614032)
(Unfortunately, the overflow will still be visible in Firefox if `layout.css.has-selector.enabled` is not `true`.)