### PR TITLE
Apply grid layout on create torrent dialog

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -334,7 +334,7 @@ div.space {flex-grow: 1;}
 /* Custom rules for medium devices */
 div#tadd {max-width: 95vw;}
 .buttons-list {
-  margin: 0 0.5rem 0.5rem 0.5rem;
+  margin: 0.5rem;
   gap: 0.25rem;
   display: flex;
   flex-direction: column;
@@ -350,7 +350,7 @@ div#tadd {max-width: 95vw;}
   /* Custom rules for medium devices */
   div#tadd {max-width: 600px;}
   .buttons-list {
-    margin: 0 0.5rem 0.5rem 0.5rem;
+    margin: 1rem 0.5rem;
     gap: 0.25rem;
     display: flex;
     flex-direction: row;

--- a/css/style.css
+++ b/css/style.css
@@ -102,7 +102,6 @@ Input.TextboxShort {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; w
 Input.TextboxMid {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 110px}
 Input.TextboxLarge {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 220px}
 Input.TextboxVShort {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 30px}
-input.textbox-grow {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; flex: 1;}
 button, input.Button {padding: 1px 10px; background: #F0F0F0 url(../images/h.gif) repeat-x center bottom; width: 80px; height: 19px; border: 1px solid #A0A0A0; cursor: pointer }
 button[disabled],input.Button[disabled] { opacity: 0.3; cursor: default }
 button:not([disabled]):hover, input.Button:not([disabled]):hover { background-color: #F5F5F5; }
@@ -300,7 +299,7 @@ div#tadd fieldset {margin: 0 0 0.25rem 0; padding: 0.25rem;}
 #st_system .sthdr { padding-left: 8px }
 
 .ie fieldset {padding: 5px}
-.buttons-list {  margin-bottom: 5px }
+div.space {flex-grow: 1;}
 #servertime { text-align: center }
 #viewrows { text-align: center; }
 
@@ -334,6 +333,12 @@ div#tadd fieldset {margin: 0 0 0.25rem 0; padding: 0.25rem;}
 /* No media query for `xs` since this is the default in Bootstrap */
 /* Custom rules for medium devices */
 div#tadd {max-width: 95vw;}
+.buttons-list {
+  margin: 0 0.5rem 0.5rem 0.5rem;
+  gap: 0.25rem;
+  display: flex;
+  flex-direction: column;
+}
 
 /* Small devices (landscape phones, 576px and up) */
 @media (min-width: 576px) { 
@@ -344,6 +349,13 @@ div#tadd {max-width: 95vw;}
 @media (min-width: 768px) { 
   /* Custom rules for medium devices */
   div#tadd {max-width: 600px;}
+  .buttons-list {
+    margin: 0 0.5rem 0.5rem 0.5rem;
+    gap: 0.25rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: end;
+  }
 }
 
 /* Large devices (desktops, 992px and up) */

--- a/plugins/_getdir/_getdir.css
+++ b/plugins/_getdir/_getdir.css
@@ -17,4 +17,4 @@ body {background-color: window; color: windowtext; border: 0px; margin: 0px; pad
 .rmenuitem { color: windowtext; }
 .rmenuitemselected { color: highlighttext; background-color: highlight; }
 
-input.browseButton {width:30px}
+input.browseButton {width:30px; margin-left: 0.25rem; margin-right: 0.25rem;}

--- a/plugins/create/create.css
+++ b/plugins/create/create.css
@@ -19,6 +19,7 @@ div#tcreate {min-width: 90vw;}
 @media (min-width: 576px) { 
   /* Custom rules for small devices */
   div#tcreate {min-width: 518px;}
+  div#tcreate textarea {height: 16rem;}
 }
 
 /* Medium devices (tablets, 768px and up) */

--- a/plugins/create/create.css
+++ b/plugins/create/create.css
@@ -1,15 +1,42 @@
-div#tcreate {min-width: 405px; min-height: 385px}
 div#tcreate div.dlg-header {background-image: url(./images/create16.gif)}
-div#tcreate #path_edit {width: 305px}
-div#tcreate textarea#trackers {width: 230px; height: 70px; border: 1px solid #D0D0D0; font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif; cursor: text}
-div#tcreate fieldset div {line-height: 16px}
+div#tcreate .container {padding: 0;}
+div#tcreate .row {margin: 0 0 0.25rem 0; padding: 0; align-items: center;}
+div#tcreate .row > div {padding: 0 0.25rem; margin-bottom: 0.1rem;}
+div#tcreate fieldset {margin: 0 0 0.25rem 0; padding: 0.25rem;}
+div#tcreate textarea {resize: none; height: 8rem;}
 
-div#tcreate label {width: 120px; display: block; float: left; margin-top: 5px; margin-bottom: 5px; margin-left: 10px; }
-div#tcreate label.nomargin { margin-top: 0px; margin-bottom: 0px; }
-div#tcreate input, select {margin-top: 5px; margin-bottom: 5px;}
-div#tcreate br {clear: left; line-height: 0}
+#recentTrackers {width: 130px;}
+#deleteFromRecentTrackers {text-align: left;}
 
-#browse_path {width: 30px;}
+/* Custom break point settings for responsiveness */
 
-#recentTrackers { float: left; width: 130px }
-#deleteFromRecentTrackers {float: left; text-align: left}
+/* X-Small devices (portrait phones, less than 576px) */
+/* No media query for `xs` since this is the default in Bootstrap */
+/* Custom rules for medium devices */
+div#tcreate {min-width: 90vw;}
+
+/* Small devices (landscape phones, 576px and up) */
+@media (min-width: 576px) { 
+  /* Custom rules for small devices */
+  div#tcreate {min-width: 518px;}
+}
+
+/* Medium devices (tablets, 768px and up) */
+@media (min-width: 768px) { 
+  /* Custom rules for medium devices */
+}
+
+/* Large devices (desktops, 992px and up) */
+@media (min-width: 992px) { 
+  /* Custom rules for large devices */
+}
+
+/* X-Large devices (large desktops, 1200px and up) */
+@media (min-width: 1200px) { 
+  /* Custom rules for x-large devices */
+}
+
+/* XX-Large devices (larger desktops, 1400px and up) */
+@media (min-width: 1400px) { 
+  /* Custom rules for xx-large devices */
+}

--- a/plugins/create/init.js
+++ b/plugins/create/init.js
@@ -129,57 +129,101 @@ plugin.onLangLoaded = function()
 			 );
 		plugin.addButtonToToolbar("create",theUILang.mnu_create,"theWebUI.showCreate()","remove");
 		plugin.addSeparatorToToolbar("remove");
-		var pieceSize =
-			"<label>"+theUILang.PieceSize+": </label>"+
-			"<select id='piece_size' name='piece_size'>"+
-				"<option value=\"32\">32"+theUILang.KB+"</option>"+
-				"<option value=\"64\">64"+theUILang.KB+"</option>"+
-				"<option value=\"128\">128"+theUILang.KB+"</option>"+
-				"<option value=\"256\" selected=\"selected\">256"+theUILang.KB+"</option>"+
-				"<option value=\"512\">512"+theUILang.KB+"</option>"+
-				"<option value=\"1024\">1"+theUILang.MB+"</option>"+
-				"<option value=\"2048\">2"+theUILang.MB+"</option>"+
-				"<option value=\"4096\">4"+theUILang.MB+"</option>"+
-				"<option value=\"8192\">8"+theUILang.MB+"</option>"+
-				"<option value=\"16384\">16"+theUILang.MB+"</option>"+
-				"<option value=\"32768\">32"+theUILang.MB+"</option>"+
-				"<option value=\"65536\">64"+theUILang.MB+"</option>"+
-				"</select>";
+		var pieceSize = $("<div>").addClass("row").append(
+			$("<div>").addClass("col-md-2").append(
+				$("<label>").attr({for: "piece_size", name: "lbl_piece_size", id: "lbl_piece_size"}).text(theUILang.PieceSize + ": "),
+			),
+			$("<div>").addClass("col-md-4 d-flex flex-row").append(
+				$("<select>").attr({id: "piece_size", name: "piece_size"}).addClass("flex-grow-1").append(
+					[32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536].map(
+						(ele) => $("<option>").val(ele).text(
+							ele < 1024 ? ele + theUILang.KB : (ele / 1024) + theUILang.MB
+						)
+					),
+				),
+			),
+		);
 		if(plugin.hidePieceSize)
 			pieceSize = "";
 
-		var hybridTorrent =
-				"<label for='hybrid' id='lbl_hybrid' class='nomargin'>"+
-				"<input type='checkbox' name='hybrid' id='hybrid'/>"+theUILang.HybridTorrent+"</label>";
-
+		var hybridTorrent = $("<div>").addClass("col-md-4 d-flex flex-row align-items-center").append(
+			$("<input>").attr({type: "checkbox", name: "hybrid", id: "hybrid"}),
+			$("<label>").attr({for: "hybrid", id: "lbl_hybrid"}).text(theUILang.HybridTorrent),
+		);
 		if(plugin.hideHybrid)
 			hybridTorrent = "";
 
 		theDialogManager.make("tcreate",theUILang.CreateNewTorrent,
-			"<div class='cont fxcaret'>"+
-				"<fieldset>"+
-					"<legend>"+theUILang.SelectSource+"</legend>"+
-					"<input type='text' id='path_edit' name='path_edit' class='TextboxLarge' autocomplete='off'/>"+
-					"<input type=button value='...' id='browse_path' class='Button'><br/>"+
-				"</fieldset>"+
-				"<fieldset>"+
-					"<legend>"+theUILang.TorrentProperties+"</legend>"+
-                       	               "	<label>"+theUILang.Trackers+": </label>"+
-					"<textarea id='trackers' name='trackers'></textarea><br/>"+
-        	                       	       "<label>"+theUILang.Comment+": </label>"+
-        		               	"<input type='text' id='comment' name='comment' class='TextboxLarge'/><br/>"+
-        	                       	       "<label>" + theUILang.source + ": </label>"+
-        		               	"<input type='text' id='source' name='source' class='TextboxLarge'/><br/>"+
-					pieceSize+
-				"</fieldset>"+
-				"<fieldset>"+
-					"<legend>"+theUILang.Other+"</legend>"+
-					"<label for='start_seeding' id='lbl_start_seeding' class='nomargin'><input type='checkbox' name='start_seeding' id='start_seeding'/>"+theUILang.StartSeeding+"</label>"+
-					"<label class='nomargin'><input type='checkbox' name='private' id='private'/>"+theUILang.PrivateTorrent+"</label>"+
-					hybridTorrent+"<br/>"+
-				"</fieldset>"+
-			"</div>"+
-			"<div class='aright buttons-list'><input type='button' id='recentTrackers' value='"+theUILang.recentTrackers+"...' class='Button menuitem' onclick='theWebUI.showRecentTrackers()'/><input type='button' id='deleteFromRecentTrackers' value='"+theUILang.deleteFromRecentTrackers+"' class='Button' onclick='theWebUI.deleteFromRecentTrackers()'/><input type='button' id='torrentCreate' value='"+theUILang.torrentCreate+"' class='OK Button' onclick='theWebUI.checkCreate()'/><input type='button' class='Cancel Button' value='"+theUILang.Cancel+"'/></div>",true);
+			$("<div>").addClass("cont fxcaret").append(
+				$("<fieldset>").append(
+					$("<legend>").text(theUILang.SelectSource),
+					$("<div>").addClass("row").append(
+						$("<div>").addClass("col-12 d-flex flex-row").append(
+							$("<input>").attr({type: "text", id: "path_edit", name: "path_edit", autocomplete: "off"}).addClass("flex-grow-1"),
+							$("<input>").attr({type: "button", id: "browse_path"}).addClass("Button").val("..."),
+						),
+					),
+				),
+				$("<fieldset>").append(
+					$("<legend>").text(theUILang.TorrentProperties),
+					$("<div>").addClass("row").append(
+						$("<div>").addClass("col-md-2 align-self-start").append(
+							$("<label>").attr({for: "trackers", name: "lbl_trackers", id: "lbl_trackers"}).text(theUILang.Trackers + ": "),
+						),
+						$("<div>").addClass("col-md-10 d-flex flex-row").append(
+							$("<textarea>").attr({id: "trackers", name: "trackers"}).addClass("flex-grow-1"),
+						),
+					),
+					$("<div>").addClass("row").append(
+						$("<div>").addClass("col-md-2").append(
+							$("<label>").attr({for: "comment", name: "lbl_comment", id: "lbl_comment"}).text(theUILang.Comment + ": "),
+						),
+						$("<div>").addClass("col-md-10 d-flex flex-row").append(
+							$("<input>").attr({type: "text", id: "comment", name: "comment"}).addClass("flex-grow-1"),
+						),
+					),
+					$("<div>").addClass("row").append(
+						$("<div>").addClass("col-md-2").append(
+							$("<label>").attr({for: "source", name: "lbl_source", id: "lbl_source"}).text(theUILang.source + ": "),
+						),
+						$("<div>").addClass("col-md-10 d-flex flex-row").append(
+							$("<input>").attr({type: "text", id: "source", name: "source"}).addClass("flex-grow-1"),
+						),
+					),
+					pieceSize,
+				),
+				$("<fieldset>").append(
+					$("<legend>").text(theUILang.Other),
+					$("<div>").addClass("row").append(
+						$("<div>").addClass("col-md-4 d-flex flex-row align-items-center").append(
+							$("<input>").attr({type: "checkbox", name: "start_seeding", id: "start_seeding"}),
+							$("<label>").attr({for: "start_seeding", id: "lbl_start_seeding"}).text(theUILang.StartSeeding),
+						),
+						$("<div>").addClass("col-md-4 d-flex flex-row align-items-center").append(
+							$("<input>").attr({type: "checkbox", name: "private", id: "private"}),
+							$("<label>").attr({for: "private", id: "lbl_private"}).text(theUILang.PrivateTorrent),
+						),
+						...hybridTorrent,
+					),
+				),
+			)[0].outerHTML + 
+			$("<div>").addClass("buttons-list").append(
+				$("<input>").attr(
+					{type: "button", id: "recentTrackers", onclick: "theWebUI.showRecentTrackers();"}
+				).val(theUILang.recentTrackers + "...").addClass("Button menuitem"),
+				$("<input>").attr(
+					{type: "button", id: "deleteFromRecentTrackers", onclick: "theWebUI.deleteFromRecentTrackers();"}
+				).val(theUILang.deleteFromRecentTrackers).addClass("Button"),
+				$("<div>").addClass("space d-none d-md-block"),
+				$("<input>").attr(
+					{type: "button", id: "torrentCreate", onclick: "theWebUI.checkCreate();"}
+				).val(theUILang.torrentCreate).addClass("OK Button"),
+				$("<input>").attr({type: "button"}).addClass("Cancel Button").val(theUILang.Cancel),
+			)[0].outerHTML,
+			true
+		);
+		$("option[value='1024']").attr({selected: ""});
+
 		$(document.body).append($("<iframe name='xcreatefrm'/>").css({visibility: "hidden"}).attr( { name: "xcreatefrm", id: "xcreatefrm" } ).width(0).height(0));
 		$(document.body).append(
 			$('<form action="plugins/create/action.php" id="xgetfile" method="post" target="xcreatefrm">'+

--- a/plugins/create/init.js
+++ b/plugins/create/init.js
@@ -236,7 +236,7 @@ plugin.onLangLoaded = function()
 		});
 		if(thePlugins.isInstalled("_getdir"))
 		{
-			plugin.btn = new theWebUI.rDirBrowser( 'tcreate', 'path_edit', 'browse_path', null, true, 300 );
+			plugin.btn = new theWebUI.rDirBrowser( 'tcreate', 'path_edit', 'browse_path', null, true, 375 );
 			theDialogManager.setHandler('tcreate','afterHide',function()
 			{
 				plugin.btn.hide();


### PR DESCRIPTION
Taking another step closer to making ruTorrent mobile friendly, by applying the bootstrap grid layout to the create torrent dialog. I think we still need to re-work the "URL replacement in RSS" dialog and the "Ratio Rules" dialog before the next minor update release.

1. `md` screen size and larger:
![Screenshot 2024-06-27 220927](https://github.com/Novik/ruTorrent/assets/26022962/739007df-9f3f-4d07-8764-2c8b72f45f5b)

2. Smaller screens:
![Screenshot 2024-06-27 220953](https://github.com/Novik/ruTorrent/assets/26022962/b809a3fc-cab3-47c1-990f-9a34f16b34a3)
