### PR TITLE
Apply flex layout to save-to dialog window

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -22,6 +22,28 @@ select, input[type=file], input[type=text] {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
 }
+button, input[type=button], .Button {
+  border: 1px solid #B0B0B0;
+  border-radius: 3px;
+  padding: 1px 10px;
+  background: #F0F0F0 url(../images/h.gif) repeat-x center bottom;
+  width: 80px;
+  cursor: pointer;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
+button:disabled, input[type=button]:disabled, a.Button:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+button:not(:disabled):hover, input[type=button]:not(:disabled):hover, a.Button:not(:disabled):hover {
+  background-color: #F5F5F5;
+}
+button:not(:disabled):active, input[type=button]:not(:disabled):active, a.Button:not(:disabled):active {
+  background-color: #FAFAFA;
+}
+
 .light-theme { color-scheme: light; }
 .dark-theme { color-scheme: dark; }
 :root {
@@ -117,14 +139,10 @@ div#t div#plugins {background: transparent url(../images/plugin.png) no-repeat 0
 div#t a#mnu_go {margin: 3px 0 0 0; padding: 3px}
 div#t #ind {margin-top: 2px; background: transparent url(../images/ajax-loader.gif) no-repeat 0px center; width: 32px; margin-right: 2px; line-height: 26px; cursor: default; }
 
-input.Textbox, button, input.Button {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px}
+input.Textbox {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px}
 Input.TextboxShort {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 50px}
 Input.TextboxMid {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 110px}
 Input.TextboxLarge {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; width: 220px}
-button, input.Button {padding: 1px 10px; background: #F0F0F0 url(../images/h.gif) repeat-x center bottom; width: 80px; height: 19px; border: 1px solid #A0A0A0; cursor: pointer }
-button[disabled],input.Button[disabled] { opacity: 0.3; cursor: default }
-button:not([disabled]):hover, input.Button:not([disabled]):hover { background-color: #F5F5F5; }
-button:not([disabled]):hover:active, input.Button:not([disabled]):hover:active { background-color: #FAFAFA; }
 #pview_save_view_button { align-self: center; width: 38px; height: 19px; padding: 0px; line-height: 2px; font-size: 19px;  }
 
 a {font-size: 11px;  color: #686868}

--- a/plugins/_getdir/_getdir.css
+++ b/plugins/_getdir/_getdir.css
@@ -17,4 +17,8 @@ body {background-color: window; color: windowtext; border: 0px; margin: 0px; pad
 .rmenuitem { color: windowtext; }
 .rmenuitemselected { color: highlighttext; background-color: highlight; }
 
-input.browseButton {width:30px; margin-left: 0.25rem; margin-right: 0.25rem;}
+input.browseButton, button.browseButton {
+  width:30px;
+  margin-left: 0.25rem;
+  margin-right: 0.25rem;
+}

--- a/plugins/_getdir/init.js
+++ b/plugins/_getdir/init.js
@@ -8,12 +8,22 @@ theWebUI.rDirBrowser = function( dlg_id, edit_id, btn_id, frame_id, withFiles, h
 	if(!frame_id)
 		frame_id = edit_id+"_frame";
 	var self = this;
-	this.btn.val("...").on( "click", function() { return(self.toggle()); } ).addClass("browseButton");
+	this.setButtonText("...")
+	this.btn.on( "click", function() { return(self.toggle()); } ).addClass("browseButton");
 	this.edit.prop("autocomplete", "off").on( browser.isIE ? "focusin" : "focus", function() { return(self.hide()); } ).addClass("browseEdit");
 	this.frame = $("<iframe>").attr( {id: frame_id, src: ""} ).css({position: "absolute", width: 0, visibility: "hidden"}).addClass("browseFrame");
 	this.dlg_id = dlg_id;
 	$('#'+dlg_id).append( this.frame );
 	this.height = !height ? 150 : height
+}
+
+theWebUI.rDirBrowser.prototype.setButtonText = function(buttonText)
+{
+	if(this.btn[0].tagName === "INPUT") {
+		this.btn.val(buttonText);
+	} else if(this.btn[0].tagName === "BUTTON") {
+		this.btn.text(buttonText);
+	}
 }
 
 theWebUI.rDirBrowser.prototype.show = function()
@@ -39,7 +49,7 @@ theWebUI.rDirBrowser.prototype.show = function()
 			width: this.edit.width()+2,
 			height: this.height
 		}).show();
-	this.btn.val("X");
+	this.setButtonText("X");
 	theDialogManager.bringToTop(this.frame.attr("id"));
 	this.edit.prop( "read-only", true );
 	return(false);
@@ -47,9 +57,9 @@ theWebUI.rDirBrowser.prototype.show = function()
 
 theWebUI.rDirBrowser.prototype.hide = function()
 {
-        if(this.frame.css("visibility")!="hidden")
-        {
-	        this.btn.val("...");
+	if(this.frame.css("visibility")!="hidden")
+	{
+		this.setButtonText("...");
 		this.edit.prop( "read-only", false );
 		this.frame.css( { visibility: "hidden" } );
 		this.frame.hide().css( {width: 0} );	

--- a/plugins/datadir/datadir.css
+++ b/plugins/datadir/datadir.css
@@ -1,13 +1,35 @@
-div#dlg_datadir {width: 450px; height: 193px; overflow: visible}
-
-div#dlg_datadir fieldset div {line-height: 16px}
-div#dlg_datadir fieldset div.props-spacer {width: 90%; float: left}
-
-div#dlg_datadir label {width: 120px; vertical-align: middle; margin-top: 5px; margin-bottom: 5px; margin-left: 10px; }
-div#dlg_datadir input {vertical-align: middle; margin-top: 5px; margin-bottom: 5px;}
-
-div#dlg_datadir #edit_datadir {width: 290px}
-
-div#dlg_datadir br {clear: left; line-height: 0}
-
 div#dlg_datadir div.dlg-header {background-image: url(../../images/settings.gif)}
+div#dlg_datadir div.row {row-gap: 1.5rem;}
+
+/* Custom break point settings for responsiveness */
+
+/* X-Small devices (portrait phones, less than 576px) */
+/* No media query for `xs` since this is the default in Bootstrap */
+/* Custom rules for medium devices */
+div#dlg_datadir {max-width: 95vw;}
+
+/* Small devices (landscape phones, 576px and up) */
+@media (min-width: 576px) { 
+  /* Custom rules for small devices */
+}
+
+/* Medium devices (tablets, 768px and up) */
+@media (min-width: 768px) { 
+  /* Custom rules for medium devices */
+  div#dlg_datadir {max-width: 600px;}
+}
+
+/* Large devices (desktops, 992px and up) */
+@media (min-width: 992px) { 
+  /* Custom rules for large devices */
+}
+
+/* X-Large devices (large desktops, 1200px and up) */
+@media (min-width: 1200px) { 
+  /* Custom rules for x-large devices */
+}
+
+/* XX-Large devices (larger desktops, 1400px and up) */
+@media (min-width: 1400px) { 
+  /* Custom rules for xx-large devices */
+}

--- a/plugins/datadir/init.js
+++ b/plugins/datadir/init.js
@@ -136,33 +136,41 @@ rTorrentStub.prototype.setdatadir = function()
 
 plugin.onLangLoaded = function()
 {
-	theDialogManager.make( 'dlg_datadir', theUILang.datadirDlgCaption,
-		"<div class='content fxcaret'>" +
-			"<fieldset>" +
-				"<label id='lbl_datadir' for='edit_datadir'>" + theUILang.DataDir + ": </label>" +
-				"<input type='text' id='edit_datadir' class='TextboxLarge' maxlength='200'/>" +
-				"<input type='button' id='btn_datadir_browse' class='Button' value='...' />" +
-				"<div class='checkbox'>" +
-					"<input type='checkbox' checked id='move_not_add_path'/>"+
-					"<label for='move_not_add_path'>"+ theUILang.Dont_add_tname +"</label>"+
-				"</div>" +
-				"<div class='checkbox'>" +
-					"<input type='checkbox' checked id='move_datafiles'/>"+
-					"<label for='move_datafiles'>"+ theUILang.DataDirMove +"</label>"+
-				"</div>" +
-				"<div class='checkbox'>" +
-					"<input type='checkbox' checked id='move_fastresume'/>"+
-					"<label for='move_fastresume'>"+ theUILang.doFastResume +"</label>"+
-				"</div>" +
-			"</fieldset>" +
-		"</div>"+
-		"<div class='aright buttons-list'>" +
-			"<input type='button' value='" + theUILang.ok + "' class='OK Button' id='btn_datadir_ok'" +
-				" onclick='theWebUI.sendDataDir(); return(false);' />" +
-			"<input type='button' value='"+ theUILang.Cancel + "' class='Cancel Button'/>" +
-		"</div><br/>" +
-		"<div />", 
-		true);
+	theDialogManager.make('dlg_datadir', theUILang.datadirDlgCaption,
+		$("<div>").addClass("cont fxcaret").append(
+			$("<fieldset>").append(
+				$("<legend>").text(theUILang.DataDir),
+				$("<div>").addClass("row align-items-center").append(
+					$("<div>").addClass("col-md-2 d-none d-md-flex justify-content-end").append(
+						$("<label>").attr({id: "lbl_datadir", for: "edit_datadir"}).text(theUILang.DataDir + ": "),
+					),
+					$("<div>").addClass("col-md-10 d-flex align-items-center").append(
+						$("<input>").attr({type: "text", id: "edit_datadir"}).addClass("flex-grow-1"),
+						$("<button>").attr({id: "btn_datadir_browse"}).text("..."),
+					),
+					$("<div>").addClass("offset-md-2 col-md-10 d-flex align-items-center").append(
+						$("<input>").attr({type: "checkbox", id: "move_not_add_path"}),
+						$("<label>").attr({for: "move_not_add_path"}).text(theUILang.Dont_add_tname),
+					),
+					$("<div>").addClass("offset-md-2 col-md-10 d-flex align-items-center").append(
+						$("<input>").attr({type: "checkbox", id: "move_datafiles"}),
+						$("<label>").attr({for: "move_datafiles"}).text(theUILang.DataDirMove),
+					),
+					$("<div>").addClass("offset-md-2 col-md-10 d-flex align-items-center").append(
+						$("<input>").attr({type: "checkbox", id: "move_fastresume"}),
+						$("<label>").attr({for: "move_fastresume"}).text(theUILang.doFastResume),
+					),
+				),
+			),
+		)[0].outerHTML +
+		$("<div>").addClass("buttons-list").append(
+			$("<button>").addClass("OK").attr(
+				{id: "btn_datadir_ok", onclick: "theWebUI.sendDataDir(); return(false);"}
+			).text(theUILang.ok),
+			$("<button>").addClass("Cancel").text(theUILang.Cancel),
+		)[0].outerHTML,
+		true,
+	);
 	if(thePlugins.isInstalled("_getdir"))
 	{
 		var btn = new theWebUI.rDirBrowser( 'dlg_datadir', 'edit_datadir', 'btn_datadir_browse', 'frame_datadir_browse' );


### PR DESCRIPTION
This is a relatively simple dialog window, so the layout is quite straightforward. Below are the screenshots. Besides the layout, I also set some general rules for `button`s in `css/style.css`.

1. Desktop screens (min 768px wide):
![20240719170204](https://github.com/user-attachments/assets/741a0b10-eeba-4c70-afc0-1c3e73ed5cdd)

2. Smaller screens (less than 768px wide):
![20240719170240](https://github.com/user-attachments/assets/65712ddb-0241-4398-8d66-18c9abfe0313)
