### PR TITLE
Apply grid layout to Ratio Rules dialog

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -294,6 +294,7 @@ div#tadd fieldset {margin: 0 0 0.25rem 0; padding: 0.25rem;}
 .optionColumn input[type=number],.optionColumn select { padding: 1px; margin: 0.1em 0.5em; width: 6em; }
 .optionColumn div { display:flex; align-items: center; padding-left: 0; }
 .statuscell td { padding: 0 }
+.buttons-group-row {margin: 0.25rem; gap: 0.25rem; display: flex; flex-direction: row;}
 #st_fd .sthdr { padding-left: 8px; }
 #st_fd .stval { text-align: center; width: 4.3em; }
 #st_system .sthdr { padding-left: 8px }

--- a/plugins/extratio/extratio.css
+++ b/plugins/extratio/extratio.css
@@ -25,12 +25,12 @@ div#dlgEditRatioRules {max-width: 95vw;}
 /* Small devices (landscape phones, 576px and up) */
 @media (min-width: 576px) { 
   /* Custom rules for small devices */
-  div#dlgEditRatioRules {min-width: 600px;}
 }
 
 /* Medium devices (tablets, 768px and up) */
 @media (min-width: 768px) { 
   /* Custom rules for medium devices */
+  div#dlgEditRatioRules {min-width: 600px;}
 }
 
 /* Large devices (desktops, 992px and up) */

--- a/plugins/extratio/extratio.css
+++ b/plugins/extratio/extratio.css
@@ -1,30 +1,49 @@
-div#dlgEditRatioRules {width: 610px; height: 300px; font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif; overflow: visible}
+div#dlgEditRatioRules {font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif; overflow: visible}
 div#dlgEditRatioRules div.dlg-header {background-image: url(../../images/settings.gif)}
+div#dlgEditRatioRules .container {margin: 0.25rem; padding: 0; width: auto;}
+div#dlgEditRatioRules .row {margin: 0 0 0.25rem 0; padding: 0;}
+div#dlgEditRatioRules .row > div {padding: 0 0.25rem; margin-bottom: 0.1rem;}
+div#dlgEditRatioRules fieldset {margin: 0 0 0.25rem 0; padding: 0.25rem 0.5rem;}
 
