### PR TITLE
Add keyboard shortcuts to search field

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -212,15 +212,16 @@ function makeContent()
 		'<div class="content">'+
 				'<table width=100% border=0>'+
 					'<tr><td><strong>F1</strong></td><td>'+theUILang.This_screen+'</td></tr>'+
-					'<tr><td><strong><strong>Ctrl-F1</strong></td><td><a href="javascript://void();" onclick="theDialogManager.toggle(\'dlgAbout\'); return(false);">'+theUILang.About_program+'</a></td></tr>'+
-					'<tr><td><strong><strong>F4</strong></td><td><a href="javascript://void();" onclick="theWebUI.toggleMenu(); return(false);">'+theUILang.Toggle_menu+'</a></td></tr>'+
-					'<tr><td><strong><strong>F6</strong></td><td><a href="javascript://void();" onclick="theWebUI.toggleDetails(); return(false);">'+theUILang.Toggle_details+'</a></td></tr>'+
-					'<tr><td><strong><strong>F7</strong></td><td><a href="javascript://void();" onclick="theWebUI.toggleCategories(); return(false);">'+theUILang.Toggle_categories+'</a></td></tr>'+
-					'<tr><td><strong><strong>Ctrl-O</strong></td><td><a href="javascript://void();" onclick="theWebUI.showAdd(); return(false);">'+theUILang.torrent_add+'</a></td></tr>'+
-					'<tr><td><strong><strong>Ctrl-P</strong></td><td><a href="javascript://void();" onclick="theWebUI.showSettings(); return(false);">'+theUILang.ruTorrent_settings+'</a></td></tr>'+
-					'<tr><td><strong><strong>Del</strong></td><td>'+theUILang.Delete_current_torrents+'</td></tr>'+
-					'<tr><td><strong><strong>Ctrl-A</strong></td><td>'+theUILang.Select_all+'</td></tr>'+
-					'<tr><td><strong><strong>Ctrl-Z</strong></td><td>'+theUILang.Deselect_all+'</td></tr>'+
+					'<tr><td><strong>Ctrl-F1</strong></td><td><a href="javascript://void();" onclick="theDialogManager.toggle(\'dlgAbout\'); return(false);">'+theUILang.About_program+'</a></td></tr>'+
+					'<tr><td><strong>F4</strong></td><td><a href="javascript://void();" onclick="theWebUI.toggleMenu(); return(false);">'+theUILang.Toggle_menu+'</a></td></tr>'+
+					'<tr><td><strong>F6</strong></td><td><a href="javascript://void();" onclick="theWebUI.toggleDetails(); return(false);">'+theUILang.Toggle_details+'</a></td></tr>'+
+					'<tr><td><strong>F7</strong></td><td><a href="javascript://void();" onclick="theWebUI.toggleCategories(); return(false);">'+theUILang.Toggle_categories+'</a></td></tr>'+
+					'<tr><td><strong>Ctrl-O</strong></td><td><a href="javascript://void();" onclick="theWebUI.showAdd(); return(false);">'+theUILang.torrent_add+'</a></td></tr>'+
+					'<tr><td><strong>Ctrl-P</strong></td><td><a href="javascript://void();" onclick="theWebUI.showSettings(); return(false);">'+theUILang.ruTorrent_settings+'</a></td></tr>'+
+          '<tr><td><strong>Ctrl-F</strong></td><td>'+theUILang.Quick_search+'</td></tr>'+
+					'<tr><td><strong>Del</strong></td><td>'+theUILang.Delete_current_torrents+'</td></tr>'+
+					'<tr><td><strong>Ctrl-A</strong></td><td>'+theUILang.Select_all+'</td></tr>'+
+					'<tr><td><strong>Ctrl-Z</strong></td><td>'+theUILang.Deselect_all+'</td></tr>'+
 				'</table>'+
 		'</div>');
 	theDialogManager.make("dlgAbout","ruTorrent v"+theWebUI.version,

--- a/js/content.js
+++ b/js/content.js
@@ -218,7 +218,7 @@ function makeContent()
 					'<tr><td><strong>F7</strong></td><td><a href="javascript://void();" onclick="theWebUI.toggleCategories(); return(false);">'+theUILang.Toggle_categories+'</a></td></tr>'+
 					'<tr><td><strong>Ctrl-O</strong></td><td><a href="javascript://void();" onclick="theWebUI.showAdd(); return(false);">'+theUILang.torrent_add+'</a></td></tr>'+
 					'<tr><td><strong>Ctrl-P</strong></td><td><a href="javascript://void();" onclick="theWebUI.showSettings(); return(false);">'+theUILang.ruTorrent_settings+'</a></td></tr>'+
-          '<tr><td><strong>Ctrl-F</strong></td><td>'+theUILang.Quick_search+'</td></tr>'+
+					'<tr><td><strong>Ctrl-F</strong></td><td>'+theUILang.Quick_search+'</td></tr>'+
 					'<tr><td><strong>Del</strong></td><td>'+theUILang.Delete_current_torrents+'</td></tr>'+
 					'<tr><td><strong>Ctrl-A</strong></td><td>'+theUILang.Select_all+'</td></tr>'+
 					'<tr><td><strong>Ctrl-Z</strong></td><td>'+theUILang.Deselect_all+'</td></tr>'+

--- a/js/webui.js
+++ b/js/webui.js
@@ -265,13 +265,21 @@ var theWebUI =
 		var keyEvent = function (e)
 		{
 			switch(e.which)
-			{
-		   		case 27 : 				// Esc
-		   		{
-		   			if(theContextMenu.hide() || theDialogManager.hideTopmost())
-						return(false);
-		   			break;
-		   		}
+      {
+        case 27: // Esc
+        {
+          if(theContextMenu.hide() || theDialogManager.hideTopmost())
+            return(false);
+          if($$("query").value === "")
+          {
+            theWebUI.endSearch();
+          }
+          else
+          {
+            theWebUI.clearSearch();
+          }
+          break;
+        }
 		   		case 79 : 				// ^O
    				{
 					if(e.metaKey && !theDialogManager.isModalState())
@@ -290,6 +298,14 @@ var theWebUI =
       					}
 		   			break;
 				}
+        case 70 : // ^F
+        {
+          if(e.metaKey && !theDialogManager.isModalState())
+          {
+            theWebUI.startSearch(e);
+          }
+          break;
+        }
 		  		case 112:				// F1
    				{
    				        if((!browser.isOpera || !e.fromTextCtrl) && !theDialogManager.isModalState())
@@ -498,14 +514,9 @@ var theWebUI =
 		theWebUI.categoryList.config(this.settings);
 		// Setup quick search
 		const searchField = $$("query");
-		const updateQuickSearch = () => {
-			this.categoryList.setQuickSearch(
-				theSearchEngines.current === -1 ? searchField.value : null
-			);
-		};
-		searchField.addEventListener("focus", () => updateQuickSearch());
-		searchField.addEventListener("input", () => updateQuickSearch());
-		updateQuickSearch();
+    searchField.addEventListener("focus", theWebUI.updateQuickSearch);
+    searchField.addEventListener("input", theWebUI.updateQuickSearch);
+    theWebUI.updateQuickSearch();
 
 		// user must be able add peer when peers are empty
 		$("#PeerList .stable-body").mouseclick(function(e)
@@ -2378,6 +2389,30 @@ var theWebUI =
 	{
    		theDialogManager.toggle("tadd");
    	},
+  
+  startSearch: function(e)
+  {
+    e.preventDefault();
+    $$("query").focus();
+  },
+
+  clearSearch: function()
+  {
+    $$("query").value = "";
+    theWebUI.updateQuickSearch();
+  },
+
+  endSearch: function()
+  {
+    $$("query").blur();
+  },
+
+  updateQuickSearch: function()
+  {
+    theWebUI.categoryList.setQuickSearch(
+      theSearchEngines.current === -1 ? $$("query").value : null
+    );
+  },
 
 	resetInterval: function()
 	{

--- a/js/webui.js
+++ b/js/webui.js
@@ -265,21 +265,21 @@ var theWebUI =
 		var keyEvent = function (e)
 		{
 			switch(e.which)
-      {
-        case 27: // Esc
-        {
-          if(theContextMenu.hide() || theDialogManager.hideTopmost())
-            return(false);
-          if($$("query").value === "")
-          {
-            theWebUI.endSearch();
-          }
-          else
-          {
-            theWebUI.clearSearch();
-          }
-          break;
-        }
+			{
+				case 27: // Esc
+				{
+					if(theContextMenu.hide() || theDialogManager.hideTopmost())
+						return(false);
+					if($$("query").value === "")
+					{
+						theWebUI.endSearch();
+					}
+					else
+					{
+						theWebUI.clearSearch();
+					}
+					break;
+				}
 		   		case 79 : 				// ^O
    				{
 					if(e.metaKey && !theDialogManager.isModalState())
@@ -298,14 +298,14 @@ var theWebUI =
       					}
 		   			break;
 				}
-        case 70 : // ^F
-        {
-          if(e.metaKey && !theDialogManager.isModalState())
-          {
-            theWebUI.startSearch(e);
-          }
-          break;
-        }
+				case 70 : // ^F
+				{
+					if(e.metaKey && !theDialogManager.isModalState())
+					{
+						theWebUI.startSearch(e);
+					}
+					break;
+				}
 		  		case 112:				// F1
    				{
    				        if((!browser.isOpera || !e.fromTextCtrl) && !theDialogManager.isModalState())
@@ -514,9 +514,9 @@ var theWebUI =
 		theWebUI.categoryList.config(this.settings);
 		// Setup quick search
 		const searchField = $$("query");
-    searchField.addEventListener("focus", theWebUI.updateQuickSearch);
-    searchField.addEventListener("input", theWebUI.updateQuickSearch);
-    theWebUI.updateQuickSearch();
+		searchField.addEventListener("focus", theWebUI.updateQuickSearch);
+		searchField.addEventListener("input", theWebUI.updateQuickSearch);
+		theWebUI.updateQuickSearch();
 
 		// user must be able add peer when peers are empty
 		$("#PeerList .stable-body").mouseclick(function(e)
@@ -2389,30 +2389,30 @@ var theWebUI =
 	{
    		theDialogManager.toggle("tadd");
    	},
-  
-  startSearch: function(e)
-  {
-    e.preventDefault();
-    $$("query").focus();
-  },
 
-  clearSearch: function()
-  {
-    $$("query").value = "";
-    theWebUI.updateQuickSearch();
-  },
+	startSearch: function(e)
+	{
+	e.preventDefault();
+	$$("query").focus();
+	},
 
-  endSearch: function()
-  {
-    $$("query").blur();
-  },
+	clearSearch: function()
+	{
+		$$("query").value = "";
+		theWebUI.updateQuickSearch();
+	},
 
-  updateQuickSearch: function()
-  {
-    theWebUI.categoryList.setQuickSearch(
-      theSearchEngines.current === -1 ? $$("query").value : null
-    );
-  },
+	endSearch: function()
+	{
+		$$("query").blur();
+	},
+
+	updateQuickSearch: function()
+	{
+		theWebUI.categoryList.setQuickSearch(
+			theSearchEngines.current === -1 ? $$("query").value : null
+		);
+	},
 
 	resetInterval: function()
 	{

--- a/lang/bn.js
+++ b/lang/bn.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "বিবরণ টগল করুন",
  Toggle_categories		: "ক্যাটাগরি টগল করুন",
  Delete_current_torrents	: "বর্তমান টরেন্ট (গুলি) মুছুন",
+ Quick_search   : "Quick search",
  Select_all			: "সব নির্বাচন করুন",
  Deselect_all			: "সব গুলো অনির্বাচিত করুন",
  showSpeedInTitle		: "শিরোনামে স্পিড দেখান",

--- a/lang/bn.js
+++ b/lang/bn.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "বিবরণ টগল করুন",
  Toggle_categories		: "ক্যাটাগরি টগল করুন",
  Delete_current_torrents	: "বর্তমান টরেন্ট (গুলি) মুছুন",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "সব নির্বাচন করুন",
  Deselect_all			: "সব গুলো অনির্বাচিত করুন",
  showSpeedInTitle		: "শিরোনামে স্পিড দেখান",

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
+ Quick_search   : "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/da.js
+++ b/lang/da.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Slet nuværende torrent(s)",
+ Quick_search   : "Quick search",
  Select_all			: "Vælg alle",
  Deselect_all			: "Fravælg alle",
  showSpeedInTitle		: "Vis hastighed i titlen",

--- a/lang/da.js
+++ b/lang/da.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Slet nuværende torrent(s)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Vælg alle",
  Deselect_all			: "Fravælg alle",
  showSpeedInTitle		: "Vis hastighed i titlen",

--- a/lang/de.js
+++ b/lang/de.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Details anzeigen",
  Toggle_categories		: "Kategorien anzeigen",
  Delete_current_torrents	: "Löscht markierte(n) Torrent(s)",
- Quick_search   : "Schnell suchen",
+ Quick_search			: "Schnell suchen",
  Select_all			: "Alle auswählen",
  Deselect_all			: "Alle abwählen",
  showSpeedInTitle		: "Geschwindigkeit in Titel anzeigen",

--- a/lang/de.js
+++ b/lang/de.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Details anzeigen",
  Toggle_categories		: "Kategorien anzeigen",
  Delete_current_torrents	: "Löscht markierte(n) Torrent(s)",
+ Quick_search   : "Schnell suchen",
  Select_all			: "Alle auswählen",
  Deselect_all			: "Alle abwählen",
  showSpeedInTitle		: "Geschwindigkeit in Titel anzeigen",

--- a/lang/el.js
+++ b/lang/el.js
@@ -289,6 +289,7 @@ var theUILang =
  Toggle_details			: "Εμφάνιση/Απόκρυψη λεπτομερειών",
  Toggle_categories		: "Εμφάνιση/Απόκρυψη κατηγοριών",
  Delete_current_torrents	: "Διαγραφή υπάρχοντων torrent",
+ Quick_search   : "Quick search",
  Select_all			: "Επιλογή όλων",
  Deselect_all			: "Αποεπιλογή όλων",
  showSpeedInTitle		: "Προβολή ταχύτητας στον τίτλο",

--- a/lang/el.js
+++ b/lang/el.js
@@ -289,7 +289,7 @@ var theUILang =
  Toggle_details			: "Εμφάνιση/Απόκρυψη λεπτομερειών",
  Toggle_categories		: "Εμφάνιση/Απόκρυψη κατηγοριών",
  Delete_current_torrents	: "Διαγραφή υπάρχοντων torrent",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Επιλογή όλων",
  Deselect_all			: "Αποεπιλογή όλων",
  showSpeedInTitle		: "Προβολή ταχύτητας στον τίτλο",

--- a/lang/en.js
+++ b/lang/en.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
+ Quick_search   : "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/en.js
+++ b/lang/en.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/es.js
+++ b/lang/es.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Alternar detalles",
  Toggle_categories		: "Alternar categorias",
  Delete_current_torrents	: "Borrar torrent(s) actuales",
+ Quick_search   : "Quick search",
  Select_all			: "Seleccionar todo",
  Deselect_all			: "Deseleccionar todo",
  showSpeedInTitle		: "Mostrar velocidad en el título",

--- a/lang/es.js
+++ b/lang/es.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Alternar detalles",
  Toggle_categories		: "Alternar categorias",
  Delete_current_torrents	: "Borrar torrent(s) actuales",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Seleccionar todo",
  Deselect_all			: "Deseleccionar todo",
  showSpeedInTitle		: "Mostrar velocidad en el título",

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
+ Quick_search   : "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Basculer l'affichage des détails",
  Toggle_categories		: "Basculer l'affichage des catégories",
  Delete_current_torrents	: "Supprimer le(s) torrent(s) actuel(s)",
- Quick_search   : "Rechercher rapidement",
+ Quick_search			: "Rechercher rapidement",
  Select_all			: "Sélectionner tout",
  Deselect_all			: "Désélectionner tout",
  showSpeedInTitle		: "Vitesse de transfert dans la barre de titre",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Basculer l'affichage des détails",
  Toggle_categories		: "Basculer l'affichage des catégories",
  Delete_current_torrents	: "Supprimer le(s) torrent(s) actuel(s)",
+ Quick_search   : "Rechercher rapidement",
  Select_all			: "Sélectionner tout",
  Deselect_all			: "Désélectionner tout",
  showSpeedInTitle		: "Vitesse de transfert dans la barre de titre",

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Részletek megjelenítése",
  Toggle_categories		: "Kategória megjelenítése",
  Delete_current_torrents	: "Kiválasztott torrent(ek) törlése",
+ Quick_search   : "Quick search",
  Select_all			: "Összes kijelölés",
  Deselect_all			: "Kijelölés törlése",
  showSpeedInTitle		: "Sebesség megjelenítése a címben",

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Részletek megjelenítése",
  Toggle_categories		: "Kategória megjelenítése",
  Delete_current_torrents	: "Kiválasztott torrent(ek) törlése",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Összes kijelölés",
  Deselect_all			: "Kijelölés törlése",
  showSpeedInTitle		: "Sebesség megjelenítése a címben",

--- a/lang/it.js
+++ b/lang/it.js
@@ -292,6 +292,7 @@ var theUILang =
  Toggle_details			: "Mostra/Nascondi dettagli",
  Toggle_categories		: "Mostra/Nascondi Categorie",
  Delete_current_torrents	: "Elimina torrent selezionati",
+ Quick_search   : "Quick search",
  Select_all			: "Seleziona tutti",
  Deselect_all			: "Cancella selezione",
  showSpeedInTitle		: "Mostra velocità nel titolo",

--- a/lang/it.js
+++ b/lang/it.js
@@ -292,7 +292,7 @@ var theUILang =
  Toggle_details			: "Mostra/Nascondi dettagli",
  Toggle_categories		: "Mostra/Nascondi Categorie",
  Delete_current_torrents	: "Elimina torrent selezionati",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Seleziona tutti",
  Deselect_all			: "Cancella selezione",
  showSpeedInTitle		: "Mostra velocità nel titolo",

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -289,6 +289,7 @@ var theUILang =
  Toggle_details			: "세부 정보 표시 전환",
  Toggle_categories		: "카테고리 표시 전환",
  Delete_current_torrents	: "현재 토렌트 삭제",
+ Quick_search   : "Quick search",
  Select_all			: "모두 선택",
  Deselect_all			: "모두 선택 해제",
  showSpeedInTitle		: "제목에 속도 표시",

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -289,7 +289,7 @@ var theUILang =
  Toggle_details			: "세부 정보 표시 전환",
  Toggle_categories		: "카테고리 표시 전환",
  Delete_current_torrents	: "현재 토렌트 삭제",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "모두 선택",
  Deselect_all			: "모두 선택 해제",
  showSpeedInTitle		: "제목에 속도 표시",

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
+ Quick_search   : "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Verwijder huidige torrent(s)",
+ Quick_search   : "Quick search",
  Select_all			: "Alles selecteren",
  Deselect_all			: "Alles deselecteren",
  showSpeedInTitle		: "Toon snelheid in titelbalk",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Verwijder huidige torrent(s)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Alles selecteren",
  Deselect_all			: "Alles deselecteren",
  showSpeedInTitle		: "Toon snelheid in titelbalk",

--- a/lang/no.js
+++ b/lang/no.js
@@ -290,7 +290,7 @@ var theUILang =
  Toggle_details			: "Vis/skjul detaljer",
  Toggle_categories		: "Vis/skjul kategorier",
  Delete_current_torrents	: "Slett følgende torrent(er)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Velg alle",
  Deselect_all			: "Velg ingen",
  showSpeedInTitle		: "Vis hastighet i tittelen",

--- a/lang/no.js
+++ b/lang/no.js
@@ -290,6 +290,7 @@ var theUILang =
  Toggle_details			: "Vis/skjul detaljer",
  Toggle_categories		: "Vis/skjul kategorier",
  Delete_current_torrents	: "Slett følgende torrent(er)",
+ Quick_search   : "Quick search",
  Select_all			: "Velg alle",
  Deselect_all			: "Velg ingen",
  showSpeedInTitle		: "Vis hastighet i tittelen",

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -292,6 +292,7 @@ var theUILang =
  Toggle_details			: "Przełącz szczegóły",
  Toggle_categories		: "Przełącz kategorie",
  Delete_current_torrents	: "Usuń torrent",
+ Quick_search   : "Quick search",
  Select_all			: "Zaznacz wszystkie",
  Deselect_all			: "Odznacz wszystkie",
  showSpeedInTitle		: "Pokaż prędkość w tytule",

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -292,7 +292,7 @@ var theUILang =
  Toggle_details			: "Przełącz szczegóły",
  Toggle_categories		: "Przełącz kategorie",
  Delete_current_torrents	: "Usuń torrent",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Zaznacz wszystkie",
  Deselect_all			: "Odznacz wszystkie",
  showSpeedInTitle		: "Pokaż prędkość w tytule",

--- a/lang/pt-br.js
+++ b/lang/pt-br.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Excluir torrent(s) atuais(s)",
+ Quick_search   : "Quick search",
  Select_all			: "Marcar todos",
  Deselect_all			: "Desmarcar todos",
  showSpeedInTitle		: "Mostrar velocidade no título",

--- a/lang/pt-br.js
+++ b/lang/pt-br.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Excluir torrent(s) atuais(s)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Marcar todos",
  Deselect_all			: "Desmarcar todos",
  showSpeedInTitle		: "Mostrar velocidade no título",

--- a/lang/pt-pt.js
+++ b/lang/pt-pt.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Mostrar/Ocultar detalhes",
  Toggle_categories		: "Mostrar/Ocultar categorias",
  Delete_current_torrents	: "Remover torrent(s) atuais(s)",
+ Quick_search   : "Quick search",
  Select_all			: "Marcar todos",
  Deselect_all			: "Desmarcar todos",
  showSpeedInTitle		: "Mostrar velocidade no título",

--- a/lang/pt-pt.js
+++ b/lang/pt-pt.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Mostrar/Ocultar detalhes",
  Toggle_categories		: "Mostrar/Ocultar categorias",
  Delete_current_torrents	: "Remover torrent(s) atuais(s)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Marcar todos",
  Deselect_all			: "Desmarcar todos",
  showSpeedInTitle		: "Mostrar velocidade no título",

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Показать/скрыть детали",
  Toggle_categories		: "Показать/скрыть категории",
  Delete_current_torrents	: "Удалить торрент(ы)",
+ Quick_search   : "Быстрый поиск",
  Select_all			: "Выделить все",
  Deselect_all			: "Отмена выделения",
  showSpeedInTitle		: "Скорость в заголовке",

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Показать/скрыть детали",
  Toggle_categories		: "Показать/скрыть категории",
  Delete_current_torrents	: "Удалить торрент(ы)",
- Quick_search   : "Быстрый поиск",
+ Quick_search			: "Быстрый поиск",
  Select_all			: "Выделить все",
  Deselect_all			: "Отмена выделения",
  showSpeedInTitle		: "Скорость в заголовке",

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
+ Quick_search   : "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -289,7 +289,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -289,6 +289,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
+ Quick_search   : "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -289,7 +289,7 @@ var theUILang =
  Toggle_details			: "Visa/dölj detaljer",
  Toggle_categories		: "Visa/dölj kategorier",
  Delete_current_torrents	: "Ta bort aktuell(a) torrent(er)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Markera alla",
  Deselect_all			: "Avmarkera alla",
  showSpeedInTitle		: "Visa hastighet i titel",

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -289,6 +289,7 @@ var theUILang =
  Toggle_details			: "Visa/dölj detaljer",
  Toggle_categories		: "Visa/dölj kategorier",
  Delete_current_torrents	: "Ta bort aktuell(a) torrent(er)",
+ Quick_search   : "Quick search",
  Select_all			: "Markera alla",
  Deselect_all			: "Avmarkera alla",
  showSpeedInTitle		: "Visa hastighet i titel",

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Ayrıntıları aç/kapat",
  Toggle_categories		: "Kategorileri aç/kapat",
  Delete_current_torrents	: "Geçerli torrent'(lar)ı sil",
+ Quick_search   : "Quick search",
  Select_all : "Tümünü seç",
  Deselect_all : "Tüm seçimi kaldır",
  showSpeedInTitle : "Başlıkta hızı göster",

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Ayrıntıları aç/kapat",
  Toggle_categories		: "Kategorileri aç/kapat",
  Delete_current_torrents	: "Geçerli torrent'(lar)ı sil",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all : "Tümünü seç",
  Deselect_all : "Tüm seçimi kaldır",
  showSpeedInTitle : "Başlıkta hızı göster",

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "Перемкнути деталі",
  Toggle_categories		: "Перемкнути категорії",
  Delete_current_torrents	: "Видлити поточні торенти",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Вибрати все",
  Deselect_all			: "Скасувати вибір",
  showSpeedInTitle		: "Показувати швидкість у заголовку",

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "Перемкнути деталі",
  Toggle_categories		: "Перемкнути категорії",
  Delete_current_torrents	: "Видлити поточні торенти",
+ Quick_search   : "Quick search",
  Select_all			: "Вибрати все",
  Deselect_all			: "Скасувати вибір",
  showSpeedInTitle		: "Показувати швидкість у заголовку",

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -289,6 +289,7 @@ var theUILang =
  Toggle_details			: "Bật tắt chi tiết",
  Toggle_categories		: "Bật tắt danh mục",
  Delete_current_torrents	: "Xóa torrent hiện tại",
+ Quick_search   : "Quick search",
  Select_all			: "Chọn tất cả",
  Deselect_all			: "Bỏ chọn tất cả",
  showSpeedInTitle		: "Hiển thị tốc độ ở tiêu đề",

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -289,7 +289,7 @@ var theUILang =
  Toggle_details			: "Bật tắt chi tiết",
  Toggle_categories		: "Bật tắt danh mục",
  Delete_current_torrents	: "Xóa torrent hiện tại",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Chọn tất cả",
  Deselect_all			: "Bỏ chọn tất cả",
  showSpeedInTitle		: "Hiển thị tốc độ ở tiêu đề",

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -291,7 +291,7 @@ var theUILang =
  Toggle_details			: "切换详情",
  Toggle_categories		: "切换分类",
  Delete_current_torrents	: "删除当前 torrent(s)",
- Quick_search   : "快速搜索",
+ Quick_search			: "快速搜索",
  Select_all			: "全选",
  Deselect_all			: "全不选",
  showSpeedInTitle		: "在标题中显示速度",

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -291,6 +291,7 @@ var theUILang =
  Toggle_details			: "切换详情",
  Toggle_categories		: "切换分类",
  Delete_current_torrents	: "删除当前 torrent(s)",
+ Quick_search   : "快速搜索",
  Select_all			: "全选",
  Deselect_all			: "全不选",
  showSpeedInTitle		: "在标题中显示速度",

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -289,7 +289,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
- Quick_search   : "Quick search",
+ Quick_search			: "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -289,6 +289,7 @@ var theUILang =
  Toggle_details			: "Toggle details",
  Toggle_categories		: "Toggle categories",
  Delete_current_torrents	: "Delete current torrent(s)",
+ Quick_search   : "Quick search",
  Select_all			: "Select all",
  Deselect_all			: "Deselect all",
  showSpeedInTitle		: "Show speed in the title",

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -735,7 +735,7 @@ plugin.refreshCategories = function()
 		for( var i=0; i<theSearchEngines.sites[theSearchEngines.current].cats.length; i++)
 			$('#exscategory').append("<option value='"+theSearchEngines.sites[theSearchEngines.current].cats[i]+"'>"+theSearchEngines.sites[theSearchEngines.current].cats[i]+"</option>");
 	}
-	$("#exscategory").prop("disabled",(theSearchEngines.current == -1));
+  $("#exscategory").prop("hidden", (theSearchEngines.current === -1));
 }
 
 plugin.shutdownOldVersion = function()

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -735,7 +735,7 @@ plugin.refreshCategories = function()
 		for( var i=0; i<theSearchEngines.sites[theSearchEngines.current].cats.length; i++)
 			$('#exscategory').append("<option value='"+theSearchEngines.sites[theSearchEngines.current].cats[i]+"'>"+theSearchEngines.sites[theSearchEngines.current].cats[i]+"</option>");
 	}
-  $("#exscategory").prop("hidden", (theSearchEngines.current === -1));
+	$("#exscategory").prop("hidden", (theSearchEngines.current === -1));
 }
 
 plugin.shutdownOldVersion = function()


### PR DESCRIPTION
Made a few changes to the search field, which I feel may come in handy.

1. Keyboard shortcut "Ctrl+F" to focus on the search field, and "Esc" once to clear the search result, and "Esc" again to escape from searching.

2. A help note to the help dialog.
![help-dialog](https://github.com/Novik/ruTorrent/assets/26022962/679bd664-c16b-441c-bf4c-ba4df88c9f1a)

3. Category dropdown list hidden when searching locally, instead of disabling it.
![search-field-before](https://github.com/Novik/ruTorrent/assets/26022962/e65535e2-cdee-404e-987d-4cf4b873a113)
