### PR TITLE
added a copy button to console window

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,24 +20,24 @@
 		<link rel="icon" type="image/png" href="./images/favicon-16x16.png" sizes="16x16" />
 		<meta name="msapplication-TileColor" content="#FFFFFF" />
 		<meta name="msapplication-TileImage" content="./images/mstile-144x144.png" />
-		<link href="./css/style.css?v=430" rel="stylesheet" type="text/css" />
-		<link href="./css/stable.css?v=430" rel="stylesheet" type="text/css" />
-		<link rel="preload" as="style" href="./css/category-panel.css?v=430" />
-		<link rel="preload" as="style" href="./css/panel-label.css?v=430" />
-		<script type="text/javascript" src="./js/jquery.js?v=430"></script>
-		<script type="text/javascript" src="./js/jquery.flot.js?v=430"></script>
-		<script type="text/javascript" src="./js/sanitize.js?v=430"></script>
-		<script type="text/javascript" src="./js/sanitize.config.js?v=430"></script>
-		<script type="text/javascript" src="./js/custom-elements.js?v=430"></script>
-		<script type="text/javascript" src="./lang/langs.js?v=430"></script>
-		<link rel="preload" as="script" href="./js/common.js?v=430" />
-		<link rel="preload" as="script" href="./js/objects.js?v=430" />
-		<link rel="preload" as="script" href="./js/content.js?v=430" />
-		<link rel="preload" as="script" href="./js/stable.js?v=430" />
-		<link rel="preload" as="script" href="./js/graph.js?v=430" />
-		<link rel="preload" as="script" href="./js/plugins.js?v=430" />
-		<link rel="preload" as="script" href="./js/rtorrent.js?v=430" />
-		<link rel="preload" as="script" href="./js/webui.js?v=430" />
+		<link href="./css/style.css?v=432" rel="stylesheet" type="text/css" />
+		<link href="./css/stable.css?v=432" rel="stylesheet" type="text/css" />
+		<link rel="preload" as="style" href="./css/category-panel.css?v=432" />
+		<link rel="preload" as="style" href="./css/panel-label.css?v=432" />
+		<script type="text/javascript" src="./js/jquery.js?v=432"></script>
+		<script type="text/javascript" src="./js/jquery.flot.js?v=432"></script>
+		<script type="text/javascript" src="./js/sanitize.js?v=432"></script>
+		<script type="text/javascript" src="./js/sanitize.config.js?v=432"></script>
+		<script type="text/javascript" src="./js/custom-elements.js?v=432"></script>
+		<script type="text/javascript" src="./lang/langs.js?v=432"></script>
+		<link rel="preload" as="script" href="./js/common.js?v=432" />
+		<link rel="preload" as="script" href="./js/objects.js?v=432" />
+		<link rel="preload" as="script" href="./js/content.js?v=432" />
+		<link rel="preload" as="script" href="./js/stable.js?v=432" />
+		<link rel="preload" as="script" href="./js/graph.js?v=432" />
+		<link rel="preload" as="script" href="./js/plugins.js?v=432" />
+		<link rel="preload" as="script" href="./js/rtorrent.js?v=432" />
+		<link rel="preload" as="script" href="./js/webui.js?v=432" />
 		<script>
 			loadUILang(() => {
 				// Load scripts which depend on theUILang to be loaded
@@ -51,10 +51,10 @@
 				}
 			});
 		</script>
-		<script type="module" src="./js/backgroundtask.js?v=430"></script>
-		<script type="module" src="./js/category-list.js?v=430"></script>
-		<script type="module" src="./js/panel.js?v=430"></script>
-		<script type="text/javascript" src="./js/category-list-elements.js?v=430" defer></script>
+		<script type="module" src="./js/backgroundtask.js?v=432"></script>
+		<script type="module" src="./js/category-list.js?v=432"></script>
+		<script type="module" src="./js/panel.js?v=432"></script>
+		<script type="text/javascript" src="./js/category-list-elements.js?v=432" defer></script>
 	</head>
 	<body>
 		<div id="preload"></div>
