### PR TITLE
PHP 5.x fixes

### DIFF
--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -242,7 +242,7 @@ class rRSS
 				}
 				$item = [
 					'title'=> $xText('title', $i),
-					'timestamp'=>strtotime($xText('updated', $i)) ?? false,
+					'timestamp'=>strtotime($xText('updated', $i)) ?: false,
 					'link'=> $urlPrefix.$xText('link/@href', $i),
 					'description'=> join("\n\n", $description),
 				];

--- a/plugins/rss/rss_reader.php
+++ b/plugins/rss/rss_reader.php
@@ -66,7 +66,7 @@ class RegexRSSReader
 	public function searchNodes($path, $ctx = null)
 	{
 		if (!is_array($path)) {
-			yield from $this->searchNodes(explode('/', $path), $ctx);
+			yield from ($this->searchNodes(explode('/', $path), $ctx));
 		} elseif (count($path) > 0) {
 			// find parent nodes
 			while (count($path) > 1) {
@@ -170,7 +170,7 @@ function rssXpath($data)
 		};
 		$xIter = function ($expr, &$ctx = null) use (&$regxSearch) {
 			foreach (explode('|', $expr) as $e)
-				yield from $regxSearch->searchNodes($e, $ctx);
+				yield from ($regxSearch->searchNodes($e, $ctx));
 		};
 		$errors = function () use (&$regxSearch) {
 			return $regxSearch->errors;


### PR DESCRIPTION
Found 2 small problems when running with PHP 5.6. I only found [one particular note](https://github.com/Novik/ruTorrent/wiki) about ruTorrent requiring only PHP5. If that has changed ignore this PR I suppose.

The RSS plugin had a big merge which incorporated the usage of `??`. This operator was newly added in PHP7. I switched this to the older style ternary operator `?:`.

There also seemed to be a problem (likely specific to PHP5 versions) which made the 2 yield expressions somewhat ambiguous to the parser. Adding parenthesis around them seems to allow them to be understood. RSS plugin now working as expected.