### PR TITLE
Fix retracker plugin update.php

### DIFF
--- a/plugins/retrackers/update.php
+++ b/plugins/retrackers/update.php
@@ -5,7 +5,7 @@ if(count($argv)>2)
 
 require_once( 'retrackers.php' );
 require_once( dirname(__FILE__)."/../../php/xmlrpc.php" );
-require_once( dirname(__FILE__)."/../../php/cache.php" );
+require_once( dirname(__FILE__)."/../../php/rtorrent.php" );
 
 function clearTracker($addition,$tracker)
 {
@@ -29,12 +29,15 @@ function deleteTrackers(&$lst,$todelete)
 	{
 		foreach( $group as $kt=>$trk )
 		{
-			if(in_array($trk,$todelete))
+			foreach ( $todelete as $kd )
 			{
-				unset($lst[$kg][$kt]);
-				if(!count($lst[$kg]))
+				if(stristr($trk,$kd))
+				{
+					unset($lst[$kg][$kt]);
+					if(!count($lst[$kg]))
 					unset($lst[$kg]);
-				$ret = true;
+					$ret = true;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fix retracker plugin

Plugin check each URL in the tracker list of the torrent.
Also when you add a torrent file that contains a tracker url you added in retracker to be removed, the torrent is being added in a start state.