### PR TITLE
category-panel: Reorder panels with drag and drop

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -141,6 +141,8 @@ div#HDivider, div#VDivider { font-size: 0; }
 div#VDivider { width: 100%; height: 5px; padding: 0; margin: 0; cursor: n-resize; }
 div#dividerDrag { width: 5px; height: 5px; padding: 0; margin: 0; background: #A0A0A0; position: absolute; display: none }
 
+div#catpanelDrag { width: 5px; height: 5px; padding: 2px 21px; margin: 0; background: #A0A0A0; color: #fff; font-size: 11px; line-height: 16px; position: absolute; pointer-events: none; display: none; opacity: 0; transition-delay: 100ms; transition-property: opacity; }
+
 div#stg {width: 600px; height: 560px; position: absolute; left: 0px; top: 50px; display: none; overflow: visible}
 div#stg_c {overflow: hidden}
 div#stg-header { background-image: url(../images/settings.gif); }

--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
 		<table id="maincont" cellpadding="0" cellspacing="0" summary="layout table">
 			<tr>
 				<td class="uicell" rowspan="3">
+					<div id="catpanelDrag"></div>
 					<div id="CatList">
 						<div id="pview" class="catpanel" onclick="theWebUI.togglePanel(this); return(false);"><span uilang>pnlViews</span><input class="Button" type="button" value="+" uilangtitle="SaveCurrentView" id="pview_save_view_button" onclick="theWebUI.saveCurrentView(); event.stopPropagation(); return(false);"/></div>
 						<ul id="pview_cont" class="catpanel_cont">

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -489,6 +489,15 @@ li.sel .label-count, li.sel .label-size {
 	border:none
 }
 
+div#catpanelDrag {
+	font-size:12px;
+	font-weight:700;
+	font-family:'Roboto';
+	line-height:25px;
+	padding:2px 30px;
+	color:#DCDCDC;
+}
+
 .catpanelcont
 {
 	margin:15px 2px;


### PR DESCRIPTION
Before, the order of the panels was fixed. Now, it is possible to reorder the panels with drag and drop.
![panel-reorder](https://github.com/Novik/ruTorrent/assets/83290594/fe9b42e4-87c1-4b94-bf3c-dfa25938eb7c)


Draft: I want to *refactor into `panel.js`* first