### PR TITLE
Fix theWebUI.getTrackerName to reject invalid announcelist items

### DIFF
--- a/plugins/history/init.js
+++ b/plugins/history/init.js
@@ -278,10 +278,10 @@ if(plugin.canChangeTabs() || plugin.canChangeColumns())
 	{
 		theWebUI.getTrackerName = function(announce)
 		{
-		        var domain = '';
+			var domain = '';
 			if(announce)
 			{
-				var parts = announce.match(/^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/);
+				var parts = announce.match(/^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/);
 				if(parts && (parts.length>6))
 				{
 					domain = parts[6];

--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -73,10 +73,10 @@ if(!$type(theWebUI.getTrackerName))
 {
 	theWebUI.getTrackerName = function(announce)
 	{
-	        var domain = '';
+		var domain = '';
 		if(announce)
 		{
-			var parts = announce.match(/^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/);
+			var parts = announce.match(/^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/);
 			if(parts && (parts.length>6))
 			{
 				domain = parts[6];


### PR DESCRIPTION
In public trackers with long announce-lists, there can be a rather large number of valid and invalid trackers. Examples of trackers seen in the wild include "0", "announce", "dht" (rather than "dht://") which rtorrent discards as invalid.

The regex already had a group checking for the division between protocol and domain "://" but it was marked as optional.

By making it mandatory so that malformed announce urls are skipped as expected, we can parse invalid names without errors.

Without this fix, the trackerlabels plugin stops working if any torrent contains a seriously malformed domain.

These lines demonstrate the problem:

```js
announce = "dht";
// Note this is the old regex
parts = announce.match(/^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/);
if(parts && (parts.length>6))
{
	domain = parts[6];
	// Error "domain is undefined", because parts[6] was undefined
	domain.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
}
```