### PR TITLE
added a copy button to console window

### DIFF
--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -116,10 +116,23 @@ plugin.fromBackground = function( no )
 	plugin.onStart(this.foreground); 
 }
 
+plugin.copyConsoleLog = function()
+{
+  let consoleLog = $('#tskcmdlog')[0].innerText;
+  if(consoleLog !== "")
+  {
+    navigator.clipboard.writeText(consoleLog);
+  }
+  else
+  {
+    log("Console log is empty.");
+  }
+}
+
 plugin.toBackground = function()
 {
-       	if(!plugin.isInBackground())
-		plugin.background[ plugin.foreground.no ] = cloneObject( this.foreground );
+  if(!plugin.isInBackground())
+	plugin.background[ plugin.foreground.no ] = cloneObject( this.foreground );
 	plugin.callNotification("HideInterface");	
 	plugin.clear();			
 	theDialogManager.hide('tskConsole');	
@@ -594,6 +607,7 @@ plugin.onLangLoaded = function()
 			"</fieldset>"+
 		"</div>"+
 		"<div class='aright buttons-list' id='tsk_btns'>"+
+      "<input type='button' id='tskCopy' class='Button' value='"+theUILang.tskCopy+"'/>"+
 			"<input type='button' id='tskBackground' class='Button' value='"+theUILang.tskBackground+"'/>"+
 			"<input type='button' id='tskCancel' class='Cancel Button' value='"+theUILang.Cancel+"'/>"+
 		"</div>",true);
@@ -614,4 +628,5 @@ plugin.onLangLoaded = function()
 	});
 	$('#tskBackground').on('click', plugin.toBackground );
 	$(".tskconsole").enableSysMenu();
+  $("#tskCopy").on('click', plugin.copyConsoleLog);
 }

--- a/plugins/_task/lang/cs.js
+++ b/plugins/_task/lang/cs.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/da.js
+++ b/plugins/_task/lang/da.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/de.js
+++ b/plugins/_task/lang/de.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konsole";
  theUILang.tskErrors		= "Diagnose";
  theUILang.tskBackground	= "Verstecken";
+ theUILang.tskCopy		= "Kopieren";
  theUILang.tskStart		= "Gestartet";
  theUILang.tskFinish		= "Fertiggestellt";
  theUILang.tskElapsed		= "Verstrichen";

--- a/plugins/_task/lang/el.js
+++ b/plugins/_task/lang/el.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Κονσόλα";
  theUILang.tskErrors		= "Διαγνωστικά";
  theUILang.tskBackground	= "Απόκρυψη";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Εκκίνηση";
  theUILang.tskFinish		= "Ολοκλήρωση";
  theUILang.tskElapsed		= "Χρόνος που πέρασε";

--- a/plugins/_task/lang/en.js
+++ b/plugins/_task/lang/en.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/es.js
+++ b/plugins/_task/lang/es.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Consola";
  theUILang.tskErrors		= "Diagnosticos";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/fi.js
+++ b/plugins/_task/lang/fi.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/fr.js
+++ b/plugins/_task/lang/fr.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostiques";
  theUILang.tskBackground	= "Cacher";
+ theUILang.tskCopy		= "Copier";
  theUILang.tskStart		= "Démarrée";
  theUILang.tskFinish		= "Terminée";
  theUILang.tskElapsed		= "Écoulée";

--- a/plugins/_task/lang/hu.js
+++ b/plugins/_task/lang/hu.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konzol";
  theUILang.tskErrors		= "Diagnosztika";
  theUILang.tskBackground	= "Elrejtés";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Elindult";
  theUILang.tskFinish		= "Végzett";
  theUILang.tskElapsed		= "Eltelt";

--- a/plugins/_task/lang/it.js
+++ b/plugins/_task/lang/it.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostiche";
  theUILang.tskBackground	= "Nascondi";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Avviato";
  theUILang.tskFinish		= "Terminato";
  theUILang.tskElapsed		= "Trascorso";

