### PR TITLE
Apply flex layout to RSS Rule Manager dialog

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,7 +1,27 @@
 * { -webkit-touch-callout: none; -webkit-tap-highlight-color: rgba(0,0,0,1.0); }
 html, body {border: 0; margin: 0; padding: 0; cursor: default; overflow: hidden; background-color: #F5F5F5; height: 100%;}
 html, body, input,select,button,textarea{font-family: Tahoma, Arial, Helvetica, sans-serif; font-size: 11px;}
-input[type=file] {border: solid 1px #676774; border-radius: 3px; width: 100%;}
+div {
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
+fieldset {
+  border: 1px solid #D0D0D0;
+  border-radius:6px;
+  margin: 0.25rem 0;
+  padding: 0.25rem 0.5rem;
+}
+select, input[type=file], input[type=text] {
+  border: 1px solid #B0B0B0;
+  border-radius: 3px;
+  margin: 0.25rem 0;
+  padding: 0.25rem;
+  width: 100%;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
 .light-theme { color-scheme: light; }
 .dark-theme { color-scheme: dark; }
 :root {
@@ -97,18 +117,16 @@ div#t div#plugins {background: transparent url(../images/plugin.png) no-repeat 0
 div#t a#mnu_go {margin: 3px 0 0 0; padding: 3px}
 div#t #ind {margin-top: 2px; background: transparent url(../images/ajax-loader.gif) no-repeat 0px center; width: 32px; margin-right: 2px; line-height: 26px; cursor: default; }
 
-input.Textbox, button, input.Button, select {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px}
+input.Textbox, button, input.Button {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px}
 Input.TextboxShort {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 50px}
 Input.TextboxMid {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 110px}
 Input.TextboxLarge {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 220px}
-Input.TextboxVShort {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 30px}
 button, input.Button {padding: 1px 10px; background: #F0F0F0 url(../images/h.gif) repeat-x center bottom; width: 80px; height: 19px; border: 1px solid #A0A0A0; cursor: pointer }
 button[disabled],input.Button[disabled] { opacity: 0.3; cursor: default }
 button:not([disabled]):hover, input.Button:not([disabled]):hover { background-color: #F5F5F5; }
 button:not([disabled]):hover:active, input.Button:not([disabled]):hover:active { background-color: #FAFAFA; }
 #pview_save_view_button { align-self: center; width: 38px; height: 19px; padding: 0px; line-height: 2px; font-size: 19px;  }
 
-select {margin-top: 5px}
 a {font-size: 11px;  color: #686868}
 table#maincont {margin: 5px 0 0 0; min-width: 600px;}
 table#maincont td.uicell {vertical-align: top; padding: 0 }
@@ -164,8 +182,6 @@ div.algnright {text-align: right; clear: right}
 .ie .lm li a {margin: 0 0 0 -5px; padding: 0}
 .stg_con { display: none; float: right; position: relative; width: 450px; height: 500px; margin: 4px; background-color: var(--settings-background-color); }
 .ie9 .stg_con {position: static}
-fieldset {margin: 4px}
-* > fieldset {border: 1px solid #D0D0D0; -moz-border-radius: 6px; -webkit-border-radius:6px; border-radius:6px;}
 .stg_con table {width: 100%}
 .stg_con td {font-weight: normal; height: 19px}
 .stg_con td.alr {text-align: right}

--- a/plugins/extratio/extratio.css
+++ b/plugins/extratio/extratio.css
@@ -3,7 +3,6 @@ div#dlgEditRatioRules div.dlg-header {background-image: url(../../images/setting
 div#dlgEditRatioRules .container {margin: 0.25rem; padding: 0; width: auto;}
 div#dlgEditRatioRules .row {margin: 0 0 0.25rem 0; padding: 0;}
 div#dlgEditRatioRules .row > div {padding: 0 0.25rem; margin-bottom: 0.1rem;}
-div#dlgEditRatioRules fieldset {margin: 0 0 0.25rem 0; padding: 0.25rem 0.5rem;}
 
 ul#rlsul {margin: 0.25rem; padding: 0.25rem; list-style: none; white-space: nowrap;}
 ul#rlsul > li {margin: 0.2rem 0; display: flex; flex-direction: row;}

--- a/plugins/extsearch/extsearch.css
+++ b/plugins/extsearch/extsearch.css
@@ -4,7 +4,7 @@ div#tegLoadTorrents div.dlg-header {background-image: url(../../images/world.gif
 div#tegLoadTorrents div.content {margin: 5px; padding: 5px; line-height: 16px}
 div#tegLoadTorrents div.content input {margin-top: 0px}
 div#tegLoadTorrents label {width: 75px; display: block; float: left; margin-top: 0px; margin-bottom: 5px; margin-left: 5px; }
-div#tegLoadTorrents input, select {margin-top: 2px; margin-bottom: 2px;}
+div#tegLoadTorrents input, div#tegLoadTorrents select {margin-top: 2px; margin-bottom: 2px;}
 div#tegLoadTorrents br {clear: left; line-height: 0}
 
 #st_extsearch { overflow: auto }

--- a/plugins/rss/rss.css
+++ b/plugins/rss/rss.css
@@ -6,7 +6,7 @@ div#dlgAddRSS div.content {width: 330px; margin: 5px; padding: 5px; line-height:
 div#dlgAddRSS div.content input {margin-top: 5px}
 div#dlgAddRSS label {width: 70px; display: block; float: left; margin-top: 5px; margin-bottom: 5px; margin-left: 10px; }
 div#dlgAddRSS label#nomargin { margin-top: 0px; margin-bottom: 0px; }
-div#dlgAddRSS input, select {margin-top: 5px; margin-bottom: 5px;}
+div#dlgAddRSS input, div#dlgAddRSS select {margin-top: 5px; margin-bottom: 5px;}
 div#dlgAddRSS br {clear: left; line-height: 0}
 
 div#dlgEditRSS {width: 355px; height: 132px}
@@ -15,7 +15,7 @@ div#dlgEditRSS div.content {width: 330px; margin: 5px; padding: 5px; line-height
 div#dlgEditRSS div.content input {margin-top: 5px}
 div#dlgEditRSS label {width: 70px; display: block; float: left; margin-top: 5px; margin-bottom: 5px; margin-left: 10px; }
 div#dlgEditRSS label#nomargin { margin-top: 0px; margin-bottom: 0px; }
-div#dlgEditRSS input, select {margin-top: 5px; margin-bottom: 5px;}
+div#dlgEditRSS input, div#dlgEditRSS select {margin-top: 5px; margin-bottom: 5px;}
 div#dlgEditRSS br {clear: left; line-height: 0}
 
 div#dlgLoadTorrents #RSSBtn {width: 30px;}
@@ -24,7 +24,7 @@ div#dlgLoadTorrents div.dlg-header {background-image: url(../../images/world.gif
 div#dlgLoadTorrents div.content {margin: 5px; padding: 5px; line-height: 16px}
 div#dlgLoadTorrents div.content input {margin-top: 0px}
 div#dlgLoadTorrents label {width: 75px; display: block; float: left; margin-top: 0px; margin-bottom: 5px; margin-left: 5px; }
-div#dlgLoadTorrents input, select {margin-top: 2px; margin-bottom: 2px;}
+div#dlgLoadTorrents input, div#dlgLoadTorrents select {margin-top: 2px; margin-bottom: 2px;}
 div#dlgLoadTorrents br {clear: left; line-height: 0}
 
 div#dlgEditFilters {width: 690px; height: 360px; font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif; overflow: visible}

--- a/plugins/rssurlrewrite/init.js
+++ b/plugins/rssurlrewrite/init.js
@@ -260,43 +260,73 @@ plugin.onLangLoaded = function()
 {
 	this.registerTopMenu(5);
 	theDialogManager.make( "dlgEditRules", theUILang.rssRulesManager,
-		"<div class='fxcaret'>"+
-			"<div class='lfc_rur'>"+
-				"<div class='lf_rur' id='ruleList'>"+
-					"<ul id='rlslist'></ul>"+
-				"</div>"+
-				"<div id='RLSchk_buttons'>"+
-					"<input type='button' class='Button' value='"+theUILang.rssAddRule+"' onclick='theWebUI.addNewRule(); return(false);'/>"+
-					"<input type='button' class='Button' value='"+theUILang.rssDelRule+"' onclick='theWebUI.deleteCurrentRule(); return(false);'/>"+
-					"<input type='button' id='chkRuleBtn' class='Button' value='"+theUILang.rssCheckRule+"' onclick='theWebUI.checkCurrentRule(); return(false);'/>"+
-				"</div>"+
-			"</div>"+
-			"<div class='rf_rur' id='ruleProps'>"+
-				"<fieldset id='rulePropsFieldSet'>"+
-					"<legend>"+theUILang.rssRulesLegend+"</legend>"+
-					"<select id='RLS_src'>"+
-						"<option value='1'>"+theUILang.rssSrcHref+"</option>"+
-						"<option value='0'>"+theUILang.rssSrcGuid+"</option>"+
-					"</select><br/>"+
-					"<input type='text' id='RLS_pattern' class='TextboxLarge'/><br/>"+
-					"<select id='RLS_dst'>"+
-						"<option value='1'>"+theUILang.rssDstHref+"</option>"+
-						"<option value='0'>"+theUILang.rssDstGuid+"</option>"+
-					"</select><br/>"+
-					"<input type='text' id='RLS_replacement' class='TextboxLarge'/><br/>"+
-					"<label>"+theUILang.rssStatus+":</label><select id='RLS_rss'><option value=''>"+theUILang.allFeeds+"</option></select>"+
-				"</fieldset>"+
-				"<fieldset id='rulePropsFieldSet'>"+
-					"<legend>"+theUILang.rssRulesDebug+"</legend>"+
-					"<label>"+theUILang.rssTestString+":</label><input type='text' id='RLS_test' class='TextboxLarge' value='http://www.mininova.org/get/12345'/><br/>"+
-					"<label>"+theUILang.rssTestResult+":</label><input type='text' id='RLS_result' class='TextboxLarge'/><br/>"+
-				"</fieldset>"+
-			"</div>"+
-		"</div>"+
-		"<div id='RLS_buttons' class='aright buttons-list'>"+
-			"<input type='button' class='OK Button' value='"+theUILang.ok+"' onclick='theDialogManager.hide(\"dlgEditRules\");theWebUI.setRules();return(false);'/>"+
-			"<input type='button' class='Cancel Button' value='"+theUILang.Cancel+"'/>"+
-		"</div>");
+		$("<div>").addClass("cont fxcaret").append(
+			$("<div>").addClass("row").append(
+				$("<div>").addClass("col-md-6 d-flex flex-column align-items-center").append(
+					$("<div>").addClass("lf_rur align-self-stretch").append(
+						$("<ul>").attr({id: "rlslist"}),
+					),
+					$("<div>").addClass("buttons-group-row").append(
+						$("<button>").attr({onclick: "theWebUI.addNewRule(); return(false);"}).text(theUILang.rssAddRule),
+						$("<button>").attr({onclick: "theWebUI.deleteCurrentRule(); return(false);"}).text(theUILang.rssDelRule),
+						$("<button>").attr({id: "chkRuleBtn", onclick: "theWebUI.checkCurrentRule(); return(false);"}).text(theUILang.rssCheckRule),
+					),
+				),
+				$("<div>").addClass("rf_rur col-md-6 d-flex flex-column align-items-stretch").append(
+					$("<fieldset>").append(
+						$("<legend>").text(theUILang.rssRulesLegend),
+						$("<div>").addClass("d-flex flex-column align-items-stretch").append(
+							$("<select>").attr({id: "RLS_src"}).append(
+								$("<option>").val(1).text(theUILang.rssSrcHref),
+								$("<option>").val(0).text(theUILang.rssSrcGuid),
+							),
+							$("<input>").attr({type: "text", id: "RLS_pattern"}),
+							$("<select>").attr({id: "RLS_dst"}).append(
+								$("<option>").val(1).text(theUILang.rssDstHref),
+								$("<option>").val(0).text(theUILang.rssDstGuid),
+							),
+							$("<input>").attr({type: "text", id: "RLS_replacement"}),
+							$("<div>").addClass("row align-items-center").append(
+								$("<div>").addClass("p-0 pe-2 col-md-3 d-flex justify-content-start justify-content-md-end").append(
+									$("<label>").attr({for: "RLS_rss"}).text(theUILang.rssStatus + ": "),
+								),
+								$("<div>").addClass("p-0 col-md-9 d-flex").append(
+									$("<select>").attr({id: "RLS_rss"}).append(
+										$("<option>").val("").text(theUILang.allFeeds),
+									),
+								),
+							),
+						),
+					),
+					$("<fieldset>").append(
+						$("<legend>").text(theUILang.rssRulesDebug),
+						$("<div>").addClass("row align-items-center").append(
+							$("<div>").addClass("p-0 pe-2 col-md-3 d-flex justify-content-start justify-content-md-end").append(
+								$("<label>").attr({for: "RLS_test"}).text(theUILang.rssTestString + ": "),
+							),
+							$("<div>").addClass("p-0 col-md-9 d-flex").append(
+								$("<input>").attr(
+									{type: "text", id: "RLS_test", placeholder: "http://www.mininova.org/get/12345"}
+								),
+							),
+						),
+						$("<div>").addClass("row align-items-center").append(
+							$("<div>").addClass("p-0 pe-2 col-md-3 d-flex justify-content-start justify-content-md-end").append(
+								$("<label>").attr({for: "RLS_result"}).text(theUILang.rssTestResult + ":"),
+							),
+							$("<div>").addClass("p-0 col-md-9 d-flex").append(
+								$("<input>").attr({type: "text", id: "RLS_result", readonly: ""}),
+							),
+						),
+					),
+				),
+			),
+		)[0].outerHTML + 
+		$("<div>").addClass("buttons-list").append(
+			$("<button>").addClass("OK").text(theUILang.ok).on("click", () => {theDialogManager.hide("dlgEditRules"); theWebUI.setRules()}),
+			$("<button>").addClass("Cancel").text(theUILang.Cancel),
+		)[0].outerHTML,
+	);
 };
 
 plugin.onRemove = function()

--- a/plugins/rssurlrewrite/rssurlrewrite.css
+++ b/plugins/rssurlrewrite/rssurlrewrite.css
@@ -1,28 +1,92 @@
-div#dlgEditRules {width: 610px; height: 320px; font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif; overflow: visible}
 div#dlgEditRules div.dlg-header {background-image: url(./images/rss.gif)}
+div#dlgEditRules .row {
+  margin: 0 0 0.25rem 0;
+  padding: 0;
+}
+div#dlgEditRules .row > div {
+  padding: 0 0.25rem;
+  margin-bottom: 0.1rem;
+}
 
-.lfc_rur {float: left; }
-.lf_rur {width: 245px; height: 200px; margin: 5px; margin-right: 0; padding: 5px; background-color: #FFFFFF; border: 1px solid #D0D0D0; overflow: auto}
-.lf_rur ul {width: 100%; margin: 2px; padding: 0; list-style-position: inside; list-style: none; white-space: nowrap}
-.lf_rur li input { margin: 0 5px 0 0; padding: 4px; } 
-.lf_rur li {margin: 0 ; padding: 0}
-.lf_rur li input.TextboxFocus { width: 85%; background-color: #CFDEEF; }
-.lf_rur li input.TextboxNormal { width: 85%; background-color: #FFFFFF }
-.lf_rur li input { border: 0; font-size: 11px; font-family: Tahoma, Verdana, Arial, Helvetica, sans-serif; cursor: default; font-weight: bold; }
-div#RLSchk_buttons {padding-top: 5px; width: 260px; text-align:center}
-.rf_rur fieldset {margin: 3px; }
-.rf_rur {float: right; margin: 4px; background-color: #FAFAFA}
-.rf_rur label {width: 75px; display: block; float: left; margin-top: 5px; margin-bottom: 5px; margin-left: 10px; }
-.rf_rur br {clear: left; line-height: 0}
-.rf_rur select {width: 305px; margin: 3px; }
-.rf_rur input.TextboxLarge {margin: 3px; width: 300px;}
-.rf_rur select#RLS_rss { width: 220px;}
-.rf_rur input#RLS_test { width: 215px;}
-.rf_rur input#RLS_result { width: 215px;}
-
-.rf_rur input.Button {margin: 3px;}
-div#RLS_buttons {clear: both}
+.lf_rur {
+  background-color: #FFFFFF; 
+  border: 1px solid #D0D0D0;
+  border-radius: 3px;
+  flex: 1 0 160px;
+  overflow-y: auto;
+}
+.lf_rur ul {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  margin: 0.25rem;
+  padding: 0.15rem;
+  list-style-position: inside;
+  list-style: none;
+  white-space: nowrap;
+}
+.lf_rur li {
+  display: flex;
+  flex-direction: row;
+  margin: 0;
+  padding: 0;
+}
+.lf_rur input[type=text] {
+  flex: 1 1 auto;
+}
+.lf_rur input.TextboxFocus {background-color: #CFDEEF;}
+.lf_rur input.TextboxNormal {background-color: #FFFFFF;}
 
 #chkRuleBtn {width: 50px}
 
+/* Custom break point settings for responsiveness */
 
+/* X-Small devices (portrait phones, less than 576px) */
+/* No media query for `xs` since this is the default in Bootstrap */
+/* Custom rules for medium devices */
+div#dlgEditRules {max-width: 95vw;}
+div#dlgEditRules .buttons-list {
+  margin: 0.5rem 0.25rem;
+  gap: 0.25rem;
+  display: flex;
+  flex-direction: column;
+}
+#rlslist {
+  max-height: 130px;
+}
+
+/* Small devices (landscape phones, 576px and up) */
+@media (min-width: 576px) { 
+  /* Custom rules for small devices */
+}
+
+/* Medium devices (tablets, 768px and up) */
+@media (min-width: 768px) { 
+  /* Custom rules for medium devices */
+  div#dlgEditRules {min-width: 600px;}
+  div#dlgEditRules .buttons-list {
+    margin: 1rem 0.5rem;
+    gap: 0.25rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: end;
+  }
+  #rlslist {
+    max-height: 260px;
+  }
+}
+
+/* Large devices (desktops, 992px and up) */
+@media (min-width: 992px) { 
+  /* Custom rules for large devices */
+}
+
+/* X-Large devices (large desktops, 1200px and up) */
+@media (min-width: 1200px) { 
+  /* Custom rules for x-large devices */
+}
+
+/* XX-Large devices (larger desktops, 1400px and up) */
+@media (min-width: 1400px) { 
+  /* Custom rules for xx-large devices */
+}

--- a/plugins/theme/themes/MaterialDesign/plugins.css
+++ b/plugins/theme/themes/MaterialDesign/plugins.css
@@ -74,7 +74,6 @@ div#dlgAddRSS-header, div#dlgAddRSS div.dlg-header { background: #181818 url(./i
 div#dlgEditRules-header,#dlgEditRatioRules-header,div#dlgEditRules div.dlg-header { background:#181818 url(./images/dlg-toolbars.gif) no-repeat 0 -72px !important; border-bottom: 1px solid #333333; text-shadow: 0px -1px 0px #000; }
 div#dlgEditRules,div#dlgEditRatioRules { width:600px; }
 
-.lfc_rru, .lfc_rur { width:250px;}
 .lf_rru, .lf_rur { border:none; border-radius:2px; background-color:#2D2D2D;}
 
 #exratio_buttons1 input.Button {margin:0px 3px;}


### PR DESCRIPTION
This is basically a copy of the previous refined Ratio Rules dialog. Besides, I set some universal rules for general HTML elements like `div`, `input`, and `select`, instead of defining the display styles in each and every plugin separately. 

1. Desktop screens (equal to or wider than 768px):
![20240712182719](https://github.com/user-attachments/assets/6e955445-d971-4515-a2ba-32ab2005736c)

2. Mobile screens (smaller than 768px):
![20240712182547](https://github.com/user-attachments/assets/20fa0f37-909e-4f8f-939a-3800d8de57b6)
