### PR TITLE
lang: Ensure cache invalidation

### DIFF
--- a/lang/langs.js
+++ b/lang/langs.js
@@ -110,7 +110,7 @@ function loadUILang(onLoadFunc)
 			translateDOM();
 		}
 	};
-	langScript.src = `./lang/${lang}.js`;
+	langScript.src = `./lang/${lang}.js?v=430`;
 	document.head.appendChild(langScript);
 }
 


### PR DESCRIPTION
The browser's cache is also invalid for language files after updating.
My guess is that this was the problem here:

Fixes: https://github.com/Novik/ruTorrent/issues/2623

(There are still some files which could be cached by the browser after updating (for instance `style.css`, `stable.css`, `images/favicon.ico`).)