### PR TITLE
tree-view: Rewrite updateCustomLabels

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,18 +117,14 @@
 							</li>
 						</ul>
 						<div class="catpanel" id="plabel" onclick="theWebUI.togglePanel(this); return(false);" uilang>Labels</div>
-						<div class="catpanel_cont" id="plabel_cont">
-							<ul id="clabel_cont">
-								<li class="-_-_-all-_-_- sel cat">
-									<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>All</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-								</li>
-								<li id="-_-_-nlb-_-_-" class="cat">
-									<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>No_label</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-								</li>
-							</ul>
-							<ul id="lbll">
-							</ul>
-						</div>
+						<ul class="catpanel_cont" id="plabel_cont">
+							<li class="-_-_-all-_-_- sel cat">
+								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>All</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
+							</li>
+							<li id="-_-_-nlb-_-_-" class="cat">
+								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>No_label</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
+							</li>
+						</ul>
 						<div class="catpanel" id="flabel" onclick="theWebUI.togglePanel(this); return(false);" uilang>mnu_search</div>
 						<div class="catpanel_cont" id="flabel_cont">
 							<ul id="lblf">

--- a/js/common.js
+++ b/js/common.js
@@ -763,13 +763,12 @@ var theFormatter =
 	},
 	treePrefix: function({hasNext, level})
 	{
-		const prefix = [];
-		for (let l = 1; l < level+1; l++) {
-			prefix.push(hasNext[l] ?
-				(l === level ? '├' : '│') :
-				(l === level ? '└' : ' '));
-		}
-		return prefix.join('');
+		return hasNext
+			.slice(1)
+			.map((next,l) => next
+				? (l+1 === level ? '├' : '│')
+				: (l+1 === level ? '└' : ' ')
+			).join('');
 	}
 };
 

--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -89,9 +89,9 @@ plugin.updateLabel = theWebUI.updateLabel;
 theWebUI.updateLabel = function(label, ...args)
 {
 	plugin.updateLabel.call(this, label, ...args);
-	var icon = $(label).children('.label-icon');
-	var id = icon.parent().attr('id');
-	if (id && icon.parents('#plabel_cont')[0] && !icon.children('img')[0])
+	const icon = $(label).children('.label-icon');
+	const id = label.id;
+	if (id && (id === '-_-_-nlb-_-_-' || id.startsWith('clabel__')) && !icon.children('img')[0])
 	{
 		var lbl = id.startsWith('-_-_-') ? theWebUI.idToLbl(id) : id.substr(8);
 		icon.append($("<img>")


### PR DESCRIPTION
It looks like, I forgot in https://github.com/Novik/ruTorrent/commit/5fc2a7f0f2bd6f2556279326a7d2fcfb1983d356 to change `this.labels[el.id]?.size` here:
https://github.com/Novik/ruTorrent/blob/3251c5bcda9730e3d3237f5efb7d906e083f8399/js/webui.js#L2117-L2117

Since `updateCustomLabels` had the plain label listing as default, it made it hard to understand the tree logic.

Now, the custom labels are explicitly processed as a tree. Empty label nodes which only have one child are flattened unless `webui.show_empty_path_labels` is `true`.
Additionally, the children of `clabel_cont` and `lbll` now both reside in `plabel_cont`
and are updated in `updateCustomLabels`, as well.

Fixes #2548 #2549 #2550
![tree-view-screenshots](https://github.com/Novik/ruTorrent/assets/83290594/bb286e6d-0e8b-430a-a073-c0cccdbd7840)

