### PR TITLE
Make responsive status bar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -275,15 +275,46 @@ div#tadd fieldset {margin: 0 0 0.25rem 0; padding: 0.25rem;}
 .konqueror div#tadd { height: 290px; }
 .konqueror #st_con { height: 340px; overflow: auto; }
 
-#StatusBar { border-top: 1px solid #A0A0A0; background-color: #FFFFFF; margin-top: 4px; height: 24px; font-size: 11px;  color: #000000; white-space: nowrap; overflow: hidden;}
+#StatusBar {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  border-top: 1px solid #A0A0A0;
+  background-color: #FFFFFF;
+  margin-top: 4px;
+  color: #000000;
+  white-space: nowrap;
+  overflow: hidden;
+}
 #StatusBar table { line-height: 24px; }
-#st_up { background:url(../images/status_up.gif) 6px no-repeat; }
-#st_down { background:url(../images/status_down.gif) 6px no-repeat; }
-#st_up td:first-child .sthdr { margin-left: 25px }
-#st_down td:first-child .sthdr { margin-left: 25px }
-.statuscell {height: 20px; line-height: 20px; border-right: 1px solid #A0A0A0;}
+#st_up .icon {
+  background: url(../images/status_up.gif) center no-repeat;
+  width: 16px;
+  height: 16px;
+}
+#st_down .icon {
+  background: url(../images/status_down.gif) center no-repeat;
+  width: 16px;
+  height: 16px;
+}
+.status-cell {
+  padding: 0 0.25rem;
+  margin: 0;
+  min-height: 24px;
+  border-right: dotted 1px #A0A0A0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+.status-row:last-of-type {
+  border-left: solid 1px #A0A0A0;
+}
 .sthdr { font-weight: bold; padding-right: 3px; text-align: right; }
-.stval { padding-right: 3px; overflow: hidden; width: 65px; }
+.stval {
+  padding-right: 3px;
+  overflow: hidden;
+  min-width: 3rem;
+}
 .speedEdit { width: 320px }
 .decimalDigitEdit input[type=number] { padding: 1px; margin: 0; width: 3em; }
 .decimalDigitEdit tr:first-child th { text-align: center; }
@@ -293,11 +324,7 @@ div#tadd fieldset {margin: 0 0 0.25rem 0; padding: 0.25rem;}
 .optionColumn { display: flex; justify-content: space-between; flex-flow: column wrap; }
 .optionColumn input[type=number],.optionColumn select { padding: 1px; margin: 0.1em 0.5em; width: 6em; }
 .optionColumn div { display:flex; align-items: center; padding-left: 0; }
-.statuscell td { padding: 0 }
 .buttons-group-row {margin: 0.25rem; gap: 0.25rem; display: flex; flex-direction: row;}
-#st_fd .sthdr { padding-left: 8px; }
-#st_fd .stval { text-align: center; width: 4.3em; }
-#st_system .sthdr { padding-left: 8px }
 
 .ie fieldset {padding: 5px}
 div.space {flex-grow: 1;}
@@ -340,6 +367,9 @@ div#tadd .buttons-list {
   display: flex;
   flex-direction: column;
 }
+div.status-row:not(:first-of-type) {
+  border-bottom: dotted 1px #A0A0A0;
+}
 
 /* Small devices (landscape phones, 576px and up) */
 @media (min-width: 576px) { 
@@ -357,6 +387,9 @@ div#tadd .buttons-list {
     flex-direction: row;
     justify-content: end;
   }
+  div.status-row:not(:first-of-type) {
+    border-bottom: none;
+  }  
 }
 
 /* Large devices (desktops, 992px and up) */

--- a/css/style.css
+++ b/css/style.css
@@ -286,16 +286,17 @@ div#tadd fieldset {margin: 0 0 0.25rem 0; padding: 0.25rem;}
   white-space: nowrap;
   overflow: hidden;
 }
+#StatusBar .icon {
+  height: 16px;
+  width: 16px;
+  margin: 0 0.25rem;
+}
 #StatusBar table { line-height: 24px; }
 #st_up .icon {
   background: url(../images/status_up.gif) center no-repeat;
-  width: 16px;
-  height: 16px;
 }
 #st_down .icon {
   background: url(../images/status_down.gif) center no-repeat;