@@ -112,7 +112,7 @@
 			<tr>
 				<td class="uicell" rowspan="3">
 					<template id="panel-label-template">
-						<link href="./css/panel-label.css?v=430" rel="stylesheet" type="text/css" />
+						<link href="./css/panel-label.css?v=432" rel="stylesheet" type="text/css" />
 						<div part="prefix" hidden></div>
 						<div part="icon"></div>
 						<div part="text"></div>
@@ -120,7 +120,7 @@
 						<div part="size" style="display: none;"></div>
 					</template>
 					<template id="category-panel-template">
-						<link href="./css/category-panel.css?v=430" rel="stylesheet" type="text/css" />
+						<link href="./css/category-panel.css?v=432" rel="stylesheet" type="text/css" />
 						<div part="heading">
 							<span class="text"></span><slot name="decorator" class="decorator"></slot>
 						</div>

--- a/js/content.js
+++ b/js/content.js
@@ -70,7 +70,7 @@ function makeContent()
 	{
 		$("#torrent_file").val("");
 		$("#add_button").prop("disabled",false);
-		var d = (this.contentDocument || this.contentWindow.document);
+		var d = this.contentDocument;
 		if(d && (d.location.href != "about:blank"))
 		{
 			try { var txt = d.body.textContent ? d.body.textContent : d.body.innerText; eval(txt); } catch(e) {}
@@ -79,7 +79,7 @@ function makeContent()
 	$(document.body).append($("<iframe name='uploadfrmurl'/>").css({visibility: "hidden"}).attr( { name: "uploadfrmurl" } ).width(0).height(0).on('load', function()
 	{
 		$("#url").val("");
-		var d = (this.contentDocument || this.contentWindow.document);
+		var d = this.contentDocument;
 		if(d.location.href != "about:blank")
 			try { eval(d.body.textContent ? d.body.textContent : d.body.innerText); } catch(e) {}
 	}));

--- a/js/webui.js
+++ b/js/webui.js
@@ -5,7 +5,7 @@
 
 var theWebUI =
 {
-  	version: "4.3.0",
+  	version: "4.3.2",
 	tables:
 	{
 		trt:

--- a/lang/langs.js
+++ b/lang/langs.js
@@ -110,7 +110,7 @@ function loadUILang(onLoadFunc)
 			translateDOM();
 		}
 	};
-	langScript.src = `./lang/${lang}.js?v=430`;
+	langScript.src = `./lang/${lang}.js?v=432`;
 	document.head.appendChild(langScript);
 }
 

--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -116,10 +116,23 @@ plugin.fromBackground = function( no )
 	plugin.onStart(this.foreground); 
 }
 
+plugin.copyConsoleLog = function()
+{
+  let consoleLog = $('#tskcmdlog')[0].innerText;
+  if(consoleLog !== "")
+  {
+    navigator.clipboard.writeText(consoleLog);
+  }
+  else
+  {
+    log("Console log is empty.");
+  }
+}
+
 plugin.toBackground = function()
 {
-       	if(!plugin.isInBackground())
-		plugin.background[ plugin.foreground.no ] = cloneObject( this.foreground );
+  if(!plugin.isInBackground())
+	plugin.background[ plugin.foreground.no ] = cloneObject( this.foreground );
 	plugin.callNotification("HideInterface");	
 	plugin.clear();			
 	theDialogManager.hide('tskConsole');	
@@ -594,6 +607,7 @@ plugin.onLangLoaded = function()
 			"</fieldset>"+
 		"</div>"+
 		"<div class='aright buttons-list' id='tsk_btns'>"+
+      "<input type='button' id='tskCopy' class='Button' value='"+theUILang.tskCopy+"'/>"+
 			"<input type='button' id='tskBackground' class='Button' value='"+theUILang.tskBackground+"'/>"+
 			"<input type='button' id='tskCancel' class='Cancel Button' value='"+theUILang.Cancel+"'/>"+
 		"</div>",true);
