### PR TITLE
Make throttle an optional dependency for extratio

### DIFF
--- a/plugins/extratio/init.js
+++ b/plugins/extratio/init.js
@@ -50,19 +50,27 @@ plugin.loadRules = function( rle )
 	if(fltThrottle.length)
 	{
 		$('#dst_throttle option').remove();
-		fltThrottle.append("<option value=''>"+theUILang.dontSet+"</option>");
+		fltThrottle.append(
+			$("<option>").val("").text(theUILang.dontSet),
+		);
 		for(var i=0; i<theWebUI.maxThrottle; i++)
 			if(theWebUI.isCorrectThrottle(i))
-				fltThrottle.append("<option value='thr_"+i+"'>"+theWebUI.throttles[i].name+"</option>");
+				fltThrottle.append(
+					$("<option>").val("thr_" + i).text(theWebUI.throttles[i].name),
+				);
 	}
 	var fltRatio = $('#dst_ratio');
 	if(fltRatio.length)
 	{
 		$('#dst_ratio option').remove();
-		fltRatio.append("<option value=''>"+theUILang.dontSet+"</option>");
+		fltRatio.append(
+			$("<option>").val("").text(theUILang.dontSet),
+		);
 		for(var i=0; i<theWebUI.maxRatio; i++)
 			if(theWebUI.isCorrectRatio(i))
-				fltRatio.append("<option value='rat_"+i+"'>"+theWebUI.ratios[i].name+"</option>");
+				fltRatio.append(
+					$("<option>").val("rat_" + i).text(theWebUI.ratios[i].name),
+				);
 	}
 	plugin.curRule = null;
 	var list = $("#rlsul");
@@ -74,10 +82,14 @@ plugin.loadRules = function( rle )
 		var f = plugin.rules[i];
 		if(plugin.maxRuleNo<f.no)
 			plugin.maxRuleNo = f.no;
-		list.append( $("<li>").html("<input type='checkbox' id='_rre"+i+"'/><input type='text' class='TextboxNormal' onfocus=\"theWebUI.selectRatioRule(this);\" id='_rrn"+i+"'/>"));
-		$("#_rrn"+i).val(f.name);
-		if(f.enabled)
-			$("#_rre"+i).prop("checked",true);
+		list.append(
+			$("<li>").append(
+				$("<input>").attr({type: "checkbox", id: "_rre" + i}).prop("checked", f.enabled),
+				$("<input>").attr(
+					{type: "text", id: "_rrn" + i, onfocus: "theWebUI.selectRatioRule(this);"}
+				).addClass("TextboxNormal").val(f.name),
+			),
+		);
 	}
 	for(var i=0; i<plugin.rules.length; i++)
 	{
@@ -219,10 +231,12 @@ rTorrentStub.prototype.setratiorules = function()
 		var rle = plugin.rules[i];
 		var enabled = $("#_rre"+i).prop("checked") ? 1 : 0;
 		var name = $("#_rrn"+i).val();
-		this.content = this.content+"&name="+encodeURIComponent(name)+"&pattern="+encodeURIComponent(rle.pattern)+"&enabled="+enabled+
-		        "&reason="+rle.reason+
-			"&channel="+rle.channel+"&ratio="+rle.ratio+
-			"&no="+rle.no;
+		this.content += "&name="+encodeURIComponent(name) + "&pattern=" + encodeURIComponent(rle.pattern) + 
+			"&enabled=" + enabled + "&reason=" + rle.reason + 
+			"&ratio=" + rle.ratio + "&no="+rle.no;
+		if (thePlugins.isInstalled("throttle")) {
+			this.content += "&channel=" + rle.channel;
+		}
 	}
 	this.contentType = "application/x-www-form-urlencoded";
 	this.mountPoint = "plugins/extratio/action.php";
@@ -347,7 +361,7 @@ plugin.onLangLoaded = function()
 								$("<select>").attr({id: "dst_ratio"}).addClass("flex-grow-1"),
 							),
 						),
-						$("<div>").addClass("row align-items-center").append(
+						thePlugins.isInstalled("throttle") && $("<div>").addClass("row align-items-center").append(
 							$("<div>").addClass("col-md-6 d-flex justify-content-md-end").append(
 								$("<label>").attr({for: "dst_throttle"}).text(theUILang.setChannelTo),
 							),

--- a/plugins/extratio/init.js
+++ b/plugins/extratio/init.js
@@ -226,6 +226,7 @@ rTorrentStub.prototype.setratiorules = function()
 {
 	this.content = "mode=setrules";
 	plugin.storeRuleParams();
+	const thrtlInstalled = thePlugins.isInstalled("throttle");
 	for(var i=0; i<plugin.rules.length; i++)
 	{
 		var rle = plugin.rules[i];
@@ -234,9 +235,7 @@ rTorrentStub.prototype.setratiorules = function()
 		this.content += "&name="+encodeURIComponent(name) + "&pattern=" + encodeURIComponent(rle.pattern) + 
 			"&enabled=" + enabled + "&reason=" + rle.reason + 
 			"&ratio=" + rle.ratio + "&no="+rle.no;
-		if (thePlugins.isInstalled("throttle")) {
-			this.content += "&channel=" + rle.channel;
-		}
+		thrtlInstalled && (this.content += "&channel=" + rle.channel);
 	}
 	this.contentType = "application/x-www-form-urlencoded";
 	this.mountPoint = "plugins/extratio/action.php";

--- a/plugins/extratio/plugin.info
+++ b/plugins/extratio/plugin.info
@@ -2,7 +2,7 @@ plugin.description: This plugin extends the functionality of the ratio plugin.
 plugin.author: Novik
 plugin.runlevel: 12
 plugin.version: 4.3
-plugin.dependencies: ratio,throttle
+plugin.dependencies: ratio
 php.extensions.error: json
 rtorrent.version: 0.8.6
 plugin.help: https://github.com/Novik/ruTorrent/wiki/PluginExtRatio


### PR DESCRIPTION
Added a conditional statement to check if the throttle plugin is installed, and to initialize the WebUI and adjust the http request accordingly. 

There is one thing that's worth our notice, though. If we set up a rule that contains a throttle option, and disable the throttle plugin, and modify the rule setting again, and then enable the throttle plugin again, the original throttle option will be lost. It behaves this way because the PHP scripts take every submission of rule sets as creating new rules, instead of updating the existing ones.

1. With the throttle plugin installed
![Screenshot 2024-06-29 154820](https://github.com/Novik/ruTorrent/assets/26022962/4190a953-d6ab-462b-9265-e843a18057f0)

2. With the throttle plugin disabled
![Screenshot 2024-06-29 160054](https://github.com/Novik/ruTorrent/assets/26022962/c2ffeb11-175d-482b-82ce-ad87e30bd8b7)
