### PR TITLE
extsearch: Fix regressions by #2588

### DIFF
--- a/js/webui.js
+++ b/js/webui.js
@@ -1912,7 +1912,7 @@ var theWebUI =
 		return(e.fromTextCtrl);
 	},
 
-	contextMenuTable: function(labelType, el) {
+	contextMenuTable: function(panelId, labelId) {
 		return theWebUI.getTable('trt');
 	},
 

--- a/plugins/datadir/init.js
+++ b/plugins/datadir/init.js
@@ -1,12 +1,18 @@
 plugin.loadMainCSS();
 plugin.loadLang();
 
+function firstSelectedTorrent() {
+	const table = theWebUI.getTable("trt");
+	const id = table.selCount > 0 ? table.getFirstSelected() : null;
+	return id && id.length === 40 ? theWebUI.torrents[id] : undefined;
+}
+
 theWebUI.EditDataDir = function()
 {
-	var id = theWebUI.getTable("trt").getFirstSelected();
-	if( id && (id.length==40) && this.torrents[id] )
+	const torrent = firstSelectedTorrent();
+	if( torrent )
 	{
-	        var save_path = this.torrents[id].save_path.trim();
+	        var save_path = torrent.save_path.trim();
 		if( !save_path.length ) // torrent is not open
 			this.request( "?action=getsavepath&hash=" + id, [this.showDataDirDlg, this] );
 		else
@@ -16,13 +22,13 @@ theWebUI.EditDataDir = function()
 
 theWebUI.showDataDirDlg = function( d )
 {
-	var id = theWebUI.getTable("trt").getFirstSelected();
 	var is_done = false;
 	var is_multy = false;
-	if( id && (id.length==40) && this.torrents[id] )
+	const torrent = firstSelectedTorrent();
+	if( torrent )
 	{
-		is_done = String(this.torrents[id].done).trim() === "1000";
-		is_multy = String(this.torrents[id].multi_file).trim() !== "0";
+		is_done = String(torrent.done).trim() === "1000";
+		is_multy = String(torrent.multi_file).trim() !== "0";
 	}
 	$('#edit_datadir').val( d.savepath.trim() );
 	$('#btn_datadir_ok').prop("disabled",false);
@@ -73,12 +79,10 @@ if(plugin.canChangeMenu())
 		plugin.createMenu.call(this, e, id);
 		if(plugin.enabled && plugin.allStuffLoaded)
 		{
-			var table = this.getTable("trt");
-			
 			var el = theContextMenu.get( theUILang.Properties );
 			if( el )
 				theContextMenu.add( el, [theUILang.DataDir + "...", 
-					((table.selCount > 1) || (table.getFirstSelected().length==40)) ? "theWebUI.EditDataDir()" : null] );
+					firstSelectedTorrent() ? "theWebUI.EditDataDir()" : null] );
 		}
 	}
 }

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -429,10 +429,10 @@ function idIsExTeg(labelId) {
 }
 
 plugin.contextMenuTable = theWebUI.contextMenuTable;
-theWebUI.contextMenuTable = function(panelId, el) {
-	return panelId === 'psearch' && idIsExTeg(el.id) ?
+theWebUI.contextMenuTable = function(panelId, labelId) {
+	return panelId === 'psearch' && idIsExTeg(labelId) ?
 		theWebUI.getTable('teg')
-		: plugin.contextMenuTable.call(theWebUI, panelId, el);
+		: plugin.contextMenuTable.call(theWebUI, panelId, labelId);
 },
 
 plugin.contextMenuEntries = catlist.contextMenuEntries.bind(catlist);
@@ -444,7 +444,7 @@ catlist.contextMenuEntries = function(panelId, labelId) {
 			[ theUILang.tegMenuDelete, "theWebUI.extTegDelete()"]
 		] : false;
 	}
-	return catlist.contextMenuEntries(panelId, labelId);
+	return plugin.contextMenuEntries(panelId, labelId);
 }
 
 plugin.createMenu = theWebUI.createMenu;

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -285,7 +285,7 @@ catlist.switchLabel = function(panelId, targetId, toggle=false, range=false)
 		}
 		table.scrollTo(0);
 		table.calcSize().resizeHack();
-	} else {
+	} else if (tegList.is(":visible")) {
 		// switch away from extsearch view
 		tegList.hide();
 		list.show();
@@ -465,7 +465,8 @@ catlist.refreshPanel.psearch = (attribs) => psearchEntries(attribs).concat(Objec
 			...attribs.get(tegId),
 			text: teg.val,
 			icon: `url:./plugins/extsearch/images/${teg.eng === 'all' ? 'search' : teg.eng}.png`,
-			count: String(teg.data.filter(d => !d.deleted).length)
+			count: String(teg.data.filter(d => !d.deleted).length),
+			selected: catlist.isLabelIdSelected("psearch", tegId),
 		}
 	]));
 

--- a/plugins/rss/init.js
+++ b/plugins/rss/init.js
@@ -328,10 +328,10 @@ theWebUI.RSSManager = function()
 }
 
 plugin.contextMenuTable = theWebUI.contextMenuTable;
-theWebUI.contextMenuTable = function(panelId, el) {
+theWebUI.contextMenuTable = function(panelId, labelId) {
 	return panelId === 'prss' ?
 		theWebUI.getTable('rss')
-		: plugin.contextMenuTable.call(theWebUI, panelId, el);
+		: plugin.contextMenuTable.call(theWebUI, panelId, labelId);
 },
 
 plugin.contextMenuEntries = catlist.contextMenuEntries.bind(catlist);


### PR DESCRIPTION
Extsearch was broken by #2588.
[extsearch: Fix highlight selection and switch away](https://github.com/Novik/ruTorrent/commit/c781d51a1fb93fd96482727470214bfbecc72fd1)

Fixes: https://github.com/Novik/ruTorrent/issues/2619

`contextMenuTable` was also broken:
[webui: Fix contextMenuTable parameters](https://github.com/Novik/ruTorrent/commit/15a0698ecf26be48651b447f72999da33e7f70e2)

Additionally, with `table.selCount === 0`,  `table.getFirstSelected()` could be `null` in this check: `(table.selCount > 1) || (table.getFirstSelected().length==40)`. I assume `(table.selCount >= 1) && (table.getFirstSelected().length==40)` is correct here. This commit resolves this:
[datadir: Extract first selected torrent function](https://github.com/Novik/ruTorrent/commit/f5ec8be26064ff476e98344a48ca7a718d8ca64b)