--- a/plugins/_task/lang/ko.js
+++ b/plugins/_task/lang/ko.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "콘솔";
  theUILang.tskErrors		= "진단";
  theUILang.tskBackground	= "숨기기";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "시작됨";
  theUILang.tskFinish		= "완료됨";
  theUILang.tskElapsed		= "경과";

--- a/plugins/_task/lang/lv.js
+++ b/plugins/_task/lang/lv.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/nl.js
+++ b/plugins/_task/lang/nl.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/no.js
+++ b/plugins/_task/lang/no.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konsoll";
  theUILang.tskErrors		= "Diagnostikk";
  theUILang.tskBackground	= "Skjul";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Startet";
  theUILang.tskFinish		= "Fullført";
  theUILang.tskElapsed		= "Forløpt";

--- a/plugins/_task/lang/pl.js
+++ b/plugins/_task/lang/pl.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konsola";
  theUILang.tskErrors		= "Diagnostyka";
  theUILang.tskBackground	= "Ukryj";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Rozpoczęty";
  theUILang.tskFinish		= "Zakończony";
  theUILang.tskElapsed		= "Upłynęło";

--- a/plugins/_task/lang/pt-br.js
+++ b/plugins/_task/lang/pt-br.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/pt-pt.js
+++ b/plugins/_task/lang/pt-pt.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Consola";
  theUILang.tskErrors		= "Diagnóstico";
  theUILang.tskBackground	= "Ocultar";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Iniciado";
  theUILang.tskFinish		= "Terminado";
  theUILang.tskElapsed		= "Decorrido";

--- a/plugins/_task/lang/ru.js
+++ b/plugins/_task/lang/ru.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Консоль";
  theUILang.tskErrors		= "Диагностика";
  theUILang.tskBackground	= "Спрятать";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Старт";
  theUILang.tskFinish		= "Завершение";
  theUILang.tskElapsed		= "Затрачено";

--- a/plugins/_task/lang/sk.js
+++ b/plugins/_task/lang/sk.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/sr.js
+++ b/plugins/_task/lang/sr.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/sv.js
+++ b/plugins/_task/lang/sv.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konsoll";
  theUILang.tskErrors		= "Diagnostik";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/tr.js
+++ b/plugins/_task/lang/tr.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konsol";
  theUILang.tskErrors		= "Tanılama";
  theUILang.tskBackground	= "Gizle";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Başlatıldı";
  theUILang.tskFinish		= "Bitti";
  theUILang.tskElapsed		= "Geçen";

--- a/plugins/_task/lang/uk.js
+++ b/plugins/_task/lang/uk.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Консоль";
  theUILang.tskErrors		= "Діагностика";
  theUILang.tskBackground	= "Приховати";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Початок";
  theUILang.tskFinish		= "Завершення";
  theUILang.tskElapsed		= "Минуло";

--- a/plugins/_task/lang/vi.js
+++ b/plugins/_task/lang/vi.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/zh-cn.js
+++ b/plugins/_task/lang/zh-cn.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "控制台";
  theUILang.tskErrors		= "诊断";
  theUILang.tskBackground	= "隐藏";
+ theUILang.tskCopy		= "复制";
  theUILang.tskStart		= "已开始";
  theUILang.tskFinish		= "已完成";
  theUILang.tskElapsed		= "已用时间";

--- a/plugins/_task/lang/zh-tw.js
+++ b/plugins/_task/lang/zh-tw.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";


### PR DESCRIPTION
Added a copy button to console window, making copying console log like mediainfo result a little bit more confortable, without having to select the entire text and hit Ctrl+C. Log a message and nothing else when the console log is empty, e.g. when screenshots are being generated.

![console_log](https://github.com/Novik/ruTorrent/assets/26022962/f6d4e538-068a-4caf-a0f7-71654a0f29d0)
