### PR TITLE
files: Fix file link null

### DIFF
--- a/js/webui.js
+++ b/js/webui.js
@@ -1252,7 +1252,7 @@ var theWebUI =
 				{
 					var entry = dir[i];
 					if(entry.link==null)
-						table.setRowById(entry.data, i, entry.icon, {link : null});
+						table.setRowById(entry.data, i, entry.icon, {link: undefined});
 				}
 			}
 		}


### PR DESCRIPTION
`setAttr` only removes an attribute which is set to `undefined` and `getAttr` only returns `null` for an attribute if it does not  exist.

Fixes: #2600