-.lfc_rru {float: left; }
-.lf_rru {width: 245px; height: 200px; margin: 5px; margin-right: 0; padding: 5px; background-color: #FFFFFF; border: 1px solid #D0D0D0; overflow: auto}
-.lf_rru ul {width: 100%; margin: 2px; padding: 0; list-style-position: inside; list-style: none; white-space: nowrap}
-.lf_rru li input { margin: 0 5px 0 0; padding: 4px; } 
-.lf_rru li {margin: 0 ; padding: 0}
-.lf_rru li input.TextboxFocus { width: 85%; background-color: #CFDEEF; }
-.lf_rru li input.TextboxNormal { width: 85%; background-color: #FFFFFF }
-.lf_rru li input { border: 0; font-size: 11px; font-family: Tahoma, Verdana, Arial, Helvetica, sans-serif; cursor: default; font-weight: bold; }
+div#ratioRuleList {border: solid 1px #A0A0A0; border-radius: 3px; height: 260px; overflow-y: auto;}
 
-div#exratio_buttons1 {padding-top: 5px; padding-left: 3px; width: 260px; text-align:center}
+ul#rlsul {margin: 0.25rem; padding: 0.25rem; list-style: none; white-space: nowrap;}
+ul#rlsul > li {margin: 0.2rem 0; display: flex; flex-direction: row;}
+ul#rlsul > li input[type="text"] {border: solid 1px #000000; border-radius: 3px; flex-grow: 1;}
+ul#rlsul > li input.TextboxFocus {background-color: #CFDEEF; }
+ul#rlsul > li input.TextboxNormal {background-color: #FFFFFF }
 
-.rf_rru fieldset {margin: 3px; }
-.rf_rru {float: right; margin: 4px; background-color: #FAFAFA}
-.rf_rru label {width: 75px; display: block; float: left; margin-top: 5px; margin-bottom: 5px; margin-left: 10px; }
-.rf_rru br {clear: left; line-height: 0}
-.rf_rru select {width: 200px; margin: 3px; }
-.rf_rru input.TextboxLarge {margin: 3px; width: 300px;}
-.rf_rru input.Button {margin: 3px}
-#ratio_reason {width: 305px; margin: 3px; }
+#exratio_buttons1 input.Button {width: 57px;}
 
-#exratio_buttons1 input.Button {width: 57px}
+/* Custom break point settings for responsiveness */
 
-div#exratio_buttons2 {clear: both}
+/* X-Small devices (portrait phones, less than 576px) */
+/* No media query for `xs` since this is the default in Bootstrap */
+/* Custom rules for medium devices */
+div#dlgEditRatioRules {max-width: 95vw;}
 
+/* Small devices (landscape phones, 576px and up) */
+@media (min-width: 576px) { 
+  /* Custom rules for small devices */
+  div#dlgEditRatioRules {min-width: 600px;}
+}
 
+/* Medium devices (tablets, 768px and up) */
+@media (min-width: 768px) { 
+  /* Custom rules for medium devices */
+}
 
+/* Large devices (desktops, 992px and up) */
+@media (min-width: 992px) { 
+  /* Custom rules for large devices */
+}
 
+/* X-Large devices (large desktops, 1200px and up) */
+@media (min-width: 1200px) { 
+  /* Custom rules for x-large devices */
+}
+
+/* XX-Large devices (larger desktops, 1400px and up) */
+@media (min-width: 1400px) { 
+  /* Custom rules for xx-large devices */
+}

--- a/plugins/extratio/extratio.css
+++ b/plugins/extratio/extratio.css
@@ -5,8 +5,6 @@ div#dlgEditRatioRules .row {margin: 0 0 0.25rem 0; padding: 0;}
 div#dlgEditRatioRules .row > div {padding: 0 0.25rem; margin-bottom: 0.1rem;}
 div#dlgEditRatioRules fieldset {margin: 0 0 0.25rem 0; padding: 0.25rem 0.5rem;}
 
-div#ratioRuleList {border: solid 1px #A0A0A0; border-radius: 3px; height: 260px; overflow-y: auto;}
-
 ul#rlsul {margin: 0.25rem; padding: 0.25rem; list-style: none; white-space: nowrap;}
 ul#rlsul > li {margin: 0.2rem 0; display: flex; flex-direction: row;}
 ul#rlsul > li input[type="text"] {border: solid 1px #000000; border-radius: 3px; flex-grow: 1;}
@@ -21,6 +19,13 @@ ul#rlsul > li input.TextboxNormal {background-color: #FFFFFF }
 /* No media query for `xs` since this is the default in Bootstrap */
 /* Custom rules for medium devices */
 div#dlgEditRatioRules {max-width: 95vw;}
+div#dlgEditRatioRules .buttons-list {
+  margin: 0.5rem 0.25rem;
+  gap: 0.25rem;
+  display: flex;
+  flex-direction: column;
+}
+div#ratioRuleList {border: solid 1px #A0A0A0; border-radius: 3px; height: 120px; overflow-y: auto;}
 
 /* Small devices (landscape phones, 576px and up) */
 @media (min-width: 576px) { 
@@ -31,6 +36,14 @@ div#dlgEditRatioRules {max-width: 95vw;}
 @media (min-width: 768px) { 
   /* Custom rules for medium devices */
   div#dlgEditRatioRules {min-width: 600px;}
+  div#dlgEditRatioRules .buttons-list {
+    margin: 1rem 0.5rem;
+    gap: 0.25rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: end;
+  }
+  div#ratioRuleList {border: solid 1px #A0A0A0; border-radius: 3px; height: 260px; overflow-y: auto;}
 }
 
 /* Large devices (desktops, 992px and up) */

--- a/plugins/extratio/init.js
+++ b/plugins/extratio/init.js
@@ -303,47 +303,112 @@ plugin.onLangLoaded = function()
 {
 	this.registerTopMenu(7);
 	theDialogManager.make( "dlgEditRatioRules", theUILang.ratioRulesManager,
-		"<div class='fxcaret'>"+
-			"<div class='lfc_rru'>"+
-				"<div class='lf_rru' id='ratioRuleList'>"+
-					"<ul id='rlsul'></ul>"+
-				"</div>"+
-				"<div id='exratio_buttons1'>"+
-					"<input type='button' id='ratAddRule' class='Button' value='"+theUILang.ratAddRule+"' onclick='theWebUI.addNewRatioRule(); return(false);'/>"+
-					"<input type='button' id='ratDelRule' class='Button' value='"+theUILang.ratDelRule+"' onclick='theWebUI.deleteCurrentRatioRule(); return(false);'/>"+
-					"<input type='button' id='ratUpRule' class='Button' value='"+theUILang.ratUpRule+"' onclick='theWebUI.upRatioRule(); return(false);'/>"+
-					"<input type='button' id='ratDownRule' class='Button' value='"+theUILang.ratDownRule+"' onclick='theWebUI.downRatioRule(); return(false);'/>"+
-				"</div>"+
-			"</div>"+
-			"<div class='rf_rru'>"+
-				"<fieldset>"+
-					"<legend>"+theUILang.ratioIfLegend+"</legend>"+
-					"<select id='ratio_reason'>"+
-						"<option value='0'>"+theUILang.ratLabelContain+"</option>"+
-						"<option value='1'>"+theUILang.ratTrackerContain+"</option>"+
-						"<option value='3'>"+theUILang.ratTrackerPublic+"</option>"+
-						"<option value='2'>"+theUILang.ratTrackerPrivate+"</option>"+
-					"</select><br/>"+
-					"<input type='text' id='ratio_pattern' class='TextboxLarge'/><br/>"+
-				"</fieldset>"+
-				"<fieldset>"+
-					"<legend>"+theUILang.ratioThenLegend+"</legend>"+
-					"<table>"+
-						"<tr><td>"+theUILang.setRatioTo+"</td>"+
-						"<td><select id='dst_ratio'></select></td></tr>"+
-						"<tr><td>"+theUILang.setChannelTo+"</td>"+
-						"<td><select id='dst_throttle'></select></td></tr>"+
-					"</table>"+
-				"</fieldset>"+
-			"</div>"+
-		"</div>"+
-		"<div id='exratio_buttons2' class='aright buttons-list'>"+
-			"<input type='button' class='OK Button' value='"+theUILang.ok+"' onclick='theDialogManager.hide(\"dlgEditRatioRules\");theWebUI.setRatioRules();return(false);'/>"+
-			"<input type='button' class='Cancel Button' value='"+theUILang.Cancel+"'/>"+
-		"</div>");
-  	$('#ratio_reason').on('change', function() 
-  	{ 
+		$("<div>").addClass("cont fxcaret").append(
+			$("<div>").addClass("row").append(
+				$("<div>").addClass("col-md-6 d-flex flex-column align-items-center").append(
+					$("<div>").attr({id: "ratioRuleList"}).addClass("flex-grow-1 align-self-stretch").append(
+						$("<ul>").attr({id: "rlsul"}),
+					),
+					$("<div>").attr({id: "exratio_buttons1"}).addClass("buttons-group-row").append(
+						...[
+							["ratAddRule", theUILang.ratAddRule, "addNewRatioRule"],
+							["ratDelRule", theUILang.ratDelRule, "deleteCurrentRatioRule"],
+							["ratUpRule", theUILang.ratUpRule, "upRatioRule"],
+							["ratDownRule", theUILang.ratDownRule, "downRatioRule"],
+						].map(([id, value, onclick]) => $("<input>").attr(
+							{type: "button", id: id, onclick: "theWebUI." + onclick + "(); return(false);"}
+						).addClass("Button").val(value)),
+					),
+				),
+				$("<div>").addClass("col-md-6").append(
+					$("<fieldset>").append(
+						$("<legend>").text(theUILang.ratioIfLegend),
+						$("<div>").addClass("d-flex flex-row").append(
+							$("<select>").attr({id: "ratio_reason"}).addClass("flex-grow-1").append(
+								...[
+									theUILang.ratLabelContain, 
+									theUILang.ratTrackerContain, 
+									theUILang.ratTrackerPublic, 
+									theUILang.ratTrackerPrivate,
+								].map((val, index) => $("<option>").attr({value: index}).text(val)),
+							),
+						),
+						$("<div>").addClass("d-flex flex-row").append(
+							$("<input>").attr({type: "text", id: "ratio_pattern"}).addClass("flex-grow-1"),
+						),
+					),
+					$("<fieldset>").append(
+						$("<legend>").text(theUILang.ratioThenLegend),
+						$("<div>").addClass("row align-items-center").append(
+							$("<div>").addClass("col-md-6 d-flex justify-content-md-end").append(
+								$("<label>").attr({for: "dst_ratio"}).text(theUILang.setRatioTo),
+							),
+							$("<div>").addClass("col-md-6 d-flex").append(
+								$("<select>").attr({id: "dst_ratio"}).addClass("flex-grow-1"),
+							),
+						),
+						$("<div>").addClass("row align-items-center").append(
+							$("<div>").addClass("col-md-6 d-flex justify-content-md-end").append(
+								$("<label>").attr({for: "dst_throttle"}).text(theUILang.setChannelTo),
+							),
+							$("<div>").addClass("col-md-6 d-flex").append(
+								$("<select>").attr({id: "dst_throttle"}).addClass("flex-grow-1"),
+							),
+						),
+					),
+					$("<fieldset>").append(
+						$("<legend>").text(theUILang.ratShortcutLegend),
+						$("<div>").addClass("row").append(
+							$("<div>").addClass("col-4").append(
+								$("<kbd>").text("Alt"),
+								$("<span>").text(" + "),
+								$("<kbd>").text("↑"),
+							),
+							$("<div>").addClass("col-8").append(
+								$("<span>").text(theUILang.ratUpRule),
+							),
+						),
+						$("<div>").addClass("row").append(
+							$("<div>").addClass("col-4").append(
+								$("<kbd>").text("Alt"),
+								$("<span>").text(" + "),
+								$("<kbd>").text("↓"),
+							),
+							$("<div>").addClass("col-8").append(
+								$("<span>").text(theUILang.ratDownRule),
+							),
+						),
+					),
+				),
+			),
+		)[0].outerHTML +
+		$("<div>").addClass("buttons-list").append(
+			$("<input>").attr(
+				{type: "button", onclick: "theDialogManager.hide(\"dlgEditRatioRules\");theWebUI.setRatioRules();return(false);"}
+			).addClass("OK Button").val(theUILang.ok),
+			$("<input>").attr({type: "button"}).addClass("Cancel Button").val(theUILang.Cancel),
+		)[0].outerHTML
+	);
+	$('#ratio_reason').on('change', function() { 
 		$('#ratio_pattern').css("visibility", iv($(this).val())>1 ? "hidden" : "visible");
+	});
+	$("#dlgEditRatioRules").on("keyup", (e) => {
+		if (e.altKey) {
+			switch (e.which) {
+				case 38: // Alt+ArrowUp
+				{
+					theWebUI.upRatioRule();
+					$("#dlgEditRatioRules").focus();
+					break;
+				}
+				case 40: // Alt+ArrowDown
+				{
+					theWebUI.downRatioRule();
+					$("#dlgEditRatioRules").focus();
+					break;
+				}
+			}
+		}
 	});
 };
 

--- a/plugins/extratio/lang/cs.js
+++ b/plugins/extratio/lang/cs.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";

--- a/plugins/extratio/lang/da.js
+++ b/plugins/extratio/lang/da.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";

--- a/plugins/extratio/lang/de.js
+++ b/plugins/extratio/lang/de.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";

--- a/plugins/extratio/lang/el.js
+++ b/plugins/extratio/lang/el.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Όλοι οι trackers του torrent είναι δημόσιοι";
  theUILang.ratTrackerPrivate	= "Ένας από τους trackers του torrent είναι ιδιωτικός";
  theUILang.ratioThenLegend	= "Τότε";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Όρισε αναλογία σε";
  theUILang.setChannelTo		= "Όρισε περιοριστή σε";
  theUILang.ratioNewRule		= "Νέος κανόνας";

--- a/plugins/extratio/lang/en.js
+++ b/plugins/extratio/lang/en.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";

--- a/plugins/extratio/lang/es.js
+++ b/plugins/extratio/lang/es.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Todos los trackers son públicos";
  theUILang.ratTrackerPrivate	= "Uno de los trackers es privado";
  theUILang.ratioThenLegend	= "Entonces";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "setear ratio a";
  theUILang.setChannelTo		= "Setear acelerador a";
  theUILang.ratioNewRule		= "Nueva regla";

--- a/plugins/extratio/lang/fi.js
+++ b/plugins/extratio/lang/fi.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";

--- a/plugins/extratio/lang/fr.js
+++ b/plugins/extratio/lang/fr.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Tous les trackers du torrent sont publics";
  theUILang.ratTrackerPrivate	= "Un des trackers du torrent est privé";
  theUILang.ratioThenLegend	= "Alors";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Groupe de ratio";
  theUILang.setChannelTo		= "Groupe de vitesse";
  theUILang.ratioNewRule		= "Nouvelle règle";

--- a/plugins/extratio/lang/hu.js
+++ b/plugins/extratio/lang/hu.js
@@ -18,7 +18,8 @@ theUILang.ratTrackerContain    = "A torrent egyik tracker URL-je tartalmazza";
 theUILang.ratTrackerPublic = "A torrent tracker nyilvános(public)";
 theUILang.ratTrackerPrivate    = "A torrent tracker privát";
 theUILang.ratioThenLegend   = "Akkor";
-theUILang.setRatioTo       = "Állítsa be az arányt";
+theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
+ theUILang.setRatioTo       = "Állítsa be az arányt";
 theUILang.setChannelTo     = "Csatorna";
 theUILang.ratioNewRule     = "Új szabály";
 

--- a/plugins/extratio/lang/it.js
+++ b/plugins/extratio/lang/it.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Tutti i tracker del torrent sono pubblici";
  theUILang.ratTrackerPrivate	= "Uno dei tracker del torrent è privato";
  theUILang.ratioThenLegend	= "Allora";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Imposta ratio a";
  theUILang.setChannelTo		= "Imposta limite a";
  theUILang.ratioNewRule		= "Nuova regola";

--- a/plugins/extratio/lang/ko.js
+++ b/plugins/extratio/lang/ko.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "모든 트래커가 공개 트래커인 경우";
  theUILang.ratTrackerPrivate	= "하나 이상의 트래커가 비공개 트래커인 경우";
  theUILang.ratioThenLegend	= "그렇다면";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "다음 비율로 설정";
  theUILang.setChannelTo		= "다음 채널로 설정";
  theUILang.ratioNewRule		= "새 규칙";

--- a/plugins/extratio/lang/lv.js
+++ b/plugins/extratio/lang/lv.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";

--- a/plugins/extratio/lang/nl.js
+++ b/plugins/extratio/lang/nl.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";

--- a/plugins/extratio/lang/no.js
+++ b/plugins/extratio/lang/no.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Alle torrentens trackere er offentlige";
  theUILang.ratTrackerPrivate	= "En av torrentens trackere er privat";
  theUILang.ratioThenLegend	= "Så";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Sett ratio til";
  theUILang.setChannelTo		= "Sett regulering til";
  theUILang.ratioNewRule		= "Ny regel";

--- a/plugins/extratio/lang/pl.js
+++ b/plugins/extratio/lang/pl.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Wszystkie trackery są publiczne";
  theUILang.ratTrackerPrivate	= "Jeden z trackerów jest prywatny";
  theUILang.ratioThenLegend	= "Wtedy";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Ustaw ratio na";
  theUILang.setChannelTo		= "Ustaw limit na";
  theUILang.ratioNewRule		= "Nowa reguła";

--- a/plugins/extratio/lang/pt-br.js
+++ b/plugins/extratio/lang/pt-br.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";

--- a/plugins/extratio/lang/pt-pt.js
+++ b/plugins/extratio/lang/pt-pt.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Todos os rastreadores de torrent são públicos";
  theUILang.ratTrackerPrivate	= "Um dos rastreadores do torrent é privado";
  theUILang.ratioThenLegend	= "Então"; // Then
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Definir racio para";
  theUILang.setChannelTo		= "Definir velocidade para"; // Set thtottle to: check better translation
  theUILang.ratioNewRule		= "Nova regra";

--- a/plugins/extratio/lang/ru.js
+++ b/plugins/extratio/lang/ru.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Все трекеры закачки публичные";
  theUILang.ratTrackerPrivate	= "Один из трекеров закачки частный";
  theUILang.ratioThenLegend	= "То";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Установить ratio";
  theUILang.setChannelTo		= "Установить канал";
  theUILang.ratioNewRule		= "Новое правило";

--- a/plugins/extratio/lang/sk.js
+++ b/plugins/extratio/lang/sk.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";

--- a/plugins/extratio/lang/sr.js
+++ b/plugins/extratio/lang/sr.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";

--- a/plugins/extratio/lang/sv.js
+++ b/plugins/extratio/lang/sv.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Alla torrentens trackers är offentliga";
  theUILang.ratTrackerPrivate	= "En av torrentens trackers är privat";
  theUILang.ratioThenLegend	= "Då";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Sätt ratio till";
  theUILang.setChannelTo		= "Sätt strypning till";
  theUILang.ratioNewRule		= "Ny regel";

--- a/plugins/extratio/lang/tr.js
+++ b/plugins/extratio/lang/tr.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";

--- a/plugins/extratio/lang/uk.js
+++ b/plugins/extratio/lang/uk.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Усі трекери завантаження публічні";
  theUILang.ratTrackerPrivate	= "Один із трекерів завантаження приватний";
  theUILang.ratioThenLegend	= "То";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Установити коефіцієнт";
  theUILang.setChannelTo		= "Установити канал";
  theUILang.ratioNewRule		= "Нове правило";

--- a/plugins/extratio/lang/vi.js
+++ b/plugins/extratio/lang/vi.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Tất cả máy theo dõi torrent đều là công cộng";
  theUILang.ratTrackerPrivate	= "Một trong số máy theo dõi torrent là riêng tư";
  theUILang.ratioThenLegend	= "Thì";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Đặt tỉ lệ là";
  theUILang.setChannelTo		= "Đặt băng thông là";
  theUILang.ratioNewRule		= "Thêm quy luật mới";

--- a/plugins/extratio/lang/zh-cn.js
+++ b/plugins/extratio/lang/zh-cn.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "Torrent 的所有 trackers 是公共的";
  theUILang.ratTrackerPrivate	= "Torrent 的某个 tracker 是私有的";
  theUILang.ratioThenLegend	= "然后";
+ theUILang.ratShortcutLegend	= "键盘快捷方式";
  theUILang.setRatioTo		= "把分享率设为";
  theUILang.setChannelTo		= "把限制设为";
  theUILang.ratioNewRule		= "新规则";

--- a/plugins/extratio/lang/zh-tw.js
+++ b/plugins/extratio/lang/zh-tw.js
@@ -18,6 +18,7 @@
  theUILang.ratTrackerPublic	= "All torrent's trackers are public";
  theUILang.ratTrackerPrivate	= "One of torrent's trackers is private";
  theUILang.ratioThenLegend	= "Then";
+ theUILang.ratShortcutLegend	= "Keyboard Shortcuts";
  theUILang.setRatioTo		= "Set ratio to";
  theUILang.setChannelTo		= "Set throttle to";
  theUILang.ratioNewRule		= "New rule";


### PR DESCRIPTION
Applied Bootstrap grid layout to the Ratio Rules dialog, as well as added two quick keyboard shortcuts for moving rules up and down in the list.

1. `md` screens and larger
![Screenshot 2024-06-28 223503](https://github.com/Novik/ruTorrent/assets/26022962/2f5a84a7-8601-4958-a749-e1589b8ad199)

2. Smaller screens
![Screenshot 2024-06-28 223528](https://github.com/Novik/ruTorrent/assets/26022962/8c9030c8-4bd4-452c-a11c-f559553ff6a6)