@@ -614,4 +628,5 @@ plugin.onLangLoaded = function()
 	});
 	$('#tskBackground').on('click', plugin.toBackground );
 	$(".tskconsole").enableSysMenu();
+  $("#tskCopy").on('click', plugin.copyConsoleLog);
 }

--- a/plugins/_task/lang/cs.js
+++ b/plugins/_task/lang/cs.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/da.js
+++ b/plugins/_task/lang/da.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/de.js
+++ b/plugins/_task/lang/de.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konsole";
  theUILang.tskErrors		= "Diagnose";
  theUILang.tskBackground	= "Verstecken";
+ theUILang.tskCopy		= "Kopieren";
  theUILang.tskStart		= "Gestartet";
  theUILang.tskFinish		= "Fertiggestellt";
  theUILang.tskElapsed		= "Verstrichen";

--- a/plugins/_task/lang/el.js
+++ b/plugins/_task/lang/el.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Κονσόλα";
  theUILang.tskErrors		= "Διαγνωστικά";
  theUILang.tskBackground	= "Απόκρυψη";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Εκκίνηση";
  theUILang.tskFinish		= "Ολοκλήρωση";
  theUILang.tskElapsed		= "Χρόνος που πέρασε";

--- a/plugins/_task/lang/en.js
+++ b/plugins/_task/lang/en.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/es.js
+++ b/plugins/_task/lang/es.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Consola";
  theUILang.tskErrors		= "Diagnosticos";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/fi.js
+++ b/plugins/_task/lang/fi.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/fr.js
+++ b/plugins/_task/lang/fr.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostiques";
  theUILang.tskBackground	= "Cacher";
+ theUILang.tskCopy		= "Copier";
  theUILang.tskStart		= "Démarrée";
  theUILang.tskFinish		= "Terminée";
  theUILang.tskElapsed		= "Écoulée";

--- a/plugins/_task/lang/hu.js
+++ b/plugins/_task/lang/hu.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konzol";
  theUILang.tskErrors		= "Diagnosztika";
  theUILang.tskBackground	= "Elrejtés";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Elindult";
  theUILang.tskFinish		= "Végzett";
  theUILang.tskElapsed		= "Eltelt";

--- a/plugins/_task/lang/it.js
+++ b/plugins/_task/lang/it.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostiche";
  theUILang.tskBackground	= "Nascondi";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Avviato";
  theUILang.tskFinish		= "Terminato";
  theUILang.tskElapsed		= "Trascorso";

--- a/plugins/_task/lang/ko.js
+++ b/plugins/_task/lang/ko.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "콘솔";
  theUILang.tskErrors		= "진단";
  theUILang.tskBackground	= "숨기기";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "시작됨";
  theUILang.tskFinish		= "완료됨";
  theUILang.tskElapsed		= "경과";

--- a/plugins/_task/lang/lv.js
+++ b/plugins/_task/lang/lv.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/nl.js
+++ b/plugins/_task/lang/nl.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/no.js
+++ b/plugins/_task/lang/no.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konsoll";
  theUILang.tskErrors		= "Diagnostikk";
  theUILang.tskBackground	= "Skjul";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Startet";
  theUILang.tskFinish		= "Fullført";
  theUILang.tskElapsed		= "Forløpt";

--- a/plugins/_task/lang/pl.js
+++ b/plugins/_task/lang/pl.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konsola";
  theUILang.tskErrors		= "Diagnostyka";
  theUILang.tskBackground	= "Ukryj";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Rozpoczęty";
  theUILang.tskFinish		= "Zakończony";
  theUILang.tskElapsed		= "Upłynęło";