-  width: 16px;
-  height: 16px;
 }
 .status-cell {
   padding: 0 0.25rem;

--- a/index.html
+++ b/index.html
@@ -248,61 +248,50 @@
 					</div>
 				</td>
 			</tr>
-			<tr>
-				<td class="uicell" colspan=3>
-					<div id="StatusBar">
-					<table cellpadding="0" cellspacing="0">
-					        <tr id="firstStatusRow">
-							<td>
-							        <table id="st_up" class="statuscell" cellpadding="0" cellspacing="0">
-							        	<tr>
-										<td><div class="sthdr"><span uilang>Speed</span>:</div></td><td><div class="stval" id="stup_speed"></div></td>
-										<td class="desktop"><div class="sthdr"><span uilang>limit</span>:</div></td><td class="desktop"><div class="stval" id="stup_limit"></div></td>
-										<td class="desktop"><div class="sthdr"><span uilang>Total</span>:</div></td><td class="desktop"><div class="stval" id="stup_total"></div></td>
-									</tr>
-								</table>
-							</td>
-							<td>
-							        <table id="st_down" class="statuscell" cellpadding="0" cellspacing="0">
-							        	<tr>
-										<td><div class="sthdr"><span uilang>Speed</span>:</div></td><td><div class="stval" id="stdown_speed"></div></td>
-										<td class="desktop"><div class="sthdr"><span uilang>limit</span>:</div></td><td class="desktop"><div class="stval" id="stdown_limit"></div></td>
-										<td class="desktop"><div class="sthdr"><span uilang>Total</span>:</div></td><td class="desktop"><div class="stval" id="stdown_total"></div></td>
-									</tr>
-								</table>
-							</td>
-							<td class="desktop">
-								<table id="st_fd" class="statuscell" cellpadding="0" cellspacing="0">
-									<tr>
-										<td><div class="sthdr"><span uilang>Open_label</span>:</div></td><td><div class="stval" id="stopen_http_count"></div></td><td><div class="stval" id="stopen_sock_count"></div></td><td><div class="stval" id="stopen_fd_count"></div></td>
-									</tr>
-								</table>
-							</td>
-							<td class="desktop">
-							        <table id="st_system" class="statuscell" cellpadding="0" cellspacing="0">
-							        	<tr>
-										<td><div class="sthdr">rTorrent:</div></td><td><div class="stval" id="rtorrentv"></div></td>
-									</tr>
-								</table>
-							</td>
-							<td class="statusCell desktop">
-								<table id="st_system" class="statuscell" cellpadding="0" cellspacing="0">
-									<tr>
-										<td><div class="sthdr"><span uilang>Torrents</span>:</div></td><td><div class="stval" id="viewrows"></div></td>
-										<td><div class="stval" id="viewrows_size"></div></td>
-									</tr>
-								</table>
-							</td>
-							<td class="statuscell">
-								<div class="stval" id="servertime"></div>
-							</td>
-							<td width=100%></td>
-						</tr>
-					</table>
-					</div>
-				</td>
-			</tr>
 		</table>
+		<div id="StatusBar" class="d-flex flex-column-reverse align-items-stretch justify-content-between flex-md-row">
+			<div id="system-cells" class="status-row d-flex flex-row align-items-stretch">
+				<div id="st_up" class="status-cell">
+					<div class="icon"></div>
+					<div class="sthdr"><span uilang>Speed</span>:</div>
+					<div class="stval" id="stup_speed"></div>
+					<div class="sthdr d-none d-lg-block"><span uilang>limit</span>:</div>
+					<div class="stval d-none d-lg-block" id="stup_limit"></div>
+					<div class="sthdr d-none d-lg-block"><span uilang>Total</span>:</div>
+					<div class="stval d-none d-lg-block" id="stup_total"></div>
+				</div>
+				<div id="st_down" class="status-cell">
+					<div class="icon"></div>
+					<div class="sthdr"><span uilang>Speed</span>:</div>
+					<div class="stval" id="stdown_speed"></div>
+					<div class="sthdr d-none d-lg-block"><span uilang>limit</span>:</div>
+					<div class="stval d-none d-lg-block" id="stdown_limit"></div>
+					<div class="sthdr d-none d-lg-block"><span uilang>Total</span>:</div>
+					<div class="stval d-none d-lg-block" id="stdown_total"></div>
+				</div>
+				<div id="st_fd" class="status-cell">
+					<div class="sthdr d-none d-lg-block"><span uilang>Open_label</span>:</div>
+					<div class="stval" id="stopen_http_count"></div>
+					<div class="stval" id="stopen_sock_count"></div>
+					<div class="stval" id="stopen_fd_count"></div>
+				</div>
+				<div class="status-cell d-none d-md-flex">
+					<div class="sthdr">rTorrent:</div>
+					<div class="stval" id="rtorrentv"></div>
+				</div>
+				<div class="status-cell d-none d-md-flex">
+					<div class="sthdr"><span uilang>Torrents</span>:</div>
+					<div class="stval" id="viewrows"></div>
+					<div class="stval" id="viewrows_size"></div>
+				</div>
+			</div>
+			<div id="plugin-cells" class="status-row d-flex flex-row align-items-stretch flex-wrap-reverse flex-lg-nowrap"></div>
+			<div class="status-row ms-md-auto d-none d-lg-flex flex-lg-row align-items-lg-stretch">
+				<div class="status-cell">
+					<div class="stval" id="servertime"></div>
+				</div>
+			</div>
+		</div>
 		<div class="graph_tab_grid"></div>
 		<div class="graph_tab_legend"></div>
 	</body>

--- a/index.html
+++ b/index.html
@@ -249,47 +249,42 @@
 				</td>
 			</tr>
 		</table>
-		<div id="StatusBar" class="d-flex flex-column-reverse align-items-stretch justify-content-between flex-md-row">
-			<div id="system-cells" class="status-row d-flex flex-row align-items-stretch">
-				<div id="st_up" class="status-cell">
-					<div class="icon"></div>
-					<div class="sthdr"><span uilang>Speed</span>:</div>
-					<div class="stval" id="stup_speed"></div>
-					<div class="sthdr d-none d-lg-block"><span uilang>limit</span>:</div>
-					<div class="stval d-none d-lg-block" id="stup_limit"></div>
-					<div class="sthdr d-none d-lg-block"><span uilang>Total</span>:</div>
-					<div class="stval d-none d-lg-block" id="stup_total"></div>
-				</div>
-				<div id="st_down" class="status-cell">
-					<div class="icon"></div>
-					<div class="sthdr"><span uilang>Speed</span>:</div>
-					<div class="stval" id="stdown_speed"></div>
-					<div class="sthdr d-none d-lg-block"><span uilang>limit</span>:</div>
-					<div class="stval d-none d-lg-block" id="stdown_limit"></div>
-					<div class="sthdr d-none d-lg-block"><span uilang>Total</span>:</div>
-					<div class="stval d-none d-lg-block" id="stdown_total"></div>
-				</div>
-				<div id="st_fd" class="status-cell">
-					<div class="sthdr d-none d-lg-block"><span uilang>Open_label</span>:</div>
-					<div class="stval" id="stopen_http_count"></div>
-					<div class="stval" id="stopen_sock_count"></div>
-					<div class="stval" id="stopen_fd_count"></div>
-				</div>
-				<div class="status-cell d-none d-md-flex">
-					<div class="sthdr">rTorrent:</div>
-					<div class="stval" id="rtorrentv"></div>
-				</div>
-				<div class="status-cell d-none d-md-flex">
-					<div class="sthdr"><span uilang>Torrents</span>:</div>
-					<div class="stval" id="viewrows"></div>
-					<div class="stval" id="viewrows_size"></div>
-				</div>
+		<div id="StatusBar" class="d-flex flex-row align-items-stretch justify-content-start">
+			<div id="st_up" class="status-cell">
+				<div class="icon"></div>
+				<div class="sthdr d-none d-lg-block"><span uilang>Speed</span>:</div>
+				<div class="stval" id="stup_speed"></div>
+				<div class="sthdr d-none d-lg-block"><span uilang>limit</span>:</div>
+				<div class="stval d-none d-lg-block" id="stup_limit"></div>
+				<div class="sthdr d-none d-lg-block"><span uilang>Total</span>:</div>
+				<div class="stval d-none d-lg-block" id="stup_total"></div>
 			</div>
-			<div id="plugin-cells" class="status-row d-flex flex-row align-items-stretch flex-wrap-reverse flex-lg-nowrap"></div>
-			<div class="status-row ms-md-auto d-none d-lg-flex flex-lg-row align-items-lg-stretch">
-				<div class="status-cell">
-					<div class="stval" id="servertime"></div>
-				</div>
+			<div id="st_down" class="status-cell">
+				<div class="icon"></div>
+				<div class="sthdr d-none d-lg-block"><span uilang>Speed</span>:</div>
+				<div class="stval" id="stdown_speed"></div>
+				<div class="sthdr d-none d-lg-block"><span uilang>limit</span>:</div>
+				<div class="stval d-none d-lg-block" id="stdown_limit"></div>
+				<div class="sthdr d-none d-lg-block"><span uilang>Total</span>:</div>
+				<div class="stval d-none d-lg-block" id="stdown_total"></div>
+			</div>
+			<div id="st_fd" class="status-cell">
+				<div class="sthdr d-none d-lg-block"><span uilang>Open_label</span>:</div>
+				<div class="stval" id="stopen_http_count"></div>
+				<div class="stval" id="stopen_sock_count"></div>
+				<div class="stval" id="stopen_fd_count"></div>
+			</div>
+			<div class="status-cell d-none d-md-flex">
+				<div class="sthdr">rTorrent:</div>
+				<div class="stval" id="rtorrentv"></div>
+			</div>
+			<div class="status-cell d-none d-md-flex">
+				<div class="sthdr"><span uilang>Torrents</span>:</div>
+				<div class="stval" id="viewrows"></div>
+				<div class="stval" id="viewrows_size"></div>
+			</div>
+			<div class="status-cell ms-auto d-none d-lg-flex">
+				<div class="stval" id="servertime"></div>
 			</div>
 		</div>
 		<div class="graph_tab_grid"></div>

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -395,13 +395,13 @@ rPlugin.prototype.addPaneToStatusbar = function(id, statusCell, no, mobileVisibl
 		mobileVisible || statusCell.addClass("d-none d-md-flex");
 
 		if (
-			!$("#plugin-cells div.status-cell").length || 
-			no >= $("#plugin-cells div.status-cell").length ||
+			!$("#StatusBar div.status-cell").length || 
+			no >= $("#StatusBar div.status-cell").length ||
 			no < 0
 		) {
-			$("#plugin-cells").append(statusCell);
+			statusCell.insertBefore($("div#servertime").parent());
 		} else {
-			statusCell.insertBefore($("#plugin-cells div.status-cell").get(no));
+			statusCell.insertBefore($("#StatusBar div.status-cell").get(no));
 		}
 	}
 	return(this);

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -387,13 +387,22 @@ rPlugin.prototype.removeSeparatorFromToolbar = function(idBefore)
 	$("#mnu_"+idBefore).prev().remove();
 }
 
