### PR TITLE
fix DE translations for "alternating list background"

### DIFF
--- a/lang/de.js
+++ b/lang/de.js
@@ -18,7 +18,7 @@ var theUILang =
  Confirm_del_torr		: "Löschen von Torrents bestätigen",
  Update_GUI_every		: "Aktualisierungsintervall",
  ms				: "ms",
- Alt_list_bckgnd		: "Alternativer Listenhintergrund",
+ Alt_list_bckgnd		: "Abwechselnder Zeilenhintergrund",
  Show_cat_start			: "Zeige Gruppen beim Start",
  Show_det_start			: "Zeige Details beim Start",
  KeepSearches			: "Keep searches",


### PR DESCRIPTION
the current translation means "alternative background" as opposed to the likely intended "alternating background". in german, the latter would be "Alternierender Listenhintergrund", but that is clunky phrasing. the change in this commit translates to "alternating line backgrounds" and is verbiage common to e.g. Excel.