--- a/plugins/_task/lang/pt-br.js
+++ b/plugins/_task/lang/pt-br.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/pt-pt.js
+++ b/plugins/_task/lang/pt-pt.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Consola";
  theUILang.tskErrors		= "Diagnóstico";
  theUILang.tskBackground	= "Ocultar";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Iniciado";
  theUILang.tskFinish		= "Terminado";
  theUILang.tskElapsed		= "Decorrido";

--- a/plugins/_task/lang/ru.js
+++ b/plugins/_task/lang/ru.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Консоль";
  theUILang.tskErrors		= "Диагностика";
  theUILang.tskBackground	= "Спрятать";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Старт";
  theUILang.tskFinish		= "Завершение";
  theUILang.tskElapsed		= "Затрачено";

--- a/plugins/_task/lang/sk.js
+++ b/plugins/_task/lang/sk.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/sr.js
+++ b/plugins/_task/lang/sr.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/sv.js
+++ b/plugins/_task/lang/sv.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konsoll";
  theUILang.tskErrors		= "Diagnostik";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/tr.js
+++ b/plugins/_task/lang/tr.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Konsol";
  theUILang.tskErrors		= "Tanılama";
  theUILang.tskBackground	= "Gizle";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Başlatıldı";
  theUILang.tskFinish		= "Bitti";
  theUILang.tskElapsed		= "Geçen";

--- a/plugins/_task/lang/uk.js
+++ b/plugins/_task/lang/uk.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Консоль";
  theUILang.tskErrors		= "Діагностика";
  theUILang.tskBackground	= "Приховати";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Початок";
  theUILang.tskFinish		= "Завершення";
  theUILang.tskElapsed		= "Минуло";

--- a/plugins/_task/lang/vi.js
+++ b/plugins/_task/lang/vi.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/zh-cn.js
+++ b/plugins/_task/lang/zh-cn.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "控制台";
  theUILang.tskErrors		= "诊断";
  theUILang.tskBackground	= "隐藏";
+ theUILang.tskCopy		= "复制";
  theUILang.tskStart		= "已开始";
  theUILang.tskFinish		= "已完成";
  theUILang.tskElapsed		= "已用时间";