-rPlugin.prototype.addPaneToStatusbar = function(id,div,no)
+rPlugin.prototype.addPaneToStatusbar = function(id, statusCell, no, mobileVisible)
 {
-        if(this.canChangeStatusBar())
-        {
-		var row = $("#firstStatusRow").get(0);
-		var td = row.insertCell(iv(no));
-		$(td).attr("id",id).addClass("statuscell").append( $(div) );
+	if(this.canChangeStatusBar())
+	{
+		statusCell.attr({id: id}).addClass("status-cell");
+		mobileVisible || statusCell.addClass("d-none d-lg-flex");
+
+		if (
+			!$("#plugin-cells div.status-cell").length || 
+			no >= $("#plugin-cells div.status-cell").length ||
+			no < 0
+		) {
+			$("#plugin-cells").append(statusCell);
+		} else {
+			statusCell.insertBefore($("#plugin-cells div.status-cell").get(no));
+		}
 	}
 	return(this);
 }

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -392,7 +392,7 @@ rPlugin.prototype.addPaneToStatusbar = function(id, statusCell, no, mobileVisibl
 	if(this.canChangeStatusBar())
 	{
 		statusCell.attr({id: id}).addClass("status-cell");
-		mobileVisible || statusCell.addClass("d-none d-lg-flex");
+		mobileVisible || statusCell.addClass("d-none d-md-flex");
 
 		if (
 			!$("#plugin-cells div.status-cell").length || 

--- a/plugins/check_port/check_port.css
+++ b/plugins/check_port/check_port.css
@@ -1,8 +1,16 @@
-#port-ip-text { font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif }
-
-#StatusBar table tr td.pstatus0 { background: url(./images/yellow.png) 5px no-repeat; }
-#StatusBar table tr td.pstatus1 { background: url(./images/red.png) 5px no-repeat; }
-#StatusBar table tr td.pstatus2 { background: url(./images/green.png) 5px no-repeat; }
+#port-pane .icon {
+  background-position: center;
+  background-repeat: no-repeat;
+}
+#port-pane .pstatus0 {
+  background-image: url(./images/yellow.png);
+}
+#port-pane .pstatus1 {
+  background-image: url(./images/red.png);
+}
+#port-pane .pstatus2 {
+  background-image: url(./images/green.png);
+}
 
 @media only screen and (min-width: 730px) {
   #port-holder { height: 19px; line-height: 19px; margin-left: 24px; margin-right: 8px; display: inline-block; }

--- a/plugins/check_port/check_port.css
+++ b/plugins/check_port/check_port.css
@@ -11,11 +11,3 @@
 #port-pane .pstatus2 {
   background-image: url(./images/green.png);
 }
