### PR TITLE
category-list: Separate presentation and control

### DIFF
--- a/css/category-panel.css
+++ b/css/category-panel.css
@@ -1,0 +1,38 @@
+:host {
+	display: contents;
+	font-size: 11px;
+	--open-background-image: url(../images/pnl_open.gif);
+	--close-background-image: url(../images/pnl_close.gif);
+	--heading-background-color: #f0f0f0;
+	--heading-border-color: #a0a0a0;
+}
+
+:host([closed]) slot[name="content"] {
+	display: none;
+}
+
+
+div[part=heading] {
+	display: flex;
+	background: var(--open-background-image) 2px no-repeat;
+	background-color: var(--heading-background-color);
+	border-bottom: 1px solid var(--heading-border-color);
+	border-top: 1px solid var(--heading-border-color);
+	padding: 2px 5px 2px 21px;
+	margin: 0px;
+	line-height: 16px;
+	cursor: pointer;
+	-moz-user-select: none;
+	-moz-user-focus: normal;
+	-moz-user-input: enabled;
+	user-select: none;
+}
+
+:host([closed]) div[part="heading"] {
+	background-image: var(--close-background-image);
+}
+
+.text {
+	flex: 1;
+	white-space: nowrap;
+}

--- a/css/panel-label.css
+++ b/css/panel-label.css
@@ -1,0 +1,139 @@
+:host {
+  display: flex;
+  padding: 3px;
+  flex-flow: row nowrap;
+  align-items: center;
+  height: 16px;
+  cursor: pointer;
+  overflow: hidden;
+  --prefix-color: black;
+  --prefix-fontsize: 19px;
+  --badge-color: black;
+  --badge-background-color: #f0f0f0;
+  --status-image: url(../images/tstatus.png);
+  --icon-size: 16px;
+}
+
+:host([selected]) {
+  background-color: #cfdeef;
+  border-color: #cfdeef;
+}
+
+div {
+  margin-right: 0.5em;
+}
+
+[part="prefix"] {
+  color: var(--prefix-color);
+  flex: 0 0 auto;
+  display: flex;
+  flex-flow: row nowrap;
+  opacity: 0.1;
+  font-family: monospace;
+  font-size: var(--prefix-fontsize);
+  margin-left: -2px;
+  margin-right: 2px;
+}
+[part="prefix"] div {
+  margin-right: 0px;
+  min-width: 12px;
+  max-width: 12px;
+}
+
+[part="text"] {
+  white-space: pre;
+}
+
+[part="count"],
+[part="size"] {
+  color: var(--badge-color);
+  background-color: var(--badge-background-color);
+  padding: var(--badge-padding, 0.1em 0.3em 0.1em 0.3em);
+  border-radius: var(--badge-border-radius, 0.8em);
+  white-space: pre;
+}
+
+[part="icon"] {
+  min-width: var(--icon-size);
+  min-height: var(--icon-size);
+  background-image: var(--status-image);
+  background-position: var(--icon-offset, 0px 0px);
+  background-repeat: no-repeat;
+  background-size: var(--icon-image-size, unset);
+}
+
+[part="icon"].icon-letter {
+  background-image: none;
+  color: var(--icon-letter-color, --badge-color);
+  background-color: var(
+    --icon-letter-background-color,
+    --badge-background-color
+  );
+  border: 1px solid var(--icon-letter-border-color, rgba(128, 128, 128, 0.2));
+  border-radius: calc(var(--icon-size) / 2);
+  width: calc(var(--icon-size) - 2px);
+  height: calc(var(--icon-size) - 2px);
+  font-size: calc(var(--icon-size) - 5px);
+  display: flex;
+  font-style: normal;
+}
+
+[part="icon"].icon-letter > span {
+  flex: 1;
+  text-align: center;
+  font-weight: bold;
+  line-height: calc(var(--icon-size) - 3px);
+}
+.icon-by-url {
+  background-position: 0px 0px;
+  background-size: var(--icon-size) var(--icon-size);
+  background-image: none;
+}
+
+:host([icon="down"]) {
+  --icon-offset: 0px 0px;
+}
+:host([icon="up"]) {
+  --icon-offset: 0px -16px;
+}
+:host([icon="search"]),
+:host([icon="inactive"]) {
+  --icon-offset: 0px -32px;
+}
+:host([icon="paused"]) {
+  --icon-offset: 0px -48px;
+}
+:host([icon="error-down"]) {
+  --icon-offset: 0px -64px;
+}
+:host([icon="error-up"]) {
+  --icon-offset: 0px -80px;
+}
+:host([icon="error"]) {
+  --icon-offset: 0px -96px;
+}
+:host([icon="completed"]) {
+  --icon-offset: 0px -112px;
+}
+:host([icon="queued-down"]) {
+  --icon-offset: 0px -128px;
+}
+:host([icon="queued-up"]) {
+  --icon-offset: 0px -144px;
+}
+:host([icon="up-down"]) {
+  --icon-offset: 0px -160px;
+}
+:host([icon="checking"]),
+:host([icon="all"]) {
+  --icon-offset: 0px -176px;
+}
+:host([icon="rss"]) {
+  --icon-offset: 0px -208px;
+}
+:host([icon="rss-dis"]) {
+  --icon-offset: 0px -192px;
+}
+:host([icon="rss-group"]) {
+  --icon-offset: 0px -240px;
+}

