### PR TITLE
style: Add button hover indication

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -85,6 +85,8 @@ Input.TextboxLarge {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; w
 Input.TextboxVShort {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 30px}
 input.Button {padding: 1px 10px; background: #F0F0F0 url(../images/h.gif) repeat-x center bottom; width: 80px; height: 19px; border: 1px solid #A0A0A0; cursor: pointer }
 input.Button[disabled] { opacity: 0.3; cursor: default }
+input.Button:not([disabled]):hover { background-color: #F5F5F5; }
+input.Button:not([disabled]):hover:active { background-color: #FAFAFA; }
 #pview { display: flex; padding-right: 0px; }
 #pview > span { flex: 1; }
 #pview_save_view_button { align-self: center; width: 38px; height: 19px; padding: 0px; line-height: 2px; font-size: 19px;  }
@@ -302,7 +304,7 @@ div#tadd select { width: 220px }
 .userInterfaceOptions > div { max-width: 50% }
 .optionColumn { display: flex; justify-content: space-between; flex-flow: column wrap; }
 .optionColumn input[type=number],.optionColumn select { padding: 1px; margin: 0.1em 0.5em; width: 6em; }
-.optionColumn div { padding-left: 0; }
+.optionColumn div { display:flex; align-items: center; padding-left: 0; }
 .statuscell td { padding: 0 }
 #st_fd .sthdr { padding-left: 8px; }
 #st_fd .stval { text-align: center; width: 4.3em; }

--- a/plugins/theme/themes/Dark/style.css
+++ b/plugins/theme/themes/Dark/style.css
@@ -45,7 +45,7 @@ Input.TextboxShort {border: 1px solid #333333}
 Input.TextboxMid {border: 1px solid #333333}
 Input.TextboxLarge {border: 1px solid #333333}
 Input.TextboxVShort {border: 1px solid #333333}
-input.Button {background-color: #999999}
+input.Button {color: #111111; background-color: #999999}
 a {color: #686868}
 
 div#CatList {border: 1px solid #333333; background-color: #181818}

--- a/plugins/theme/themes/DarkBetter/style.css
+++ b/plugins/theme/themes/DarkBetter/style.css
@@ -150,6 +150,7 @@ input.Button {
 	filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#d6d6d6', endColorstr='#c7c7c7',GradientType=0);
 	background-color:#d6d6d6;
 	border:1px solid #333333;
+	color: #111111;
 }
 
 input.Button:active {

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -214,7 +214,14 @@ div#t a
 
 div#t a:hover
 {
-	background:none
+	background: none;
+	filter: brightness(1.2);
+}
+
+div#t a:active
+{
+	background: none;
+	filter: brightness(1.3);
 }
 
 div#t div.TB_Separator
@@ -230,19 +237,9 @@ div#t div#add
 	background:transparent url(./images/toolbar.png) no-repeat 0 1px;
 }
 
-div#t div#add:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat 0 -24px
-}
-
 div#t div#create
 {
 	background:transparent url(./images/toolbar.png) no-repeat -24px 0
-}
-
-div#t div#create:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat -24px -24px
 }
 
 div#t div#remove
@@ -250,19 +247,9 @@ div#t div#remove
 	background:transparent url(./images/toolbar.png) no-repeat -48px 0
 }
 
-div#t div#remove:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat -48px -24px
-}
-
 div#t div#start
 {
 	background:transparent url(./images/toolbar.png) no-repeat -72px 0
-}
-
-div#t div#start:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat -72px -24px
 }
 
 div#t div#pause
@@ -270,19 +257,9 @@ div#t div#pause
 	background:transparent url(./images/toolbar.png) no-repeat -96px 0
 }
 
-div#t div#pause:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat -96px -24px
-}
-
 div#t div#stop
 {
 	background:transparent url(./images/toolbar.png) no-repeat -120px 0
-}
-
-div#t div#stop:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat -120px -24px
 }
 
 div#t div#moveu
@@ -290,19 +267,9 @@ div#t div#moveu
 	background:transparent url(./images/toolbar.png) no-repeat -144px 0
 }
 
-div#t div#moveu:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat -144px -24px
-}
-
 div#t div#moved
 {
 	background:transparent url(./images/toolbar.png) no-repeat -168px 0
-}
-
-div#t div#moved:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat -168px -24px
 }
 
 div#t div#search
@@ -310,19 +277,9 @@ div#t div#search
 	background:transparent url(./images/toolbar.png) no-repeat -192px 0
 }
 
-div#t div#search:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat -192px -24px
-}
-
 div#t div#rss
 {
 	background:transparent url(./images/toolbar.png) no-repeat -241px 0
-}
-
-div#t div#rss:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat -241px -24px
 }
 
 div#t div#setting