-
-@media only screen and (min-width: 730px) {
-  #port-holder { height: 19px; line-height: 19px; margin-left: 24px; margin-right: 8px; display: inline-block; }
-}
-
-@media only screen and (max-width: 729px) {
-  #port-holder { display: none; }
-}

--- a/plugins/check_port/init.js
+++ b/plugins/check_port/init.js
@@ -3,19 +3,19 @@ plugin.loadMainCSS();
 
 plugin.init = function()
 {
-	$$("port-td").className = "statuscell pstatus0";
+	$$("port-td").className = "status-cell pstatus0";
 	theWebUI.request("?action=initportcheck", [plugin.getPortStatus, plugin]);
 }
 
 plugin.update = function()
 {
-	$$("port-td").className = "statuscell pstatus0";
+	$$("port-td").className = "status-cell pstatus0";
 	theWebUI.request("?action=updateportcheck", [plugin.getPortStatus, plugin]);
 }
 
 plugin.getPortStatus = function(d)
 {
-	$("#port-td").prop("title",d.ip+":"+d.port+": "+theUILang.portStatus[d.status]).get(0).className = "statuscell pstatus"+d.status;
+	$("#port-td").prop("title",d.ip+":"+d.port+": "+theUILang.portStatus[d.status]).get(0).className = "status-cell pstatus"+d.status;
 	$("#port-ip-text").text(d.ip+':'+d.port);
 }
 