--- a/css/style.css
+++ b/css/style.css
@@ -3,6 +3,30 @@ html, body {border: 0; margin: 0; padding: 0; cursor: default; overflow: hidden;
 html, body, input,select,button,textarea{font-family: Tahoma, Arial, Helvetica, sans-serif;}
 .light-theme { color-scheme: light; }
 .dark-theme { color-scheme: dark; }
+:root {
+  --menu-color: #000000;
+  --menu-background-color: #ffffff;
+  --menu-border-color: #d0d0d0;
+
+  --menu-disabled-color: #c0c0c0;
+  --menu-disabled-background-color: #ffffff;
+
+  --menu-highlight-color: #ffffff;
+  --menu-highlight-background-color: #cfdeef;
+
+  --settings-background-color: #fafafa;
+}
+category-list.rightalign-labelsize panel-label::part(size) {
+  margin-left: auto;
+}
+category-list.hide-textoverflow panel-label::part(text) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+dialog {
+  background-color: var(--settings-background-color);
+  border-color: var(--menu-border-color);
+}
 form{margin:0;}
 div#preload {width: 0px; height: 0px; display: none; background-image: url(../images/toolbar.png); background-image: url(../images/tstatus.png); background-image: url(../images/t_bg.png); background-image: url(../images/r_bg.gif); background-image: url(../images/i_bg.gif); background-image: url(../images/asc.gif); background-image: url(../images/desc.gif); background-image: url(../images/close.png); background-image: url(../images/file.gif); background-image: url(../images/dir.gif); background-image: url(../images/pnl_open.gif); background-image: url(../images/pnl_close.gif)}
 div#cover {width: 100%; height: 100%; left: 0px; top: 0px; position: absolute; z-index: 500; background: #FFFFFF}
@@ -28,24 +52,18 @@ div#sc ul li {margin: 0; padding: 0}
 div#sc li div {line-height: 14px; padding: 4px; font-weight: bold; font-size: 11px;}
 div#sc li.se_act div {background-color: #808080; color: #FFFFFF}
 ul.CMenu {width: 150px; left: 0px; top: 0px; display: none; border: 1px solid #A0A0A0; border-right: 2px solid #A0A0A0; border-bottom: 2px solid #808080; background: #F0F0F0; text-decoration: none; padding: 2px 0 0 2px; margin: 0; list-style-type: none; z-index: 1000}
-ul.CMenu li {float: left; margin-right: 1px; position: relative; width: 150px; background: #FFFFFF}
-ul.CMenu li a {display: block}
-ul.CMenu li a.dis {color: #C0C0C0}
-ul.CMenu li a.dis:hover {background-color: #FFFFFF; color: #C0C0C0}
-ul.CMenu li a {line-height: 16px; padding: 3px 4px 3px 16px; font-weight: normal}
-ul.CMenu li hr {width: 90%; border-top: 1px solid #D0D0D0; height: 0px; margin-top: 2px; margin-bottom: 2px; }
+ul.CMenu li {float: left; margin-right: 1px; position: relative; width: 150px; background: var(--menu-background-color); }
+ul.CMenu li a {display: block; line-height: 16px; padding: 3px 4px 3px 16px; font-weight: normal; background-color: var(--menu-background-color); color: var(--menu-color);}
+ul.CMenu li ul li a.dis, ul.CMenu li a.dis { color: var(--menu-disabled-color); }
+ul.CMenu li hr {width: 90%; border-top: 1px solid var(--menu-border-color); height: 0px; margin-top: 2px; margin-bottom: 2px; }
 .ie ul.CMenu li hr { line-height:1px; font-size:1px; margin: 0 }
 ul.CMenu li a.exp {background: transparent url(../images/menuexp.gif) no-repeat scroll 140px center; }
 ul.CMenu li a.sel {background: transparent url(../images/menusel.gif) no-repeat scroll 4px center}
-ul.CMenu li a:hover {background-color: #CFDEEF; color: #000000}
+ul.CMenu li a:not(.dis):hover {background-color: var(--menu-highlight-background-color); color: var(--menu-highlight-color)}
 
 ul.CMenu li:hover ul {display: block; position: absolute; top: 0; left: 146px; width:150px;}
 ul.CMenu li:hover ul li ul {display: none;}
-ul.CMenu li:hover ul li a {display: block; background-color: #FFFFFF; color: #000000}
-ul.CMenu li:hover ul li a:hover {background-color: #CFDEEF; color: #000000}
 ul.CMenu li:hover ul.left {left: -150px}
-ul.CMenu li ul li a.dis {color: #C0C0C0}
-ul.CMenu li ul li a.dis:hover {background-color: #FFFFFF; color: #C0C0C0}
 
 span.htkey {text-align:right; position: absolute; right: 16px; z-index:100}
 #sel {width: 0px; height: 0px; position: absolute; left: 0px; top: 0px; border: 1px dotted #000000; display: none; z-index: 1000}
@@ -78,51 +96,23 @@ div#t div#plugins {background: transparent url(../images/plugin.png) no-repeat 0
 div#t a#mnu_go {margin: 3px 0 0 0; padding: 3px}
 div#t #ind {margin-top: 2px; background: transparent url(../images/ajax-loader.gif) no-repeat 0px center; width: 32px; margin-right: 2px; line-height: 26px; cursor: default; }
 
-input.Textbox, input.Button, select {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px}
+input.Textbox, button, input.Button, select {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px}
 Input.TextboxShort {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 50px}
 Input.TextboxMid {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 110px}
 Input.TextboxLarge {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 220px}
 Input.TextboxVShort {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 30px}
-input.Button {padding: 1px 10px; background: #F0F0F0 url(../images/h.gif) repeat-x center bottom; width: 80px; height: 19px; border: 1px solid #A0A0A0; cursor: pointer }
-input.Button[disabled] { opacity: 0.3; cursor: default }
-input.Button:not([disabled]):hover { background-color: #F5F5F5; }
-input.Button:not([disabled]):hover:active { background-color: #FAFAFA; }
-#pview { display: flex; padding-right: 0px; }
-#pview > span { flex: 1; }
+button, input.Button {padding: 1px 10px; background: #F0F0F0 url(../images/h.gif) repeat-x center bottom; width: 80px; height: 19px; border: 1px solid #A0A0A0; cursor: pointer }
+button[disabled],input.Button[disabled] { opacity: 0.3; cursor: default }
+button:not([disabled]):hover, input.Button:not([disabled]):hover { background-color: #F5F5F5; }
+button:not([disabled]):hover:active, input.Button:not([disabled]):hover:active { background-color: #FAFAFA; }
 #pview_save_view_button { align-self: center; width: 38px; height: 19px; padding: 0px; line-height: 2px; font-size: 19px;  }
-#pview_cont .label-text { white-space: pre; }
-.pview_custom_view .label-icon { background-image: none; background-color: #F0F0F0; border: 1px solid rgba(128,128,128,0.2); border-radius: 0.8em; min-width: 14px; min-height: 14px; display: flex; font-style: normal;  }
-.pview_custom_view .label-icon > span { flex: 1; text-align: center; font-size: 11px; font-weight: bold; }
 
 select {margin-top: 5px}
 a {font-size: 11px;  color: #686868}
 table#maincont {margin: 5px 0 0 0; min-width: 600px;}
 table#maincont td.uicell {vertical-align: top; padding: 0 }
 
-div#CatList {width: 0px; border: 1px solid #A0A0A0; background-color: #FFFFFF; overflow-y: auto; overflow-x: hidden; min-width: 160px; }
-div#CatList ul { margin: 0; padding: 0; list-style: none; white-space: nowrap}
-div#CatList ul li { display: flex; padding: 3px; flex-flow: row nowrap; align-items: center; height: 16px; font-size: 11px;  cursor: pointer; border: 0px solid #FFFFFF; overflow: hidden;}
-div#CatList ul li.sel {background-color: #CFDEEF; border-color: #CFDEEF }
-div#CatList ul li div { margin-right: 0.5em; }
-div#CatList .label-prefix { flex: 0 0 auto; display: flex; flex-flow: row nowrap; opacity: 0.1; font-family: monospace; font-size: 19px; margin-left: -2px; margin-right: 2px; }
-div#CatList .label-prefix div { margin-right: 0px; width: 12px; }
-.label-icon { min-width: 16px; min-height: 16px; background-image: url(../images/tstatus.png); background-repeat: no-repeat; }
-.label-icon img { width: 16px; height: 16px; }
-.-_-_-all-_-_- .label-icon, #-_-_-all-_-_- .label-icon {background-position: 0px -176px;}
-#-_-_-dls-_-_- .label-icon {background-position: 0px 0px;}
-#-_-_-com-_-_- .label-icon {background-position: 0px -16px;}
-#-_-_-act-_-_- .label-icon {background-position: 0px -160px;}
-#-_-_-iac-_-_- .label-icon {background-position: 0px -32px;}
-#-_-_-err-_-_- .label-icon {background-position: 0px -96px;}
-.label-count,.label-size { background-color: #F0F0F0; padding: 0.1em 0.3em 0.1em 0.3em; border-radius: 0.8em; }
-#CatList.rightalign-labelsize .label-size {
-	margin-left: auto;
-}
-#CatList.hide-textoverflow .label-text {
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-#flabel_cont li:not(.-_-_-all-_-_-) .label-icon { background-position: 0px -32px; }
+#CatList { display: block; margin: 0; padding: 0; width: 0px; border: 1px solid #A0A0A0; background-color: #FFFFFF; overflow-y: auto; overflow-x: hidden; min-width: 160px; }
 
 .stable-icon {background-image: url(../images/tstatus.png); background-repeat: no-repeat}
 .Status_Down {background-position: 0px 0px}
@@ -148,7 +138,7 @@ div#stg {width: 600px; height: 560px; position: absolute; left: 0px; top: 50px; 
 div#stg_c {overflow: hidden}
 div#stg-header { background-image: url(../images/settings.gif); }
 
-div#stg .lm {width: 120px; height: 511px; margin: 5px; margin-right: 0; padding: 5px; float: left; position: relative; background-color: #FFFFFF; border: 1px solid #D0D0D0; overflow: auto}
+div#stg .lm {width: 120px; height: 511px; margin: 5px; margin-right: 0; padding: 5px; float: left; position: relative; background-color: var(--menu-background-color); border: 1px solid var(--menu-border-color); overflow: auto}
 .ie div#stg .lm {width: 125px; position: static;}
 .ie9 div#stg .lm {position: static}
 .ie div#stg {width: 605px;}
@@ -171,7 +161,7 @@ div.algnright {text-align: right; clear: right}
 .lm li a {color: #000000; padding: 1px 2px}
 .lm li a.focus {background-color: #E0E0E0}
 .ie .lm li a {margin: 0 0 0 -5px; padding: 0}
-.stg_con { display: none; float: right; position: relative; width: 450px; height: 500px; margin: 4px; background-color: #FAFAFA}
+.stg_con { display: none; float: right; position: relative; width: 450px; height: 500px; margin: 4px; background-color: var(--settings-background-color); }
 .ie9 .stg_con {position: static}
 fieldset {margin: 4px}
 * > fieldset {border: 1px solid #D0D0D0; -moz-border-radius: 6px; -webkit-border-radius:6px; border-radius:6px;}
@@ -220,7 +210,7 @@ div.graph_tab {background-color: #FFFFFF; overflow: hidden; display: block; -moz
 .graph_tab_tooltip { position: absolute; border: 1px solid #fdd; padding: 2px; background-color: #fee; color: black; font-size: 11px; font-weight: bold; font-family: Tahoma, Arial, Helvetica, sans-serif; opacity: 0.80; }
 
 div.table_tab {background-color: #FFFFFF; overflow: hidden; display: block; -moz-user-select: none; -moz-user-focus: normal; -moz-user-input: enabled; user-select: none; }
-div#List {border: 1px solid #A0A0A0;}
+div#List,.main-table {border: 1px solid #A0A0A0;}
 
 div.cont {padding: 6px; font-size: 11px;}
 
@@ -274,8 +264,6 @@ span#loadimg {padding: 20px; background: transparent url(../images/ajax-loader.g
 
 div#HDivider:hover, div#VDivider:hover { background: #A0A0A0; }
 textarea { overflow: auto; }
-
-.catpanel { background: url(../images/pnl_open.gif) 2px no-repeat; background-color: #F0F0F0; border-bottom: 1px solid #A0A0A0; border-top: 1px solid #A0A0A0; padding: 2px 21px; margin: 0px; line-height: 16px; font-size: 11px;  cursor: pointer; -moz-user-select: none; -moz-user-focus: normal; -moz-user-input: enabled; user-select: none; }
 
 div#tadd-header {background-image: url(../images/world.gif)}
 div#tadd {display: none; left: 100px; top: 100px; position: absolute; margin: 0 auto }

--- a/index.html
+++ b/index.html
@@ -22,10 +22,13 @@
 		<meta name="msapplication-TileImage" content="./images/mstile-144x144.png" />
 		<link href="./css/style.css" rel="stylesheet" type="text/css" />
 		<link href="./css/stable.css" rel="stylesheet" type="text/css" />
+		<link rel="preload" as="style" href="./css/category-panel.css" />
+		<link rel="preload" as="style" href="./css/panel-label.css" />
 		<script type="text/javascript" src="./js/jquery.js?v=430"></script>
 		<script type="text/javascript" src="./js/jquery.flot.js?v=430"></script>
 		<script type="text/javascript" src="./js/sanitize.js?v=430"></script>
 		<script type="text/javascript" src="./js/sanitize.config.js?v=430"></script>
+		<script type="text/javascript" src="./js/custom-elements.js?v=430"></script>
 		<script type="text/javascript" src="./lang/langs.js?v=430"></script>
 		<link rel="preload" as="script" href="./js/common.js?v=430" />
 		<link rel="preload" as="script" href="./js/objects.js?v=430" />
@@ -49,6 +52,9 @@
 			});
 		</script>
 		<script type="module" src="./js/backgroundtask.js?v=430"></script>
+		<script type="module" src="./js/category-list.js?v=430"></script>
+		<script type="module" src="./js/panel.js?v=430"></script>
+		<script type="text/javascript" src="./js/category-list-elements.js?v=430" defer></script>
 	</head>
 	<body>
 		<div id="preload"></div>
@@ -105,53 +111,51 @@
 		<table id="maincont" cellpadding="0" cellspacing="0" summary="layout table">
 			<tr>
 				<td class="uicell" rowspan="3">
-					<div id="CatList">
-						<div id="pview" class="catpanel" onclick="theWebUI.togglePanel(this); return(false);"><span uilang>pnlViews</span><input class="Button" type="button" value="+" uilangtitle="SaveCurrentView" id="pview_save_view_button" onclick="theWebUI.saveCurrentView(); event.stopPropagation(); return(false);"/></div>
-						<ul id="pview_cont" class="catpanel_cont">
-							<li class="-_-_-all-_-_- sel cat">
-								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>All</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-							</li>
-							<li id="pview_dirty_view" style="display:none"></li>
-						</ul>
-						<div class="catpanel" id="pstate" onclick="theWebUI.togglePanel(this); return(false);" uilang>pnlState</div>
-						<ul id="pstate_cont" class="catpanel_cont">
-							<li class="-_-_-all-_-_- sel cat">
-								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>All</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-							</li>
-							<li id="-_-_-dls-_-_-" class="cat">
-								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>Downloading</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-							</li>
-							<li id="-_-_-com-_-_-" class="cat">
-								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>Finished</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-							</li>
-							<li id="-_-_-act-_-_-" class="cat">
-								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>Active</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-							</li>
-							<li id="-_-_-iac-_-_-" class="cat">
-								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>Inactive</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-							</li>
-							<li id="-_-_-err-_-_-" class="cat">
-								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>Error</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-							</li>
-						</ul>
-						<div class="catpanel" id="plabel" onclick="theWebUI.togglePanel(this); return(false);" uilang>Labels</div>
-						<ul class="catpanel_cont" id="plabel_cont">
-							<li class="-_-_-all-_-_- sel cat">
-								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>All</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-							</li>
-							<li id="-_-_-nlb-_-_-" class="cat">
-								<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>No_label</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-							</li>
-						</ul>
-						<div class="catpanel" id="flabel" onclick="theWebUI.togglePanel(this); return(false);" uilang>mnu_search</div>
-						<div class="catpanel_cont" id="flabel_cont">
-							<ul id="lblf">
-								<li class="-_-_-all-_-_- sel cat">
-									<div class="label-prefix"></div><div class="label-icon"></div><div class="label-text" uilang>All</div><div class="label-count">0</div><div class="label-size" style="display: none"></div>
-								</li>
-							</ul>
+					<template id="panel-label-template">
+						<link href="./css/panel-label.css" rel="stylesheet" type="text/css" />
+						<div part="prefix" hidden></div>
+						<div part="icon"></div>
+						<div part="text"></div>
+						<div part="count">0</div>
+						<div part="size" style="display: none;"></div>
+					</template>
+					<template id="category-panel-template">
+						<link href="./css/category-panel.css" rel="stylesheet" type="text/css" />
+						<div part="heading">
+							<span class="text"></span><slot name="decorator" class="decorator"></slot>
 						</div>
-					</div>
+						<slot name="content"></slot>
+					</template>
+					<template id="pview-rename-dialog-template">
+						<div class="content">
+							<input type="text" onfocus="this.select()"/>
+						</div>
+						<div class="aright buttons-list" style="margin-top: 10px">
+							<button class="Button" value="confirm" uilang>ok</button>
+							<button class="Button Cancel" uilang>Cancel</button>
+						</div>
+					</template>
+					<category-list id="CatList">
+						<category-panel id="pview" uilangtext="pnlViews">
+							<input slot="decorator" class="Button" type="button" value="+" uilangtitle="SaveCurrentView" id="pview_save_view_button" />
+							<panel-label id="pview_all" icon="all" uilangtext="All" selected></panel-label>
+						</category-panel>
+						<category-panel id="pstate" uilangtext="pnlState">
+							<panel-label id="pstate_all" icon="all" uilangtext="All" selected></panel-label>
+							<panel-label id="-_-_-dls-_-_-" icon="down" uilangtext="Downloading"></panel-label>
+							<panel-label id="-_-_-com-_-_-" icon="completed" uilangtext="Finished"></panel-label>
+							<panel-label id="-_-_-act-_-_-" icon="up-down" uilangtext="Active"></panel-label>
+							<panel-label id="-_-_-iac-_-_-" icon="inactive" uilangtext="Inactive"></panel-label>
+							<panel-label id="-_-_-err-_-_-" icon="error" uilangtext="Error"></panel-label>
+						</category-panel>
+						<category-panel id="plabel" uilangtext="Labels">
+							<panel-label id="plabel_all" icon="all" uilangtext="All" selected></panel-label>
+							<panel-label id="-_-_-nlb-_-_-" icon="no-label" uilangtext="No_label"></panel-label>
+						</category-panel>
+						<category-panel id="psearch" uilangtext="mnu_search">
+							<panel-label id="psearch_all" icon="all" uilangtext="All" selected></panel-label>
+						</category-panel>
+					</category-list>
 				</td>
 				<td class="uicell" rowspan="3">
 					<div id="HDivider"></div><div id="dividerDrag"></div>

--- a/js/category-list-elements.js
+++ b/js/category-list-elements.js
@@ -1,0 +1,268 @@
+customElements.define(
+  "category-panel",
+  class extends CustomHTMLElement {
+    static template = document.getElementById("category-panel-template");
+    static stringAttributeNames = ["text"];
+    static booleanAttributeNames = ["closed"];
+    static attributeChangeCallbacks = {
+      closed: function () {
+        this.dispatchEvent(new Event("close"));
+      },
+      text: function (_, newValue) {
+        this.textEl.textContent = newValue;
+      },
+    };
+
+    constructor() {
+      super();
+      const shadow = this.customAttachShadow();
+      this.parts.heading.addEventListener("click", () => {
+        this.closed = !this.closed;
+        return false;
+      });
+      this.textEl = shadow.querySelector(".text");
+      this.customDefineAttributes();
+    }
+  }
+);
+
+customElements.define(
+  "panel-label",
+  class extends CustomHTMLElement {
+    static template = document.getElementById("panel-label-template");
+    static stringAttributeNames = ["prefix", "icon", "text", "count", "size"];
+    static booleanAttributeNames = ["selected"];
+    static attributeChangeCallbacks = {
+      prefix: function (_, newValue) {
+        const el = this.parts.prefix;
+        if (newValue != null) {
+          el.hidden = false;
+          const divs = el.children;
+          el.replaceChildren(
+            ...newValue.split("").map((c, i) => {
+              const e =
+                i < divs.length ? divs[i] : document.createElement("div");
+              e.textContent = c;
+              return e;
+            })
+          );
+        } else {
+          el.hidden = true;
+        }
+      },
+      icon: function (oldValue, newValue) {
+        const el = this.parts.icon;
+        if (oldValue) {
+          if (oldValue.startsWith("url:")) {
+            el.style.backgroundImage = null;
+            el.classList.remove("icon-by-url");
+          } else if (oldValue.length === 1) {
+            el.classList.remove("icon-letter");
+            el.replaceChildren();
+          }
+        }
+        if (newValue) {
+          if (newValue.startsWith("url:")) {
+            el.style.backgroundImage = `url("${newValue.slice(4)}")`;
+            el.classList.add("icon-by-url");
+          } else if (newValue.length == 1) {
+            const span = document.createElement("span");
+            el.classList.add("icon-letter");
+            span.textContent = newValue;
+            el.appendChild(span);
+          }
+        }
+      },
+      text: function (_, newValue) {
+        this.parts.text.textContent = newValue ?? "";
+      },
+      size: function (_, newValue) {
+        this._hideOrSetText(this.parts.size, newValue);
+      },
+      count: function (_, newValue) {
+        this._hideOrSetText(this.parts.count, newValue);
+      },
+    };
+
+    constructor() {
+      super();
+      this.customAttachShadow();
+
+      this.customDefineAttributes();
+    }
+
+    _hideOrSetText(el, newValue) {
+      if (newValue != null) {
+        el.style.display = "block";
+        el.textContent = newValue;
+      } else {
+        el.style.display = "none";
+      }
+    }
+  }
+);
+
+customElements.define(
+  "category-list",
+  class extends HTMLElement {
+    constructor() {
+      super();
+      this._expectedStyleLoads = 0;
+      for (const panel of this.querySelectorAll(":scope > category-panel")) {
+        this._registerPanel(panel);
+        for (const label of panel.querySelectorAll(":scope > panel-label")) {
+          this._registerLabel(panel, label);
+        }
+      }
+    }
+    _expectStyleLoad(element) {
+      if (element.pendingStyleLoad) {
+        this._expectedStyleLoads += 1;
+        element.addEventListener(
+          "style-load",
+          () => {
+            this._expectedStyleLoads -= 1;
+            if (this._expectedStyleLoads === 0) {
+              this.dispatchEvent(new CustomEvent("style-load"));
+            }
+          },
+          { once: true }
+        );
+      }
+    }
+
+    get pendingStyleLoad() {
+      return this._expectedStyleLoads > 0;
+    }
+
+    _registerPanel(panel) {
+      this._expectStyleLoad(panel);
+      panel.addEventListener("close", () => {
+        const event = new Event("panel-close");
+        event.panelId = panel.id;
+        event.closed = panel.closed;
+        this.dispatchEvent(event);
+      });
+    }
+
+    _registerLabel(panel, label) {
+      this._expectStyleLoad(label);
+      label.slot = "content";
+      const onClickEvent = ({ which, button, metaKey, ctrlKey, shiftKey }) => {
+        this.dispatchEvent(
+          Object.assign(new Event("label-click"), {
+            labelElement: label,
+            labelId: label.id,
+            panelId: panel.id,
+            rightClick: which === 3,
+            metaKey: metaKey || ctrlKey || false,
+            shiftKey,
+            button,
+            which,
+          })
+        );
+      };
+      label.addEventListener("mousedown", (e) => onClickEvent(e));
+      label.addEventListener("contextmenu", () =>
+        onClickEvent({
+          which: 3,
+          button: 2,
+          metaKey: false,
+          shiftKey: false,
+        })
+      );
+    }
+
+    panelClosed(panelId) {
+      return document.getElementById(panelId).closed;
+    }
+
+    labelSelected(labelId) {
+      return document.getElementById(labelId).selected;
+    }
+
+    get panelAttribs() {
+      return Object.fromEntries(
+        [...this.querySelectorAll(":scope > category-panel")].map((panel) => [
+          panel.id,
+          Object.fromEntries(
+            panel.constructor.mutObservedAttributes
+              .filter((attr) => panel.hasAttribute(attr))
+              .map((attr) => [attr, panel[attr]])
+          ),
+        ])
+      );
+    }
+
+    get panelLabelAttribs() {
+      return Object.fromEntries(
+        [...this.querySelectorAll(":scope > category-panel")].map((panel) => [
+          panel.id,
+          new Map(
+            [...panel.querySelectorAll(":scope > panel-label")].map((label) => [
+              label.id,
+              Object.fromEntries(
+                label.constructor.mutObservedAttributes
+                  .filter((attr) => label.hasAttribute(attr))
+                  .map((attr) => [attr, label[attr]])
+              ),
+            ])
+          ),
+        ])
+      );
+    }
+
+    /**
+     * Sync the category list attributes to the DOM.
+     */
+    sync(panelLabelAttribs, panelAttribs) {
+      const arraysEqual = (a, b) =>
+        a?.length === b?.length && a.every((aa, i) => aa === b[i]);
+      for (const [panelId, labelAttribs] of Object.entries(panelLabelAttribs)) {
+        // Get or create category-panel element
+        let panel = document.getElementById(panelId);
+        if (!panel) {
+          panel = document.createElement("category-panel");
+          panel.id = panelId;
+          this._registerPanel(panel);
+          this.appendChild(panel);
+        }
+        Object.assign(panel, panelAttribs[panelId]);
+
+        for (const [labelId, attribs] of labelAttribs) {
+          // Get or create panel-label element
+          let label = document.getElementById(labelId);
+          if (!label) {
+            label = document.createElement("panel-label");
+            label.id = labelId;
+            this._registerLabel(panel, label);
+            panel.appendChild(label);
+          }
+          Object.assign(label, attribs);
+        }
+        const previousLabelIds = [
+          ...panel.querySelectorAll(":scope > panel-label"),
+        ].map((label) => label.id);
+        const sortedLabelIds = [...labelAttribs.keys()];
+        if (!arraysEqual(previousLabelIds, sortedLabelIds)) {
+          // Sort labelids
+          panel.replaceChildren(
+            ...panel.querySelectorAll(":scope > :not(panel-label)"),
+            ...sortedLabelIds.map((labelId) => document.getElementById(labelId))
+          );
+        }
+      }
+      const previousPanelIds = [
+        ...this.querySelectorAll(":scope > category-panel"),
+      ].map((panel) => panel.id);
+      const sortedPanelIds = Object.keys(panelAttribs);
+      if (!arraysEqual(previousPanelIds, sortedPanelIds)) {
+        // Sort panels
+        this.replaceChildren(
+          ...this.querySelectorAll(":scope > :not(category-panel)"),
+          ...sortedPanelIds.map((panelId) => document.getElementById(panelId))
+        );
+      }
+    }
+  }
+);

--- a/js/category-list.js
+++ b/js/category-list.js
@@ -1,0 +1,622 @@
+import {
+  PanelLabelSelection,
+  CategoryListStatistic,
+  TextSearch,
+  TorrentLabelTree,
+} from "./panel.js";
+
+/**
+ * The CategoryList controls which torrents should be shown in the torrent table.
+ *
+ */
+export class CategoryList {
+  constructor(props) {
+    Object.assign(this, props);
+
+    this.selection = null;
+    this.searches = [];
+    this.views = [];
+    this.quickSearch = {
+      search: { val: "" },
+      debounce: { timeoutId: 0, delayMs: 220 },
+    };
+    this.statistic = CategoryListStatistic.from("pview", this.viewSelections, {
+      pstate: [
+        (_, torrent) => [
+          torrent.done < 1000 ? "-_-_-dls-_-_-" : "-_-_-com-_-_-",
+          torrent.dl >= 1024 || torrent.ul >= 1024
+            ? "-_-_-act-_-_-"
+            : "-_-_-iac-_-_-",
+        ],
+        {
+          "-_-_-err-_-_-": (_, torrent) => torrent.state & this.dStatus.error,
+        },
+      ],
+      plabel: [
+        (_, torrent) => [
+          torrent.label ? "clabel__" + torrent.label : "-_-_-nlb-_-_-",
+        ],
+      ],
+
+      psearch: [
+        (_, torrent) =>
+          this.searches
+            .map((_, searchIndex) => [_, searchIndex])
+            .filter(([search]) => search.match(torrent.name))
+            .map(([_, searchIndex]) => `psearch_${searchIndex}`),
+        {
+          quick_search: (_, torrent) => this.matchQuickSearch(torrent.name),
+        },
+      ],
+    });
+    this.refreshPanel = {
+      pview: () => [
+        this.updatedStatisticEntry("pview", "pview_all"),
+        ...this.views.map((view, i) =>
+          this.updatedStatisticEntry("pview", this.statistic.indexToViewId(i), {
+            text: view.name,
+            icon: view.name.charAt(0),
+          })
+        ),
+      ],
+      pstate: (attribs) =>
+        [...attribs.keys()].map((labelId) =>
+          this.updatedStatisticEntry("pstate", labelId)
+        ),
+      plabel: (attribs) => [
+        ...[...attribs.keys()]
+          .filter((labelId) => !labelId.startsWith("clabel__"))
+          .map((labelId) => this.updatedStatisticEntry("plabel", labelId)),
+        ...[...this.torrentLabelTree.torrentLabels.keys()]
+          .map((torrentLabel) => ["clabel__" + torrentLabel, torrentLabel])
+          .map(([labelId, torrentLabel]) =>
+            this.updatedStatisticEntry(
+              "plabel",
+              labelId,
+              this.torrentLabelTree.prefixSuffix(
+                torrentLabel,
+                !this.settings["webui.show_label_path_tree"],
+                !this.settings["webui.show_empty_path_labels"]
+              ) ?? {},
+              torrentLabel
+            )
+          ),
+      ],
+      psearch: () => [
+        this.updatedStatisticEntry("psearch", "psearch_all"),
+        ...this.searches.map((search, i) =>
+          this.updatedStatisticEntry("psearch", `psearch_${i}`, {
+            text: search.text,
+            icon: "search",
+          })
+        ),
+      ],
+    };
+    this.configured = false;
+  }
+
+  config(settings) {
+    if (this.configured) {
+      console.warn("Category list is only configured once");
+      return;
+    }
+    this.settings = settings;
+    console.assert(
+      [
+        "webui.closed_panels",
+        "webui.category_panels",
+        "webui.open_tegs.last",
+        "webui.selected_labels.keep",
+        "webui.selected_labels.last",
+        "webui.selected_labels.views",
+      ].every((key) => key in settings),
+      "should find required setting values"
+    );
+    if (this.settings["webui.open_tegs.keep"]) {
+      // Restore text searches
+      for (const text of this.settings["webui.open_tegs.last"]) {
+        this.addTextSearch(text, true);
+      }
+    }
+    const configChanged = this.updatePanels();
+    const mapLegacyActLbls = (actLbls) =>
+      Object.fromEntries(
+        Object.entries(actLbls).map(([panelId, labelIds]) => [
+          mapLegacyPanelId(panelId),
+          labelIds.map(mapLegacyLabelId),
+        ])
+      );
+
+    // Restore selection from settings
+    this.selection = PanelLabelSelection.fromConfig(
+      this.settings["webui.selected_labels.keep"]
+        ? mapLegacyActLbls(this.settings["webui.selected_labels.last"])
+        : {},
+      this.sortedPanelIds
+    );
+    // Init views
+    this.views = this.settings["webui.selected_labels.views"].map((view) => ({
+      name: view.name,
+      selection: PanelLabelSelection.fromConfig(
+        mapLegacyActLbls(view.labels),
+        this.statistic.panelIds
+      ),
+    }));
+    this.selection.adjustViewToCurrent(
+      this.viewSelections,
+      this.statistic.panelIds
+    );
+    this.statistic.viewSelections = this.viewSelections;
+
+    this.configured = true;
+    if (configChanged) {
+      this.onConfigChangeFn();
+    }
+    this.syncFn();
+  }
+
+  updatedStatisticEntry(panelId, labelId, attrs, titleText) {
+    attrs = { ...this.panelLabelAttribs[panelId].get(labelId), ...attrs };
+    const bucket =
+      labelId === `${panelId}_all`
+        ? this.statistic
+        : this.statistic.lookup(panelId, labelId);
+    const sizeString = this.byteSizeToStringFn(bucket.size);
+    return [
+      labelId,
+      {
+        ...attrs,
+        count: String(bucket.count),
+        size: this.showSize(panelId) && bucket.size > 0 ? sizeString : null,
+        title: `${titleText || attrs.text} (${bucket.count} ; ${sizeString})`,
+        selected: this.isLabelIdSelected(panelId, labelId),
+      },
+    ];
+  }
+
+  get viewSelections() {
+    return this.views.map((view) => view.selection);
+  }
+
+  onViewsChange() {
+    this.settings["webui.selected_labels.views"] = this.views.map((view) => ({
+      name: view.name,
+      labels: view.selection.toConfig(),
+    }));
+    this.selection.adjustCurrentToView(
+      this.viewSelections,
+      this.statistic.panelIds
+    );
+    this.statistic.viewSelections = this.viewSelections;
+    this.rescan("pview");
+    this.refresh("pview");
+    this.onSelectionChange("pview");
+  }
+
+  selectionActive(panelId, labelId) {
+    return this.selection.active(panelId, labelId);
+  }
+
+  showSize(panelId) {
+    return (
+      {
+        pview: this.settings["webui.show_viewlabelsize"],
+        pstate: this.settings["webui.show_statelabelsize"],
+        psearch: this.settings["webui.show_searchlabelsize"],
+      }[panelId] ?? this.settings["webui.show_labelsize"]
+    );
+  }
+
+  get sortedPanelIds() {
+    return this.settings["webui.category_panels"]
+      .map(mapLegacyPanelId)
+      .filter((panelId) => panelId in this.panelAttribs);
+  }
+
+  updatePanels() {
+    // Expand 'webui.category_panels' to include all panelIds (in panelAttribs)
+    const oldPanelIds = new Set(this.sortedPanelIds);
+    const newPanelIds = Object.keys(this.panelAttribs).filter(
+      (panelId) => !oldPanelIds.has(panelId)
+    );
+    if (newPanelIds.length) {
+      this.settings["webui.category_panels"] =
+        this.sortedPanelIds.concat(newPanelIds);
+    }
+    // Sort panelAttribs and panelLabelAttribs by 'webui.category_panels'
+    this.panelAttribs = Object.fromEntries(
+      this.sortedPanelIds.map((panelId) => [
+        panelId,
+        this.panelAttribs[panelId],
+      ])
+    );
+    this.panelLabelAttribs = Object.fromEntries(
+      this.sortedPanelIds.map((panelId) => [
+        panelId,
+        this.panelLabelAttribs[panelId],
+      ])
+    );
+    // Read panel closed from config
+    for (const [panelId, attribs] of Object.entries(this.panelAttribs)) {
+      attribs.closed = this.panelClosed(panelId);
+    }
+    return newPanelIds.length > 0;
+  }
+
+  addPanel(panelId, name, labelAttribs, statisticInit) {
+    if (panelId in this.panelAttribs) {
+      throw Error(`Panel '${panelId}' has already been added!`);
+    }
+    this.panelAttribs[panelId] = { text: name };
+    this.panelLabelAttribs[panelId] = new Map(labelAttribs);
+
+    if (statisticInit) {
+      this.statistic.panelAdd(panelId, ...statisticInit);
+    }
+    if (this.configured) {
+      this.selection.panelAdd(panelId);
+      if (this.statistic.hasPanel(panelId)) {
+        // New view controlled panel
+        for (const view of this.views) {
+          view.selection.panelAdd(panelId);
+        }
+      }
+      this.updatePanels();
+      this.syncFn();
+    }
+  }
+
+  removePanel(panelId) {
+    if (!(panelId in this.panelAttribs)) {
+      return;
+    }
+    delete this.panelAttribs[panelId];
+    delete this.panelLabelAttribs[panelId];
+    this.statistic.panelRemove(panelId);
+
+    if (this.configured) {
+      this.selection.panelRemove(panelId);
+      for (const view of this.views) {
+        view.selection.panelRemove(panelId);
+      }
+      this.updatePanels();
+      this.syncFn();
+    }
+  }
+
+  setPanelClosed(panelId, closed, fromAtrribs) {
+    if (this.panelClosed(panelId, closed) !== closed) {
+      this.settings["webui.closed_panels"][panelId] = closed;
+      this.panelAttribs[panelId].closed = closed;
+      if (!fromAtrribs) {
+        this.syncFn();
+      }
+      this.onConfigChangeFn();
+    }
+  }
+
+  panelClosed(panelId) {
+    return this.settings["webui.closed_panels"][panelId];
+  }
+
+  //
+  // Views
+  //
+
+  saveNewView() {
+    this.views.push({
+      name: this.theUILang.NewView,
+      selection: this.selection
+        .withReducedPanels(this.statistic.panelIds)
+        .toggled("psearch", "quick_search", false),
+    });
+    this.onViewsChange();
+  }
+
+  removeActiveViews() {
+    // Remove previously selected view rows
+    this.views = this.views.filter(
+      (_, i) => !this.selection.active("pview", this.statistic.indexToViewId(i))
+    );
+    this.selection.select("pview", []);
+    this.onViewsChange();
+  }
+
+  renameView(viewId, viewName) {
+    const view = this.views[this.statistic.viewIdToIndex(viewId)];
+    if (viewName !== view.name) {
+      view.name = viewName;
+      this.onViewsChange();
+    }
+  }
+
+  moveView(viewId, action) {
+    // Move view according to action (to targetIndex)
+    const viewIndex = this.statistic.viewIdToIndex(viewId);
+    const viewCount = this.views.length;
+    if (viewIndex < viewCount) {
+      const targetIndex =
+        {
+          top: 0,
+          up: Math.max(viewIndex - 1, 0),
+          down: Math.min(viewIndex + 1, viewCount),
+          bottom: viewCount - 1,
+        }[action] ?? viewIndex;
+      this.views.splice(targetIndex, 0, this.views.splice(viewIndex, 1)[0]);
+      this.selection.select("pview", [
+        this.statistic.indexToViewId(targetIndex),
+      ]);
+      this.onViewsChange();
+    }
+  }
+
+  //
+  // Labels
+  //
+
+  selected(hash) {
+    return this.statistic.selected(hash, this.selection);
+  }
+
+  rescan(panelId, labelId) {
+    const torrents = this.borrowTorrentsFn();
+    this.statistic.rescan(torrents, panelId, labelId);
+  }
+
+  switchLabel(panelId, targetId, toggle = false, range = false) {
+    const change = this.selection.switch(
+      panelId,
+      targetId !== `${panelId}_all` ? targetId : null,
+      [...this.panelLabelAttribs[panelId].keys()].filter(
+        (labelId) => labelId !== panelId + "_all"
+      ),
+      toggle,
+      range
+    );
+    if (change) {
+      this.onSelectionChange(panelId);
+    }
+    return change;
+  }
+
+  refreshAndSyncPanel(panelId, prunedSelection) {
+    this.refresh(panelId);
+    if (prunedSelection) {
+      this.syncWithPrunedSelection(panelId);
+    } else {
+      this.syncFn();
+    }
+  }
+
+  syncAfterScan() {
+    // Rebuild torrent label tree
+    const torrentLabels = this.statistic
+      .ids("plabel")
+      .filter((labelId) => labelId.startsWith("clabel__"))
+      .map((labelId) => labelId.substring(8));
+    this.torrentLabelTree = new TorrentLabelTree(torrentLabels);
+
+    // Refresh all panels affected by the statistic scan
+    this.refresh("pview", ...this.statistic.panelIds);
+    this.syncWithPrunedSelection("plabel");
+  }
+
+  syncWithPrunedSelection(...pruneSelectionPanelIds) {
+    const prunedPanelIds = [];
+    for (const panelId of pruneSelectionPanelIds) {
+      // Remove non-existent selected labels (to potentially show 'All' label as selected)
+      const count = this.selection.count(panelId);
+      const limitedSelection = this.selection
+        .ids(panelId)
+        .filter((labelId) => this.panelLabelAttribs[panelId].has(labelId));
+      if (limitedSelection.length < count) {
+        this.selection.select(panelId, limitedSelection);
+        prunedPanelIds.push(panelId);
+      }
+    }
+    if (prunedPanelIds.length) {
+      this.onSelectionChange(...prunedPanelIds);
+    } else {
+      this.syncFn();
+    }
+  }
+
+  isLabelIdSelected(panelId, labelId) {
+    return labelId === `${panelId}_all`
+      ? this.selection.count(panelId) === 0
+      : this.selection.active(panelId, labelId);
+  }
+
+  onSelectionChange(...panelIds) {
+    if (panelIds.every((panelId) => panelId === "pview")) {
+      this.selection.adjustCurrentToView(
+        this.viewSelections,
+        this.statistic.panelIds
+      );
+      this.refresh(...this.statistic.panelIds);
+    } else if (panelIds.some((panelId) => this.statistic.hasPanel(panelId))) {
+      this.selection.adjustViewToCurrent(
+        this.viewSelections,
+        this.statistic.panelIds
+      );
+      if (!panelIds.includes("pview")) {
+        panelIds.push("pview");
+      }
+    }
+
+    this.refresh(...panelIds);
+    this.syncFn();
+    if (panelIds.some((panelId) => panelId === "pview")) {
+      // Current selection is only saved for this.statistic.panelIds
+      this.settings["webui.selected_labels.last"] = this.selection
+        .withReducedPanels(this.statistic.panelIds)
+        .toggled("psearch", "quick_search", false)
+        .toConfig();
+      this.onSelectionChangeFn();
+      this.onConfigChangeFn();
+    }
+  }
+
+  refresh(...panelIds) {
+    for (const panelId of panelIds) {
+      this.panelLabelAttribs[panelId] = new Map(
+        this.refreshPanel[panelId](this.panelLabelAttribs[panelId])
+      );
+    }
+  }
+
+  quickSearchActive() {
+    return this.selection.active("psearch", "quick_search");
+  }
+
+  currentViewIsNew() {
+    return (
+      !this.quickSearchActive() && this.selection.active("pview", "pview_isnew")
+    );
+  }
+
+  resetSelection() {
+    this.selection.clear();
+    this.onSelectionChange(...this.selection.panelIds);
+  }
+
+  //
+  // Quick Search
+  //
+  setQuickSearch(searchString) {
+    if (!this.configured) return;
+    const qsd = this.quickSearch.debounce;
+    if (qsd.timeoutId) {
+      clearTimeout(qsd.timeoutId);
+      qsd.timeoutId = 0;
+    }
+    if (searchString) {
+      this.quickSearch.search = new TextSearch(searchString);
+      qsd.timeoutId = setTimeout(() => {
+        this.rescan("psearch", "quick_search");
+        // Reset search selection when using quick search
+        if (!this.switchLabel("psearch", "quick_search")) {
+          this.onSelectionChangeFn();
+        }
+      }, qsd.delayMs);
+    } else if (this.selection.toggle("psearch", "quick_search", false)) {
+      this.onSelectionChange("psearch");
+    }
+  }
+
+  matchQuickSearch(torrentName) {
+    return (
+      this.quickSearch.search.text && this.quickSearch.search.match(torrentName)
+    );
+  }
+
+  //
+  // Text Search
+  //
+  onSearchesChanged() {
+    this.settings["webui.open_tegs.last"] = this.searches.map(
+      (search) => search.text
+    );
+    this.rescan("psearch");
+    this.refresh("psearch");
+    this.onSelectionChange("psearch");
+  }
+
+  addTextSearch(text, noPanelChange) {
+    const change =
+      text && this.searches.every((search) => search.text !== text);
+    if (change) {
+      this.searches.push(new TextSearch(text));
+      if (!noPanelChange) {
+        this.selection.toggle("psearch", "quick_search", false);
+        this.selection.toggle(
+          "psearch",
+          `psearch_${this.searches.length - 1}`,
+          true
+        );
+        this.onSearchesChanged();
+      }
+    }
+    return change;
+  }
+
+  removeActiveTextSearches() {
+    const removedSearchIndices = new Set(
+      this.selection.ids("psearch").map((searchId) => {
+        const [_, searchIndex] = searchId.split("_", 2);
+        return Number(searchIndex);
+      })
+    );
+
+    this.searches = this.searches.filter(
+      (_, i) => !removedSearchIndices.has(i)
+    );
+    this.selection.select("psearch", []);
+    this.onSearchesChanged();
+  }
+
+  removeAllTextSearches() {
+    this.searches = [];
+    this.selection.select("psearch", []);
+    this.onSearchesChanged();
+  }
+
+  //
+  // Context Menu
+  //
+  contextMenuEntries(panelId, labelId) {
+    return (
+      {
+        psearch: (this.selection.count("psearch") > 0
+          ? [[this.theUILang.removeTeg, () => this.removeActiveTextSearches()]]
+          : []
+        ).concat([
+          [this.theUILang.removeAllTegs, () => this.removeAllTextSearches()],
+        ]),
+        pview:
+          this.selection.count("pview") > 0
+            ? [
+                [
+                  this.theUILang.RenameView,
+                  () =>
+                    this.renameViewDialogFn(
+                      labelId,
+                      this.views[this.statistic.viewIdToIndex(labelId)]?.name ??
+                        ""
+                    ),
+                ],
+                [
+                  CMENU_CHILD,
+                  this.theUILang.MoveView.base,
+                  ["top", "up", "down", "bottom"].map((action) => [
+                    this.theUILang.MoveView[action],
+                    () => this.moveView(labelId, action),
+                  ]),
+                ],
+                [
+                  this.theUILang.RemoveActiveViews,
+                  () => this.removeActiveViews(),
+                ],
+              ]
+            : [],
+      }[panelId] ?? []
+    );
+  }
+}
+
+//
+// Legacy Mappings
+//
+
+function mapLegacyPanelId(panelId) {
+  return panelId.endsWith("_cont")
+    ? panelId === "flabel_cont"
+      ? "psearch"
+      : // Remove legacy _cont suffix
+        panelId.slice(0, -5)
+    : panelId;
+}
+
+function mapLegacyLabelId(labelId) {
+  return labelId.startsWith("teg_") ? "psearch_" + labelId.slice(4) : labelId;
+}

--- a/js/common.js
+++ b/js/common.js
@@ -761,15 +761,6 @@ var theFormatter =
 	   	}
 		return(arr);
 	},
-	treePrefix: function({hasNext, level})
-	{
-		return hasNext
-			.slice(1)
-			.map((next,l) => next
-				? (l+1 === level ? '├' : '│')
-				: (l+1 === level ? '└' : ' ')
-			).join('');
-	}
 };
 
 var theSearchEngines =
@@ -793,6 +784,10 @@ var theSearchEngines =
 	set: function( no, noSave )
 	{
 		theSearchEngines.current = no;
+		if (no !== -1)
+		{
+			theWebUI.categoryList.setQuickSearch(null);
+		}
 		if(!noSave)
 			theWebUI.save();
 	},

--- a/js/content.js
+++ b/js/content.js
@@ -5,7 +5,6 @@
 
 function makeContent()
 {
-	$(".cat").mouseclick(theWebUI.labelContextMenu);
 	$("#st_up").mouseclick(theWebUI.upRateMenu);
 	$("#st_down").mouseclick(theWebUI.downRateMenu);
 
@@ -146,11 +145,8 @@ function makeContent()
 		$("#tadd_label_select").empty()
 			.append('<option selected>'+theUILang.No_label+'</option>')
 			.append('<option>'+theUILang.newLabel+'</option>').show();
-		for (var lbl in theWebUI.cLabels)
-		{
-			var lblText = lbl.substring(8);
-			$("#tadd_label_select").append("<option>"+lblText+"</option>");
-		}
+		for(const [torrentLabel] of theWebUI.categoryList.torrentLabelTree.torrentLabels)
+			$("#tadd_label_select").append("<option>"+torrentLabel+"</option>");
 		$("#add_button").prop("disabled",false);
 		$("#tadd_label_select").trigger('change');
 	});

--- a/js/custom-elements.js
+++ b/js/custom-elements.js
@@ -1,0 +1,152 @@
+class CustomHTMLElement extends HTMLElement {
+  static stringAttributeNames = [];
+  static booleanAttributeNames = [];
+  static attributeChangeCallbacks = {};
+
+  static get mutObservedAttributes() {
+    return this.booleanAttributeNames.concat(this.stringAttributeNames);
+  }
+
+  pendingStyleLoad = false;
+
+  customAttachShadow() {
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.appendChild(this.constructor.template.content.cloneNode(true));
+    const styleLinkEl = shadow.querySelector('link[rel="stylesheet"]');
+    if (styleLinkEl && !styleLinkEl.sheet) {
+      this.pendingStyleLoad = true;
+      styleLinkEl.addEventListener(
+        "load",
+        () => {
+          this.pendingStyleLoad = false;
+          this.dispatchEvent(new CustomEvent("style-load"));
+        },
+        { once: true }
+      );
+    }
+    const partEls = [...shadow.querySelectorAll("[part]")];
+    if (partEls.length) {
+      this.parts = Object.fromEntries(
+        partEls.map((e) => [e.getAttribute("part"), e])
+      );
+    }
+    return shadow;
+  }
+
+  customDefineAttributes() {
+    this._restartMutationObserver((pendingMutations) => {
+      for (const attrName of this.constructor.stringAttributeNames) {
+        if (!this.hasOwnProperty(attrName)) {
+          Object.defineProperty(this, attrName, {
+            set(value) {
+              if (value !== this.getAttribute(attrName)) {
+                if (value !== null) {
+                  this.setAttribute(attrName, value);
+                } else {
+                  this.removeAttribute(attrName);
+                }
+              }
+            },
+            get() {
+              return this.getAttribute(attrName);
+            },
+          });
+          pendingMutations.push({ attributeName: attrName, oldValue: null });
+        }
+      }
+      for (const attrName of this.constructor.booleanAttributeNames) {
+        if (!this.hasOwnProperty(attrName)) {
+          Object.defineProperty(this, attrName, {
+            set(value) {
+              this.toggleAttribute(attrName, value);
+            },
+            get() {
+              return this.hasAttribute(attrName);
+            },
+          });
+          pendingMutations.push({ attributeName: attrName, oldValue: null });
+        }
+      }
+    });
+  }
+  _restartMutationObserver(withoutObserver) {
+    // Changing observedAttributes after calling customElements.define is not allowed.
+    // Thus, instead of observedAttributes we use a MutationObserver
+    // to support plugin-defined attributes.
+    if (!this._mutationObserver) {
+      this._mutationObserver = new MutationObserver(
+        this._attributeMutationCallback.bind(this)
+      );
+    }
+    // Process pending mutations now
+    this._mutationObserver.disconnect();
+    const pendingMutations = this._mutationObserver.takeRecords();
+    withoutObserver(pendingMutations);
+    this._attributeMutationCallback(pendingMutations);
+
+    // Restart mutation observer
+    this._mutationObserver.observe(this, {
+      attributeFilter: this.constructor.mutObservedAttributes,
+      attributeOldValue: true,
+    });
+  }
+
+  _attributeMutationCallback(records) {
+    for (const record of records) {
+      const fn =
+        this.constructor.attributeChangeCallbacks[record.attributeName];
+      if (fn) {
+        fn.call(this, record.oldValue, this.getAttribute(record.attributeName));
+      }
+    }
+  }
+}
+
+//
+// Plugin Helpers
+//
+function injectCustomElementAttribute(
+  elementTag,
+  attributeName,
+  attributeChangedCallbackFn,
+  isBooleanAttrib = false
+) {
+  const clazz = customElements.get(elementTag);
+  if (!clazz) {
+    throw new Error(`Custom element not defined: ${elementTag}!`);
+  }
+  (isBooleanAttrib
+    ? clazz.booleanAttributeNames
+    : clazz.stringAttributeNames
+  ).push(attributeName);
+  clazz.attributeChangeCallbacks[attributeName] = attributeChangedCallbackFn;
+  for (const element of document.getElementsByTagName(elementTag)) {
+    element.customDefineAttributes();
+  }
+}
+
+function queryCustomElementShadowRoots(elementTag) {
+  const template = customElements.get(elementTag).template;
+  if (!template) {
+    throw new Error(`Template not defined for custom element: ${elementTag}!`);
+  }
+  return [...document.getElementsByTagName(elementTag)]
+    .map((element) => element.shadowRoot)
+    .concat([template.content]);
+}
+
+function injectCustomElementCSS(elementTag, styleSheetURL) {
+  for (const e of queryCustomElementShadowRoots(elementTag)) {
+    const lastStyleEl = e.querySelector('link[rel="stylesheet"]:last-of-type');
+    const injectStyleEl = Object.assign(document.createElement("link"), {
+      rel: "stylesheet",
+      href: styleSheetURL,
+      type: "text/css",
+    });
+    if (lastStyleEl) {
+      lastStyleEl.after(injectStyleEl);
+    } else {
+      e.prepend(injectStyleEl);
+    }
+  }
+}

--- a/js/panel.js
+++ b/js/panel.js
@@ -1,0 +1,597 @@
+/**
+ * A panel label selection consisting of a set of selected labels for each panel.
+ */
+class PanelLabelSelection {
+  static fromConfig(actLbls, panelIds) {
+    const selection = new PanelLabelSelection();
+    for (const panelId of panelIds) {
+      selection.panelAdd(panelId);
+      if (panelId in actLbls) {
+        const lbl = actLbls[panelId];
+        // Consider legacy single-label selection
+        const labelIds = Array.isArray(lbl) ? lbl : lbl ? [lbl] : [];
+        selection.select(panelId, labelIds);
+        // Expect range anchor at first position
+        selection.rangeAnchor(panelId, labelIds[0] ?? null);
+      }
+    }
+    return selection;
+  }
+
+  constructor(activeLabelIds, rangeAnchors) {
+    this.activeLabelIds = activeLabelIds ?? {};
+    this.rangeAnchors = rangeAnchors ?? {};
+  }
+
+  toConfig() {
+    return Object.fromEntries(
+      Object.entries(this.activeLabelIds)
+        .filter(([_, labelIds]) => labelIds.size)
+        .map(([panelId, labelIds]) => [
+          panelId,
+          [...labelIds].sort(),
+          this.rangeAnchors[panelId],
+        ])
+        .map(([panelId, labelIds, anchor]) => [
+          panelId,
+          // Move anchor to first position
+          anchor
+            ? [anchor, ...labelIds.filter((labelId) => labelId !== anchor)]
+            : labelIds,
+        ])
+    );
+  }
+
+  rangeAnchor(panelId, anchor) {
+    if (anchor !== undefined) {
+      this.rangeAnchors[panelId] = anchor;
+    }
+    return this.rangeAnchors[panelId];
+  }
+  count(panelId) {
+    return this.activeLabelIds[panelId].size;
+  }
+  ids(panelId) {
+    return [...this.activeLabelIds[panelId]];
+  }
+
+  select(panelId, selectedIds) {
+    this.activeLabelIds[panelId] = new Set(selectedIds);
+    return this;
+  }
+  active(panelId, labelId) {
+    return this.activeLabelIds[panelId].has(labelId);
+  }
+  isEmpty() {
+    return Object.values(this.activeLabelIds).every(
+      (selection) => selection.size === 0
+    );
+  }
+  clear() {
+    for (const selection of Object.values(this.activeLabelIds)) {
+      selection.clear();
+    }
+    return this;
+  }
+
+  toggle(panelId, labelId, force) {
+    const labelIds = this.activeLabelIds[panelId];
+    const enable = force != null ? force : !labelIds.has(labelId);
+    return enable ? labelIds.add(labelId) : labelIds.delete(labelId);
+  }
+
+  equal(selection) {
+    return Object.entries(this.activeLabelIds).every(([panelId, labelIds]) => {
+      const otherLabelIds = selection.activeLabelIds[panelId];
+      return (
+        labelIds.size === otherLabelIds.size &&
+        [...labelIds].every((labelId) => otherLabelIds.has(labelId))
+      );
+    });
+  }
+
+  subset(greaterSelection) {
+    return Object.entries(this.activeLabelIds).every(
+      ([panelId, smallerLabelIds]) => {
+        const greaterLabelIds = greaterSelection.activeLabelIds[panelId];
+        return (
+          !greaterLabelIds.size ||
+          (smallerLabelIds.size &&
+            greaterLabelIds.size >= smallerLabelIds.size &&
+            [...smallerLabelIds].every((labelId) =>
+              greaterLabelIds.has(labelId)
+            ))
+        );
+      }
+    );
+  }
+
+  switch(panelId, targetId, sortedLabelIds, toggle, range) {
+    const labelIds = this.activeLabelIds[panelId];
+    const anchor = this.rangeAnchors[panelId];
+    let nextLabelIds = targetId ? [targetId] : [];
+
+    if (targetId) {
+      if (!range) {
+        this.rangeAnchors[panelId] = targetId;
+      }
+      if (range && targetId !== anchor) {
+        // Range selection: Select labelIds between anchor and target
+        const a = anchor
+          ? sortedLabelIds.findIndex((labelId) => labelId === anchor)
+          : 0;
+        const t = sortedLabelIds.findIndex((labelId) => labelId === targetId);
+        const tt = t === -1 ? sortedLabelIds.length - 1 : t;
+        const [start, end] = [Math.min(a, tt), Math.max(a, tt)];
+        const rangeLabelIds = sortedLabelIds.slice(start, end + 1);
+
+        if (toggle) {
+          // Range toggle
+          nextLabelIds = new Set(labelIds);
+          const enable = labelIds.has(anchor);
+          for (const labelId of rangeLabelIds) {
+            if (enable) {
+              nextLabelIds.add(labelId);
+            } else {
+              nextLabelIds.delete(labelId);
+            }
+          }
+          nextLabelIds = [...nextLabelIds];
+        } else {
+          // Switch to range
+          nextLabelIds = rangeLabelIds;
+        }
+      } else if (toggle) {
+        // Toggle one label
+        nextLabelIds = labelIds.has(targetId)
+          ? [...labelIds].filter((labelId) => labelId !== targetId)
+          : [...labelIds, targetId];
+      }
+    } else if (toggle) {
+      // Toggling the 'All' label swaps the selection in the panel
+      nextLabelIds = sortedLabelIds.filter((labelId) => !labelIds.has(labelId));
+    } else {
+      this.rangeAnchors[panelId] = null;
+    }
+
+    const change =
+      labelIds.size !== nextLabelIds.length ||
+      !nextLabelIds.every((labelId) => labelIds.has(labelId));
+    if (change) {
+      this.activeLabelIds[panelId] = new Set(nextLabelIds);
+    }
+    return change;
+  }
+  get panelIds() {
+    return Object.keys(this.activeLabelIds);
+  }
+  panelAdd(...panelIds) {
+    for (const panelId of panelIds) {
+      if (!(panelId in this.activeLabelIds)) {
+        this.activeLabelIds[panelId] = new Set();
+        this.rangeAnchors[panelId] = null;
+      }
+    }
+    return this;
+  }
+  panelRemove(...panelIds) {
+    for (const panelId of panelIds) {
+      delete this.activeLabelIds[panelId];
+      delete this.rangeAnchors[panelId];
+    }
+    return this;
+  }
+
+  //
+  // View selection <--adjust--> Current Selection
+  //
+
+  withReducedPanels(panelIds) {
+    return new PanelLabelSelection(
+      Object.fromEntries(
+        panelIds.map((panelId) => [
+          panelId,
+          new Set(this.activeLabelIds[panelId]),
+        ])
+      ),
+      Object.fromEntries(
+        panelIds.map((panelId) => [panelId, this.rangeAnchors[panelId]])
+      )
+    );
+  }
+
+  toggled(panelId, labelId, force) {
+    this.toggle(panelId, labelId, force);
+    return this;
+  }
+
+  adjustCurrentToView(viewSelections, viewControlledPanelIds) {
+    for (const panelId of viewControlledPanelIds) {
+      const viewLabelIds = this.ids("pview")
+        .filter((viewId) => viewId !== "pview_isnew")
+        .map((viewId) => viewSelections[Number(viewId.split("_").at(-1))])
+        .filter((viewSelection) => viewSelection)
+        .map((viewSelection) =>
+          // View selection is allowed to have missing panel ids
+          panelId in viewSelection.activeLabelIds
+            ? viewSelection.ids(panelId)
+            : []
+        );
+      this.select(
+        panelId,
+        // Select 'All' if there is a view which selects 'All'
+        viewLabelIds.some((labelIds) => !labelIds.length)
+          ? []
+          : viewLabelIds.flat()
+      );
+      this.rangeAnchor(panelId, null);
+    }
+    const currentSelection = this.withReducedPanels(viewControlledPanelIds);
+    this.toggle(
+      "pview",
+      "pview_isnew",
+      currentSelection.isNewView(viewSelections)
+    );
+    return this;
+  }
+
+  adjustViewToCurrent(viewSelections, viewControlledPanelIds) {
+    // A view is active if it is a subset of the current selection.
+    // The 'All' view is only active with a empty current selection.
+    const currentSelection = this.withReducedPanels(viewControlledPanelIds);
+    this.select(
+      "pview",
+      currentSelection.isEmpty()
+        ? []
+        : viewSelections
+            .map((viewSelection, viewIndex) => [viewSelection, viewIndex])
+            .filter(([viewSelection]) => viewSelection.subset(currentSelection))
+            .map(([_, viewIndex]) => `pview_${viewIndex}`)
+            .concat(
+              currentSelection.isNewView(viewSelections) ? ["pview_isnew"] : []
+            )
+    );
+    this.rangeAnchor("pview", null);
+    return this;
+  }
+
+  isNewView(viewSelections) {
+    // If the current selection does not equal an existing view, it is new.
+    // (A new view may be saved as a 'New View')
+    return (
+      !this.isEmpty() &&
+      !viewSelections.some((viewSelection) => viewSelection.equal(this))
+    );
+  }
+}
+
+class TorrentStatisticBucket {
+  constructor() {
+    this.hashes = new Set();
+    this.size = 0;
+    this.download = 0;
+    this.upload = 0;
+  }
+
+  get count() {
+    return this.hashes.size;
+  }
+
+  add(hash, torrent) {
+    const added = this.hashes.add(hash);
+    if (added) {
+      this.size += torrent.size;
+      this.upload += torrent.ul;
+      this.download += torrent.dl;
+    }
+    return added;
+  }
+  contains(hash) {
+    return this.hashes.has(hash);
+  }
+}
+
+class CategoryPanelStatistic {
+  constructor(getLabelIdsFn, labelIdPredicates) {
+    this.buckets = new Map();
+    this.getLabelIdsFn = getLabelIdsFn;
+    this.labelIdPredicates = labelIdPredicates ?? {};
+  }
+
+  getLabelIds(hash, torrent) {
+    return this.getLabelIdsFn(hash, torrent).concat(
+      Object.entries(this.labelIdPredicates)
+        .filter(([_, predicate]) => predicate(hash, torrent))
+        .map(([labelId]) => labelId)
+    );
+  }
+
+  empty() {
+    return new this.constructor(this.getLabelIdsFn, this.labelIdPredicates);
+  }
+
+  add(hash, torrent, labelId) {
+    const bucket = this.buckets.get(labelId) ?? new TorrentStatisticBucket();
+    const added = bucket.add(hash, torrent);
+    this.buckets.set(labelId, bucket);
+    return added;
+  }
+
+  rescan(torrents, labelId) {
+    let getLabelIds = this.getLabelIds.bind(this);
+    if (labelId && labelId in this.labelIdPredicates) {
+      const predicate = this.labelIdPredicates[labelId];
+      this.buckets.set(labelId, new TorrentStatisticBucket());
+      getLabelIds = (hash, torrent) =>
+        predicate(hash, torrent) ? [labelId] : [];
+    } else {
+      this.buckets = new Map();
+    }
+    for (const [hash, torrent] of Object.entries(torrents)) {
+      for (const lId of getLabelIds(hash, torrent)) {
+        this.add(hash, torrent, lId);
+      }
+    }
+    return this;
+  }
+
+  scan(hash, torrent) {
+    for (const labelId of this.getLabelIds(hash, torrent)) {
+      this.add(hash, torrent, labelId);
+    }
+    return this;
+  }
+
+  lookup(labelId) {
+    return this.buckets.get(labelId) ?? new TorrentStatisticBucket();
+  }
+
+  selected(hash, selectedLabelIds) {
+    return (
+      !selectedLabelIds.length ||
+      selectedLabelIds.some((labelId) =>
+        this.buckets.get(labelId)?.contains(hash)
+      )
+    );
+  }
+}
+
+class CategoryListStatistic extends TorrentStatisticBucket {
+  static from(viewPanelId, viewSelections, panelsObj) {
+    return new this(
+      viewPanelId,
+      viewSelections,
+      Object.fromEntries(
+        Object.entries(panelsObj).map(
+          ([panelId, [getLabelIdsFn, labelIdPredicates]]) => [
+            panelId,
+            new CategoryPanelStatistic(getLabelIdsFn, labelIdPredicates),
+          ]
+        )
+      )
+    );
+  }
+
+  panelAdd(panelId, getLabelIdsFn, labelIdPredicates) {
+    this._panels[panelId] = new CategoryPanelStatistic(
+      getLabelIdsFn,
+      labelIdPredicates
+    );
+  }
+
+  panelRemove(panelId) {
+    delete this._panels[panelId];
+  }
+
+  constructor(viewPanelId, viewSelections, panels) {
+    super();
+    this._viewPanelId = viewPanelId;
+    this._viewSelections = viewSelections;
+    this._viewPanel = new CategoryPanelStatistic((hash) =>
+      this._viewSelections
+        .map((viewSelection, viewIndex) => [viewSelection, viewIndex])
+        .filter(([viewSelection]) => this.selected(hash, viewSelection))
+        .map(([_, viewIndex]) => this.indexToViewId(viewIndex))
+    );
+    this._panels = panels;
+  }
+
+  /**
+   * @param {PanelLabelSelection[]} viewSelections
+   */
+  set viewSelections(viewSelections) {
+    this._viewSelections = viewSelections;
+  }
+
+  indexToViewId(index) {
+    return `${this._viewPanelId}_${index}`;
+  }
+
+  viewIdToIndex(viewId) {
+    return Number(viewId.split("_").at(-1));
+  }
+
+  /**
+   * Rescan torrents.
+   * @param {object} torrents - Same torrents that were used for `scan`
+   * @param {string} panelId - panelId with a change in its filtering
+   * @param {string?} labelId - optional labelId with a change in its filtering
+   */
+  rescan(torrents, panelId, labelId) {
+    if (panelId !== this._viewPanelId) {
+      this._panels[panelId].rescan(torrents, labelId);
+    }
+    this._viewPanel.rescan(torrents);
+  }
+
+  empty() {
+    return new this.constructor(
+      this._viewPanelId,
+      this._viewSelections,
+      Object.fromEntries(
+        Object.entries(this._panels).map(([panelId, panel]) => [
+          panelId,
+          panel.empty(),
+        ])
+      )
+    );
+  }
+
+  /**
+   * Scan a single torrent and accumulate its statistical data.
+   * @param {string} hash - torrent hash
+   * @param {object} torrent - scanned torrent
+   */
+  scan(hash, torrent) {
+    if (super.add(hash, torrent)) {
+      for (const panel of Object.values(this._panels)) {
+        panel.scan(hash, torrent);
+      }
+      this._viewPanel.scan(hash, torrent);
+    }
+  }
+  ids(panelId) {
+    return [...this._panels[panelId]?.buckets.keys()];
+  }
+
+  selected(hash, panelLabelSelection) {
+    return Object.entries(this._panels).every(([panelId, panel]) =>
+      panel.selected(hash, panelLabelSelection.ids(panelId))
+    );
+  }
+
+  lookup(panelId, labelId) {
+    const panelStat =
+      panelId === this._viewPanelId ? this._viewPanel : this._panels[panelId];
+    return panelStat.lookup(labelId);
+  }
+
+  get panelIds() {
+    return Object.keys(this._panels);
+  }
+  hasPanel(panelId) {
+    return panelId in this._panels;
+  }
+}
+class TextSearch {
+  constructor(text) {
+    this.text = text;
+    this.pattern = new RegExp(
+      text.replace(/[-[\]{}()+?.,\\^$|#\s]/g, "\\$&").replace("*", ".+"),
+      "i"
+    );
+  }
+
+  match(name) {
+    return this.pattern.test(name);
+  }
+}
+
+class TorrentLabelTree {
+  constructor(torrentLabels) {
+    if (!(torrentLabels instanceof Set)) {
+      torrentLabels = new Set(torrentLabels);
+    }
+    // Build tree from torrent labels/paths
+    const labelTree = {};
+    for (const label of torrentLabels) {
+      let node = labelTree;
+      for (const pathSegment of label.split("/")) {
+        if (!(pathSegment in node)) {
+          node[pathSegment] = {};
+        }
+        node = node[pathSegment];
+      }
+    }
+    const traverse = (node, path = [], hasNext = [], level = 0) =>
+      Object.keys(node)
+        .sort()
+        .flatMap((name, i) => {
+          const nextPath = path.concat(name);
+          const nextHasNext = hasNext.concat(
+            i !== Object.keys(node).length - 1
+          );
+          const child = node[name];
+          const childCount = Object.keys(child).length;
+
+          return [
+            [
+              nextPath.join("/"),
+              nextPath,
+              nextHasNext,
+              level,
+              /* can be flattened if one child */ childCount === 1,
+            ],
+            ...traverse(
+              node[name],
+              nextPath,
+              nextHasNext,
+              childCount <= 1 ? level : nextPath.length
+            ),
+          ];
+        });
+    this.torrentLabels = new Map(
+      traverse(labelTree).map(
+        ([torrentLabel, path, hasNext, level, oneChild]) => [
+          torrentLabel,
+          {
+            path,
+            hasNext,
+            level,
+            oneChild,
+            empty: !torrentLabels.has(torrentLabel),
+          },
+        ]
+      )
+    );
+  }
+
+  /**
+   * Display torrent label as a tree.
+   * @param {boolean} flat - Always show the complete label paths.
+   * @param {boolean} hideEmpty - If possible, hide empty label paths.
+   */
+  prefixSuffix(torrentLabel, flat, hideEmpty) {
+    const { empty, path, level, oneChild, hasNext } =
+      this.torrentLabels.get(torrentLabel);
+    const wantHide = empty && hideEmpty;
+    const hidePossible = flat || oneChild;
+
+    const shownLevel = flat ? 0 : hideEmpty ? level : path.length - 1;
+    return wantHide && hidePossible
+      ? null
+      : {
+          prefix: this.prefix({
+            hasNext: hasNext.slice(0, shownLevel + 1),
+            level: shownLevel,
+          }),
+          text: path.slice(shownLevel).join("/"),
+        };
+  }
+
+  list(flat, hideEmpty) {
+    return new Map(
+      [...this.torrentLabels.keys()]
+        .map((torrentLabel) => [
+          torrentLabel,
+          this.prefixSuffix(torrentLabel, flat, hideEmpty),
+        ])
+        .filter(([_, info]) => info != null)
+    );
+  }
+  prefix({ level, hasNext }) {
+    return hasNext
+      .slice(1)
+      .map((next, l) =>
+        next ? (l + 1 === level ? "├" : "│") : l + 1 === level ? "└" : " "
+      )
+      .join("");
+  }
+}
+
+export {
+  PanelLabelSelection,
+  CategoryListStatistic,
+  TextSearch,
+  TorrentLabelTree,
+};

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -404,18 +404,17 @@ rPlugin.prototype.removePaneFromStatusbar = function(id)
 	return(this);
 }
 
-rPlugin.prototype.addPaneToCategory = function(id,name)
+rPlugin.prototype.addPaneToCategory = function(id,name, labelAttribs, statisticInit)
 {
 	if(this.canChangeCategory())
 	{
-		theWebUI.addPanel(id, name);
+		theWebUI.categoryList.addPanel(id, name, labelAttribs, statisticInit);
 	}
-	return($("#"+id+"_cont"));
+	return($($$(id)));
 }
 
 rPlugin.prototype.removePaneFromCategory = function(id)
 {
-	$("#"+id).remove();
-	$("#"+id+"_cont").remove();
+	theWebUI.categoryList.removePanel(id);
 	return(this);
 }

--- a/js/webui.js
+++ b/js/webui.js
@@ -870,6 +870,16 @@ var theWebUI =
 								theWebUI.updatePanel('pview');
 								break;
 							}
+							case "webui.show_viewlabelsize":
+							case "webui.show_statelabelsize":
+							case "webui.show_labelsize":
+							case "webui.show_searchlabelsize":
+							case "webui.labelsize_rightalign":
+							case "webui.show_label_text_overflow":
+							{
+								theWebUI.updateLabels()
+								break;
+							}
 						}
 					}
 					else

--- a/js/webui.js
+++ b/js/webui.js
@@ -2,17 +2,6 @@
  *      Main object.
  *
  */
-function mapPanelIdtoLegacyPanelId(panelId) {
-	return {
-		psearch: 'flabel',
-	}[panelId] ?? panelId;
-}
-function mapPanelIdtoLegacyLabelType(panelId) {
-	return panelId.endsWith('_cont') ? panelId : mapPanelIdtoLegacyPanelId(panelId) + '_cont';
-}
-function mapLabelIdToLegacyLabelId(labelId) {
-	return labelId.startsWith("psearch_") ? "teg_" + labelId.slice(8) : labelId;
-}
 
 var theWebUI =
 {
@@ -229,16 +218,6 @@ var theWebUI =
 	trackers:	{},
 	props:		{},
 	peers:		{},
-	labels: {},
-	viewPanelLabelTypes: ['pstate_cont', 'plabel_cont', 'flabel_cont'],
-	actLbls:
-	{
-		'pstate_cont': [],
-		'plabel_cont': []
-	},
-	cLabels:	{},
-	staticLabels: ['dls','com','act','iac','nlb','err'],
-	quickSearch: { teg: {val: ''}, debounce: { timeoutId: 0, delayMs: 220 } },
 	dID:		"",
 	pID:		"",
 	speedGraph:	new rSpeedGraph(),
@@ -246,11 +225,10 @@ var theWebUI =
 	timer:		new Timer(),
 	activeView:	null,
 	delmode:	"remove",
-	tegs:		{},
-	lastTeg:	0,
 	deltaTime:	0,
 	serverDeltaTime:0,
 	taskAddTorrents: null,
+	categoryList: null,
 	taskAddTorrentsAnimateHandleId: 0,
 
 //
@@ -517,39 +495,17 @@ var theWebUI =
 		if(!theWebUI.systemInfo.rTorrent.started)
 			$(theWebUI.getTable("trt").scp).text(theUILang.noTorrentList).show();
 
-		// Restore category panels (fold and sort)
-		$(".catpanel").each( function()
-		{
-			theWebUI.updatePanel(this.id);
-		});
-		theWebUI.sortPanels();
-		theWebUI.updateViewPanelLabels();
-
-		// recreate tegs if enabled
-		if (theWebUI.settings["webui.open_tegs.keep"]) {
-			for(const tegStr of theWebUI.settings["webui.open_tegs.last"]) {
-				theWebUI.createTeg(tegStr);
-			}
-		}
-		// switch to labels if keeping selected labels is enabled
-		if (theWebUI.settings["webui.selected_labels.keep"]) {
-			const actLbls = this.settings['webui.selected_labels.last'];
-			for(const [labelType, lbls] of Object.entries(actLbls)) {
-				// consider legacy single-label selection
-				const labelIds = Array.isArray(lbls) ? lbls : lbls ? [lbls] : [];
-				this.actLbls[mapPanelIdtoLegacyLabelType(labelType)] = labelIds.map(mapLabelIdToLegacyLabelId);
-			}
-		}
-		theWebUI.settings["webui.selected_labels.views"] = theWebUI.settings["webui.selected_labels.views"]
-			.map(view => ({...view, labels: Object.fromEntries(
-				Object.entries(view.labels)
-				.map(([panelId, labelIds]) => [
-					mapPanelIdtoLegacyLabelType(panelId),
-					labelIds.map(mapLabelIdToLegacyLabelId)
-			]))}));
-
-		this.adjustViewSelectionToActiveLabels();
-		this.refreshLabelSelection('pview_cont', ...(this.viewPanelLabelTypes));
+		theWebUI.categoryList.config(this.settings);
+		// Setup quick search
+		const searchField = $$("query");
+		const updateQuickSearch = () => {
+			this.categoryList.setQuickSearch(
+				theSearchEngines.current === -1 ? searchField.value : null
+			);
+		};
+		searchField.addEventListener("focus", () => updateQuickSearch());
+		searchField.addEventListener("input", () => updateQuickSearch());
+		updateQuickSearch();
 
 		// user must be able add peer when peers are empty
 		$("#PeerList .stable-body").mouseclick(function(e)
@@ -563,35 +519,6 @@ var theWebUI =
 		});
 
 		this.registerMagnetHandler();
-		// setup quick search
-		const searchField = $('#query');
-		const updateQuickSearch = () => {
-			this.quickSearch.teg = this.searchToTeg(searchField.val());
-		};
-		const qsd = this.quickSearch.debounce;
-		searchField.on('input focus', () => {
-			updateQuickSearch();
-			if (qsd.timeoutId) {
-				clearTimeout(qsd.timeoutId);
-			}
-			qsd.timeoutId = setTimeout(() => {
-				this.labels['quick_search'] = new Set(
-					Object.entries(this.torrents)
-					.filter(([_, torrent]) => this.quickSearch.teg.val &&
-						this.matchTeg(this.quickSearch.teg, torrent.name))
-					.map(([hash]) => hash)
-				);
-				if ((this.actLbls['flabel_cont'] ?? []).length) {
-					this.actLbls['flabel_cont'] = [];
-					this.onLabelSelectionChanged('flabel_cont');
-				} else {
-					this.refreshLabelSelection('pview_cont', 'flabel_cont');
-					this.filterTorrentTable();
-				}
-			}, qsd.delayMs);
-		});
-		updateQuickSearch();
-		this.refreshLabelSelection('pview_cont', 'flabel_cont');
 		this.configured = true;
 	},
 
@@ -794,6 +721,7 @@ var theWebUI =
 	        var req = '';
 	        var needSave = false;
 		var needResize = false;
+		let needCatListSync = false;
 		var reply = null;
 		$.each(this.settings, function(i,v)
 		{
@@ -812,6 +740,7 @@ var theWebUI =
 				}
 				if(nv!=v)
 				{
+					theWebUI.settings[i] = nv;
 					if((/^webui\./).test(i))
 					{
 						needSave = true;
@@ -873,21 +802,14 @@ var theWebUI =
 							}
 							case "webui.update_interval":
 							{
-								theWebUI.settings["webui.update_interval"] = nv;
 								if(theWebUI.systemInfo.rTorrent.started)
 									theWebUI.resetInterval();
 								break;
 							}
 							case "webui.speedgraph.max_seconds":
 							{
-								theWebUI.settings["webui.speedgraph.max_seconds"] = nv;
 								theWebUI.speedGraph.setMaxSeconds(parseInt(theWebUI.settings['webui.speedgraph.max_seconds']))
 								theWebUI.speedGraph.draw();
-								break;
-							}
-							case "webui.show_view_panel":
-							{
-								theWebUI.updatePanel('pview');
 								break;
 							}
 							case "webui.show_viewlabelsize":
@@ -896,8 +818,9 @@ var theWebUI =
 							case "webui.show_searchlabelsize":
 							case "webui.labelsize_rightalign":
 							case "webui.show_label_text_overflow":
+							case "webui.show_view_panel":
 							{
-								theWebUI.updateLabels()
+								needCatListSync = true;
 								break;
 							}
 						}
@@ -907,10 +830,15 @@ var theWebUI =
 						var k_type = o.is("input:checkbox") || o.is("select") || o.hasClass("num") ? "n" : "s";
 						req+=("&s="+k_type+i+"&v="+nv);
 					}
-					theWebUI.settings[i] = nv;
 				}
 			}
 		});
+		if (needCatListSync)
+		{
+			const c = this.categoryList;
+			c.refresh(...c.statistic.panelIds);
+			c.syncFn();
+		}
 		if(needResize)
 			this.resize();
 		if((req.length>0) && theWebUI.systemInfo.rTorrent.started)
@@ -967,12 +895,6 @@ var theWebUI =
 		});
 
 		theWebUI.settings['webui.selected_tab.last'] = theWebUI.activeView;
-		const savedActLbls = {}
-		for (const labelType of ['pstate_cont', 'plabel_cont', 'flabel_cont', 'ptrackers_cont']) {
-			savedActLbls[labelType] = theWebUI.actLbls[labelType];
-		}
-		theWebUI.settings['webui.selected_labels.last'] = savedActLbls;
-		theWebUI.settings['webui.open_tegs.last'] = Object.values(theWebUI.tegs).map(t => t.val);
 		var cookie = {};
 		theWebUI.settings["webui.search"] = theSearchEngines.current;
 		for(const [i,v] of Object.entries(theWebUI.settings))
@@ -1513,16 +1435,15 @@ var theWebUI =
 		_bf.push([theUILang.New_label, (table.selCount > 1) || this.isTorrentCommandEnabled("setlabel",id) ? "theWebUI.newLabel()" : null]);
    		_bf.push([theUILang.Remove_label, (table.selCount > 1) || this.isTorrentCommandEnabled("setlabel",id) ? "theWebUI.removeLabel()" : null]);
    		_bf.push([CMENU_SEP]);
-		for(var labelId in this.cLabels)
+		for(const [torrentLabel, info]  of theWebUI.categoryList.torrentLabelTree.torrentLabels)
 		{
-			const lbl = labelId.substring(8);
-			var lblText = this.settings['webui.show_label_path_tree'] ?
-				'│'.repeat(this.cLabels[labelId].level) + this.cLabelText(labelId):
-				lbl;
-			if((table.selCount == 1) && (this.torrents[id].label === lbl))
+			const lblText = this.settings["webui.show_label_path_tree"]
+				? ('│'.repeat(info.level) + info.path.slice(info.level).join("/"))
+				: torrentLabel;
+			if((table.selCount == 1) && (this.torrents[id].label == torrentLabel))
 				_bf.push([CMENU_SEL, lblText]);
 			else
-				_bf.push([lblText, (table.selCount > 1) || this.isTorrentCommandEnabled("setlabel",id) ? "theWebUI.setLabel('" + addslashes(lbl) + "')" : null]);
+				_bf.push([lblText, (table.selCount > 1) || this.isTorrentCommandEnabled("setlabel",id) ? "theWebUI.setLabel('" + addslashes(torrentLabel) + "')" : null]);
 		}
    		theContextMenu.add([CMENU_CHILD, theUILang.Labels, _bf]);
    		theContextMenu.add([CMENU_SEP]);
@@ -1713,14 +1634,6 @@ var theWebUI =
 	{
 	},
 
-	labelStat: function(lbl) {
-		const torrentHashes = this.labels[lbl] ?? new Set();
-		let size = 0;
-		for (const hash of torrentHashes)
-			size += this.torrents[hash].size;
-		return { cnt: torrentHashes.size, size };
-	},
-
 	/**
 	 * @typedef {Object} WebUITorrent
 	 * @property {string} name
@@ -1752,42 +1665,17 @@ var theWebUI =
 		const dataTorrents = data.torrents;
 		data = null;
 
-		const torrentViews = Object.fromEntries(theWebUI.settings['webui.selected_labels.views']
-				.map((view, i) => [`pview_custom_view_${i}`, view])
-		);
-		let torrentLabels = Object.fromEntries(
-			Object.keys(torrentViews)
-			.concat([...this.staticLabels, 'nlb'].map(n => `-_-_-${n}-_-_-`))
-			.map((lbl) => [lbl, new Set()])
-		);
-		let [tdl, tul, tsize] = [0, 0, 0];
-		const newHashes = [];
+		let statistic = this.categoryList.statistic.empty();
 
 		this.taskAddTorrents
 			.reset()
 			.map(Object.entries(dataTorrents), ([hash, torrent]) => {
 				const sInfo = this.getStatusIcon(torrent);
 				torrent.status = sInfo[1];
-				// Determine labels of torrent
-				const lbls = this.getLabels(hash, torrent);
-				for (const lblId of lbls) {
-					const labels = torrentLabels[lblId] ?? new Set();
-					labels.add(hash);
-					torrentLabels[lblId] = labels;
-				}
-				for (const [lbl, view] of Object.entries(torrentViews)) {
-					if (this.shouldShowTorrentRow(hash, torrentLabels, view.labels, true)) {
-						torrentLabels[lbl].add(hash);
-					}
-				}
-				// Accumulate torrent data
-				tdl += iv(torrent.dl);
-				tul += iv(torrent.ul);
-				tsize += torrent.size;
-				if (!(hash in this.torrents))
-					newHashes.push(hash);
+				// Accumulate into view category list
+				statistic.scan(hash, torrent);
 				// Update torrent table
-				table.setRowById(torrent, hash, sInfo[0], {labels: lbls.join('-_-_-')})
+				table.setRowById(torrent, hash, sInfo[0], {})
 			})
 			.enqueueFunc(() => {
 				// update details page
@@ -1813,11 +1701,12 @@ var theWebUI =
 						table.removeRow(hash);
 					}
 				}
+				const newHashes = Object.keys(dataTorrents)
+					.filter(hash => !(hash in this.torrents));
 				// Assign new torrent data
 				this.torrents = dataTorrents;
-				this.labels = torrentLabels;
-				this.allLabelSize = tsize;
-				this.setSpeedValues(tul, tdl);
+				this.categoryList.statistic = statistic;
+				this.setSpeedValues(statistic.upload, statistic.download);
 
 				// Filter torrent table
 				for (const hash in this.torrents)
@@ -1843,7 +1732,7 @@ var theWebUI =
 				const domUpdates = async () => {
 					// update state, custom, and teg labels
 					await nextAFrame();
-					this.updateLabels();
+					this.categoryList.syncAfterScan();
 					if (!this.firstLoad)
 						await nextAFrame();
 					this.updateViewRows(table);
@@ -1859,12 +1748,6 @@ var theWebUI =
 			});
 	},
 
-	updateAllFilterLabel: function(labelType, showSize) {
-		this.updateLabel(
-			'#' + labelType + ' .-_-_-all-_-_-',
-			Object.keys(this.torrents).length,
-			this.allLabelSize, showSize);
-	},
 
 	updateViewRows: function(table)
 	{
@@ -1887,7 +1770,16 @@ var theWebUI =
 		if(this.firstLoad)
 		{
 			this.firstLoad = false;
-			this.show();
+			const catList = $$('CatList');
+			if (catList.pendingStyleLoad) {
+				catList.addEventListener(
+					'style-load',
+					() => this.show(),
+					{ once: true }
+				);
+			} else {
+				this.show();
+			}
 		}
 		this.updateDetails();
    	},
@@ -1983,95 +1875,21 @@ var theWebUI =
 //
 // labels
 //
-	searchToTeg: function(str) {
-		return {
-			val: str,
-			pattern: new RegExp(str.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace('*', '.+'), 'i')
-		};
-	},
-
-	createTeg: function(str) {
-		const tegId = "teg_"+this.lastTeg;
-		this.lastTeg++;
-		const el = this.createSelectableLabelElement(tegId, str, theWebUI.labelContextMenu).addClass('teg');
-		$("#lblf").append( el );
-		this.tegs[tegId] = this.searchToTeg(str);
-		this.updateTegs([tegId]);
-		this.updateLabels();
-		return el;
-	},
-
-	setTeg: function(str)
-	{
-		str = str.trim();
-		let tegId = str !== '' && (
-			Object.entries(this.tegs)
-			.find(([_,teg]) => teg.val == str)?.[0] ||
-			this.createTeg(str).attr('id')
-		);
-		if (tegId) {
-			// Select the search teg
-			const tegIds = this.actLbls['flabel_cont'] ?? [];
-			if (!tegIds.includes(tegId)) {
-				this.actLbls['flabel_cont'] = tegIds.concat([tegId]);
-				this.onLabelSelectionChanged('flabel_cont');
-			}
-		}
-	},
-
-	matchTeg: function(teg, name)
-	{
-		return teg.pattern.test(name);
-	},
-
-	updateTegs: function(tegIds)
-	{
-		for (const tegId of tegIds) {
-			this.labels[tegId] = new Set(Object.entries(this.torrents)
-				.filter(([_, torrent]) => this.matchTeg(this.tegs[tegId], torrent.name))
-				.map(([tegId]) => tegId));
-		}
-	},
-
-	removeActiveTegs: function()
-	{
-		const tegIds = this.actLbls['flabel_cont'] ?? [];
-		for (const tegId of tegIds) {
-			delete this.labels[tegId];
-			delete this.tegs[tegId];
-			$($$(tegId)).remove();
-		}
-		this.resetLabels();
-	},
-
-	removeAllTegs: function()
-	{
-		for (var id in this.tegs) {
-			delete this.labels[id];
-			delete this.tegs[id];
-			$($$(id)).remove();
-		}
-		this.resetLabels();
-	},
-
 	labelContextMenu: function(e)
 	{
-		const el = e.delegateTarget;
-		const labelType = $(el).parents('.catpanel_cont')[0].id;
-		const table = theWebUI.contextMenuTable(labelType, el);
-		const rightClick = e.which===3;
-		if (rightClick)
+		const table = theWebUI.contextMenuTable(e.panelId, e.labelId);
+		if (e.rightClick)
 		{
 			table.clearSelection();
 		}
-		if (!(rightClick && (theWebUI.actLbls[labelType] ?? []).includes(el.id))) {
-			theWebUI.switchLabel(labelType, el.id, e.metaKey, e.shiftKey);
+		if (!(e.rightClick && theWebUI.categoryList.selectionActive(e.panelId, e.labelId))) {
+			theWebUI.categoryList.switchLabel(e.panelId, e.labelId, e.metaKey, e.shiftKey);
 		}
-		if (rightClick)
+		if (e.rightClick)
 		{
 			table.fillSelection();
 			const id = table.getFirstSelected();
-			const entries = theWebUI.contextMenuEntries(labelType, el);
+			const entries = theWebUI.categoryList.contextMenuEntries(e.panelId, e.labelId);
 			if (!(entries && (id || entries.length)))
 			{
 				theContextMenu.hide();
@@ -2098,157 +1916,14 @@ var theWebUI =
 		return theWebUI.getTable('trt');
 	},
 
-	contextMenuEntries: function(labelType, el) {
-		if (labelType === 'flabel_cont') {
-			return (
-				(this.actLbls['flabel_cont'] ?? []).length ? [
-					[theUILang.removeTeg, "theWebUI.removeActiveTegs();"]
-				] : []
-			).concat([
-				[theUILang.removeAllTegs, "theWebUI.removeAllTegs();"]
-			]);
-		} else if (labelType === 'pview_cont') {
-			return (this.actLbls['pview_cont'] ?? []).length ? [
-					[theUILang.RenameView, `theWebUI.renameView('${el.id}');`],
-					[CMENU_CHILD, theUILang.MoveView.base, ['top', 'up', 'down', 'bottom']
-							.map(action => [theUILang.MoveView[action], `theWebUI.moveView('${el.id}', '${action}');`])
-					],
-					[theUILang.RemoveActiveViews, "theWebUI.removeActiveViews();"]
-				] : [];
-		}
-		return [];
+	setTeg: function(str) {
+		this.categoryList.addTextSearch(str);
 	},
 
-	cLabelText: function(lbl) {
-		const l = this.cLabels[lbl];
-		return l.path.slice(l.level).join('/');
-	},
-
-	/**
-	 *
-	 * @param {Object.<string, number>} c - <label_name, count>
-	 * @param {Object.<string, number>} s - labels size
-	 */
-	updateCustomLabels: function()
-	{
-		const customLabels = Object.keys(this.labels)
-			.filter((lbl) => lbl.startsWith("clabel__"))
-			.map((lbl) => lbl.substring(8));
-
-		const showlabelsize = this.settings["webui.show_labelsize"];
-
-		// Build tree from path labels
-		const labelTree = {};
-		for (const label of customLabels) {
-			let node = labelTree;
-			for (const pathSegment of label.split('/')) {
-				if (!(pathSegment in node)) {
-					node[pathSegment] = {};
-				}
-				node = node[pathSegment];
-			}
-		}
-		let customLabelElements = [];
-		this.cLabels = {};
-		{
-			const showAsTree = this.settings['webui.show_label_path_tree'];
-			const showEmptyLabels = this.settings['webui.show_empty_path_labels'];
-			// Create a panel-label element for existing labels. Additionally,
-			// for showAsTree: show non-flat parent labels,
-			// for showEmptyLabels: show all parent labels.
-			const nextVisits = (n, path, nextLevel, hasNext) =>
-				Object.keys(n)
-					.sort((a, b) => /* reversed order for stack */ b.localeCompare(a))
-					.map((name, i) => [
-						n[name],
-						path.concat([name]),
-						nextLevel,
-						hasNext.concat([i !== /* last */ 0]),
-					]);
-			const pathToLabelId = (path) => 'clabel__' + path.join('/');
-			let stack = nextVisits(labelTree, [], 0, []);
-			let visit;
-			while ((visit = stack.pop())) {
-				let [node, path, level, hasNext] = visit;
-				let nextLevel = level + 1;
-				while (
-					showAsTree &&
-					!showEmptyLabels &&
-					/* Path is flat parent */ !(pathToLabelId(path) in this.labels) &&
-					Object.keys(node).length === 1
-				) {
-					// Flatten tree
-					let [name, flatNode] = Object.entries(node)[0];
-					path.push(name);
-					nextLevel += 1;
-					node = flatNode;
-				}
-				stack.push(...nextVisits(node, path, nextLevel, hasNext));
-
-				const labelId = pathToLabelId(path);
-				if (showAsTree || showEmptyLabels || labelId in this.labels) {
-					// Create panel-label leaf node
-					const titleText = path.join('/');
-					this.cLabels[labelId] = { level, path };
-					let el = $$(labelId);
-					if (el === null) {
-						el = this.createSelectableLabelElement(
-							labelId, "new", this.labelContextMenu
-						)[0];
-					}
-					const stat = this.labelStat(labelId);
-					this.updateLabel(
-						el,
-						stat.cnt,
-						stat.size,
-						showlabelsize,
-						showAsTree ? this.cLabelText(labelId) : titleText,
-						showAsTree
-						? theFormatter.treePrefix({ hasNext, level })
-						: null,
-						titleText
-					);
-					customLabelElements.push(el);
-				}
-			}
-		}
-
-		const labelPanelEl = document.getElementById('plabel_cont');
-		labelPanelEl.replaceChildren(
-			...labelPanelEl.querySelectorAll(':scope > :not(li[id^="clabel__"])'),
-			...customLabelElements
-		);
-		if ((this.actLbls['plabel_cont'] ?? []).some(lbl => !document.getElementById(lbl)))
-		{
-			// Remove non-existent active labels (to potentially show 'All' label as selected)
-			this.actLbls['plabel_cont'] = this.actLbls['plabel_cont']
-				.filter((lbl) => document.getElementById(lbl));
-			// no theWebUI.switchLabel: to avoid switching away from other table views (extsearch, rss)
-			this.refreshLabelSelection('plabel_cont');
-		}
-	},
-
-	/**
-	 *
-	 * @param {string} id - torrent hash
-	 * @param {WebUITorrent} torrent
-	 */
-	getLabels: function(id, torrent)
-	{
-		return [
-				torrent.done < 1000 ? 'dls' : 'com',
-				(torrent.dl >= 1024) || (torrent.ul >= 1024) ? 'act' : 'iac',
-				torrent.state & dStatus.error ? 'err' : ''
-			]
-			.filter(lbl => lbl.length)
-			.map(lbl => '-_-_-' + lbl + '-_-_-')
-			.concat([torrent.label ? 'clabel__' + torrent.label : '-_-_-nlb-_-_-'])
-			.concat(Object.entries(this.tegs)
-				.filter(([_,teg]) => this.matchTeg(teg, torrent.name))
-				.map(([tegId]) => tegId))
-			.concat(this.quickSearch.teg.val && this.matchTeg(this.quickSearch.teg, torrent.name)
-				? ['quick_search']
-				: []);
+	sizeDecimalPlaces: function(context, unit) {
+		let n = parseInt(this.settings['webui.size_decimal_places.'+context+'.'+unit]);
+		n = isNaN(n) ? parseInt(this.settings['webui.size_decimal_places.'+context+'.default']) : n;
+		return isNaN(n) ? (context === 'other' ? 0 : this.sizeDecimalPlaces('other', unit)) : n;
 	},
 
 	/**
@@ -2304,254 +1979,8 @@ var theWebUI =
 			if(req.length>0)
 				this.request("?action=setlabel"+req+"&list=1",[this.addTorrents, this]);
 		}
-   	},
-
-	createSelectableLabelElement: function(id, text, onClick) {
-		return( $("<LI>").attr("id",id)
-		.append($('<div>').addClass('label-prefix').hide())
-		.append($('<div>').addClass('label-icon'))
-		.append($('<div>').addClass('label-text').text(text))
-		.append($('<div>').addClass('label-count').text(0))
-		.append($('<div>').addClass('label-size').hide())
-		.attr("title",text+" (0)")
-		.mouseclick(onClick)
-		.addClass("cat"));
 	},
 
-
-	sizeDecimalPlaces: function(context, unit) {
-		let n = parseInt(this.settings['webui.size_decimal_places.'+context+'.'+unit]);
-		n = isNaN(n) ? parseInt(this.settings['webui.size_decimal_places.'+context+'.default']) : n;
-		return isNaN(n) ? (context === 'other' ? 0 : this.sizeDecimalPlaces('other', unit)) : n;
-	},
-
-	updateLabel: function(label, count, size, showSize, text, prefix, titleText) {
-		const li = $(label);
-		if (prefix !== li.attr('prefix')) {
-			li.attr('prefix', prefix);
-			const pfx = li.children('.label-prefix');
-			if (!prefix) {
-				pfx.hide();
-			} else {
-				pfx.empty();
-				for (const c of prefix) {
-					pfx.append($('<div>').text(c));
-				}
-				pfx.show();
-			}
-		}
-		const txt = li.children('.label-text');
-		if ((text || text === '') && text !== txt.text())
-			txt.text(text);
-		const lblSize = theConverter.bytes(size, 'catlist');
-		const title = (titleText||text||txt.contents().not(txt.children('script')).text()) +
-			' ('+ count + ( showSize ? ' ; '+ lblSize : '') +')';
-		if (title !== li.attr('title')) {
-			li.attr('title', title);
-			li.children('.label-count').text(count);
-			const sizeSpan = li.children('.label-size');
-			if (size && showSize) {
-				sizeSpan.text(lblSize);
-				sizeSpan.show();
-			} else sizeSpan.hide();
-		}
-	},
-
-	idToLbl: function(id) {
-		return(id.substr(5, id.length - 10));
-	},
-
-	updateLabels: function()
-	{
-		this.updateCustomLabels();
-		this.updateViewPanelLabels();
-
-		const catlist = $($$('CatList'));
-		if (theWebUI.settings['webui.labelsize_rightalign'])
-			catlist.addClass('rightalign-labelsize');
-		else
-			catlist.removeClass('rightalign-labelsize');
-		if (theWebUI.settings['webui.show_label_text_overflow'])
-			catlist.removeClass('hide-textoverflow');
-		else
-			catlist.addClass('hide-textoverflow');
-		this.updateAllFilterLabel('pstate_cont', this.settings["webui.show_statelabelsize"]);
-		this.updateAllFilterLabel('plabel_cont', this.settings["webui.show_labelsize"]);
-		this.updateAllFilterLabel('flabel_cont', this.settings["webui.show_searchlabelsize"]);
-
-		for(const k in this.labels)
-		{
-			if (k !== 'quick_search' && !k.startsWith('clabel__') && !k.startsWith('pview_custom_view_')) {
-				const lbl = k.startsWith('-_-_-') ? this.idToLbl(k) : k;
-				const stat = this.labelStat(k);
-				this.updateLabel(
-					$$(k),
-					stat.cnt,
-					stat.size,
-					this.staticLabels.includes(lbl) && lbl != 'nlb'
-					? this.settings["webui.show_statelabelsize"]
-					: k.startsWith('teg_')
-					? this.settings["webui.show_searchlabelsize"]
-					: this.settings["webui.show_labelsize"],
-					false,
-				);
-			}
-		}
-	},
-
-	resetLabels: function() {
-		const labelTypes = Object.keys(this.actLbls);
-		this.actLbls = {};
-		this.onLabelSelectionChanged(...labelTypes);
-	},
-
-	switchLabel: function(labelType, targetId, toggle=false, range=false)
-	{
-		const oldLabelIds = this.actLbls[labelType] ?? [];
-		const oldSelSet = new Set(oldLabelIds);
-		let labelIds = targetId ? [targetId] : [];
-
-		if (range && targetId) {
-			// range selection
-			const anchor = oldLabelIds.length ? oldLabelIds[toggle ? oldLabelIds.length-1 : 0] : 'all';
-			if (targetId !== anchor && !(toggle && oldLabelIds.includes(targetId))) {
-				// select labelIds between anchor and target
-				const allTypeLabelIds = $($$(labelType)).find('.cat').map((_,e) => e.id || 'all');
-				const indexOfLabel = lid => Number(Object.entries(allTypeLabelIds).find(([_,l]) => l === lid)[0]);
-				const a = indexOfLabel(anchor);
-				const t = indexOfLabel(targetId);
-
-				const rangeIndices = [];
-				const step = a <= t ? 1 : -1;
-				for (let i = a; i != t; i += step) {
-					rangeIndices.push(i);
-				}
-				rangeIndices.push(t);
-
-				labelIds = rangeIndices
-					.map(i => allTypeLabelIds[i])
-					.filter(lid => lid !== 'all' && !(toggle && oldSelSet.has(lid)));
-			}
-		}
-
-		if (toggle) {
-			const selSet = new Set(labelIds);
-			// unselect ids if already selected
-			labelIds = oldLabelIds.filter(id => !selSet.has(id)).concat(
-				labelIds.filter(id => !oldSelSet.has(id))
-			);
-		}
-		const clearQuickSearch = ['pview_cont', 'flabel_cont'].includes(labelType) && !targetId;
-		if (clearQuickSearch) {
-			// Selecting 'All' in 'Views' or 'Searches' suspends the quick search until focused again
-			$$('query').blur();
-			this.quickSearch.teg = this.searchToTeg('');
-		}
-
-		if (labelIds.some(lid => !oldLabelIds.includes(lid)) || oldLabelIds.some(lid => !labelIds.includes(lid))) {
-			// change in label selection
-			this.actLbls[labelType] = labelIds;
-			this.onLabelSelectionChanged(labelType);
-		} else if (clearQuickSearch)  {
-			this.refreshLabelSelection('pview_cont', 'flabel_cont');
-			this.filterTorrentTable();
-		}
-	},
-
-	onLabelSelectionChanged: function(...labelTypes) {
-		if (labelTypes.every(lType => lType === 'pview_cont')) {
-			this.adjustActiveLabelsToViewSelection();
-			this.refreshLabelSelection(...(this.viewPanelLabelTypes));
-		} else if (labelTypes.some(lType => this.viewPanelLabelTypes.includes(lType))) {
-			this.adjustViewSelectionToActiveLabels();
-			this.refreshLabelSelection('pview_cont');
-		}
-		this.refreshLabelSelection(...labelTypes);
-
-		this.filterTorrentTable();
-		this.save();
-	},
-
-	adjustActiveLabelsToViewSelection: function() {
-		const customViews = theWebUI.settings['webui.selected_labels.views'];
-		for (const lType of this.viewPanelLabelTypes) {
-			const viewLbls = (this.actLbls['pview_cont'] ?? [])
-				.filter(viewId => viewId.startsWith('pview_custom_view_'))
-				.map(viewId => customViews[Number(viewId.split('_').at(-1))]
-					?.labels[lType] ?? []
-				);
-			this.actLbls[lType] = viewLbls.every(lbls => lbls.length)
-				? [...new Set(viewLbls.flat())]
-				: [];
-		}
-		this.checkViewDirty();
-	},
-
-	adjustViewSelectionToActiveLabels: function() {
-		const actViewPanelLbls = this.viewPanelLabelTypes
-			.map(lType => [lType, new Set(this.actLbls[lType] ?? [])]);
-		// A custom view is selected if it is a subset of the active labels.
-		// "All" is only selected if there are no active labels.
-		this.actLbls['pview_cont'] = actViewPanelLbls.some(([_,actLbls]) => actLbls.size)
-			? theWebUI.settings['webui.selected_labels.views']
-				.map((view, i) => [`pview_custom_view_${i}`, view])
-				.filter(([_, view]) => actViewPanelLbls
-					.every(([lType, actLbls]) => {
-						const viewLbls = view.labels[lType] ?? [];
-						return !actLbls.size || viewLbls.length && viewLbls
-							.every(viewLbl => actLbls.has(viewLbl));
-				}))
-				.map(([viewId]) => viewId)
-			: [];
-		this.checkViewDirty();
-	},
-
-	checkViewDirty: function() {
-		// If the active selection is not an existing view, it is dirty.
-		// (A dirty view may be saved as a 'New View')
-		const actViewIds = this.actLbls['pview_cont'];
-		const lTypes = this.viewPanelLabelTypes;
-		const actLbls = lTypes.map(lType => new Set(this.actLbls[lType] ?? []));
-		const activeSelectionIsExistingView = theWebUI.settings['webui.selected_labels.views']
-			.map(view => lTypes.map(lType => view.labels[lType] ?? []))
-			// Consider the 'All' view
-			.concat([lTypes.map(() => [])])
-			// Check if some view equals the active label selection
-			.some(viewEntries => viewEntries
-				.map((vLbls, i) => [actLbls[i], vLbls])
-				.every(([aLbls, vLbls]) => vLbls.length === aLbls.size &&
-					vLbls.every(lbl => aLbls.has(lbl)))
-			);
-		this.actLbls['pview_cont'] = actViewIds
-			.filter(v => v !== 'pview_dirty_view')
-			.concat(activeSelectionIsExistingView ? [] : ['pview_dirty_view']);
-	},
-
-	quickSearchActive: function() {
-		return this.quickSearch.teg.val && theSearchEngines.current === -1;
-	},
-
-	refreshLabelSelection: function(...dirtyLabelTypes) {
-		for (const lType of dirtyLabelTypes) {
-			const container = $($$(lType));
-			container.find('.sel').removeClass('sel');
-			const labelIds = (this.actLbls[lType] ?? []);
-			if ( labelIds.length || (['pview_cont', 'flabel_cont'].includes(lType) && this.quickSearchActive())) {
-				for (const labelId of labelIds) {
-					$($$(labelId)).addClass('sel');
-				}
-			} else {
-				container.find('.-_-_-all-_-_-').addClass('sel');
-			}
-			if (lType === 'pview_cont') {
-				// Enable view save button if view selection is dirty
-				$('#pview_save_view_button')[0]?.toggleAttribute(
-					'disabled',
-					!labelIds.includes('pview_dirty_view')
-				);
-			}
-		}
-	},
 
 	filterTorrentTable: function() {
 		var table = this.getTable("trt");
@@ -2570,24 +1999,10 @@ var theWebUI =
 
 	filterByLabel: function(table, sId)
 	{
-		if(this.shouldShowTorrentRow(
-			sId, this.labels, this.actLbls, !this.quickSearchActive()
-		))
+		if(this.categoryList.selected(sId))
 			table.unhideRow(sId);
 		else
 			table.hideRow(sId);
-	},
-
-	shouldShowTorrentRow: function(hash, labels, actLbls, noQuickSearch)
-	{
-		return this.viewPanelLabelTypes
-			.map(labelType => (actLbls[labelType] ?? [])
-				/* Let the quick search act as a search teg */
-				.concat(!noQuickSearch && labelType === 'flabel_cont' ? ['quick_search'] : [])
-			)
-			.every(activeLabels => !activeLabels.length ||
-				activeLabels.some(lbl => labels[lbl]?.has(hash))
-			);
 	},
 
 //
@@ -2959,188 +2374,6 @@ var theWebUI =
 		theWebUI.save();
 	},
 
-	sortPanels: function() {
-		// Sort category panels based on setting
-		const catList = $('#CatList');
-		const elements = Object.fromEntries(
-			Object.values(catList.children())
-			.map(e => [e.id, e])
-		);
-		const panelIds = theWebUI.settings['webui.category_panels'].map(mapPanelIdtoLegacyPanelId);
-		catList[0].replaceChildren(...
-			panelIds
-				.filter(panelId => panelId in elements)
-				.flatMap(panelId => [elements[panelId], elements[`${panelId}_cont`]])
-		);
-	},
-
-	addPanel: function(id, name) {
-		const panels = theWebUI.settings['webui.category_panels'].map(mapPanelIdtoLegacyPanelId);
-		if (!panels.includes(id)) {
-			panels.push(id);
-		}
-		const catpanel = $("<div>")
-			.addClass("catpanel")
-			.attr("id",id)
-			.text(name)
-			.on('click', function() { theWebUI.togglePanel(this); });
-		const catcont = $("<div>")
-			.attr("id",id+"_cont")
-			.addClass("catpanel_cont");
-		$('#CatList').append(catpanel, catcont);
-		theWebUI.updatePanel(id);
-		theWebUI.sortPanels();
-	},
-
-	updatePanel: function(panelId)
-	{
-		const showPanel = panelId !== 'pview' || Boolean(theWebUI.settings['webui.show_view_panel']);
-		const enable = showPanel && !theWebUI.settings['webui.closed_panels'][panelId];
-		$($$(`${panelId}_cont`)).toggle(enable);
-		$($$(panelId))
-			.toggle(showPanel)
-			.css(
-			'background-image',
-			'url('+this.getTable('trt').paletteURL+(enable ? '/images/pnl_open.gif)' : '/images/pnl_close.gif)')
-		);
-	},
-
-	togglePanel: function(pnl)
-	{
-		const panelId = pnl.id;
-		const panels = theWebUI.settings["webui.closed_panels"];
-		panels[panelId] = !panels[panelId];
-		theWebUI.updatePanel(panelId);
-		theWebUI.save();
-	},
-
-	onViewsChanged: function()
-	{
-		this.updateViewPanel();
-		this.updateViewPanelLabels();
-		this.adjustViewSelectionToActiveLabels();
-		this.refreshLabelSelection('pview_cont', ...(this.viewPanelLabelTypes));
-		this.filterTorrentTable();
-		this.save();
-	},
-
-	saveCurrentView: function()
-	{
-		const vs = 'webui.selected_labels.views';
-		this.settings[vs] = this.settings[vs]
-			.concat([{
-				name: 'New View',
-				labels: Object.fromEntries(
-					this.viewPanelLabelTypes
-					.filter(n => (this.actLbls[n] ?? []).length)
-					.map(n => [n, this.actLbls[n]])
-				)
-		}]);
-		this.onViewsChanged();
-	},
-
-	updateViewPanel: function()
-	{
-		for (const [lbl, view] of theWebUI.settings['webui.selected_labels.views']
-						.map((view, i) => [`pview_custom_view_${i}`, view])) {
-			this.labels[lbl] = new Set(Object.keys(this.torrents)
-				.filter(hash => this.shouldShowTorrentRow(hash, this.labels, view.labels, true))
-			);
-		}
-	},
-
-	updateViewPanelLabels: function()
-	{
-		const customViewRows = $('#pview_cont').children('.pview_custom_view');
-		const customViews = this.settings['webui.selected_labels.views'];
-		const showlabelsize = this.settings["webui.show_viewlabelsize"];
-
-		this.updateAllFilterLabel('pview_cont', showlabelsize);
-
-		// Update or add view rows
-		const dirtyViewEl = $('#pview_dirty_view');
-		for (let i = 0; i < customViews.length; i++) {
-			const customViewId = `pview_custom_view_${i}`;
-			const view = customViews[i];
-			const stat = this.labelStat(customViewId);
-
-			let cViewRow = $($$(customViewId));
-			if (!cViewRow.length) {
-				cViewRow = this.createSelectableLabelElement(
-					customViewId,
-					view.name,
-					theWebUI.labelContextMenu
-				).addClass('pview_custom_view');
-				cViewRow
-					.children('.label-icon')
-					.append($('<span>'));
-				dirtyViewEl.before(cViewRow);
-			}
-
-			this.updateLabel(cViewRow[0], stat.cnt, stat.size, showlabelsize, view.name);
-			cViewRow
-				.find('.label-icon > span')
-				.text(view.name.charAt(0));
-		}
-		// Remove unused view rows
-		for (let i = customViews.length; i < customViewRows.length; i++) {
-			$($$(`pview_custom_view_${i}`)).remove();
-		}
-	},
-
-	removeActiveViews: function()
-	{
-		const removeViewLbls = this.actLbls['pview_cont'] ?? [];
-		// Remove previously selected view rows
-		const vs = 'webui.selected_labels.views';
-		theWebUI.settings[vs] = theWebUI.settings[vs]
-			.filter((_, i) => !removeViewLbls.includes(`pview_custom_view_${i}`));
-		this.onViewsChanged();
-	},
-
-	renameView: function(viewId)
-	{
-		const viewIndex = Number(viewId.split('_').at(-1));
-		const customViews = theWebUI.settings['webui.selected_labels.views'];
-		if (viewIndex in customViews) {
-			const labelText = $(`#${viewId} .label-text`);
-			const renameInput = $('<input type="text">');
-			const doRename = () => {
-				const newName = renameInput.val();
-				customViews[viewIndex].name = newName;
-				renameInput.remove();
-				labelText.text(newName).show();
-				theWebUI.save();
-			};
-			labelText
-			.hide()
-			.after(renameInput
-				.on('blur', () => doRename())
-				.on('keydown', (e) => e.keyCode === /* Enter */ 13 && doRename() || true)
-				.val(customViews[viewIndex].name)
-			);
-			$(`#${viewId} input`)[0].focus();
-		}
-	},
-
-	moveView: function(viewId, action)
-	{
-		// Move view according to action (to targetIndex)
-		const viewIndex = Number(viewId.split('_').at(-1));
-		const customViews = this.settings['webui.selected_labels.views'];
-		if (viewIndex in customViews) {
-			const targetIndex = {
-				top: 0,
-				up: Math.max(viewIndex - 1, 0),
-				down: Math.min(viewIndex + 1, customViews.length),
-				bottom: customViews.length
-			}[action] ?? viewIndex;
-			const views = this.settings['webui.selected_labels.views'];
-			views.splice(targetIndex, 0, views.splice(viewIndex, 1)[0]);
-			this.onViewsChanged();
-		}
-	},
-
 	showAdd: function()
 	{
    		theDialogManager.toggle("tadd");
@@ -3245,15 +2478,92 @@ var theWebUI =
 		if(!theWebUI.settings["webui.ignore_timeouts"])
 			noty(theUILang.Request_timed_out,"alert");
 	}
+
 };
+
+
+function createCategoryList(catModule) {
+	const catList = $$('CatList');
+	const saveViewButton = $$('pview_save_view_button');
+	theDialogManager.make(
+		"dlgRenameView",
+		theUILang.RenameView,
+		$$('pview-rename-dialog-template').innerHTML,
+		true
+	);
+	$$('dlgRenameView')
+		.querySelector('button[value="confirm"]')
+		.addEventListener("click", function () {
+			const dialogEl = $$('dlgRenameView');
+			const inputEl = dialogEl.querySelector('input[type="text"]');
+			categoryList.renameView(inputEl.dataset.viewId, inputEl.value);
+			theDialogManager.hide('dlgRenameView');
+		},
+	);
+	const categoryList = new catModule.CategoryList({
+		panelAttribs: catList.panelAttribs,
+		panelLabelAttribs: catList.panelLabelAttribs,
+		syncFn: () => {
+			catList.classList.toggle(
+				"rightalign-labelsize",
+				theWebUI.settings["webui.labelsize_rightalign"]
+			);
+			catList.classList.toggle(
+				"hide-textoverflow",
+				!theWebUI.settings["webui.show_label_text_overflow"]
+			);
+			categoryList.panelAttribs.pview.hidden = !theWebUI.settings["webui.show_view_panel"];
+			catList.sync(categoryList.panelLabelAttribs, categoryList.panelAttribs);
+			// Enable view save button if view selection is new
+			saveViewButton.toggleAttribute('disabled', !categoryList.currentViewIsNew());
+		},
+		onSelectionChangeFn: () => {
+			if (theSearchEngines.current === -1 && !categoryList.quickSearchActive()) {
+				const searchField = $$('query');
+				if (searchField.value) {
+					searchField.blur();
+				}
+			}
+			theWebUI.filterTorrentTable();
+		},
+		borrowTorrentsFn: () => theWebUI.torrents,
+		onConfigChangeFn: theWebUI.save.bind(theWebUI),
+		byteSizeToStringFn: (size) => theConverter.bytes(size, 'catlist'),
+		renameViewDialogFn: (viewId, viewName) => {
+			const dialogEl = $$('dlgRenameView');
+			const inputEl = dialogEl.querySelector('input[type="text"]');
+			inputEl.value = viewName;
+			inputEl.dataset.viewId = viewId;
+			theDialogManager.show(dialogEl.id);
+			inputEl.focus();
+		},
+		dStatus,
+		theUILang
+	});
+	catList.addEventListener('panel-close', ({panelId, closed}) => {
+		categoryList.setPanelClosed(panelId, closed, true);
+	});
+	catList.addEventListener('label-click', theWebUI.labelContextMenu.bind(theWebUI));
+	// Bind button to save a new view
+	saveViewButton.addEventListener("click", (event) => {
+		categoryList.saveNewView();
+		event.stopPropagation();
+		return false;
+	});
+	return categoryList;
+}
 
 $(document).ready(function()
 {
 	makeContent();
 	theContextMenu.init();
 	theTabs.init();
-	import('./backgroundtask.js').then(bgModule => {
+	Promise.all([
+		import('./backgroundtask.js'),
+		import('./category-list.js'),
+	]).then(([bgModule, catModule]) => {
 		theWebUI.taskAddTorrents = new bgModule.BackgroundTask();
+		theWebUI.categoryList = createCategoryList(catModule);
 		theWebUI.init();
 	});
 });

--- a/lang/bn.js
+++ b/lang/bn.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "টরেন্ট সফলভাবে যুক্ত করা হয়েছে।",
  addTorrentFailed		: "টরেন্ট যুক্ত করতে ব্যর্থ হয়েছে।",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent was added successfully.",
  addTorrentFailed		: "Failed to add torrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/da.js
+++ b/lang/da.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrenten tilføjet uden problemer.",
  addTorrentFailed		: "Tilføjelse af torrent fejlede.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/de.js
+++ b/lang/de.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent wurde erfolgreich hinzugefügt.",
  addTorrentFailed		: "Fehler beim hinzufügen eines Torrents.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/el.js
+++ b/lang/el.js
@@ -184,6 +184,7 @@ var theUILang =
  addTorrentSuccess		: "Το αρχείο torrent προστέθηκε με επιτυχία.",
  addTorrentFailed		: "Αποτυχία προσθήκης του αρχείου torrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/en.js
+++ b/lang/en.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent was added successfully.",
  addTorrentFailed		: "Failed to add torrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/es.js
+++ b/lang/es.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Se agregó el torrent con éxito.",
  addTorrentFailed		: "Fallo al agregar el torrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent was added successfully.",
  addTorrentFailed		: "Failed to add torrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent ajouté à rTorrent avec succès.",
  addTorrentFailed		: "Erreur: le torrent n'a pas pu être ajouté à rTorrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent sikeresen hozzáadva.",
  addTorrentFailed		: "Sikertelen torrent hozzáadás.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/it.js
+++ b/lang/it.js
@@ -187,6 +187,7 @@ var theUILang =
  addTorrentSuccess		: "Il torrent è stato aggiunto con successo.",
  addTorrentFailed		: "Aggiunta del torrent fallita",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -184,6 +184,7 @@ var theUILang =
  addTorrentSuccess		: "토렌트를 성공적으로 추가했습니다.",
  addTorrentFailed		: "토렌트를 추가하지 못했습니다.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/langs.js
+++ b/lang/langs.js
@@ -116,7 +116,7 @@ function loadUILang(onLoadFunc)
 
 function translateDOM() {
 	// Translate uilang elements and uilangtitle/uilangvalue attributes
-	for (const attr of ['', 'title', 'value']) {
+	for (const attr of ['', 'title', 'value', 'text']) {
 		for (el of document.querySelectorAll(`[uilang${attr}]`)) {
 			const translationId = attr.length ? el.getAttribute(`uilang${attr}`) : el.textContent;
 			const translation = theUILang[translationId] ?? translationId;

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent was added successfully.",
  addTorrentFailed		: "Failed to add torrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent is succesvol verstuurd naar rTorrent.",
  addTorrentFailed		: "Fout: Torrent is niet verstuurd naar rTorrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/no.js
+++ b/lang/no.js
@@ -185,6 +185,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent ble lagt til.",
  addTorrentFailed		: "En feil skjedde, torrent ble ikke lagt til.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -187,6 +187,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent został dodany pomyślnie.",
  addTorrentFailed		: "Torrent nie został dodany.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/pt-br.js
+++ b/lang/pt-br.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent foi adicionado com sucesso.",
  addTorrentFailed		: "Falha ao adicionar torrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/pt-pt.js
+++ b/lang/pt-pt.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent foi adicionado com sucesso.",
  addTorrentFailed		: "Erro ao adicionar torrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Закачка успешно передана в rTorrent.",
  addTorrentFailed		: "Ошибка добавления закачки.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent was added successfully.",
  addTorrentFailed		: "Failed to add torrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -184,6 +184,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent was added successfully.",
  addTorrentFailed		: "Failed to add torrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -184,6 +184,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent lades till.",
  addTorrentFailed		: "Misslyckades att lägga till torrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -183,6 +183,7 @@ var theUILang =
  scrapeDownloaded		: "İndirilen",
  Total				: "Toplam",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "Завантаження успішно передано в rTorrent.",
  addTorrentFailed		: "Сталася помилка додавання завантаження.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -184,6 +184,7 @@ var theUILang =
  addTorrentSuccess		: "Torrent đã thêm vào rTorrent thành công.",
  addTorrentFailed		: "Lỗi: torrent chưa vào được rTorrent.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -186,6 +186,7 @@ var theUILang =
  addTorrentSuccess		: "添加 torrent 成功.",
  addTorrentFailed		: "添加 torrent 失败.",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -184,6 +184,7 @@ var theUILang =
  addTorrentSuccess		: "torrent 檔案上傳完成",
  addTorrentFailed		: "錯誤: torrent 檔案無法傳送到 rTorrent",
  pnlViews			: "Views",
+ NewView			: "New View",
  MoveView			: {base: "Move view", top: "To top", up: "Up", down: "Down", bottom: "To bottom"},
  RenameView			: "Rename view",
  RemoveActiveViews		: "Remove active views",

--- a/plugins/extsearch/extsearch.css
+++ b/plugins/extsearch/extsearch.css
@@ -9,10 +9,6 @@ div#tegLoadTorrents br {clear: left; line-height: 0}
 
 #st_extsearch { overflow: auto }
 #exscategory { margin-top: 6px; width: 100px }
-#flabel_cont li.exteg:not(.-_-_-all-_-_-) .label-icon { background-position: 0px 0px; background-image: url(./images/local.png); }
-.Engineall { background-image: url(./images/search.png) !important; }
-.Enginepublic { background-image: url(./images/public.png) !important; }
-.Engineprivate { background-image: url(./images/private.png) !important; }
 .bld { color: blue; font-weight: bold; }
 
 @media only screen and (orientation:portrait) 

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -2,6 +2,7 @@ plugin.loadMainCSS();
 plugin.loadLang();
 
 plugin.categories = [ 'all', 'movies', 'tv', 'music', 'games', 'anime', 'software', 'pictures', 'books' ];
+const catlist = theWebUI.categoryList;
 
 plugin.set = theSearchEngines.set;
 theSearchEngines.set = function(val, noSave)
@@ -174,7 +175,7 @@ theSearchEngines.run = function()
 		}
 		else
 		{
-			theWebUI.resetLabels();
+			theWebUI.categoryList.resetSelection();
 		}
 	}
 	else
@@ -227,7 +228,6 @@ plugin.reloadData = function(id)
 	        table.clearRows();
 		table.scrollTo(0);
 		var data = plugin.tegs[id].data;
-		var count = 0;
 		for( var i = 0; i<data.length; i++ )
 		{
 			var item = data[i];
@@ -249,41 +249,24 @@ plugin.reloadData = function(id)
 					status: item.src,
 					label: item.cat
 				}, id+'$'+i, "Engine"+item.src);
-				count++;
 			}
 		}
 		if(table.sortId)
 			table.Sort();
-		plugin.correctCounter(id,count);
+		catlist.refreshAndSyncPanel('psearch');
 		table.noSort = false;
 	}
 }
 
-plugin.correctCounter = function(id,count)
-{
-	if($type(plugin.tegs[id]))
-	{
-		if(count===null)
-		{
-			count = 0;
-			var data = plugin.tegs[id].data;
-			for( var i = 0; i<data.length; i++ )
-				if(!data[i].deleted)			
-					count++;
-		}
-		theWebUI.updateLabel($$(id), count); 
-	}
-}
 
-plugin.switchLabel = theWebUI.switchLabel;
-theWebUI.switchLabel = function(labelType, targetId, toggle=false, range=false)
+plugin.switchLabel = catlist.switchLabel.bind(catlist);
+catlist.switchLabel = function(panelId, targetId, toggle=false, range=false)
 {
 	const tegList = $("#TegList");
 	const list = $("#List");
 	if (plugin.enabled 
-		&& labelType == 'flabel_cont' 
+		&& panelId == 'psearch'
 		&& targetId in plugin.tegs 
-		&& $($$(targetId)).hasClass('exteg') 
 	) {
 		// no support for multi selection
 		toggle = false;
@@ -307,16 +290,17 @@ theWebUI.switchLabel = function(labelType, targetId, toggle=false, range=false)
 		tegList.hide();
 		list.show();
 	}
-	plugin.switchLabel.call(theWebUI, labelType, targetId, toggle, range);
+	const change = plugin.switchLabel(panelId, targetId, toggle, range);
 
 	// finally hide list if teglist shown
 	if (tegList.is(":visible")) {
 		list.hide();
 	}
+	return change;
 }
 
 theWebUI.activeExtTegId = function() {
-	return (theWebUI.actLbls['flabel_cont'] ?? []).find(lid => lid in plugin.tegs);
+	return catlist.selection.ids('psearch').find(lid => lid in plugin.tegs);
 }
 
 plugin.filterTorrentTable = theWebUI.filterTorrentTable;
@@ -367,7 +351,7 @@ theWebUI.tegItemRemove = function()
 		table.removeRow( tegId+"$"+plugin.tegArray[i].ndx );
 	}
 	table.correctSelection();
-	plugin.correctCounter(tegId,null);
+	catlist.refreshAndSyncPanel("psearch");
 	table.refreshRows();
 }
 
@@ -385,10 +369,10 @@ theWebUI.showTegURLInfo = function()
 theWebUI.extTegDelete = function()
 {
 	const tegId = theWebUI.activeExtTegId();
-	theWebUI.switchLabel('flabel_cont', '');
+	catlist.switchLabel('psearch', '');
 	if (tegId) {
 		delete plugin.tegs[tegId];
-		$($$(tegId)).remove();
+		catlist.refreshAndSyncPanel("psearch");
 	}
 }
 
@@ -440,24 +424,27 @@ plugin.createExtTegMenu = function(e, id)
 		theWebUI.createMenu(e, trtArray[0]);
 	}
 }
+function idIsExTeg(labelId) {
+	return labelId?.startsWith('extteg_') ?? false;
+}
 
 plugin.contextMenuTable = theWebUI.contextMenuTable;
-theWebUI.contextMenuTable = function(labelType, el) {
-	return labelType === 'flabel_cont' && $(el).hasClass('exteg') ?
+theWebUI.contextMenuTable = function(panelId, el) {
+	return panelId === 'psearch' && idIsExTeg(el.id) ?
 		theWebUI.getTable('teg')
-		: plugin.contextMenuTable.call(theWebUI, labelType, el);
+		: plugin.contextMenuTable.call(theWebUI, panelId, el);
 },
 
-plugin.contextMenuEntries = theWebUI.contextMenuEntries;
-theWebUI.contextMenuEntries = function(labelType, el) {
-	if (labelType === 'flabel_cont' && $(el).hasClass('exteg')) {
+plugin.contextMenuEntries = catlist.contextMenuEntries.bind(catlist);
+catlist.contextMenuEntries = function(panelId, labelId) {
+	if (panelId === 'psearch' && idIsExTeg(labelId)) {
 		theWebUI.getTable('trt').clearSelection();
 		return plugin.canChangeMenu() ? [
 			[ theUILang.tegRefresh,  "theWebUI.tegRefresh()"],
 			[ theUILang.tegMenuDelete, "theWebUI.extTegDelete()"]
 		] : false;
 	}
-	return plugin.contextMenuEntries.call(theWebUI, labelType, el);
+	return catlist.contextMenuEntries(panelId, labelId);
 }
 
 plugin.createMenu = theWebUI.createMenu;
@@ -470,6 +457,17 @@ theWebUI.createMenu = function(e,id) {
 	}
 }
 
+const psearchEntries = catlist.refreshPanel.psearch.bind(catlist);
+catlist.refreshPanel.psearch = (attribs) => psearchEntries(attribs).concat(Object.entries(plugin.tegs)
+	.map(([tegId, teg]) => [
+		tegId,
+		{
+			...attribs.get(tegId),
+			text: teg.val,
+			icon: `url:./plugins/extsearch/images/${teg.eng === 'all' ? 'search' : teg.eng}.png`,
+			count: String(teg.data.filter(d => !d.deleted).length)
+		}
+	]));
 
 theWebUI.setExtSearchTag = function( d )
 {
@@ -480,17 +478,14 @@ theWebUI.setExtSearchTag = function( d )
 		if(plugin.tegs[id].val==str)
 		{
 			plugin.tegs[id].data = d.data;
-			theWebUI.switchLabel('flabel_cont', id);
+			catlist.switchLabel('psearch', id);
 			return;
 		}
-	var tegId = "extteg_"+plugin.lastTeg;
+	const tegId = "extteg_"+plugin.lastTeg;
 	plugin.lastTeg++;
-	var el = theWebUI.createSelectableLabelElement(tegId, str, theWebUI.labelContextMenu)
-		.addClass('exteg');
-	el.find('.label-icon').addClass('Engine'+d.eng);
-	$("#lblf").append( el );
 	plugin.tegs[tegId] = { "val": str, "what": what, "cat": d.cat, "eng": d.eng, "data": d.data };
-	theWebUI.switchLabel('flabel_cont', tegId);
+	catlist.refresh('psearch');
+	catlist.switchLabel('psearch', tegId);
 }
 
 plugin.getTegByRowId = function( rowId )
@@ -782,7 +777,6 @@ plugin.onLangLoaded = function()
 	var contPrivate = "";
 	var optPublic = "";
 	var optPrivate = "";
-	var styles = "";
 	var toDisable = [];
 	$.each(theSearchEngines.sites,function(ndx,val)
 	{
@@ -832,8 +826,6 @@ plugin.onLangLoaded = function()
 			optPrivate +=
 				"<option value='"+ndx+"' id='opt_"+ndx+"'>"+ndx+"</option>";
 		}
-		styles +=
-			(".Engine"+ndx+" {background-image: url(./plugins/extsearch/images/"+ndx+".png) !important; background-repeat: no-repeat}\n");
 	});
 	if(contPublic.length)
 	{
@@ -853,8 +845,6 @@ plugin.onLangLoaded = function()
 		s+=contPrivate;
 		s+="</fieldset>";
 	}
-	if(styles.length)
-		injectCSSText(styles);
 	this.attachPageToOptions($("<div>").attr("id","st_extsearch").html(s)[0],theUILang.exsSearch);
 	for( var i in toDisable )
 	{
@@ -885,7 +875,7 @@ plugin.onRemove = function()
 	theSearchEngines.sites = plugin.sites;
 	theSearchEngines.current = -1;
 	theWebUI.save();
-	theWebUI.resetLabels();
+	catlist.resetSelection();
 	for( var teg in plugin.tegs )
 		$("#"+teg).remove();
 	plugin.tegs = {};

--- a/plugins/rss/panel-label.css
+++ b/plugins/rss/panel-label.css
@@ -1,0 +1,9 @@
+.alert {
+  color: red;
+  background-color: var(--badge-background-color);
+  padding: var(--badge-padding, 0.1em 0.3em 0.1em 0.3em);
+  border-radius: var(--badge-border-radius, 0.8em);
+  margin-left: auto;
+  font-size: 13px;
+  font-weight: bold;
+}

--- a/plugins/rss/rss.css
+++ b/plugins/rss/rss.css
@@ -1,4 +1,4 @@
-div#RSSList {border: 1px solid #A0A0A0; background-color: #FFFFFF; overflow: hidden; display: block; -moz-user-select: none; -moz-user-focus: normal; -moz-user-input: enabled}
+div#RSSList {border: 1px solid var(--menu-border-color); background-color: var(--menu-background-color); overflow: hidden; display: block; -moz-user-select: none; -moz-user-focus: normal; -moz-user-input: enabled}
 
 div#dlgAddRSS {width: 355px; height: 132px}
 div#dlgAddRSS div.dlg-header {background-image: url(./images/rss.gif)}
@@ -30,16 +30,16 @@ div#dlgLoadTorrents br {clear: left; line-height: 0}
 div#dlgEditFilters {width: 690px; height: 360px; font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif; overflow: visible}
 div#dlgEditFilters div.dlg-header {background-image: url(./images/rss.gif)}
 .lfc {float: left; }
-.lf {width: 245px; height: 230px; margin: 5px; margin-right: 0; padding: 5px; background-color: #FFFFFF; border: 1px solid #D0D0D0; overflow: auto}
+.lf {width: 245px; height: 230px; margin: 5px; margin-right: 0; padding: 5px; background-color: var(--menu-background-color); border: 1px solid var(--menu-border-color); overflow: auto}
 .lf ul {width: 100%; margin: 2px; padding: 0; list-style-position: inside; list-style: none; white-space: nowrap}
 .lf li input { margin: 0 5px 0 0; padding: 4px; } 
 .lf li {margin: 0 ; padding: 0}
-.lf li input.TextboxFocus { width: 85%; background-color: #CFDEEF; }
-.lf li input.TextboxNormal { width: 85%; background-color: #FFFFFF }
+.lf li input.TextboxFocus { width: 85%; background-color: var(--menu-highlight-background-color); }
+.lf li input.TextboxNormal { width: 85%; background-color: var(--menu-background-color) }
 .lf li input { border: 0; font-size: 11px; font-family: Tahoma, Verdana, Arial, Helvetica, sans-serif; cursor: default; font-weight: bold; }
 div#FLTchk_buttons {padding-top: 5px; width: 260px; text-align:center}
 .rf fieldset {margin: auto; height: 265px}
-.rf {float: right; width: 400px; height: 285px; margin: 4px; background-color: #FAFAFA}
+.rf {float: right; width: 400px; height: 285px; margin: 4px; background-color: var(--settings-background-color); }
 .rf label {width: 75px; display: inline-block; margin-top: 5px; margin-bottom: 5px; margin-left: 10px; }
 .rf br {clear: left; line-height: 0}
 .rf select {width: 273px; margin-left: 5px; margin-bottom: 3px; }
@@ -79,11 +79,6 @@ div#FLT_buttons {clear: both}
 div#dlgAddRSSGroup div.content {width: 302px; margin: 5px; padding: 5px; line-height: 16px}
 #rssGroupSet { overflow: auto; width: 275px; height: 160px }
 
-.RSS .label-icon { background-position: 0px -208px; }
-.disRSS .label-icon { background-position: 0px -192px; }
-.RSSGroup .label-icon { background-position: 0px -240px; }
-
-#prss_cont .notification::after { color: red; content: " ⚠"; }
 #tab_lcont.notification > a::after { color: gray; content: " ⚠"; }
 
-#rsstimer { float: right; font-weight: normal; margin-right: -18px; }
+#rsstimer { font-weight: normal; }

--- a/plugins/theme/themes/Acid/style.css
+++ b/plugins/theme/themes/Acid/style.css
@@ -1,4 +1,59 @@
 html, body { background-color: #1e2124; color: #BDDBDB }
+:root {
+  --menu-color: #00FF00;
+  --menu-background-color: #181818;
+
+  --menu-disabled-color: #c0c0c0;
+
+  --menu-border-color: #333;
+  --menu-highlight-color: #272E36;
+  --menu-highlight-background-color: #BDDBDB;
+
+  --settings-background-color: #272E36;
+}
+button, input.Button {
+  color: black;
+  background-image: url(./images/h.gif);
+  background-color: #D7D7D7;
+  border-color: #333;
+}
+button:hover, input.Button:not([disabled]):hover {
+  background-color: #D7D7D7;
+  filter: brightness(1.2);
+}
+button:hover:active, input.Button:not([disabled]):hover:active {
+  background-color: #D7D7D7;
+  filter: brightness(1.3);
+}
+
+category-panel {
+  --open-background-image: url(../plugins/theme/themes/Acid/images/pnl_open.gif);
+  --close-background-image: url(../plugins/theme/themes/Acid/images/pnl_close.gif);
+}
+
+category-panel::part(heading) {
+  background-color: #1e2124;
+  color: #00ff00;
+  font-weight: bold;
+}
+
+panel-label {
+  color: #FFF;
+  background-color: #272E36;
+  --prefix-color: #FFF;
+  --badge-color: #909090;
+  --icon-letter-color: #1e2124;
+  --icon-letter-background-color: #00ff00;
+  --badge-background-color: #1e2124;
+  --status-image: url(../plugins/theme/themes/Acid/images/tstatus.png);
+}
+
+panel-label[selected] {
+  background-color: #BDDBDB;
+  border-color: #BDDBDB;
+  color: #272E36;
+}
+
 div#preload {background-image: url(./images/toolbar.png); background-image: url(./images/tstatus.png); background-image: url(./images/t_bg.png); background-image: url(./images/r_bg.gif); background-image: url(./images/i_bg.gif); background-image: url(./images/asc.gif); background-image: url(./images/desc.gif); background-image: url(./images/file.gif); background-image: url(./images/dir.gif); background-image: url(./images/pnl_open.gif); background-image: url(./images/pnl_close.gif)}
 div#cover {background: #272E36}
 div#msg {background: #272E36; border-top: 1px solid #D0D0D0; border-bottom: 1px solid #D0D0D0; color: #00ff00;}
@@ -7,16 +62,8 @@ div.dlg-window { background-color: #1e2124; color: #BDDBDB }
 div#modalbg {background-color: #181818;}
 
 ul.CMenu { background-color: #1e2124; }
-ul.CMenu li { background: #272E36;}
-ul.CMenu li a.exp {background: transparent url(./images/menuexp.gif) no-repeat scroll 140px center; }
-ul.CMenu li a.sel {background: transparent url(./images/menusel.gif) no-repeat scroll 4px center}
-ul.CMenu li a:hover {background-color: #BDDBDB; color: #272E36;}
-
-ul.CMenu li a.dis {color: #333333}
-ul.CMenu li a.dis:hover {background-color: #181818; color: #333333}
-
-ul.CMenu li:hover ul li a {background-color: #272E36; color: #00FF00}
-ul.CMenu li:hover ul li a:hover {background-color: #BDDBDB; color: #272E36;}
+ul.CMenu li a.exp {background-image: url(./images/menuexp.gif); }
+ul.CMenu li a.sel {background-image: url(./images/menusel.gif); }
 
 div.graph_tab {background-color: #272E36; color: #BDDBDB; font-weight: bold;}
 .graph_tab_legend { color: #FFF; background-color: #272E36; }
@@ -39,7 +86,6 @@ div#t div#setting {background: transparent url(./images/toolbar.png) no-repeat -
 div#t div#help {background: transparent url(./images/quest.gif) no-repeat 0px center}
 div#t div#go {background: transparent url(./images/go.gif) no-repeat 0px center; }
 
-input.Button { background: #D7D7D7 url(./images/h.gif) repeat-x center bottom; }
 
 div#CatList { background-color: #272E36; color: #BDDBDB;}
 div#CatList ul li { border: 1px solid #272E36; font-weight: bold; }
@@ -95,11 +141,6 @@ span#loadimg { background: transparent url(./images/ajax-loader.gif) no-repeat c
 .Icon_File {background: transparent url(./images/file.gif) no-repeat left center}
 .Icon_Dir {background: transparent url(./images/dir.gif) no-repeat left center}
 .Icon_Share {background: transparent url(./images/dir.gif) no-repeat left center}
-
-.catpanel { background: url(./images/pnl_open.gif) 2px no-repeat; background-color: #1e2124; color: #00ff00; font-weight: bold;}
-.pview_custom_view .label-icon { color: #1e2124; background-color: #00ff00;}
-.label-count,.label-size,.pview_custom_view .label-icon { background-color: #1e2124; }
-li.sel .label-count,li.sel .label-size { background-color: #909090; }
 
 div#tadd-header {background-image: url(./images/world.gif); }
 div#tadd { background-color: #1e2124; border: 2px solid #909090; color: #BDDBDB;}

--- a/plugins/theme/themes/Blue/style.css
+++ b/plugins/theme/themes/Blue/style.css
@@ -1,4 +1,41 @@
 html, body { background-color: #DFE8F6 }
+:root {
+  --menu-color: #222222;
+  --menu-background-color: #F0F0F0;
+
+  --menu-disabled-color: #808080;
+
+  --menu-border-color: #718BB7;
+  --menu-highlight-color: #222222;
+  --menu-highlight-background-color: #D9E8FB;
+
+  --settings-background-color: #272E36;
+}
+#CatList, category-list {
+  border-color: #99BBE8;
+}
+
+category-panel {
+  --open-background-image: url(../plugins/theme/themes/Blue/images/pnl_open.gif);
+  --close-background-image: url(../plugins/theme/themes/Blue/images/pnl_close.gif);
+}
+
+category-panel::part(heading) {
+  color: #15428B;
+  font-weight: bold;
+  background-color: #D9E8FB;
+  border-color: #8DB2E3;
+}
+
+panel-label {
+  --badge-border-radius: 0.5em 0.5em 0 0;
+  --status-image: url(../plugins/theme/themes/Acid/images/tstatus.png);
+}
+
+panel-label[selected] {
+  background-color: #D9E8FB;
+  border-color: #D9E8FB;
+}
 
 div#t {background: #181818 url(./images/header_bg.gif) repeat-x center center; border-bottom: 1px solid #333333;}
 
@@ -19,8 +56,6 @@ div#t div#plugins {background: transparent url(./images/plugin.png) no-repeat 0p
 
 ul.CMenu li a:hover {background-color: #D9E8FB}
 ul.CMenu li:hover ul li a:hover {background-color: #D9E8FB}
-div#CatList ul li.sel {background-color: #D9E8FB; border-color: #D9E8FB }
-div#CatList { border-color: #99BBE8 }
 
 div#tdetails {background: transparent url(./images/tab-strip-bg.gif) repeat-x 0px center;} 
 
@@ -28,14 +63,11 @@ div#tdetails {background: transparent url(./images/tab-strip-bg.gif) repeat-x 0p
 .tabbar li a:hover {border-top: 1px solid #8DB2E3}
 .tabbar li.selected a { border-top: 2px solid #8DB2E3; background: transparent url(./images/tabs-bg.png) repeat-x 0 -4px; color: #15428B; font-weight: bold}
 
-input.Button { background-image: url(./images/btn-sprite.gif); background-position: 0 -43px }
+button, input.Button { background-image: url(./images/btn-sprite.gif); background-position: 0 -43px }
 
 input[type="text"], input[type="password"], input[type="file"], select, textarea { background: #FFFFFF url(./images/text-bg.gif) repeat-x 0 0; border:1px solid #B5B8C8; }
 input[type="text"][disabled],input[type="password"][disabled],input[type="file"][disabled], select[disabled], textarea[disabled] { border: 1px solid #C0C0C0; background: #F0F0F0; color: #C0C0C0}
 
-.catpanel {background-color: #D9E8FB; color: #15428B; font-weight: bold; border: 1px solid #8DB2E3; background-image: url(./images/pnl_open.gif) }
-.label-count,.label-size { background-color: #D9E8FB; border-radius: 0.5em 0.5em 0 0; }
-li.sel .label-count,li.sel .label-size { background-color: #FFFFFF; }
 
 div#tdcont { background: #FFFFFF; border: 1px solid #99BBE8; }
 
@@ -44,21 +76,10 @@ div#tdcont { background: #FFFFFF; border: 1px solid #99BBE8; }
 .sthdr { color: #15428B; }
 
 ul.CMenu { border: 1px solid #718BB7; border-right: 1px solid #718BB7; border-bottom: 1px solid #718BB7; background: #F0F0F0; color: #222222}
-ul.CMenu li {background: #F0F0F0; color: #222222}
-ul.CMenu li a {background: #F0F0F0; color: #222222}
 
 ul.CMenu li a.exp {background: transparent url(./images/menu-parent.gif) no-repeat scroll 140px center; }
 
-ul.CMenu li a:hover {background-color: #D9E8FB; color: #222222}
-ul.CMenu li:hover ul li a { background-color: #F0F0F0; color: #222222}
-ul.CMenu li:hover ul li a:hover {background-color: #D9E8FB; color: #222222}
-
 ul.CMenu li.menuitem hr {background-color: #E0E0E0; color: #000000; border-bottom-width: 1px; border-bottom-color: #FFFFFF}
-
-ul.CMenu li a.dis {color: #808080}
-ul.CMenu li a.dis:hover {background-color: #F0F0F0; color: #808080}
-ul.CMenu li ul li a.dis {color: #808080}
-ul.CMenu li ul li a.dis:hover {background-color: #F0F0F0; color: #808080}
 
 div.dlg-window { color: #000000; border: 0 }
 div.dlg-header { background: #D9E8FB url(../../images/blank.gif) no-repeat scroll 4px center; border: 0; color: #15428B; font-weight: bold}

--- a/plugins/theme/themes/Dark/style.css
+++ b/plugins/theme/themes/Dark/style.css
@@ -1,4 +1,62 @@
 html, body {background-color: #181818; color: #999999; }
+:root {
+  --menu-color: #666666;
+  --menu-background-color: #181818;
+
+  --menu-disabled-color: #333333;
+
+  --menu-border-color: #333333;
+  --menu-highlight-color: #111111;
+  --menu-highlight-background-color: #888888;
+
+  --settings-background-color: #181818;
+}
+button, input.Button {
+  color: #111111;
+  background-image: url(./images/h.gif);
+  background-color: #999999;
+  border-color: #333333;
+}
+button:not([disabled]):hover, input.Button:not([disabled]):hover {
+  background-color: #999999;
+  filter: brightness(1.2);
+}
+button:not([disabled]):hover:active, input.Button:not([disabled]):hover:active {
+  background-color: #999999;
+  filter: brightness(1.3);
+}
+
+#CatList, category-list {
+  border: 1px solid #333333;
+  background-color: #181818;
+}
+
+category-panel {
+  --open-background-image: url(../plugins/theme/themes/Dark/images/pnl_open.gif);
+  --close-background-image: url(../plugins/theme/themes/Dark/images/pnl_close.gif);
+}
+
+category-panel::part(heading) {
+  background-color: #111111;
+  border-bottom: 1px solid #333333;
+  border-top: 1px solid #333333;
+}
+
+panel-label {
+  border-color: #181818;
+  --prefix-color: #FFF;
+  --badge-color: #666666;
+  --badge-background-color: #111111;
+  --status-image: url(../plugins/theme/themes/Dark/images/tstatus.png);
+}
+
+panel-label[selected] {
+  background-color: #888888;
+  color:#111111;
+  border-color: #888888;
+  --badge-color: #111111;
+  --badge-background-color: #999999;
+}
 div#preload {width: 0px; height: 0px; display: none; background-image: url(./images/toolbar.png); background-image: url(./images/tstatus.png); background-image: url(./images/t_bg.png); background-image: url(./images/r_bg.gif); background-image: url(./images/i_bg.gif); background-image: url(./images/asc.gif); background-image: url(./images/desc.gif); background-image: url(./images/pnl_open.gif); background-image: url(./images/pnl_close.gif)}
 div#cover {background: #181818}
 div#msg {background: #181818; border-top: 1px solid #333333; border-bottom: 1px solid #333333}
@@ -6,18 +64,9 @@ div#sc {border: 1px solid #333333; background-color: #181818}
 div#sc li.se_act div {background-color: #333333; color: #888888}
 div#lng {background-color:#181818; border:1px solid #333333}
 ul.CMenu {border: 1px solid #333333; border-right: 2px solid #333333; border-bottom: 2px solid #333333; background: #181818; }
-ul.CMenu li {background: #181818}
-ul.CMenu li a.dis {color: #333333}
-ul.CMenu li a.dis:hover {background-color: #181818; color: #333333}
 ul.CMenu li hr {border-top: 1px solid #333333}
 ul.CMenu li a.exp {background: transparent url(./images/menuexp.gif) no-repeat scroll 140px center; }
 ul.CMenu li a.sel {background: transparent url(./images/menusel.gif) no-repeat scroll 4px center}
-ul.CMenu li a:hover {background-color: #888888; color: #111111}
-
-ul.CMenu li:hover ul li a {background-color: #181818; color: #666666}
-ul.CMenu li:hover ul li a:hover {background-color: #888888; color: #111111}
-ul.CMenu li ul li a.dis {color: #333333}
-ul.CMenu li ul li a.dis:hover {background-color: #181818; color: #333333}
 
 #sel {border: 1px dotted #555555;}
 
@@ -45,14 +94,8 @@ Input.TextboxShort {border: 1px solid #333333}
 Input.TextboxMid {border: 1px solid #333333}
 Input.TextboxLarge {border: 1px solid #333333}
 Input.TextboxVShort {border: 1px solid #333333}
-input.Button {color: #111111; background-color: #999999}
 a {color: #686868}
 
-div#CatList {border: 1px solid #333333; background-color: #181818}
-div#CatList ul li {border-color: #181818}
-div#CatList ul li.sel {background-color: #888888; color:#111111; border-color: #888888 }
-div#CatList ul li.RSS .label-icon {background-image: url(./images/tstatus.png); }
-div#CatList ul li.disRSS .label-icon {background-image: url(./images/tstatus.png); }
 .stable-icon {background-image: url(./images/tstatus.png); }
 .Icon_File {background: transparent url(./images/file.gif) no-repeat left center}
 .Icon_Dir {background: transparent url(./images/dir.gif) no-repeat left center}
@@ -108,10 +151,6 @@ div.tab {background-color: #181818}
 div#t div#ind {background: transparent url(./images/ajax-loader.gif) no-repeat 0px center;}
 
 span#loadimg {background: transparent url(./images/ajax-loader.gif) no-repeat center center; }
-
-.catpanel { background: url(./images/pnl_open.gif) 2px no-repeat; background-color: #111111; border-bottom: 1px solid #333333; border-top: 1px solid #333333;  }
-.label-count,.label-size { background-color: #111111; }
-li.sel .label-count,li.sel .label-size { background-color: #999999; }
 
 #StatusBar { border-top: 1px solid #333333; background-color: #181818; color: #888888 }
 #st_up { background:url(./images/status_up.gif) 6px no-repeat; }

--- a/plugins/theme/themes/DarkBetter/style.css
+++ b/plugins/theme/themes/DarkBetter/style.css
@@ -1,4 +1,142 @@
 html, body {background-color: #181818; color: #999999; }
+:root {
+  --menu-color: #666666;
+  --menu-background-color: #181818;
+
+  --menu-disabled-color: #333333;
+
+  --menu-border-color: #333333;
+  --menu-highlight-color: #111111;
+  --menu-highlight-background-color: #888888;
+
+  --settings-background-color: #181818;
+}
+button,
+input.Button {
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    color-stop(0.05, #d6d6d6),
+    color-stop(1, #c7c7c7)
+  );
+  background: -moz-linear-gradient(top, #d6d6d6 5%, #c7c7c7 100%);
+  background: -webkit-linear-gradient(top, #d6d6d6 5%, #c7c7c7 100%);
+  background: -o-linear-gradient(top, #d6d6d6 5%, #c7c7c7 100%);
+  background: -ms-linear-gradient(top, #d6d6d6 5%, #c7c7c7 100%);
+  background: linear-gradient(to bottom, #d6d6d6 5%, #c7c7c7 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#d6d6d6', endColorstr='#c7c7c7',GradientType=0);
+  background-color: #d6d6d6;
+  border: 1px solid #333333;
+  color: #111111;
+}
+button:hover,
+input.Button:not([disabled]):hover {
+  background-color: #999999;
+  filter: brightness(1.2);
+}
+button:hover:active,
+input.Button:not([disabled]):hover:active {
+  background: -webkit-gradient(
+    linear,
+    left top,
+    left bottom,
+    color-stop(0.05, #c7c7c7),
+    color-stop(1, #d6d6d6)
+  );
+  background: -moz-linear-gradient(top, #c7c7c7 5%, #d6d6d6 100%);
+  background: -webkit-linear-gradient(top, #c7c7c7 5%, #d6d6d6 100%);
+  background: -o-linear-gradient(top, #c7c7c7 5%, #d6d6d6 100%);
+  background: -ms-linear-gradient(top, #c7c7c7 5%, #d6d6d6 100%);
+  background: linear-gradient(to bottom, #c7c7c7 5%, #d6d6d6 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#c7c7c7', endColorstr='#d6d6d6',GradientType=0);
+  background-color: #c7c7c7;
+  -moz-box-shadow: inset 0px 0px 8px 0px #474747;
+  -webkit-box-shadow: inset 0px 0px 8px 0px #474747;
+}
+
+#CatList,
+category-list {
+  border: 1px solid #333333;
+  background-color: #181818;
+}
+
+category-panel::part(heading) {
+  background-color: #111111;
+  border-bottom: 1px solid #333333;
+  border-top: 1px solid #333333;
+  background: url(./images/pnl_open.svg) 4px no-repeat;
+  background-size: 14px;
+}
+category-panel[closed]::part(heading) {
+  background: url(./images/pnl_close.svg) 4px no-repeat;
+}
+
+
+panel-label {
+  border-color: #181818;
+  --prefix-color: #fff;
+  --badge-color: #666666;
+  --badge-background-color: #111111;
+  --icon-letter-color: #999999;
+  --icon-letter-background-color: #111111;
+  --icon-offset: 0px 0px;
+  --icon-size: 18px;
+  --icon-image-size: 18px;
+}
+
+panel-label[selected] {
+  background-color: #888888;
+  color: #111111;
+  border-color: #888888;
+  --badge-color: #111111;
+  --badge-background-color: #999999;
+}
+
+panel-label[icon="down"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_down.svg);
+}
+panel-label[icon="up"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_up.svg);
+}
+panel-label[icon="search"],
+panel-label[icon="inactive"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_inactive.svg);
+}
+panel-label[icon="paused"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_paused.svg);
+}
+panel-label[icon="error-down"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_error_down.svg);
+}
+panel-label[icon="error-up"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_error_up.svg);
+}
+panel-label[icon="error"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_error.svg);
+}
+panel-label[icon="completed"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_completed.svg);
+}
+panel-label[icon="queued-down"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_queued_down.svg);
+}
+panel-label[icon="queued-up"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_queued_up.svg);
+}
+panel-label[icon="active"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_active.svg);
+}
+panel-label[icon="all"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/t_all.svg);
+}
+panel-label[icon="rss"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/tb_rss.svg);
+}
+panel-label[icon="rss-group"] {
+  --status-image: url(../plugins/theme/themes/DarkBetter/images/tb_rss_group.svg);
+}
+
 div#preload {
     width: 0px; height: 0px; display: none;
     background-image: url(./images/tb_add.svg);
@@ -99,16 +237,6 @@ a.dlg-close:active {
     background: transparent url(./images/t_error.svg) center;
 }
 
-div#CatList ul li.RSS .label-icon {
-    background: url(./images/tb_rss.svg) 2px 0px no-repeat;
-    background-size: 18px !important;
-}
-
-div#CatList ul li.RSSGroup .label-icon {
-    background: url(./images/tb_rss_group.svg) 2px 0px no-repeat !important;
-    background-size: 18px !important;
-}
-
 .stable-icon {background-image: url(../images/tstatus.png); background-repeat: no-repeat}
 .Status_Down {background: transparent url(./images/t_down.svg) no-repeat center center !important; background-size: 16px !important}
 .Status_Up {background: transparent url(./images/t_up.svg) no-repeat center center !important; background-size: 16px !important}
@@ -124,60 +252,14 @@ div#CatList ul li.RSSGroup .label-icon {
 .Status_Checking {background: transparent url(./images/t_all.svg) no-repeat center center !important; background-size: 16px !important}
 .Status_RSS {background: transparent url(./images/rb_rss.svg) no-repeat center center !important; background-size: 16px !important}
 
-.label-icon { min-width: 18px; min-height: 18px; background-size: 18px !important; background-position: 0px 0px !important; }
-.label-icon img { width: 18px; }
-.-_-_-all-_-_- .label-icon, #-_-_-all-_-_- .label-icon {background-image: url(./images/t_all.svg) !important}
-#-_-_-dls-_-_- .label-icon {background-image: url(./images/t_down.svg) !important}
-#-_-_-com-_-_- .label-icon {background-image: url(./images/t_up.svg) !important}
-#-_-_-act-_-_- .label-icon {background-image: url(./images/t_active.svg) !important}
-#-_-_-iac-_-_- .label-icon {background-image: url(./images/t_inactive.svg) !important}
-#-_-_-err-_-_- .label-icon {background-image: url(./images/t_error.svg) !important}
-#flabel_cont li:not(.-_-_-all-_-_-) .label-icon {background-image: url(./images/tb_search.svg) !important}
-
-
 input.Textbox, input.Button, select {border: 1px solid #333333}
 Input.TextboxShort {border: 1px solid #333333}
 Input.TextboxMid {border: 1px solid #333333}
 Input.TextboxLarge {border: 1px solid #333333}
 Input.TextboxVShort {border: 1px solid #333333}
-input.Button {
-	background:-webkit-gradient(linear, left top, left bottom, color-stop(0.05, #d6d6d6), color-stop(1, #c7c7c7));
-	background:-moz-linear-gradient(top, #d6d6d6 5%, #c7c7c7 100%);
-	background:-webkit-linear-gradient(top, #d6d6d6 5%, #c7c7c7 100%);
-	background:-o-linear-gradient(top, #d6d6d6 5%, #c7c7c7 100%);
-	background:-ms-linear-gradient(top, #d6d6d6 5%, #c7c7c7 100%);
-	background:linear-gradient(to bottom, #d6d6d6 5%, #c7c7c7 100%);
-	filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#d6d6d6', endColorstr='#c7c7c7',GradientType=0);
-	background-color:#d6d6d6;
-	border:1px solid #333333;
-	color: #111111;
-}
-
-input.Button:active {
-    background:-webkit-gradient(linear, left top, left bottom, color-stop(0.05, #c7c7c7), color-stop(1, #d6d6d6));
-	background:-moz-linear-gradient(top, #c7c7c7 5%, #d6d6d6 100%);
-	background:-webkit-linear-gradient(top, #c7c7c7 5%, #d6d6d6 100%);
-	background:-o-linear-gradient(top, #c7c7c7 5%, #d6d6d6 100%);
-	background:-ms-linear-gradient(top, #c7c7c7 5%, #d6d6d6 100%);
-	background:linear-gradient(to bottom, #c7c7c7 5%, #d6d6d6 100%);
-	filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#c7c7c7', endColorstr='#d6d6d6',GradientType=0);
-	background-color:#c7c7c7;
-}
-
-input.Button:active {
-    -moz-box-shadow:inset 0px 0px 8px 0px #474747;
-	-webkit-box-shadow:inset 0px 0px 8px 0px #474747;
-}
-
-.pview_custom_view .label-icon { background-color: #111111; line-height: 13px; }
-.pview_custom_view .label-icon > span { color: #999999 !important; }
 
 a {color: #686868}
 
-div#CatList {border: 1px solid #333333; background-color: #181818}
-div#CatList ul li {border-color: #181818}
-div#CatList ul li.sel {background-color: #888888 !important; color:#111111; border-color: #888888}
-div#CatList ul li.disRSS .label-icon {background-image: url(./images/tstatus.png)}
 .stable-icon {background-image: url(./images/tstatus.png)}
 .Icon_File {background: transparent url(./images/file.svg) no-repeat left center; background-size: 16px}
 .Icon_Dir {background: transparent url(./images/dir.svg) no-repeat left center; background-size: 16px}
@@ -233,18 +315,6 @@ div.tab {background-color: #181818}
 div#t div#ind {background: transparent url(./images/ajax-loader.gif) no-repeat 0px center; background-size: 28px}
 
 span#loadimg {background: transparent url(./images/ajax-loader.gif) no-repeat center center; background-size: 28px}
-
-.catpanel {background: url(./images/pnl_open.svg) 4px no-repeat; background-size: 14px; background-color: #111111; border-bottom: 1px solid #333333; border-top: 1px solid #333333}
-.catpanel[style*="pnl_open.gif"] {
-    background: url(./images/pnl_open.svg) 4px no-repeat !important; background-size: 14px !important;
-}
-
-.catpanel[style*="pnl_close.gif"] {
-    background: url(./images/pnl_close.svg) 4px no-repeat !important; background-size: 14px !important;
-}
-.label-count,.label-size { background-color: #111111; }
-li.sel .label-count,li.sel .label-size { background-color: #999999; }
-
 
 #StatusBar {border-top: 1px solid #333333; background-color: #181818; color: #888888}
 #st_up {background:url(./images/up.svg) no-repeat; background-size: 22px}

--- a/plugins/theme/themes/Excel/style.css
+++ b/plugins/theme/themes/Excel/style.css
@@ -1,11 +1,32 @@
 html, body { background-color: #DFE8F6; scrollbar-arrow-color: #586585; scrollbar-base-color: #e3e9f0; scrollbar-track-color: #7797c1; }
+:root {
+  --settings-background-color: #FFFFFF;
+}
+#CatList, category-list {
+  border-top-style: none;
+  border-color: #9EB6CE;
+  background: local transparent url(./images/cbg.png) repeat-y 0 0;
+}
+category-panel::part(heading) {
+  border: none;
+  background: transparent url(./images/pbg.png) repeat-x 0 0;
+  padding: 0px 32px;
+  height: 20px;
+}
+
+panel-label {
+  border-top: 1px solid #d0d7e5;
+  border-bottom: 1px solid transparent;
+  padding: 2px 0px 0px 4px;
+  --badge-background-color: #d2e0f0;
+  --icon-letter-background-color: #d2e0f0;
+  --badge-border-radius: 0.5em 0 0 0;
+}
+
+panel-label[selected] {
+  --badge-background-color: #FFFFFF;
+}
 div#HDivider { width: 5px }
-div#CatList { border-top-style: none; border-color: #9EB6CE; background: scroll transparent url(./images/cbg.png) repeat-y 0 0 }
-div#CatList ul { background: scroll transparent url(./images/cbg.png) repeat-y 0 0 }
-div#CatList ul li { border-top: 1px solid #d0d7e5; border-bottom: 1px solid transparent; padding: 2px 0px 0px 4px; }
-.catpanel { border: none; background: transparent url(./images/pbg.png) repeat-x 0 0; padding: 0px 32px; height: 20px }
-.label-count,.label-size { background-color: #d2e0f0; border-radius: 0.5em 0 0 0; }
-li.sel .label-count,li.sel .label-size { background-color: #FFFFFF; }
 
 div.table_tab { border: none }
 

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -24,6 +24,77 @@ html,body
 	color:#fff;
 	text-shadow:0 -1px 0 #000
 }
+:root {
+	--menu-color: #757571;
+	--menu-border-color: #333;
+	--menu-background-color: #181818;
+
+	--menu-disabled-color: #333;
+
+	--menu-highlight-color: #fff;
+	--menu-highlight-background-color: #888;
+
+	--settings-background-color: #222;
+}
+
+#CatList, category-list
+{
+	border:none;
+	background-color:#1A2329;
+	border-right:1px solid #1b1b1b;
+	border-left:none
+}
+
+panel-label {
+	color:#FFF;
+	border:none;
+	padding: 4px;
+	background-color: #1A2329;
+	--prefix-color: #FFF;
+	--prefix-fontsize: 21px;
+	--badge-color: #D4D6C9;
+	--icon-letter-color: #D4D6C9;
+	--badge-background-color: #273238;
+	--status-image: url(../plugins/theme/themes/MaterialDesign/images/status_icons.png);
+}
+
+panel-label:hover {
+	background-color: #161F25;
+}
+
+panel-label[selected] {
+	background-color: #1A2329;
+	color:#009DDD;
+	text-shadow:0 -1px 0 #000;
+	--badge-color: #009DDD;
+}
+
+panel-label[selected]:hover {
+	background-color: #161F25;
+}
+
+panel-label[icon=file] {
+  --icon-offset: 0px -256px;
+}
+panel-label[icon=directory] {
+  --icon-offset: 0px -272px;
+}
+panel-label[icon=config] {
+  --icon-offset: 0px -288px;
+}
+panel-label[icon=tag] {
+  --icon-offset: 0px -304px;
+}
+panel-label[icon=measure] {
+  --icon-offset: 0px -320px;
+}
+panel-label[icon=storage] {
+  --icon-offset: 0px -336px;
+}
+panel-label[icon=search] {
+  --icon-offset: 0px -352px;
+}
+
 
 div#preload
 {
@@ -85,7 +156,7 @@ div#lng
 ul.CMenu
 {
 	opacity:.98;
-	border:1px solid #333;
+	border:1px solid var(--menu-border-color);
 	border-right:1px solid #070707;
 	border-left:1px solid #1b1b1b;
 	border-bottom:1px solid #000;
@@ -347,7 +418,6 @@ div select {
 a
 {
 	color:#686868;
-	font-family:'Roboto'
 }
 
 div#stg-header
@@ -356,103 +426,36 @@ div#stg-header
 	text-shadow:0 -1px 0 #000
 }
 
-div#CatList
-{
-	border:none;
-	background-color:#1A2329;
-	border-right:1px solid #1b1b1b;
-	border-left:none
-}
-
-div#CatList ul li
-{
-	color:#FFF;
-	border:none;
-	padding: 4px;
-	font-family:'Roboto';
-	background-color: #1A2329;
-}
-
-div#CatList ul li:hover
-{
-	background-color: #161F25;
-}
-
-div#CatList .label-prefix
-{
-	font-size: 21px;
-}
-
-
-div#CatList ul li.sel
-{
-	background-color: #1A2329;
-	color:#009DDD;
-	text-shadow:0 -1px 0 #000;
-	border:none
-}
-
-
-div#CatList ul li.sel:hover
-{
-	background-color: #161F25;
-}
-div#CatList li.sel .label-prefix
-{
-	color:#FFF;
-}
-
-
-.label-count,.label-size,.pview_custom_view .label-icon {
-	color: #D4D6C9;
-	background-color: #273238;
-}
 
 #pview_save_view_button {
 	width: 20px;
 	height: 20px;
 	font-size: 20px;
 	font-family: monospace, monospace;
+	margin: 0px;
 }
 
-li.sel .label-count, li.sel .label-size {
-	color:#009DDD;
+category-panel {
+	color: #DCDCDC;
+	--open-background-image: url(../plugins/theme/themes/MaterialDesign/images/pnl_open.gif);
+	--close-background-image: url(../plugins/theme/themes/MaterialDesign/images/pnl_close.gif);
+	--heading-background-color: #273238;
 }
 
-.label-icon {
-	background-image: url(./images/status_icons.png);
-}
-
-.catpanel
+category-panel::part(heading)
 {
-	font-size:12px;
-	font-family:'Roboto';
-	padding:2px 30px;
-	height:22px;
-	line-height:25px;
-	background:url(./images/pnl_open.gif) 0 0 no-repeat;
-	background-color:#273238;
-	font-weight:700;
-	color:#DCDCDC;
-	text-shadow:0 -1px 0 #000;
-	border:none
+	font-size: 12px;
+	padding: 2px 14px 2px 30px;
+	height: 22px;
+	line-height: 25px;
+	font-weight: 700;
+	text-shadow: 0 -1px 0 #000;
+	border: none;
 }
-
-.catpanelcont
-{
-	margin:15px 2px;
-	transition:all .3s cubic-bezier(0.68,-0.55,0.27,1.55) 0
-}
-
 
 .stable-icon
 {
 	background-image:url(./images/status_icons.png);
-}
-
-.stable-icon
-{
-	background-image:url(./images/status_icons.png)
 }
 
 .Icon_File
@@ -470,12 +473,6 @@ li.sel .label-count, li.sel .label-size {
 	background:transparent url(./images/dir.gif) no-repeat left center
 }
 
-div#CatList .sel .label-size, div#CatList .sel .label-size
-{
-	color:#009DDD
-}
-
-#flabel_cont li:not(.-_-_-all-_-_-) .label-icon { background:transparent url(./images/status_icons.png) no-repeat 0 -352px; }
 
 div.tab
 {
@@ -546,7 +543,7 @@ div#modalbg
 	background-color:#181818
 }
 
-div#List
+div#List,.main-table
 {
 	margin-right:6px;
 	border:none;
@@ -760,6 +757,7 @@ textarea
 	border-radius:2px
 }
 
+button,
 input.Button,
 input.Button:not([disabled]):focus
 {
@@ -778,12 +776,14 @@ input.Button:not([disabled]):focus
 }
 
 
+button:not([disabled]):hover,
 input.Button:not([disabled]):hover
 {
 	background-color: #3498db;
 	filter: brightness(1.2);
 }
 
+button:not([disabled]):hover:active,
 input.Button:not([disabled]):hover:active
 {
 	background-color: #3498db;

--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -1,4 +1,103 @@
 html, body {font-family: "Lucida Sans Unicode", "Lucida Grande", Tahoma, Arial, Helvetica, sans-serif;background-color: #000;color: #ffffff;text-shadow:0px -1px 0px #000;scrollbar-base-color:#181818; }
+:root {
+  --menu-color: #757571;
+  --menu-background-color: transparent;
+
+  --menu-disabled-color: #333333;
+
+  --menu-border-color: #333333;
+  --menu-highlight-color: #fff;
+  --menu-highlight-background-color: #888888;
+
+  --settings-background-color: #181818;
+}
+
+button, input.Button {
+  border: 1px solid #000;
+  background: #000 url(./images/headers.png) repeat-x 0px 0px;
+  color:#AACF27;
+  cursor: pointer;
+  font-weight: bold;
+  text-shadow:0px -1px 0px #000;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px;
+}
+button:not([disabled]):hover, input.Button:not([disabled]):hover {
+  background: #000 url(./images/headers.png) repeat-x 0px -6px;
+}
+button:not([disabled]):hover:active, input.Button:not([disabled]):hover:active {
+  background: #000 url(./images/headers.png) repeat-x 0px -8px;
+}
+
+#CatList, category-list {
+  border:none;
+  background-color: #212121;
+  border-right: 1px solid #1b1b1b;
+  border-left: 1px solid #070707;
+}
+
+category-panel {
+  --open-background-image: url(../plugins/theme/themes/Oblivion/images/pnl_open.gif);
+  --close-background-image: url(../plugins/theme/themes/Oblivion/images/pnl_close.gif);
+}
+
+category-panel::part(heading) {
+  font-size:12px;
+  font-family:inherit;
+  padding: 2px 24px;
+  height:25px;
+  line-height:25px;
+  background-color: #232323;
+  font-weight: bold;
+  color:#DCDCDC;
+  text-shadow: 0px -1px 0px #000;
+  border-top:1px solid #333;
+  border-bottom: none;
+  border-right: none;
+}
+
+panel-label {
+  color: #D4D6C9;
+  border-color: #212121;
+  --prefix-color: #FFF;
+  --badge-color: #666666;
+  --badge-background-color: #181818;
+  --icon-letter-color: #D4D6C9;
+  --icon-letter-background-color: #181818;
+  --status-image: url(../plugins/theme/themes/Oblivion/images/status_icons.png);
+}
+
+panel-label[selected] {
+  background-color: transparent;
+  color: #009DDD;
+  text-shadow:0px -1px 0px #000;
+  border:1px solid #212121;
+  --badge-color: #111111;
+  --badge-background-color: #999999;
+}
+
+panel-label[icon=file] {
+  --icon-offset: 0px -256px;
+}
+panel-label[icon=directory] {
+  --icon-offset: 0px -272px;
+}
+panel-label[icon=config] {
+  --icon-offset: 0px -288px;
+}
+panel-label[icon=tag] {
+  --icon-offset: 0px -304px;
+}
+panel-label[icon=measure] {
+  --icon-offset: 0px -320px;
+}
+panel-label[icon=storage] {
+  --icon-offset: 0px -336px;
+}
+panel-label[icon=search] {
+  --icon-offset: 0px -352px;
+}
 
 div#preload {width: 0px; height: 0px; display: none; background-image: url(./images/menus.png);background-image: url(./images/toolbar.png); background-image: url(./images/status_icons.png);  background-image: url(./images/r_bg.gif); background-image: url(./images/asc.gif); background-image: url(./images/desc.gif); background-image: url(./images/pnl_open.gif); background-image: url(./images/pnl_close.gif);background-image: url(./images/headers.png);}
 
@@ -12,24 +111,17 @@ div#lng {background-color:#181818; border:1px solid #333333}
 
 /*Drop Menu */
 ul.CMenu {opacity:0.98;border-top: 1px solid #333; border-right: 1px solid #070707; border-left: 1px solid #1b1b1b; border-bottom: 1px solid #000000;background: #000; padding:0px;-moz-border-radius: 5px; -webkit-border-radius: 5px; border-radius: 5px;}
-ul.CMenu li {background: #181818}
 ul.CMenu li.menuitem:first-child {-moz-border-radius-topleft:5px; -webkit-border-top-left-radius:5px;-moz-border-radius-topright:5px;-webkit-border-top-right-radius:5px;border-top-right-radius:5px;border-top-left-radius:5px;}
 ul.CMenu li.menuitem:last-child{-moz-border-radius-bottomleft:5px; -webkit-border-bottom-left-radius:5px;-moz-border-radius-bottomright:5px;-webkit-border-bottom-right-radius:5px;border-bottom-right-radius:5px;border-top-left-radius:5px;}
 ul.CMenu li a {color: #757571;background: transparent url(./images/menus.png) no-repeat 0px 0px;}
-ul.CMenu li a.dis {color: #333333}
-ul.CMenu li a.dis:hover {color: #333333}
 ul.CMenu li hr {background-color:#000;height:1px;border-width: 0px;border-bottom:1px solid #1b1b1b;padding:0px;margin:0px;width:100%;}
 ul.CMenu li a.exp {background: transparent url(./images/menus.png) no-repeat right -22px;}
 ul.CMenu li a.exp:hover {background: transparent url(./images/menus.png) no-repeat right -44px;}
 ul.CMenu li a.sel {color:#178FD1;background: transparent url(./images/menus.png) no-repeat 0px -66px;}
 ul.CMenu li ul li a.sel {color:#178FD1}
-ul.CMenu li a:hover {background-color: #888888;; color: #fff;text-shadow:0px -1px 0px #000;}
+ul.CMenu li a:hover { text-shadow:0px -1px 0px #000;}
 
-ul.CMenu li:hover ul li a {background-color: #181818; color: #666666}
-ul.CMenu li:hover ul li a:hover {background-color; color: #fff;text-shadow:0px -1px 0px #000;}
-ul.CMenu li ul li a.dis {color: #333333}
-ul.CMenu li ul li a.dis:hover {background-color: #181818; color: #333333}
-
+ul.CMenu li:hover ul li a:hover { text-shadow:0px -1px 0px #000;}
 
 #sel {border: 1px dotted #555555;}
 
@@ -66,33 +158,17 @@ div#t div#go {background: transparent url(./images/toolbar.png) no-repeat -72px 
 .stg_con td input {padding:1px 4px;}
 
 a {color: #686868; font-family:inherit;}
-textarea {border: 1px solid #000;background: #ffffff;-moz-border-radius: 5px; -webkit-border-radius: 5px;border-radius: 5px;}
-div#tcreate textarea#trackers {color: black;}
+textarea {color: black; border: 1px solid #000;background: #ffffff;-moz-border-radius: 5px; -webkit-border-radius: 5px;border-radius: 5px;}
 textarea[disabled] {border: 1px solid #000;background: #888888;-moz-border-radius: 5px; -webkit-border-radius: 5px;border-radius: 5px;}
 input[type="number"],input[type="text"], input[type="password"], select {color: black; border: 1px solid #000;background: #ffffff url(./images/headers.png) repeat-x 0px -138px;-moz-border-radius: 5px; -webkit-border-radius: 5px; border-radius: 5px;}
 input[type="file"] {-moz-border-radius: 5px; -webkit-border-radius: 5px; border-radius: 5px;}
 input[type="number"][disabled],input[type="text"][disabled], input[type="password"][disabled], input[type="file"][disabled], select[disabled] {color: black; border: 1px solid #000;background: #888888 url(./images/headers.png) repeat-x 0px -138px;-moz-border-radius: 5px; -webkit-border-radius: 5px; border-radius: 5px;}
-input.Button {border: 1px solid #000;background: #000 url(./images/headers.png) repeat-x 0px 0px;color:#AACF27;cursor: pointer;font-weight: bold;text-shadow:0px -1px 0px #000;-moz-border-radius: 5px; -webkit-border-radius: 5px;border-radius: 5px;}
-input.Button:not([disabled]):hover { background: #000 url(./images/headers.png) repeat-x 0px -6px; }
-input.Button:not([disabled]):hover:active { background: #000 url(./images/headers.png) repeat-x 0px -8px; }
 
-.pview_custom_view .label-icon { background-color: #181818; line-height: 13px; }
-.pview_custom_view .label-icon > span { color: #D4D6C9 !important; }
-
-div#CatList {border:none;background-color: #212121;border-right: 1px solid #1b1b1b;border-left: 1px solid #070707;}
-div#CatList ul li {color:#D4D6C9}
-div#CatList ul li.sel {color:#AACF27}
-div#CatList ul li {border-color: #212121;font-family: inherit;}
-div#CatList ul li.sel {background-color: transparent; color:#009DDD;text-shadow:0px -1px 0px #000;border:1px solid #212121; }
-.catpanel { font-size:12px;font-family:inherit;padding: 2px 24px; height:25px; line-height:25px;background: url(./images/pnl_open.gif) 0px 0px no-repeat; background-color: #232323;   font-weight: bold;color:#DCDCDC;text-shadow: 0px -1px 0px #000;border-top:1px solid #333;   border-bottom: none;border-right: none;}
-.label-icon { background-image: url(./images/status_icons.png); }
-.label-count,.label-size { background-color: #181818; }
 .stable-icon {background-image: url(./images/status_icons.png); }
 .Icon_File {background: transparent url(./images/file.gif) no-repeat left center}
 .Icon_Dir {background: transparent url(./images/dir.gif) no-repeat left center}
 .Icon_Share {background: transparent url(./images/dir.gif) no-repeat left center}
 
-div#flabel_cont li:not(.-_-_-all-_-_-) .label-icon { background-position: 0px -352px;}
 
 div.tab {background: #181818;font-family: inherit;}
 div#lcont {background: #181818;font-family: inherit;}

--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -1,10 +1,50 @@
 
-theWebUI.viewPanelLabelTypes.push('ptrackers_cont');
 theWebUI.trackerNames = [];
-theWebUI.torrentTrackerIds = {};
+theWebUI.torrentTrackerIds = new Map();
 plugin.injectedStyles = {};
+plugin.iconEditSuffix = {};
+plugin.imageEditSuffix = {
+	tracker: {},
+	label: {},
+}
 plugin.loadLang();
 
+const catlist = theWebUI.categoryList;
+const ptrackersPanelArgs = [
+	[['ptrackers_all', {text: theUILang.All, icon: 'all'}]],
+	[(hash) => theWebUI.torrentTrackerIds.get(hash) ?? []]
+];
+
+const plabelEntries = catlist.refreshPanel.plabel.bind(catlist);
+catlist.refreshPanel.plabel = (attribs) => plabelEntries(attribs)
+	.map(([labelId, aa]) => [
+		labelId,
+		aa,
+		labelId.startsWith('clabel__') ? labelId.substring(8) : 'nlb'
+	])
+	.map(([labelId, a, label]) => [
+		labelId,
+		labelId === 'plabel_all'
+		? a
+		: {
+			...a,
+			icon: 'url:'
+				+ plugin.imageURI('label', label)
+				+ (plugin.imageEditSuffix.label[label] ?? '')
+
+	}]);
+
+catlist.refreshPanel.ptrackers = () => [
+	catlist.updatedStatisticEntry('ptrackers', "ptrackers_all"),
+	...theWebUI.trackerNames
+		.map(tracker => ['i' + tracker, tracker])
+		.map(([trackerId, tracker]) => catlist.updatedStatisticEntry('ptrackers', trackerId, {
+			icon: 'url:'
+				+ plugin.imageURI('tracker', tracker)
+				+ (plugin.imageEditSuffix.tracker[tracker] ?? ''),
+			text: tracker,
+		}))
+];
 
 plugin.config = theWebUI.config;
 theWebUI.config = function()
@@ -19,11 +59,6 @@ theWebUI.config = function()
 			tracker.icon = domain ? {src: plugin.imageURI('tracker', domain)} : 'Status_Checking';
 		});
 	}
-}
-
-plugin.isActiveLabel = function(lbl)
-{
-	return (theWebUI.actLbls['ptrackers_cont'] ?? []).includes('i'+lbl);
 }
 
 plugin.addTrackers = theWebUI.addTrackers;
@@ -64,15 +99,18 @@ if(!$type(theWebUI.getTrackerName))
 	}
 }
 
-plugin.contextMenuEntries = theWebUI.contextMenuEntries;
-theWebUI.contextMenuEntries = function(labelType, el) {
-	const entries = plugin.contextMenuEntries.call(theWebUI, labelType, el);
-	if (plugin.canChangeMenu() && ['ptrackers_cont', 'plabel_cont'].includes(labelType)) {
-		const lbl = el.id.startsWith('-_-_-') ? theWebUI.idToLbl(el.id) : el.id.substr('ptrackers_cont' === labelType ? 1 : 8);
-		if (lbl)
+plugin.contextMenuEntries = catlist.contextMenuEntries.bind(catlist);
+catlist.contextMenuEntries = function(panelId, labelId) {
+	const entries = plugin.contextMenuEntries(panelId, labelId);
+	if (plugin.canChangeMenu() && ['ptrackers', 'plabel'].includes(panelId)) {
+		if (labelId !== `${panelId}_all`) {
+			const lbl = panelId === 'plabel'
+				? (labelId.startsWith('clabel__') ? labelId.substring(8) : 'nlb')
+				: labelId.substring(1);
 			return entries.concat([
 				[theUILang.EditIcon, `theWebUI.showTracklabelsDialog('${lbl}');`]
 			]);
+		}
 	}
 	return entries;
 }
@@ -84,39 +122,6 @@ theWebUI.showTracklabelsDialog = function(lbl) {
 }
 
 
-
-plugin.updateLabel = theWebUI.updateLabel;
-theWebUI.updateLabel = function(label, ...args)
-{
-	plugin.updateLabel.call(this, label, ...args);
-	const icon = $(label).children('.label-icon');
-	const id = label.id;
-	if (id && (id === '-_-_-nlb-_-_-' || id.startsWith('clabel__')) && !icon.children('img')[0])
-	{
-		var lbl = id.startsWith('-_-_-') ? theWebUI.idToLbl(id) : id.substr(8);
-		icon.append($("<img>")
-			.attr({ id: 'lbl_'+lbl, src: plugin.imageURI('label', lbl)}))
-			.css({ background: 'none' });
-	}
-}
-
-plugin.updateLabels = theWebUI.updateLabels;
-theWebUI.updateLabels = function()
-{
-	if(plugin.enabled)
-	{
-		theWebUI.updateAllFilterLabel('torrl', this.settings["webui.show_labelsize"]);
-	}
-	plugin.updateLabels.call(theWebUI);
-}
-
-plugin.getLabels = theWebUI.getLabels;
-theWebUI.getLabels = function(hash, torrent)
-{
-	return plugin.getLabels.call(theWebUI, hash, torrent)
-		.concat(this.torrentTrackerIds[hash] ?? []);
-}
-
 theWebUI.rebuildTrackersLabels = function()
 {
 	if(!plugin.allStuffLoaded)
@@ -127,71 +132,28 @@ theWebUI.rebuildTrackersLabels = function()
 
 	const table = this.getTable('trt');
 	const colId = table.getColById('tracker');
-	const setTracker = plugin.canChangeColumns()
-		? ((hash, trk) => table.setValue(hash, colId, trk))
-		: () => {};
-	const torrentHashByTrackerName = {}; 
-	this.torrentTrackerIds = {};
+	this.torrentTrackerIds.clear();
 	for(const [hash, torrent] of Object.entries(this.torrents))
 	{
 		const trackerNames = (this.trackers[hash] ?? [])
 					.filter(t => Number(t.group) === 0)
 					.map(t => theWebUI.getTrackerName(t.name))
 					.filter(name => Boolean(name));
-		this.torrentTrackerIds[hash] = trackerNames
-			.map(name => 'i' + name);
+		this.torrentTrackerIds.set(hash, trackerNames.map(name => 'i' + name));
 
 		const firstName = trackerNames[0] ?? null;
 		torrent.tracker = firstName;
-		if (firstName)
+		if (plugin.canChangeColumns() && firstName)
 		{
-			setTracker(hash, firstName);
-			for (const name of trackerNames) {
-				const names = torrentHashByTrackerName[name] ?? new Set();
-				names.add(hash);
-				torrentHashByTrackerName[name] = names;
-			}
+			table.setValue(hash, colId, firstName);
 		}
 	}
 
-	for (const [name, hashes] of Object.entries(torrentHashByTrackerName)) {
-		this.labels['i' + name] = hashes;
-	}
-
-	const ul = $("#torrl");
-	const lbls = Object.keys(torrentHashByTrackerName);
-	lbls.sort();
-
-	// Remove empty tracker rows with no torrents
-	for(const el of ul.children())
-		if(el.id.startsWith('i') && !(el.id.substr(1) in torrentHashByTrackerName))
-		{
-			$(el).remove();
-		}
-	let previousLabelEl = null;
-	for(const lbl of lbls)
-	{
-		const lblId = 'i'+lbl;
-		let labelEl = $$(lblId);
-		if(!labelEl)
-		{
-			labelEl = this.createSelectableLabelElement(lblId, lbl, theWebUI.labelContextMenu)
-				.addClass('tracker');
-			labelEl.children('.label-icon')
-				.append($('<img>').attr('src', plugin.imageURI('tracker', lbl)))
-				.css({ background: 'none' });
-			if (previousLabelEl !== null)
-				$(previousLabelEl).after(labelEl);
-			else
-				ul.append(labelEl);
-		}
-		previousLabelEl = labelEl;
-	}
-
-	this.trackerNames = lbls;
-	this.updateViewPanel();
-	this.refreshLabelSelection('ptrackers_cont');
-	this.updateLabels();
+	theWebUI.trackerNames = [...new Set([...theWebUI.torrentTrackerIds.values()].flat())]
+		.sort()
+		.map(labelId => labelId.slice(1))
+	catlist.rescan('ptrackers');
+	catlist.refreshAndSyncPanel('ptrackers', true);
 }
 
 plugin.imageURI = function (target, label) {
@@ -273,9 +235,13 @@ plugin.onLangLoaded = function()
 					// hide dialog if upload successful
 					theDialogManager.hide(plugin.dialogId);
 					// show uploaded image
-					const el = $($$((trkTarget ? 'i' : 'lbl_')+label));
-					const img = trkTarget ? el.find('img') : el;
-					img.attr('src', `${uri}&t=${new Date().getTime()}`);
+					plugin.imageEditSuffix[target][label] = `&t=${new Date().getTime()})`;
+					if (trkTarget) {
+						plugin.refresh('ptrackers');
+					} else {
+						catlist.refreshTorrentLabelTree();
+					}
+					catlist.syncFn();
 				} else {
 					noty(`Icon edit failed! ${request.response}`, 'error');
 				}
@@ -293,17 +259,18 @@ plugin.onLangLoaded = function()
 	theDialogManager.setHandler(plugin.dialogId, 'beforeShow', function()
 	{
 		$(`#${eid}-datalist`).empty().append(
-			...Object.keys(theWebUI.cLabels).concat(theWebUI.trackerNames)
-			.map(lbl => $('<option>').attr('value', lbl))
+			...[...catlist.torrentLabelTree.torrentLabels.keys()]
+				.concat(theWebUI.trackerNames)
+				.map(lbl => $('<option>').attr('value', lbl))
 		);
 		updateButtons();
 	});
 
-	plugin.addPaneToCategory('ptrackers', theUILang.Trackers)
-		.append(
-			$('<ul>').attr('id', 'torrl')
-			.append(theWebUI.createSelectableLabelElement(undefined, theUILang.All, theWebUI.labelContextMenu).addClass('-_-_-all-_-_- sel'))
-		);
+	plugin.addPaneToCategory(
+		'ptrackers',
+		theUILang.Trackers,
+		...ptrackersPanelArgs
+	);
 };
 
 plugin.onRemove = function()
@@ -313,7 +280,7 @@ plugin.onRemove = function()
 		plugin.dialogId = undefined;
 	}
 	plugin.removePaneFromCategory('ptrackers');
-	theWebUI.resetLabels();
+	theWebUI.categoryList.resetSelection();
 	if(plugin.canChangeColumns())
 	{
 		theWebUI.getTable("trt").removeColumnById("tracker");

--- a/tests/.babel-jest-wrapper.js
+++ b/tests/.babel-jest-wrapper.js
@@ -1,0 +1,6 @@
+const path = require("path");
+const { createTransformer } = require("babel-jest");
+module.exports = createTransformer({
+  presets: ["@babel/preset-env"],
+  babelrcRoots: path.resolve(__dirname),
+});

--- a/tests/.babelrc.js
+++ b/tests/.babelrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: ['@babel/preset-env'],
-};

--- a/tests/global.mock.js
+++ b/tests/global.mock.js
@@ -1,0 +1,4 @@
+CSSStyleSheet.prototype.replaceSync = function (text) {
+  this.textContent = text;
+};
+global.structuredClone = (v) => JSON.parse(JSON.stringify(v));

--- a/tests/js/category-list-elements.spec.js
+++ b/tests/js/category-list-elements.spec.js
@@ -1,0 +1,170 @@
+import { log } from "console";
+import { readFileSync } from "fs";
+const indexDocument = new DOMParser().parseFromString(
+  readFileSync("../index.html", { encoding: "utf-8" }),
+  "text/html"
+);
+
+const categoryListElements = () =>
+  indexDocument.getElementById("CatList").cloneNode(true);
+
+document.head.append(
+  indexDocument.getElementById("panel-label-template"),
+  indexDocument.getElementById("category-panel-template")
+);
+for (const src of ["../js/custom-elements.js", "../js/category-list-elements.js"]) {
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = readFileSync(src, { encoding: "utf-8" });
+  document.head.appendChild(scriptEl);
+}
+
+let catList;
+describe("category-list", () => {
+  beforeEach(() => {
+    document.body.replaceChildren(categoryListElements());
+    catList = document.getElementById("CatList");
+  });
+
+  it("should create", () => {
+    const panelLabelAttribs = catList.panelLabelAttribs;
+    const panelAttribs = catList.panelAttribs;
+    catList.sync(panelLabelAttribs, panelAttribs);
+    expect(panelAttribs).toEqual(catList.panelAttribs);
+    expect(panelLabelAttribs).toEqual(catList.panelLabelAttribs);
+    log("CategoryList: ", catList.panelAttribs, catList.panelLabelAttribs);
+  });
+
+  it("should emit label-click", () => {
+    const onClick = jest.fn();
+    const catList = document.getElementById("CatList");
+    catList.addEventListener("label-click", onClick);
+
+    // For initial element
+    const panelLabelEl = document.getElementById("-_-_-com-_-_-");
+    const e = new MouseEvent("mousedown");
+    panelLabelEl.dispatchEvent(e);
+    const callArg = onClick.mock.calls[0][0];
+    expect(callArg.labelId).toEqual(panelLabelEl.id);
+    expect(callArg.panelId).toEqual("pstate");
+    onClick.mockClear();
+
+    const plA = catList.panelLabelAttribs;
+    const newLabelId = "clabel__some/label";
+    plA.plabel.set(newLabelId, { text: "some/label" });
+    catList.sync(plA, catList.panelAttribs);
+    document.getElementById(newLabelId).dispatchEvent(e);
+    const callArg2 = onClick.mock.calls[0][0];
+    expect(callArg2.labelId).toEqual(newLabelId);
+    expect(callArg2.panelId).toEqual("plabel");
+  });
+  it("should emit panel-close", async () => {
+    const pstateEl = document.getElementById("pstate");
+    pstateEl.closed = true;
+    const onClose = jest.fn();
+    const catList = document.getElementById("CatList");
+    catList.addEventListener("panel-close", onClose);
+
+    // For initial
+    pstateEl.parts.heading.dispatchEvent(new MouseEvent("click"));
+    await new Promise(process.nextTick);
+    expect(pstateEl.closed).toBe(false);
+    const callArg = onClose.mock.calls[0][0];
+    expect(callArg.panelId).toEqual("pstate");
+    expect(callArg.closed).toBe(false);
+    onClose.mockClear();
+
+    // For added
+    const pA = catList.panelAttribs;
+    const panelId = "psome";
+    pA[panelId] = { text: "Some Panel" };
+    const plA = catList.panelLabelAttribs;
+    plA[panelId] = new Map();
+    catList.sync(plA, pA);
+    document
+      .getElementById("psome")
+      .parts.heading.dispatchEvent(new MouseEvent("click"));
+    await new Promise(process.nextTick);
+    const callArg2 = onClose.mock.calls[0][0];
+    expect(callArg2.panelId).toEqual("psome");
+    expect(callArg2.closed).toBe(true);
+  });
+});
+
+describe("category-panel", () => {
+  it("should create", () => {
+    const p = document.createElement("category-panel");
+    p.id = "ptest";
+    p.text = "Test Panel";
+    log("Panel: ", p.shadowRoot.innerHTML);
+  });
+
+  it("should open and close", async () => {
+    const p = document.createElement("category-panel");
+    expect(p.closed).toBe(false);
+    p.closed = true;
+    expect(p.closed).toBe(true);
+    p.parts.heading.dispatchEvent(new MouseEvent("click"));
+    await new Promise(process.nextTick);
+    expect(p.closed).toBe(false);
+    p.parts.heading.dispatchEvent(new MouseEvent("click"));
+    await new Promise(process.nextTick);
+    expect(p.closed).toBe(true);
+  });
+});
+
+describe("panel-label", () => {
+  it("should create", async () => {
+    const label = document.createElement("panel-label");
+    label.id = "label1";
+    const attr = {
+      prefix: "I",
+      icon: "icon",
+      text: "Test Label",
+      count: "1",
+      size: "2mb",
+    };
+    for (const [attrName, value] of Object.entries(attr)) {
+      label[attrName] = value;
+      expect(label[attrName]).toEqual(value);
+    }
+
+    document.body.appendChild(label);
+    log("Label: ", label.shadowRoot.innerHTML);
+  });
+
+  it("should display prefix attribute", async () => {
+    const label = document.createElement("panel-label");
+    expect(label.parts.prefix.hidden).toBe(true);
+    label.prefix = "II";
+    await new Promise(process.nextTick);
+    expect(label.parts.prefix.hidden).toBe(false);
+    expect(label.parts.prefix.children.length).toBe(2);
+    label.prefix = "";
+    await new Promise(process.nextTick);
+    expect(label.parts.prefix.hidden).toBe(false);
+    expect(label.parts.prefix.children.length).toBe(0);
+    label.prefix = null;
+    await new Promise(process.nextTick);
+    expect(label.parts.prefix.hidden).toBe(true);
+  });
+
+  it("should display icon attribute", async () => {
+    const label = document.createElement("panel-label");
+    const ic = label.parts.icon;
+    label.icon = "url:name";
+    await new Promise(process.nextTick);
+    expect(ic.style.backgroundImage).toEqual(`url(name)`);
+    expect(ic.children.length).toBe(0);
+    expect([...ic.classList]).toEqual(["icon-by-url"]);
+    label.icon = "name";
+    await new Promise(process.nextTick);
+    expect(ic.style.backgroundImage).toEqual("");
+    expect(ic.children.length).toBe(0);
+    expect([...ic.classList]).toEqual([]);
+    label.icon = "n";
+    await new Promise(process.nextTick);
+    expect(ic.style.backgroundImage).toEqual("");
+    expect(ic.children.length).toBeGreaterThan(0);
+    expect([...ic.classList]).toEqual(["icon-letter"]);
+  });
+});

--- a/tests/js/category-list.spec.js
+++ b/tests/js/category-list.spec.js
@@ -1,0 +1,198 @@
+import { CategoryList } from "../../js/category-list";
+
+const listSettings = {
+  "webui.category_panels": [
+    "pview",
+    "pstate",
+    "plabel",
+    "psearch",
+    "ptrackers",
+    "prss",
+  ],
+  "webui.show_label_path_tree": true,
+  "webui.show_viewlabelsize": true,
+  "webui.show_statelabelsize": true,
+  "webui.show_searchlabelsize": false,
+  "webui.show_labelsize": true,
+  "webui.show_view_panel": true,
+
+  "webui.closed_panels": {},
+  "webui.open_tegs.keep": true,
+  "webui.open_tegs.last": ["[Banana]", "less"],
+  "webui.selected_labels.keep": true,
+  "webui.selected_labels.last": {
+    plabel: ["clabel__path/for/torrent/label", "-_-_-nlb-_-_-"],
+  },
+  "webui.selected_labels.views": [],
+};
+const toMap = (obj) => new Map(Object.entries(obj));
+
+const listAttribs = () => ({
+  panelAttribs: {
+    pview: { text: "Views" },
+    pstate: { text: "State" },
+    plabel: { text: "Labels" },
+    psearch: { text: "Search" },
+  },
+  panelLabelAttribs: {
+    pview: toMap({
+      pview_all: { icon: "all", text: "All", selected: true },
+    }),
+    pstate: toMap({
+      pstate_all: { icon: "all", text: "All", selected: true },
+      "-_-_-dls-_-_-": { icon: "down", text: "Downloading" },
+      "-_-_-com-_-_-": { icon: "completed", text: "Finished" },
+      "-_-_-act-_-_-": { icon: "up-down", text: "Active" },
+      "-_-_-iac-_-_-": { icon: "incompleted", text: "Inactive" },
+      "-_-_-err-_-_-": { icon: "error", text: "Error" },
+    }),
+    plabel: toMap({
+      plabel_all: { icon: "all", text: "All", selected: true },
+      "-_-_-nlb-_-_-": { icon: "no-label", text: "No label" },
+    }),
+    psearch: toMap({
+      psearch_all: { icon: "all", text: "All", selected: true },
+    }),
+  },
+});
+
+let syncFn, onSelectionChangeFn, onConfigChangeFn, borrowTorrentsFn, list;
+
+describe("Category list", () => {
+  beforeEach(() => {
+    syncFn = jest.fn();
+    onSelectionChangeFn = jest.fn();
+    onConfigChangeFn = jest.fn();
+    borrowTorrentsFn = jest.fn().mockImplementation(() =>
+      Object.fromEntries(
+        [
+          ["AA", "", "[Test] less", 16, 100 << 20, 0, 0],
+          ["BB", "Software", "[Banana] green", 0, 12 << 20, 5000, 10],
+          ["CC", "Image/Banana", "[Banana] ripe", 15, 1 << 30, 0, 10000],
+          ["DD", "Image/Peach", "[Peach] rotten", 1, 500 << 20, 3000, 5000],
+          ["EE", "Misc/Other/More", "[More] or less", 2, 300 << 20, 200, 0],
+          ["FF", "Misc/Other/Less", "[Less] or more", 16, 200 << 20, 0, 0],
+        ].map(([hash, label, name, status, size, ul, dl]) => [
+          hash,
+          { label, name, status, size, ul, dl },
+        ])
+      )
+    );
+    list = new CategoryList({
+      panelAttribs: listAttribs().panelAttribs,
+      panelLabelAttribs: listAttribs().panelLabelAttribs,
+      syncFn,
+      onSelectionChangeFn,
+      borrowTorrentsFn,
+      onConfigChangeFn,
+      byteSizeToStringFn: (size) => `${(size / (1 << 20)).toFixed(2)} MiB`,
+      dStatus: { error: 16 },
+    });
+  });
+  it("should restore selection and searches on config", () => {
+    expect(syncFn).not.toHaveBeenCalled();
+    list.config(listSettings);
+    expect(onConfigChangeFn).not.toHaveBeenCalled();
+    expect(borrowTorrentsFn).not.toHaveBeenCalled();
+
+    //log("CategoryList: ", list.panelAttribs, list.panelLabelAttribs);
+  });
+
+  it("should allow (plugins) to add panel before config", () => {
+    list.addPanel("testpanelId", "Test panel");
+    list.addPanel("testpanelId2", "Test panel2", [
+      ["some_id2", { text: "test2" }],
+    ]);
+    list.addPanel(
+      "testpanelId3",
+      "Test panel3",
+      [["some_id3", { text: "test3" }]],
+      [() => [], () => false]
+    );
+    list.addPanel(
+      "testpanelId4",
+      "Test panel3",
+      [["some_id4", { text: "test4" }]],
+      [() => [], () => false]
+    );
+    list.addPanel("testpanelId5", "Test panel5");
+    list.addPanel("testpanelId6", "Test panel6");
+
+    expect(list.statistic.hasPanel("testpanelId3")).toBe(true);
+    list.removePanel("testpanelId3");
+    expect(list.statistic.hasPanel("testpanelId3")).toBe(false);
+
+    list.removePanel("testpanelId5");
+    expect(list.statistic.hasPanel("testpanelId4")).toBe(true);
+    expect(list.settings).toBe(undefined);
+    list.config({
+      ...listSettings,
+      "webui.selected_labels.last": {
+        testpanelId: ["testLabelId"],
+      },
+    });
+    expect(onConfigChangeFn).toHaveBeenCalled();
+    onConfigChangeFn.mockClear();
+
+    list.removePanel("testpanelId4");
+    expect(list.statistic.hasPanel("testpanelId4")).toBe(false);
+
+    expect(onConfigChangeFn).not.toHaveBeenCalled();
+    expect(list.sortedPanelIds).toEqual([
+      "pview",
+      "pstate",
+      "plabel",
+      "psearch",
+      "testpanelId",
+      "testpanelId2",
+      "testpanelId6",
+    ]);
+    expect(list.selection.ids("testpanelId")).toEqual(["testLabelId"]);
+    expect(list.panelLabelAttribs.testpanelId.size).toBe(0);
+    expect(list.panelLabelAttribs.testpanelId2.size).toBe(1);
+  });
+
+  it("should notify selection change", () => {
+    list.config(listSettings);
+    expect(list.selection.count("plabel")).toBe(2);
+    expect(list.selection.count("pstate")).toBe(0);
+
+    list.switchLabel("pstate", null);
+    expect(onSelectionChangeFn).not.toHaveBeenCalled();
+    expect(onConfigChangeFn).not.toHaveBeenCalled();
+
+    list.switchLabel("pstate", "-_-_-act-_-_-");
+    expect(onSelectionChangeFn).toHaveBeenCalled();
+    expect(onConfigChangeFn).toHaveBeenCalled();
+  });
+
+  it("should show torrent statistic", () => {
+    list.config(listSettings);
+    const torrents = borrowTorrentsFn();
+    for (const [hash, torrent] of Object.entries(torrents)) {
+      list.statistic.scan(hash, torrent);
+    }
+    list.syncAfterScan();
+    const actAttribs = list.panelLabelAttribs.pstate.get("-_-_-act-_-_-");
+    expect(actAttribs.count).toBe("3");
+    expect(actAttribs.size).toBe(
+      list.byteSizeToStringFn((500 << 20) + (12 << 20) + (1 << 30))
+    );
+    const nlbAttribs = list.panelLabelAttribs.plabel.get("-_-_-nlb-_-_-");
+    expect(nlbAttribs.count).toBe("1");
+    expect(nlbAttribs.size).toBe(list.byteSizeToStringFn(100 << 20));
+    expect(nlbAttribs.prefix).toBe(undefined);
+
+    const labelAttribs = list.panelLabelAttribs.plabel.get(
+      "clabel__Image/Banana"
+    );
+    expect(labelAttribs.count).toBe("1");
+    expect(labelAttribs.size).toBe(list.byteSizeToStringFn(1 << 30));
+    expect(labelAttribs.prefix.length).toBe(1);
+
+    const search1Attribs = list.panelLabelAttribs.psearch.get("psearch_1");
+    expect(search1Attribs.count).toBe("3");
+    expect(search1Attribs.size).toBeNull(); // since show_statelabelsize is false
+    expect(search1Attribs.prefix).toBe(undefined);
+  });
+});

--- a/tests/js/panel.spec.js
+++ b/tests/js/panel.spec.js
@@ -1,0 +1,321 @@
+import { log } from "console";
+import {
+  PanelLabelSelection,
+  CategoryListStatistic,
+  TorrentLabelTree,
+} from "../../js/panel";
+
+let sel,
+  plabelLabelIds,
+  pstateLabelIds = [
+    "-_-_-dls-_-_-",
+    "-_-_-com-_-_-",
+    "-_-_-act-_-_-",
+    "-_-_-iac-_-_-",
+    "-_-_-err-_-_-",
+  ];
+const statisticPanelIds = ["pstate", "plabel", "psearch"];
+const viewSelections = [
+  {
+    pstate: ["-_-_-act-_-_-"],
+  },
+  {
+    pstate: ["-_-_-iac-_-_-"],
+    plabel: ["-_-_-nlb-_-_-"],
+  },
+  {
+    pstate: ["-_-_-act-_-_-"],
+    psearch: ["psearch_1"],
+  },
+].map((obj) => PanelLabelSelection.fromConfig(obj, statisticPanelIds));
+describe("Panel label selection", () => {
+  beforeEach(() => {
+    sel = new PanelLabelSelection();
+    sel.panelAdd("plabel");
+    plabelLabelIds = [
+      "clabel__path/for/torrent/label",
+      "clabel__path/for/torrent/secondlabel",
+      "-_-_-nlb-_-_-",
+    ];
+    sel.select("plabel", ["clabel__path/for/torrent/label", "-_-_-nlb-_-_-"]);
+    sel.panelAdd("pstate");
+  });
+  it("should switch", () => {
+    expect(sel.count("plabel")).toBe(2);
+    sel.switch("plabel", "-_-_-nlb-_-_-");
+    expect(sel.ids("plabel")).toEqual(["-_-_-nlb-_-_-"]);
+    sel.switch("plabel", null);
+    expect(sel.count("plabel")).toBe(0);
+  });
+  it("should toggle", () => {
+    expect(sel.count("plabel")).toBe(2);
+    sel.switch("plabel", "-_-_-nlb-_-_-", plabelLabelIds, true);
+    expect(sel.ids("plabel")).toEqual(["clabel__path/for/torrent/label"]);
+    // swap current selection
+    sel.switch("plabel", null, plabelLabelIds, true);
+    expect(new Set(sel.ids("plabel"))).toEqual(
+      new Set(["-_-_-nlb-_-_-", "clabel__path/for/torrent/secondlabel"])
+    );
+    sel.switch("plabel", "-_-_-nlb-_-_-", plabelLabelIds, true);
+    expect(sel.ids("plabel")).toEqual(["clabel__path/for/torrent/secondlabel"]);
+  });
+  it("should range select", () => {
+    expect(sel.count("pstate")).toBe(0);
+    sel.switch("pstate", "-_-_-iac-_-_-", pstateLabelIds, false, true);
+    expect(sel.count("pstate")).toBe(4);
+    sel.switch("pstate", "-_-_-act-_-_-", pstateLabelIds, false, true);
+    expect(sel.count("pstate")).toBe(3);
+  });
+
+  it("should adjust view to current", () => {
+    const adjusted = () =>
+      new Set(
+        sel.adjustViewToCurrent(viewSelections, statisticPanelIds).ids("pview")
+      );
+
+    expect(sel.count("plabel")).toBe(2);
+    expect(adjusted()).toEqual(adjusted());
+    expect(adjusted()).toEqual(new Set(["pview_1", "pview_isnew"]));
+
+    sel.select("pstate", ["-_-_-iac-_-_-"]);
+    expect(adjusted()).toEqual(new Set(["pview_1", "pview_isnew"]));
+
+    sel.select("pstate", ["-_-_-act-_-_-"]);
+    expect(adjusted()).toEqual(new Set(["pview_isnew"]));
+
+    sel.select("plabel", []);
+    expect(adjusted()).toEqual(new Set(["pview_0", "pview_2"]));
+
+    sel.select("plabel", ["-_-_-nlb-_-_-"]);
+    expect(adjusted()).toEqual(new Set(["pview_isnew"]));
+
+    sel.select("pstate", ["-_-_-iac-_-_-"]);
+    expect(adjusted()).toEqual(new Set(["pview_1"]));
+
+    sel.clear();
+    expect(adjusted()).toEqual(new Set());
+  });
+
+  it("should adjust current to view", () => {
+    const adjusted = () =>
+      sel.adjustCurrentToView(viewSelections, statisticPanelIds).toConfig();
+    expect(sel.count("plabel")).toBe(2);
+    sel.select("pview", ["pview_isnew", "pview_1"]);
+    expect(adjusted()).toMatchObject(adjusted());
+    expect(adjusted()).toMatchObject({
+      pstate: ["-_-_-iac-_-_-"],
+      plabel: ["-_-_-nlb-_-_-"],
+    });
+    expect(new Set(sel.ids("pview"))).toEqual(new Set(["pview_1"]));
+
+    sel.select("pview", ["pview_0", "pview_1", "pview_2"]);
+    expect(adjusted()).toMatchObject({
+      pstate: ["-_-_-act-_-_-", "-_-_-iac-_-_-"],
+    });
+    expect(new Set(sel.ids("pview"))).toEqual(
+      new Set(["pview_0", "pview_1", "pview_2", "pview_isnew"])
+    );
+
+    sel.select("pview", ["pview_1", "pview_2"]);
+    expect(adjusted()).toMatchObject({
+      pstate: ["-_-_-act-_-_-", "-_-_-iac-_-_-"],
+    });
+    expect(new Set(sel.ids("pview"))).toEqual(
+      new Set([
+        // Not "view_0", i.e. no susequent adjustViewToCurrent call,
+        // in order to avoid disruption during view selection
+        "pview_1",
+        "pview_2",
+        "pview_isnew",
+      ])
+    );
+
+    sel.clear();
+    expect(adjusted()).toMatchObject({});
+    expect(new Set(sel.ids("pview"))).toEqual(new Set());
+  });
+});
+
+const sampleTorrentByIndex = (index, count) => {
+  const maxUpload = 1 /* MiB */ << 20;
+  const uploadActive = 0.1;
+  const maxDownload = 10 /* MiB */ << 20;
+  const downloadActive = 0.05;
+  const minSize = 50 /* KiB */ << 10;
+  const maxSize = 500 /* GiB */ * (1 << 30);
+  const [xName, xName2, xName3, xDl, xDlActive, xUl, xUlActive, xSize] = [
+    7867, 7873, 7877, 7879, 7883, 7901, 7907, 7919,
+  ].map((prime) => (prime * (index + prime)) % count);
+  // Exponential scaling with mostly small values
+  const scaleExp = (x, minValue, maxValue) =>
+    Math.round(minValue + Math.expm1(x * Math.log1p(maxValue - minValue)));
+  const speed = (xactivity, activity, xSpeed, maxSpeed) =>
+    xactivity < activity * count ? scaleExp(xSpeed / count, 100, maxSpeed) : 0;
+  const char = (x, a) => String.fromCharCode(a.charCodeAt() + (x % 26));
+  const yName = Math.max(xName, xName2);
+  // Move x in [0,1] closer to 0.5
+  const concentrate = (x) => 0.5 + 4 * Math.pow(x - 0.5, 3);
+  return {
+    name:
+      // Name '[X]-yyyyy Z' with mostly equal x,y,z
+      `[${char(xName, "A")}]-${char(yName, "a").repeat(5)} ${char(
+        Math.min(xName3, yName),
+        "A"
+      )}`,
+    // Label 'aaa/bbb/ccc' with limited characters
+    label: [xName + xName2 + xName3, xName + xName2, xName]
+      .filter((x) => x > count / 2)
+      .map((x, i) => char(x % (1 + (x % (3 + 2 * i))), "a").repeat(3))
+      .join("/"),
+    ul: speed(xUlActive, uploadActive, xUl, maxUpload),
+    dl: speed(xDlActive, downloadActive, xDl, maxDownload),
+    size: scaleExp(concentrate(xSize / count), minSize, maxSize),
+  };
+};
+
+const generateTorrents = (count) =>
+  Object.fromEntries(
+    [...Array(count).keys()].map((index) => [
+      `${index}`,
+      sampleTorrentByIndex(index, count),
+    ])
+  );
+let statistic;
+let quickSearchIds = new Set();
+describe("Category list statistic", () => {
+  beforeEach(() => {
+    statistic = CategoryListStatistic.from(
+      "pview",
+      [
+        PanelLabelSelection.fromConfig({ pstate: ["-_-_-act-_-_-"] }, [
+          "pstate",
+          "plabel",
+          "psearch",
+        ]),
+      ],
+      {
+        pstate: [
+          (_, torrent) => [
+            torrent.dl >= 1024 || torrent.ul >= 1024
+              ? "-_-_-act-_-_-"
+              : "-_-_-iac-_-_-",
+          ],
+        ],
+        plabel: [
+          (_, torrent) => [
+            torrent.label ? "clabel__" + torrent.label : "-_-_-nlb-_-_-",
+          ],
+        ],
+        psearch: [
+          (_, torrent) =>
+            ["[A]", "[B]", "[A]-aa"]
+              .map((start, i) => [start, i])
+              .filter(([start]) => torrent.name.startsWith(start))
+              .map(([_, i]) => `psearch_${i}`),
+          {
+            quick_search: (hash) => quickSearchIds.has(hash),
+          },
+        ],
+      }
+    );
+  });
+  it("should accumulate torrent statistic", () => {
+    const torrentCount = 100;
+    const torrents = generateTorrents(torrentCount);
+
+    for (const [hash, torrent] of Object.entries(torrents)) {
+      statistic.scan(hash, torrent);
+    }
+    expect(statistic.count).toBe(torrentCount);
+    const { count, size, upload, download } = statistic;
+    const newTorrent = sampleTorrentByIndex(torrentCount, torrentCount + 1);
+    //log(statistic.panels.psearch);
+    const prevBucket = statistic.lookup("psearch", "quick_search");
+    const [bucketCount, bucketSize, bucketUpload, bucketDownload] = [
+      "count",
+      "size",
+      "upload",
+      "download",
+    ].map((n) => prevBucket[n]);
+
+    // Confirm torrent is added to its label bucket
+    torrents[torrentCount] = newTorrent;
+    quickSearchIds.add(String(torrentCount));
+    statistic.rescan(torrents, "psearch", "quick_search");
+    const bucket = statistic.lookup("psearch", "quick_search");
+    expect(bucket.count).toBe(bucketCount + 1);
+    expect(bucket.size).toBe(bucketSize + newTorrent.size);
+    expect(bucket.upload).toBe(bucketUpload + newTorrent.ul);
+    expect(bucket.download).toBe(bucketDownload + newTorrent.dl);
+
+    statistic = statistic.empty();
+    for (const [hash, torrent] of Object.entries(torrents)) {
+      statistic.scan(hash, torrent);
+    }
+
+    // Verify total statistic includes newTorrent
+    const checkTotal = () => {
+      expect(statistic.count).toBe(count + 1);
+      expect(statistic.size).toBe(size + newTorrent.size);
+      expect(statistic.upload).toBe(upload + newTorrent.ul);
+      expect(statistic.download).toBe(download + newTorrent.dl);
+    };
+
+    checkTotal();
+
+    statistic.rescan(torrents, "plabel");
+    statistic.rescan(torrents, "psearch");
+    statistic.rescan(torrents, "psearch", "quick_search");
+
+    checkTotal();
+  });
+
+  it("should collect torrent label tree", () => {
+    const torrentCount = 100;
+    const torrents = generateTorrents(torrentCount);
+
+    for (const [hash, torrent] of Object.entries(torrents)) {
+      statistic.scan(hash, torrent);
+    }
+
+    const torrentLabels = statistic
+      .ids("plabel")
+      .filter((labelId) => labelId.startsWith("clabel__"))
+      .map((labelId) => labelId.substring(8))
+      .concat(["Misc/Other/More", "Misc/Other/Less", "Flattenable/Path/Label"]);
+    //log(torrentLabels);
+    const tree = new TorrentLabelTree(torrentLabels);
+    //log(tree.torrentLabels);
+    const t1 = tree.list(false, false);
+    log(t1);
+    expect(t1.size).toBeGreaterThan(10);
+    expect(t1.size).toBeLessThan(torrentCount);
+    const t2 = tree.list(false, true);
+    log(t2);
+    expect(t2.size).toBeGreaterThan(10);
+    expect(t2.size).toBeLessThan(t1.size);
+    const t3 = tree.list(true, true);
+    log(t3);
+    expect(t3.size).toBeGreaterThan(10);
+    expect(t3.size).toBeLessThan(t2.size);
+    const t4 = tree.list(true, false);
+    log(t4);
+    expect(t4.size).toBe(t1.size);
+  });
+
+  it("should accumulate torrent view", () => {
+    const torrentCount = 100;
+    const torrents = generateTorrents(torrentCount);
+
+    for (const [hash, torrent] of Object.entries(torrents)) {
+      statistic.scan(hash, torrent);
+    }
+    //log(statistic.viewPanel.buckets);
+    const viewBucket = statistic.lookup("pview", "pview_0");
+    const pstateBucket = statistic.lookup("pstate", "-_-_-act-_-_-");
+    expect(viewBucket.count).toBe(pstateBucket.count);
+    expect(viewBucket.size).toBe(pstateBucket.size);
+    expect(viewBucket.upload).toBe(pstateBucket.upload);
+    expect(viewBucket.download).toBe(pstateBucket.download);
+  });
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,16 +4,18 @@
   "description": "ruTorrent javascript tests",
   "name": "rutorrent-tests",
   "devDependencies": {
-    "@babel/core": "7.17.5",
-    "@babel/preset-env": "7.16.11",
-    "babel-jest": "27.5.1",
-    "jest": "27.5.1"
+    "@babel/core": "7.22.9",
+    "@babel/preset-env": "7.22.9",
+    "babel-jest": "29.5.0",
+    "jest": "29.5.0",
+    "jest-environment-jsdom": "29.5.0"
   },
   "dependencies": {
-    "jquery": "3.6.0"
+    "jquery": "3.7.0"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "test:debug": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand"
   },
   "jest": {
     "testEnvironment": "jsdom",
@@ -21,6 +23,11 @@
       "resources": "usable",
       "runScripts": "dangerously"
     },
+    "moduleDirectories": ["node_modules", "../js"],
+    "transform": {
+      "^.+\\.js$": "./.babel-jest-wrapper.js"
+    },
+    "setupFiles": ["<rootDir>/global.mock.js"],
     "verbose": true,
     "silent": false
   },

--- a/tests/plugins/rss/init.spec.js
+++ b/tests/plugins/rss/init.spec.js
@@ -1,4 +1,5 @@
 import { readFileSync } from "fs";
+import { CategoryList } from "../../../js/category-list";
 window.$ = require("jquery");
 window.theWebUI = {
   settings: {
@@ -13,14 +14,25 @@ window.theWebUI = {
       started: true,
     },
   },
+  categoryList: new CategoryList({}),
 };
 window.GetActiveLanguage = function () {
   return "en";
 };
+document.body.append(
+  ...["category-list", "panel-label"].map((elementTag) =>
+    Object.assign(document.createElement("template"), {
+      id: `${elementTag}-template`,
+      innerHTML: '<link rel="stylesheet" />',
+    })
+  )
+);
 
 for (const src of [
   "../js/sanitize.js",
   "../js/sanitize.config.js",
+  "../js/custom-elements.js",
+  "../js/category-list-elements.js",
   "../lang/en.js",
   "../js/common.js",
   "../js/content.js",


### PR DESCRIPTION
Unfortunately, this PR got bigger than I initially planned https://github.com/Novik/ruTorrent/pull/2535#issuecomment-1646514873. However, it is fairly well tested and limited to replacing the category-list (and quick-search).

With the aim of simplifying `js/webui.js` and improving code quality, presentation and control of the category-list have been separated and moved out of `theWebUI`. Additionally, explicit model classes for `PanelLabelSelection`, `CategoryListStatistic` and `TorrentLabelTree` have been created.

The presentation is controlled by attributes of a custom `category-list` element which consists of `category-panel` and `panel-label` elements. Plugins can inject custom attribute implementations to modify these components with the `injectCustomElementAttribute` function.

As the components use shadow DOMs, dedicated stylesheets for `category-panel` and `panel-label` have been added.
The components expose CSS variables to support theming.

Further, I changed the panel and label IDs to be more consistent:
```
pview_cont -> pview
pstate_cont -> pstate
plabel_cont -> plabel
flabel -> psearch
flabel_cont -> psearch
teg_{} -> psearch_{}
ptrackers_cont -> ptrackers
prss_cont -> prss
```
Upgrading existing IDs is not a problem but downgrading will require [category-list: Support downgrade for panel/label IDs](https://github.com/Novik/ruTorrent/commit/035723989c25b392d639f5e77044eb8e263e2535) which maps new IDs to old IDs.

## Non-Functional Changes

- Control category list in `js/category-list.js`
  - The `CategoryList` instance is accessible by `theWebUI.categoryList`
  - Legacy panel/label IDs are mapped to new IDs
  - There are jest tests for `category-list` and `panel`
- Render category list component in `js/category-list-elements.js` 
  - `category-list` contains `category-panel`s which in turn contains `panel-label`s components
  - There is jest test for `category-list-elements`

- Adjust category list dependent plugins: `extsearch`, `rss`, `tracklabels`
- Adjust themes to use the custom components CSS variables
- (Make `"New View"` translatable)

## Functional Changes
- Show a modal dialog for renaming a view
- Refresh category list when one of its display settings changes
- `Ctrl`-Click on a `All` label toggles the selection of the corresponding category
- RSS plugin: Indication of delayed errors with `⚠`  now floats right