### PR TITLE
webui: Add quick search

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 					<input type="text" class="TextboxMid" id="query" onfocus="$('#sc').hide();"/>
 				</td>
 				<td>
-					<a id="mnu_go" href="javascript://void();" onclick="theSearchEngines.run(); theSearchEngines.run(); return(false);" onfocus="this.blur()" title="Go">
+					<a id="mnu_go" href="javascript://void();" onclick="theSearchEngines.run(); return(false);" onfocus="this.blur()" title="Go">
 						<div id="go"></div>
 					</a>
 				</td>

--- a/js/common.js
+++ b/js/common.js
@@ -785,10 +785,11 @@ var theSearchEngines =
 
 	run: function()
 	{
-	        if(theSearchEngines.current>=0)
-			window.open(theSearchEngines.sites[theSearchEngines.current].url + $("#query").val(), "_blank");
+		const q = $("#query").val();
+		if(theSearchEngines.current >= 0)
+			window.open(theSearchEngines.sites[theSearchEngines.current].url + encodeURIComponent(q), "_blank");
 		else
-			theWebUI.setTeg($("#query").val());
+			theWebUI.setTeg(q);
 	},
 	set: function( no, noSave )
 	{

--- a/js/content.js
+++ b/js/content.js
@@ -24,7 +24,6 @@ function makeContent()
 		if(e.keyCode == 13)
 		{
 			theSearchEngines.run();
-			theSearchEngines.run();
 		}
 	});
 


### PR DESCRIPTION
Inspired by the [InstantSearch](https://github.com/Novik/ruTorrent/wiki/PluginInstantSearch) plugin, local torrents are searched immediately on `keydown`. As before, confirming the search by pressing `Enter` adds a new search teg.
When quick-searching, other search tegs are reset to `All`.

[webui: Add quick search](https://github.com/Novik/ruTorrent/commit/3bf66b0f4b22c8325abd60ae848376bd87c7d93a)

~~*Draft*: `master` should be merged into `develop` before merging this PR~~