@@ -46,8 +46,13 @@ plugin.createPortMenu = function(e)
 
 plugin.onLangLoaded = function()
 {
-	plugin.addPaneToStatusbar("port-td",$("<div>").attr("id","port-holder")
-		.append( $("<span></span>").attr("id","port-ip-text").css({overflow: "visible"}) ).get(0),2);
+	plugin.addPaneToStatusbar(
+		"port-td",
+		$("<div>").append(
+			$("<span>").attr("id","port-ip-text").css({overflow: "visible"}),
+		),
+		-1, true,
+	);
 	if(plugin.canChangeMenu())
 		$("#port-td").addClass("pstatus0").mouseclick( plugin.createPortMenu );
 	plugin.init();

--- a/plugins/check_port/init.js
+++ b/plugins/check_port/init.js
@@ -3,20 +3,22 @@ plugin.loadMainCSS();
 
 plugin.init = function()
 {
-	$$("port-td").className = "status-cell pstatus0";
+	$("port-pane .icon").addClass("pstatus0");
 	theWebUI.request("?action=initportcheck", [plugin.getPortStatus, plugin]);
 }
 
 plugin.update = function()
 {
-	$$("port-td").className = "status-cell pstatus0";
+	$("port-pane .icon").addClass("pstatus0");
 	theWebUI.request("?action=updateportcheck", [plugin.getPortStatus, plugin]);
 }
 
 plugin.getPortStatus = function(d)
 {
-	$("#port-td").prop("title",d.ip+":"+d.port+": "+theUILang.portStatus[d.status]).get(0).className = "status-cell pstatus"+d.status;
-	$("#port-ip-text").text(d.ip+':'+d.port);
+	$("#port-pane").data(d);
+	$("#port-pane").prop("title", "*.*.*.*:* - " + theUILang.portStatus[d.status]);
+	$("#port-pane .icon").removeClass().addClass("icon pstatus" + d.status)
+	$("#port-ip-text").addClass("censored").text("*.*.*.*:*");
 }
 
 rTorrentStub.prototype.initportcheck = function()
@@ -35,8 +37,8 @@ rTorrentStub.prototype.updateportcheck = function()
 
 plugin.createPortMenu = function(e)
 {
-        if(e.which==3)
-        {
+	if(e.which==3)
+	{
 		theContextMenu.clear();
 		theContextMenu.add([ theUILang.checkPort, plugin.update ]);
 		theContextMenu.show();
@@ -44,21 +46,45 @@ plugin.createPortMenu = function(e)
 	return(false);
 }
 
+plugin.toggleIpAddress = function()
+{
+	const ipAddr = $("#port-ip-text");
+	const ipPane = $("#port-pane");
+	if (ipAddr.hasClass("censored")) {
+		ipAddr.text("*.*.*.*:*");
+		ipPane.prop(
+			"title", `${ipAddr.text()} - ${theUILang.portStatus[ipPane.data("status")]} (${theUILang.clickReveal})`
+		);
+	} else {
+		ipAddr.text(ipPane.data("ip") + ":" + ipPane.data("port"));
+		ipPane.prop(
+			"title", `${ipAddr.text()} - ${theUILang.portStatus[ipPane.data("status")]} (${theUILang.clickHide})`
+		);
+	}
+}
+
 plugin.onLangLoaded = function()
 {
 	plugin.addPaneToStatusbar(
-		"port-td",
+		"port-pane",
 		$("<div>").append(
-			$("<span>").attr("id","port-ip-text").css({overflow: "visible"}),
+			$("<div>").addClass("icon"),
+			$("<span>").attr("id","port-ip-text"),
 		),
-		-1, true,
+		-1, false,
 	);
-	if(plugin.canChangeMenu())
-		$("#port-td").addClass("pstatus0").mouseclick( plugin.createPortMenu );
+	if(plugin.canChangeMenu()) {
+		$("#port-pane .icon").addClass("pstatus0");
+		$("#port-pane").mouseclick( plugin.createPortMenu );
+	}
+	$("#port-ip-text").on("click", () => {
+		$("#port-ip-text").toggleClass("censored");
+		this.toggleIpAddress();
+	});
 	plugin.init();
 }
 
 plugin.onRemove = function()
 {
-	plugin.removePaneFromStatusbar("port-td");
+	plugin.removePaneFromStatusbar("port-pane");
 }

--- a/plugins/check_port/init.js
+++ b/plugins/check_port/init.js
@@ -15,10 +15,9 @@ plugin.update = function()
 
 plugin.getPortStatus = function(d)
 {
-	$("#port-pane").data(d);
-	$("#port-pane").prop("title", "*.*.*.*:* - " + theUILang.portStatus[d.status]);
+	$("#port-pane").prop("title", d.ip+":"+d.port+": "+theUILang.portStatus[d.status]);
 	$("#port-pane .icon").removeClass().addClass("icon pstatus" + d.status)
-	$("#port-ip-text").addClass("censored").text("*.*.*.*:*");
+	$("#port-ip-text").text(d.ip+':'+d.port);
 }
 
 rTorrentStub.prototype.initportcheck = function()
@@ -46,41 +45,20 @@ plugin.createPortMenu = function(e)
 	return(false);
 }
 
-plugin.toggleIpAddress = function()
-{
-	const ipAddr = $("#port-ip-text");
-	const ipPane = $("#port-pane");
-	if (ipAddr.hasClass("censored")) {
-		ipAddr.text("*.*.*.*:*");
-		ipPane.prop(
-			"title", `${ipAddr.text()} - ${theUILang.portStatus[ipPane.data("status")]} (${theUILang.clickReveal})`
-		);
-	} else {
-		ipAddr.text(ipPane.data("ip") + ":" + ipPane.data("port"));
-		ipPane.prop(
-			"title", `${ipAddr.text()} - ${theUILang.portStatus[ipPane.data("status")]} (${theUILang.clickHide})`
-		);
-	}
-}
-
 plugin.onLangLoaded = function()
 {
 	plugin.addPaneToStatusbar(
 		"port-pane",
 		$("<div>").append(
 			$("<div>").addClass("icon"),
-			$("<span>").attr("id","port-ip-text"),
+			$("<span>").attr("id","port-ip-text").addClass("d-none d-lg-block"),
 		),
-		-1, false,
+		-1, true,
 	);
 	if(plugin.canChangeMenu()) {
 		$("#port-pane .icon").addClass("pstatus0");
 		$("#port-pane").mouseclick( plugin.createPortMenu );
 	}
-	$("#port-ip-text").on("click", () => {
-		$("#port-ip-text").toggleClass("censored");
-		this.toggleIpAddress();
-	});
 	plugin.init();
 }
 

--- a/plugins/check_port/lang/cs.js
+++ b/plugins/check_port/lang/cs.js
@@ -13,8 +13,5 @@
  				  "Port is closed",
  				  "Port is open"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();
-

--- a/plugins/check_port/lang/da.js
+++ b/plugins/check_port/lang/da.js
@@ -13,7 +13,5 @@
  				  "Port is closed",
  				  "Port is open"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/de.js
+++ b/plugins/check_port/lang/de.js
@@ -13,7 +13,5 @@
  				  "Port ist geschlossen",
  				  "Port ist offen"
  				  ];
- theUILang.clickReveal		= "Klicken zum Anzeigen";
- theUILang.clickHide		= "Klicken zum Ausblenden";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/el.js
+++ b/plugins/check_port/lang/el.js
@@ -13,7 +13,5 @@
  				  "Η θύρα είναι κλειστή",
  				  "Η θύρα είναι ανοικτή"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/en.js
+++ b/plugins/check_port/lang/en.js
@@ -13,7 +13,5 @@
  				  "Port is closed",
  				  "Port is open"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/es.js
+++ b/plugins/check_port/lang/es.js
@@ -13,7 +13,5 @@
  				  "Puerto cerrado",
  				  "Puerto abierto"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/fi.js
+++ b/plugins/check_port/lang/fi.js
@@ -13,7 +13,5 @@
  				  "Port is closed",
  				  "Port is open"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/fr.js
+++ b/plugins/check_port/lang/fr.js
@@ -13,7 +13,5 @@
  				  "Le port est fermé",
  				  "Le port est ouvert"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/hu.js
+++ b/plugins/check_port/lang/hu.js
@@ -13,7 +13,5 @@
  				  "Port zárva van",
  				  "Port nyitva van"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/it.js
+++ b/plugins/check_port/lang/it.js
@@ -14,7 +14,5 @@
  				  "La porta è chiusa",
  				  "La porta è aperta"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/ko.js
+++ b/plugins/check_port/lang/ko.js
@@ -13,7 +13,5 @@
  				  "포트 닫힘",
  				  "포트 열림"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/lv.js
+++ b/plugins/check_port/lang/lv.js
@@ -13,7 +13,5 @@
  				  "Port is closed",
  				  "Port is open"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/nl.js
+++ b/plugins/check_port/lang/nl.js
@@ -13,7 +13,5 @@
  				  "Port is closed",
  				  "Port is open"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/no.js
+++ b/plugins/check_port/lang/no.js
@@ -13,7 +13,5 @@
  				  "Port er lukket",
  				  "Port er åpen"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pl.js
+++ b/plugins/check_port/lang/pl.js
@@ -13,7 +13,5 @@
  				  "Port zamknięty",
  				  "Port otwarty"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pt-br.js
+++ b/plugins/check_port/lang/pt-br.js
@@ -13,7 +13,5 @@
  				  "Port is closed",
  				  "Port is open"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pt-pt.js
+++ b/plugins/check_port/lang/pt-pt.js
@@ -13,7 +13,5 @@
  				  "A porta está fechada",
  				  "A porta está aberta"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/ru.js
+++ b/plugins/check_port/lang/ru.js
@@ -13,7 +13,5 @@
  				  "Порт закрыт",
  				  "Порт открыт"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/sk.js
+++ b/plugins/check_port/lang/sk.js
@@ -13,7 +13,5 @@
  				  "Port is closed",
  				  "Port is open"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/sr.js
+++ b/plugins/check_port/lang/sr.js
@@ -13,7 +13,5 @@
  				  "Port is closed",
  				  "Port is open"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/sv.js
+++ b/plugins/check_port/lang/sv.js
@@ -13,8 +13,5 @@
  				  "Port är stängd",
  				  "Port är öppen"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();
-

--- a/plugins/check_port/lang/tr.js
+++ b/plugins/check_port/lang/tr.js
@@ -14,8 +14,6 @@
  				  "Port kapalı",
  				  "Port açık"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();
 

--- a/plugins/check_port/lang/uk.js
+++ b/plugins/check_port/lang/uk.js
@@ -13,7 +13,5 @@
  				  "Порт закрито",
  				  "Порт відкрито"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/vi.js
+++ b/plugins/check_port/lang/vi.js
@@ -13,7 +13,5 @@
  				  "Cổng bị đóng",
  				  "Cổng đang mở"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/zh-cn.js
+++ b/plugins/check_port/lang/zh-cn.js
@@ -13,8 +13,6 @@
  				  "端口是关闭的",
  				  "端口是开放的"
  				  ];
