### PR TITLE
Plugin: check_port fix for portchecker.co

### DIFF
--- a/plugins/check_port/action.php
+++ b/plugins/check_port/action.php
@@ -19,7 +19,7 @@ if($useWebsite=="portchecker")
 {
 	$url = "https://portchecker.co/";
 	$ipMatch = '/data-ip="(?P<ip>[^"]+)/';
-	$checker = "https://portchecker.co/checking";
+	$checker = "https://portchecker.co/check-it";
 	$closed = ">closed<";
 	$open = ">open<";
 }


### PR DESCRIPTION
Seems like `portchecker.co` changed their url's again.

I think it would be preferential to switch back to `yougetsignal` as default (which is up again now). Their "api" seems to be less prone to changes. Also less weirdness attempting to find the CSRF and requiring cookies.