@@ -330,19 +287,9 @@ div#t div#setting
 	background:transparent url(./images/toolbar.png) no-repeat -264px 0
 }
 
-div#t div#setting:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat -264px -24px
-}
-
 div#t div#plugins
 {
 	background:transparent url(./images/plugin.png) no-repeat 0 center
-}
-
-div#t div#plugins:hover
-{
-	background:transparent url(./images/pluginh.png) no-repeat 0 center
 }
 
 div#t div#help
@@ -350,19 +297,9 @@ div#t div#help
 	background:transparent url(./images/toolbar.png) no-repeat -288px 0
 }
 
-div#t div#help:hover
-{
-	background:transparent url(./images/toolbar.png) no-repeat -288px -24px
-}
-
 div#t div#go
 {
 	background:transparent url(./images/go.png) no-repeat 0 0
-}
-
-div#t div#go:hover
-{
-	background:transparent url(./images/goh.png) no-repeat 0 0
 }
 
 div select {
@@ -811,9 +748,10 @@ textarea
 	border-radius:2px
 }
 
-input.Button
+input.Button,
+input.Button:not([disabled]):focus
 {
-	background:#2196F3 none repeat scroll 0 0;
+	background: #3498db none repeat scroll 0 0;
 	border-radius:2px;
 	border:none;
 	color:#FFF;
@@ -824,13 +762,60 @@ input.Button
 	line-height:2px;
 	margin:0 10px 0 5px;
 	padding:0;
-	text-shadow:none
+	text-shadow: #2980b9 0px 1px;
 }
 
-input.Button:not([disabled]):hover,input.Button:not([disabled]):focus
+
+input.Button:not([disabled]):hover
 {
-	background:#1a77c9 none repeat scroll 0 0
+	background-color: #3498db;
+	filter: brightness(1.2);
 }
+
+input.Button:not([disabled]):hover:active
+{
+	background-color: #3498db;
+	filter: brightness(1.3);
+}
+
+input[type="checkbox"]
+{
+	appearance: none;
+	width: 14px;
+	height: 14px;
+	display: inline-flex;
+	background-color: #6f6f6f;
+	font-weight: 700;
+	border-radius: 2px;
+	border: none;
+}
+
+input[type="checkbox"]:checked
+{
+	background-color: #3498db;
+}
+
+input[type="checkbox"]:checked::after {
+	position: relative;
+	left: -2px;
+	font-size: 12px;
+	line-height: 12px;
+	content: "✔";
+	color: #fff;
+	text-shadow: #2980b9 0px 1px;
+}
+
+input[type="checkbox"]:hover
+{
+	filter: brightness(1.2);
+}
+
+input[type="checkbox"]:hover:active
+{
+	filter: brightness(1.3);
+}
+
+
 
 #mainlayout
 {

--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -72,6 +72,8 @@ input[type="number"],input[type="text"], input[type="password"], select {color: 
 input[type="file"] {-moz-border-radius: 5px; -webkit-border-radius: 5px; border-radius: 5px;}
 input[type="number"][disabled],input[type="text"][disabled], input[type="password"][disabled], input[type="file"][disabled], select[disabled] {color: black; border: 1px solid #000;background: #888888 url(./images/headers.png) repeat-x 0px -138px;-moz-border-radius: 5px; -webkit-border-radius: 5px; border-radius: 5px;}
 input.Button {border: 1px solid #000;background: #000 url(./images/headers.png) repeat-x 0px 0px;color:#AACF27;cursor: pointer;font-weight: bold;text-shadow:0px -1px 0px #000;-moz-border-radius: 5px; -webkit-border-radius: 5px;border-radius: 5px;}
+input.Button:not([disabled]):hover { background: #000 url(./images/headers.png) repeat-x 0px -6px; }
+input.Button:not([disabled]):hover:active { background: #000 url(./images/headers.png) repeat-x 0px -8px; }
 
 .pview_custom_view .label-icon { background-color: #181818; line-height: 13px; }
 .pview_custom_view .label-icon > span { color: #D4D6C9 !important; }


### PR DESCRIPTION
Buttons with pseudo-class `hover` and and `active`  got a slight color change. Before the rows in the `optionColumn` where top/start aligned. Now, they are `center` aligned.

Additionally, this adds some improvements to the material design theme. Toolbar icons light up when hovered, similar to buttons, and the checkbox and number input got a darker style:
![button-style](https://github.com/Novik/ruTorrent/assets/83290594/8fb4444e-5d38-4130-a322-8d6abc33b3e7)