- theUILang.clickReveal		= "点击显示";
- theUILang.clickHide		= "点击隐藏";
 
 thePlugins.get("check_port").langLoaded();
 

--- a/plugins/check_port/lang/zh-tw.js
+++ b/plugins/check_port/lang/zh-tw.js
@@ -13,7 +13,5 @@
  				  "Port is closed",
  				  "Port is open"
  				  ];
- theUILang.clickReveal		= "Click to Reveal";
- theUILang.clickHide		= "Click to Hide";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/cpuload/cpuload.css
+++ b/plugins/cpuload/cpuload.css
@@ -4,11 +4,27 @@
 #meter-cpu-holder {
   position: relative;
   height: 16px;
-  width: 50px;
 }
 #meter-cpu-text {
   position: absolute;
   width: 100%;
   height: 100%;
   text-align: center;
+}
+
+/* Custom break point settings for responsiveness */
+
+/* X-Small devices (portrait phones, less than 576px) */
+/* No media query for `xs` since this is the default in Bootstrap */
+/* Custom rules for x-small devices */
+#meter-cpu-holder {
+  width: 50px;
+}
+
+/* Large devices (desktops, 992px and up) */
+@media (min-width: 992px) { 
+  /* Custom rules for large devices */
+  #meter-cpu-holder {
+    width: 100px;
+  }
 }

