### PR TITLE
utf8: Assume utf8 w/o php-mbstring

### DIFF
--- a/php/utility/utf.php
+++ b/php/utility/utf.php
@@ -162,11 +162,15 @@ class UTF
 		return($mixed);
 	}
 
+	private static function maybe_mb_convert_to_utf8($string) {
+		return function_exists('mb_convert_encoding') ? mb_convert_encoding($string, "UTF-8", "auto") : $string;
+	}
+
 	public static function raw_url_encode($string){
-		return rawurlencode(mb_convert_encoding($string, "UTF-8", "auto"));
+		return rawurlencode(Self::maybe_mb_convert_to_utf8($string));
 	}
 
 	public static function raw_url_decode($string){
-		return rawurldecode(mb_convert_encoding($string, "UTF-8", "auto"));
+		return rawurldecode(Self::maybe_mb_convert_to_utf8($string));
 	}
 }


### PR DESCRIPTION
As @phene pointed out in https://github.com/Novik/ruTorrent/issues/2547#issuecomment-1681438221; if the `php-mbstring` extension is not installed, the AutoTools plugin should not break.

Simply no conversion is done if `php-mbstring` is not installed.