--- a/plugins/_task/lang/zh-tw.js
+++ b/plugins/_task/lang/zh-tw.js
@@ -11,6 +11,7 @@
  theUILang.tskConsole		= "Console";
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
+ theUILang.tskCopy		= "Copy";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/extsearch/engines/YggTorrent.php
+++ b/plugins/extsearch/engines/YggTorrent.php
@@ -2,7 +2,7 @@
 
 class YggTorrentEngine extends commonEngine
 {
-    const URL = 'https://www3.yggtorrent.qa';
+    const URL = 'https://www3.yggtorrent.cool';
     const MAX_PAGE = 10;
     const PAGE_SIZE = 50;
 

--- a/plugins/rss/init.js
+++ b/plugins/rss/init.js
@@ -675,7 +675,7 @@ theWebUI.isGroupContain = function( rssGroup, rssItem )
 
 plugin.updatedRSSEntry = (labelId, attrs) => {
 	attrs = { ...catlist.panelLabelAttribs.prss.get(labelId), ...attrs };
-	const icon = labelId in theWebUI.rssGroups ? 'rss-group' : 'rss';
+	let icon = labelId in theWebUI.rssGroups ? 'rss-group' : 'rss';
 	const count = String(
 		labelId === 'prss_all'
 			? Object.keys(theWebUI.rssItems).length
@@ -683,6 +683,10 @@ plugin.updatedRSSEntry = (labelId, attrs) => {
 	const title = `${attrs.text} (${count})`;
 	const selected = theWebUI.rssListVisible && catlist.isLabelIdSelected('prss', labelId);
 	const alert = labelId in theWebUI.delayedRSSErrors ? '⚠' : null;
+	// Check if enabled is 0, then change icon
+        if (theWebUI.rssLabels[labelId]?.enabled === 0) {
+                icon = 'rss-dis';
+        }
 	return [labelId, {...attrs, icon, count, title, selected, alert}];
 }
 
@@ -698,7 +702,7 @@ catlist.refreshPanel.prss = () => [
 
 theWebUI.showRSS = function()
 {
-        if($('#rssl').children().length)
+        if(Object.keys(theWebUI.rssLabels).length > 0)
         	theWebUI.RSSManager();
         else
 		theDialogManager.toggle("dlgAddRSS");

--- a/plugins/theme/themes/MaterialDesign/plugins.css
+++ b/plugins/theme/themes/MaterialDesign/plugins.css
@@ -128,3 +128,4 @@ div#logoffDlg div.dlg-header { background-image: url(./images/logoff2.png); }
 
 .noty_alert, .noty_success { color: #000000; text-shadow: 0 -1px 0 #ffffff }
 
+#port-ip-text { color: #FFF; }

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -635,8 +635,8 @@ div#stg .lm
 .lm li a
 {
 	font-size:1em;
-	font-weight:400;
-	color:#555B62;
+	font-weight:300;
+	color:#FFF;
 	transition:all .5s
 }
 
@@ -847,7 +847,7 @@ ul#tabbar li a
 {
 	background:none;
 	border:none;
-	color:#606060;
+	color:#fff;
 	cursor:pointer;
 	font-family:inherit;
 	line-height:24px;
@@ -1134,7 +1134,9 @@ div#lcont div.std
 	background:#181818 url(./images/headers.png) repeat-x 0 -37px;
 	min-height:17px;
 	line-height:17px;
-	border-bottom:1px solid #333
+	border-bottom:1px solid #333;
+	font-weight:300;
+	color:#fff;
 }
 
 div#lcont div.std:nth-child(2n+1)
@@ -1209,7 +1211,9 @@ span.det
 .stable-head table tr td
 {
 	border-right:1px solid #242424!important;
-	font-family:Roboto!important
+	font-family:Roboto!important;
+	font-weight:800;
+	color:#fff;
 }
 
 .Icon_Dir
@@ -1263,3 +1267,8 @@ span.det
 {
 	background:transparent url(./images/archive.zip) no-repeat scroll left center!important
 }
+
+.sthdr { color: #FFF; }
+.stval { color: #FFF; }
+.tickLabel { color: #FFF; }
+.fxcaret legend { color: #FFF; }

--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -61,7 +61,7 @@ panel-label {
   color: #D4D6C9;
   border-color: #212121;
   --prefix-color: #FFF;
-  --badge-color: #666666;
+  --badge-color: #999999;
   --badge-background-color: #181818;
   --icon-letter-color: #D4D6C9;
   --icon-letter-background-color: #181818;
@@ -73,8 +73,8 @@ panel-label[selected] {
   color: #009DDD;
   text-shadow:0px -1px 0px #000;
   border:1px solid #212121;
-  --badge-color: #111111;
-  --badge-background-color: #999999;
+  --badge-color: #999999;
+  --badge-background-color: #181818;
 }
 
 panel-label[icon=file] {

--- a/tests/plugins/rss/init.spec.js
+++ b/tests/plugins/rss/init.spec.js
@@ -17,6 +17,7 @@ window.theWebUI = {
     },
   },
   categoryList: new CategoryList({}),
+  resizeTop: (w, h) => console.log(`resizeTop ${w}w ${h}h`),
 };
 window.GetActiveLanguage = function () {
   return "en";


### PR DESCRIPTION
Added a copy button to console window, making copying console log like mediainfo result a little bit more confortable, without having to select the entire text and hit Ctrl+C. Log a message and nothing else when the console log is empty, e.g. when screenshots are being generated.

![console_log](https://github.com/Novik/ruTorrent/assets/26022962/f6d4e538-068a-4caf-a0f7-71654a0f29d0)

PS: closed the [old request](https://github.com/Novik/ruTorrent/pull/2663) and submitted this new one. I'm not sure if I'm making a mess, because I'm relatively new to git and still getting myself familiar with it.