### PR TITLE
scroll-table: Fix unhandled undefined attr

### DIFF
--- a/js/stable.js
+++ b/js/stable.js
@@ -1783,7 +1783,7 @@ dxSTable.prototype.setIcon = function(row, icon)
 dxSTable.prototype.setAttr = function(row, attr)
 {
 	// set attribute of row
-	const attrEntries = Object.entries(attr)
+	const attrEntries = Object.entries(attr || {})
 	const dataRow = this.rowdata[row];
 	if(dataRow && attrEntries.some(([name, val]) => dataRow[name] !== val))
 	{


### PR DESCRIPTION
#2590 occurs if `View -> As List` is set.
`View -> As Tree` does not trigger this bug.

Fixes: #2590