### PR TITLE
trafic: Fix resize when plot undefined

### DIFF
--- a/js/graph.js
+++ b/js/graph.js
@@ -60,8 +60,8 @@ class rGraph {
     this.checked = this.datasets.map(() => true);
 
     // resize to same size as parent
-    aOwner.width(aOwner.parent().width());
-    aOwner.height(aOwner.parent().height());
+    aOwner.width(Math.max(aOwner.parent().width(), 1));
+    aOwner.height(Math.max(aOwner.parent().height(), 1));
     this.width = aOwner.width();
     this.height = aOwner.height();
     this._animationRequestId = 0;
@@ -94,7 +94,9 @@ class rGraph {
   update() {
     if (
       this.badTextCache &&
-      (this.badTextCache = $($$("cover")).is(":visible"))
+      (this.badTextCache =
+        $($$("cover")).is(":visible") ||
+        !this.plot.getPlaceholder().is(":visible"))
     ) {
       // avoid that flot caches incorrect text width/height
       this.draw();

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -170,7 +170,9 @@ rPlugin.prototype.langLoaded = function()
 	try {
 	if(($type(this["onLangLoaded"])=="function") && this.enabled)
 		this.onLangLoaded();
-	} catch(e) {}			// konqueror hack
+	} catch(e) {
+		console.warn(`Plugin "${this.name}" failed to load:`, e);
+	} // konqueror hack
 	this.markLoaded();
 }
 
@@ -300,7 +302,7 @@ rPlugin.prototype.attachPageToTabs = function(dlg,name,idBefore)
 		var beforeLbl = $$("tab_"+idBefore);
 		beforeLbl.parentNode.insertBefore(newLbl,beforeLbl);
 		if (theWebUI.activeView === dlg.id) {
-			setTimeout(() => theTabs.onShow(dlg.id));
+			setTimeout(() => theTabs.show(dlg.id));
 		}
 	}
 	return(this);

--- a/plugins/trafic/init.js
+++ b/plugins/trafic/init.js
@@ -120,7 +120,7 @@ class rTraficGraph extends rGraph {
 
   resize(newWidth, newHeight) {
     if (newWidth) newWidth -= 8;
-    if (newHeight)
+    if (this.plot && newHeight)
       newHeight -=
         iv($$(this.plot.getPlaceholder().attr("id") + "_ctrl").style.height) +
         $("#tabbar").outerHeight();


### PR DESCRIPTION
Additionally, loading the `trafic` plugin failed
when `tdetails` was collapsed, since the flot plot does not allow width and height being 0.

Fixes: #2593