### PR TITLE
webui: Fix slow table update on label selection

### DIFF
--- a/js/webui.js
+++ b/js/webui.js
@@ -2512,6 +2512,7 @@ var theWebUI =
 		for(const hash of Object.keys(this.torrents))
 			this.filterByLabel(table, hash);
 		table.clearSelection();
+		table.syncDOM();
 		if(this.dID != "")
 		{
 			this.dID = "";


### PR DESCRIPTION
When `filterTorrentTable` is called, for instance when clicking on a label, the changes should be available as soon as possible.