### PR TITLE
Prepend "Save" button after spectrograms are generated

### DIFF
--- a/plugins/spectrogram/init.js
+++ b/plugins/spectrogram/init.js
@@ -78,6 +78,14 @@ if(plugin.canChangeMenu())
 					plugin.setConsoleSize(this);
 				});
 				$("#soxtaskno").val(task.no);
+        $('#tsk_btns').prepend(
+          "<input type='button' class='Button soxplay' id='soxsave' value='"+theUILang.exSave+"'>"
+        );
+        $("#soxsave").on('click', function()
+        {
+          $("#soximgcmd").val("soxgetimage");
+          $('#soxgetimg').trigger('submit');
+        });
 			}
 			else
 				$('.soxplay').hide();
@@ -134,9 +142,6 @@ plugin.onLangLoaded = function()
 		setTimeout(arguments.callee,1000);
 	else
 	{
-		$('#tsk_btns').prepend(
-			"<input type='button' class='Button soxplay' id='soxsave' value='"+theUILang.exSave+"'>"
-			 );
 		$(document.body).append($("<iframe name='soxplayfrm'/>").css({visibility: "hidden"}).attr( { name: "soxplayfrm", id: "soxplayfrm" } ).width(0).height(0));
 		$(document.body).append(
 			$('<form action="plugins/spectrogram/action.php" id="soxgetimg" method="post" target="soxplayfrm">'+
@@ -144,11 +149,6 @@ plugin.onLangLoaded = function()
 				'<input type="hidden" name="no" id="soxtaskno" value="0">'+
 				'<input type="hidden" name="file" id="soximgfile" value="frame">'+
 			'</form>').width(0).height(0));
-		$("#soxsave").on('click', function()
-		{
-			$("#soximgcmd").val("soxgetimage");
-			$('#soxgetimg').trigger('submit');
-		});
 		plugin.markLoaded();
 	}
 }


### PR DESCRIPTION
A "save" button is being added on the loading of the spectrogram plugin, which I believe is not the way it should behave in. 

It is there when any task is being carried out, when there is nothing to save. It is there when a new torrent is created, rendering two "save" buttons in the console windows, with another one being the real "save" button to download the torrent file.

![save-spectrogram](https://github.com/Novik/ruTorrent/assets/26022962/dac3caff-0e28-4394-949c-5ecbf238ed4e)
![create-torrent](https://github.com/Novik/ruTorrent/assets/26022962/ea4aa559-f5ae-416f-82f6-74760d2a0684)