--- a/plugins/cpuload/cpuload.css
+++ b/plugins/cpuload/cpuload.css
@@ -1,3 +1,14 @@
-#meter-cpu-text { position: absolute; left: 40px; top: 0px; font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif }
-#meter-cpu-holder { width: 100px; height: 19px; line-height: 19px; }
-#meter-cpu-td { display: block; width: 16px; height: 16px; background: url(./images/cpu.png) 0px no-repeat; }
+#meter-cpu-pane .icon {
+  background: url(./images/cpu.png) center no-repeat;
+}
+#meter-cpu-holder {
+  position: relative;
+  height: 16px;
+  width: 50px;
+}
+#meter-cpu-text {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+}

--- a/plugins/cpuload/init.js
+++ b/plugins/cpuload/init.js
@@ -39,6 +39,11 @@ class rLoadGraph {
     plot.draw();
   }
 
+	resize() {
+		this.plot.resize();
+		this.draw();
+	}
+
   get data() {
     return [this.load.data];
   }
@@ -99,6 +104,7 @@ class rLoadGraph {
     this.draw();
   }
 }
+
 plugin.check = function () {
   $.ajax({
     type: "GET",
@@ -130,6 +136,9 @@ plugin.init = function () {
     plugin.graph.create($("#meter-cpu-holder"));
     plugin.check();
     plugin.reqId = theRequestManager.addRequest("ttl", null, plugin.check);
+
+		$(window).on("resize", () => plugin.graph.resize());
+
     plugin.markLoaded();
   } else window.setTimeout(arguments.callee, 500);
 };

--- a/plugins/cpuload/init.js
+++ b/plugins/cpuload/init.js
@@ -120,16 +120,15 @@ plugin.init = function () {
     plugin.prgEndColor = new RGBackground("#E69999");
     plugin.addPaneToStatusbar(
       "meter-cpu-pane",
-      $("<table>")
-        .append(
-          $("<tbody>").append(
-            $("<tr>").append(
-              $("<td>").attr("id", "meter-cpu-td"),
-              $("<td>").append($("<div>").attr("id", "meter-cpu-holder"))
-            )
-          )
-        )
-        .get(0)
+      $("<table>").append(
+				$("<tbody>").append(
+					$("<tr>").append(
+						$("<td>").attr("id", "meter-cpu-td"),
+						$("<td>").append($("<div>").attr("id", "meter-cpu-holder"))
+					)
+				)
+			),
+			0, true,
     );
     plugin.graph = new rLoadGraph();
     plugin.graph.create($("#meter-cpu-holder"));

--- a/plugins/cpuload/init.js
+++ b/plugins/cpuload/init.js
@@ -9,15 +9,15 @@ class rLoadGraph {
     this._animationRequestId = 0;
 
     this.plot = $.plot(aOwner, this.data, this.options);
-    aOwner.append($("<div>").attr("id", "meter-cpu-text").css({ top: 0 }));
+    aOwner.append($("<div>").attr("id", "meter-cpu-text"));
   }
 
   update() {
     const plot = this.plot;
     const ph = plot.getPlaceholder();
     const pText = `${this.percent}%`;
-    ph.attr("title", pText);
-    $($$("meter-cpu-text")).text(pText);
+    ph.parent().attr("title", pText);
+    $("#meter-cpu-text").text(pText);
 
     const opts = this.options;
     for (const [name, axis] of Object.entries(plot.getAxes())) {
@@ -120,13 +120,9 @@ plugin.init = function () {
     plugin.prgEndColor = new RGBackground("#E69999");
     plugin.addPaneToStatusbar(
       "meter-cpu-pane",
-      $("<table>").append(
-				$("<tbody>").append(
-					$("<tr>").append(
-						$("<td>").attr("id", "meter-cpu-td"),
-						$("<td>").append($("<div>").attr("id", "meter-cpu-holder"))
-					)
-				)
+      $("<div>").append(
+				$("<div>").addClass("icon"),
+				$("<div>").attr({id: "meter-cpu-holder"}),
 			),
 			0, true,
     );

--- a/plugins/diskspace/diskspace.css
+++ b/plugins/diskspace/diskspace.css
@@ -1,4 +1,37 @@
-#meter-disk-value { float: left; border: 1px inset #BBBBBB; border-bottom: none;}
-#meter-disk-text { position: relative; text-align: left; float: left; width: 0px; height: 0px; overflow: visible; left: 40%; font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif; z-index: 1; }
-#meter-disk-holder { width: 100px; height: 18px; line-height: 18px; margin-left: 25px; }
-#meter-disk-td { background: url(./images/disk.png) 5px no-repeat; }
+#meter-disk-pane .icon {
+  background: url(./images/disk.png) center no-repeat;
+}
+#meter-disk-holder {
+  border: inset 1px #BBBBBB;
+  box-sizing: border-box;
+  position: relative;
+  height: 18px;
+}
+#meter-disk-value {
+  box-sizing: border-box;
+  height: 100%;
+}
+#meter-disk-text {
+  position: absolute;
+  top: 0;
+  text-align: center;
+  width: 100%;
+  height: 100%;
+}
+
+/* Custom break point settings for responsiveness */
+
+/* X-Small devices (portrait phones, less than 576px) */
+/* No media query for `xs` since this is the default in Bootstrap */
+/* Custom rules for x-small devices */
+#meter-disk-holder {
+  width: 50px;
+}
+
+/* Large devices (desktops, 992px and up) */
+@media (min-width: 992px) { 
+  /* Custom rules for large devices */
+  #meter-disk-holder {
+    width: 100px;
+  }
+}

--- a/plugins/diskspace/init.js
+++ b/plugins/diskspace/init.js
@@ -9,7 +9,7 @@ plugin.setValue = function( full, free )
 	$("#meter-disk-value").width( percent+"%" ).css( { "background-color": (new RGBackground()).setGradient(this.prgStartColor,this.prgEndColor,percent).getColor(),
 		visibility: !percent ? "hidden" : "visible" } );
 	$("#meter-disk-text").text(percent+'%');
-	$("#meter-disk-td").prop("title", theConverter.bytes(free)+"/"+theConverter.bytes(full));
+	$("#meter-disk-pane").prop("title", theConverter.bytes(free)+"/"+theConverter.bytes(full));
 
 	if($.noty && plugin.allStuffLoaded)
 	{
@@ -37,10 +37,13 @@ plugin.init = function()
 		plugin.prgStartColor = new RGBackground("#99D699");
 		plugin.prgEndColor = new RGBackground("#E69999");
 		plugin.addPaneToStatusbar(
-			"meter-disk-td",
-			$("<div>").attr("id","meter-disk-holder").append(
-				$("<span>").attr("id","meter-disk-text").css({overflow: "visible"}),
-				$("<div>").attr("id","meter-disk-value").css({ visibility: "hidden", float: "left" }).width(0).html("&nbsp;"),
+			"meter-disk-pane",
+			$("<div>").append(
+				$("<div>").addClass("icon"),
+				$("<div>").attr({id: "meter-disk-holder"}).append(
+					$("<div>").attr({id: "meter-disk-value"}).width(0),
+					$("<div>").attr({id: "meter-disk-text"}),
+				),
 			),
 			0, true,
 		);
@@ -75,7 +78,7 @@ plugin.init = function()
 
 plugin.onRemove = function()
 {
-	plugin.removePaneFromStatusbar("meter-disk-td");
+	plugin.removePaneFromStatusbar("meter-disk-pane");
 	if(plugin.diskTimeout)
 	{
 		window.clearTimeout(plugin.diskTimeout);

--- a/plugins/diskspace/init.js
+++ b/plugins/diskspace/init.js
@@ -36,9 +36,14 @@ plugin.init = function()
 	{
 		plugin.prgStartColor = new RGBackground("#99D699");
 		plugin.prgEndColor = new RGBackground("#E69999");
-		plugin.addPaneToStatusbar( "meter-disk-td", $("<div>").attr("id","meter-disk-holder").
-			append( $("<span></span>").attr("id","meter-disk-text").css({overflow: "visible"}) ).
-			append( $("<div>").attr("id","meter-disk-value").css({ visibility: "hidden", float: "left" }).width(0).html("&nbsp;") ).get(0) );
+		plugin.addPaneToStatusbar(
+			"meter-disk-td",
+			$("<div>").attr("id","meter-disk-holder").append(
+				$("<span>").attr("id","meter-disk-text").css({overflow: "visible"}),
+				$("<div>").attr("id","meter-disk-value").css({ visibility: "hidden", float: "left" }).width(0).html("&nbsp;"),
+			),
+			0, true,
+		);
 
 		plugin.check = function()
 		{

--- a/plugins/theme/themes/DarkBetter/plugins.css
+++ b/plugins/theme/themes/DarkBetter/plugins.css
@@ -13,12 +13,6 @@ div#dlg_unpack div.dlg-header, div#cadd div.dlg-header { background: transparent
 
 #exscategory {margin-top: 4px}
 
-#port-holder {
-    height: 22px !important;
-    line-height: 22px !important;
-    margin-left: 22px !important;
-}
-
 /* labels */
 #lbl_nlb {content:url(./images/no_label.svg)}
 


### PR DESCRIPTION
Made a responsive status bar according to previous discussion in this [PR](https://github.com/Novik/ruTorrent/pull/2687).
The CPU and disk usage meters and the port status indicator haven't been curated yet, and will be in the comming commits. Below are some screenshots:

1. Mobile screens (smaller than 768px):
![20240710225937](https://github.com/Novik/ruTorrent/assets/26022962/f14bb452-4553-420f-9b37-8012685f9b7b)

With more potential status bar cells added by plugins, showing infinite growing lines upwards (simulated now as a test)
![20240710231855](https://github.com/Novik/ruTorrent/assets/26022962/c27dd62b-fbdd-4f71-aaed-8394aba3ee77)

2. Middle-sized screens (between 768px and 992px):
Some unnecessary information is hidden like speed limit, total traffic, system time, etc, but most cells are still displayed.
![20240710225921](https://github.com/Novik/ruTorrent/assets/26022962/10ebfc43-6cea-4e58-941b-7d23e106b826)

4. Large screens (992px and up):
Showing everything that's available, pushing system time to the right end.
![20240710225854](https://github.com/Novik/ruTorrent/assets/26022962/a8afdbb6-6d18-4409-a6b0-6c700833e21a)
