### PR TITLE
lang: Load scripts after theUILang has loaded

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,19 +25,12 @@
 			@import "./css/style.css";
 		</style>
 		<script type="text/javascript" src="./js/jquery.js?v=420"></script>
+		<script type="text/javascript" src="./js/jquery.flot.js?v=420"></script>
 		<script type="text/javascript" src="./js/sanitize.js?v=420"></script>
 		<script type="text/javascript" src="./js/sanitize.config.js?v=420"></script>
 		<script type="text/javascript" src="./lang/langs.js?v=420"></script>
+		<script type="text/javascript" src="./js/main.js?v=420"></script>
 		<script type="module" src="./js/backgroundtask.js?v=420"></script>
-		<script type="text/javascript" src="./js/common.js?v=420"></script>
-		<script type="text/javascript" src="./js/objects.js?v=420"></script>
-		<script type="text/javascript" src="./js/content.js?v=420"></script>
-		<script type="text/javascript" src="./js/stable.js?v=420"></script>
-		<script type="text/javascript" src="./js/jquery.flot.js?v=420"></script>
-		<script type="text/javascript" src="./js/graph.js?v=420"></script>
-		<script type="text/javascript" src="./js/plugins.js?v=420"></script>
-		<script type="text/javascript" src="./js/rtorrent.js?v=420"></script>
-		<script type="text/javascript" src="./js/webui.js?v=420"></script>
 	</head>
 	<body>
 		<div id="preload"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,21 @@
+loadUILang(() => {
+  // Scripts which depend on theUILang to be loaded
+  const scripts = [
+    "common",
+    "objects",
+    "content",
+    "stable",
+    "graph",
+    "plugins",
+    "rtorrent",
+    "webui",
+  ];
+  document.head.append(
+    ...scripts.map((name) => {
+      const script = document.createElement("script");
+      script.src = `./js/${name}.js?v=420`;
+      script.async = false;
+      return script;
+    })
+  );
+});


### PR DESCRIPTION
@stickz https://github.com/Novik/ruTorrent/issues/2543#issuecomment-1669799148 Yeah, it seems, this not working for Safari.

Scripts which depend on theUILang must be executed after theUILang has loaded. 
Unfortunately, in order to fix #2543, the time the browser fetches these scripts is now also delayed.
Preferably, scripts should not depend on theUILang during startup.

Fixes #2543

I did not test this with Safari but with Firefox, Chromium and Epiphany.
