### PR TITLE
Apply flex layout to edit dialog window

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -11,6 +11,20 @@ fieldset {
   border-radius:6px;
   margin: 0.25rem 0;
   padding: 0.25rem 0.5rem;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+}
+textarea {
+  border: 1px solid #B0B0B0;
+  border-radius: 3px;
+  margin: 0.25rem 0;
+  padding: 0.25rem;
+  resize: none;
+  width: 100%;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
 }
 select, input[type=file], input[type=text] {
   border: 1px solid #B0B0B0;
@@ -296,7 +310,6 @@ span#loadimg {padding: 20px; background: transparent url(../images/ajax-loader.g
 .Icon_Share {background: transparent url(../images/share.gif) no-repeat left center}
 
 div#HDivider:hover, div#VDivider:hover { background: #A0A0A0; }
-textarea { overflow: auto; }
 
 div#tadd-header {background-image: url(../images/world.gif)}
 div#tadd {display: none; left: 100px; top: 100px; position: absolute; margin: 0 auto }
@@ -340,9 +353,6 @@ div#tadd fieldset {margin: 0 0 0.25rem 0; padding: 0.25rem;}
   display: flex;
   flex-direction: row;
   align-items: center;
-}
-.status-row:last-of-type {
-  border-left: solid 1px #A0A0A0;
 }
 .sthdr { font-weight: bold; padding-right: 3px; text-align: right; }
 .stval {
@@ -404,9 +414,6 @@ div.dlg-window .buttons-list {
   justify-content: start;
   flex-wrap: wrap;
 }
-div.status-row:not(:first-of-type) {
-  border-bottom: dotted 1px #A0A0A0;
-}
 
 /* Small devices (landscape phones, 576px and up) */
 @media (min-width: 576px) { 
@@ -425,9 +432,6 @@ div.status-row:not(:first-of-type) {
     justify-content: end;
     flex-wrap: nowrap;
   }
-  div.status-row:not(:first-of-type) {
-    border-bottom: none;
-  }  
 }
 
 /* Large devices (desktops, 992px and up) */

--- a/plugins/edit/edit.css
+++ b/plugins/edit/edit.css
@@ -6,15 +6,15 @@ div#tedit div.dlg-header {
   background-image: url(../../images/settings.gif);
 }
 
-textarea#etrackers {
-  height: 150px;
-  word-break: break-all;
-}
-
 /* X-Small devices (portrait phones, less than 576px) */
 /* No media query for `xs` since this is the default in Bootstrap */
 /* Custom rules for medium devices */
 div#tedit {max-width: 95vw;}
+textarea#etrackers {
+  line-height: 1.2rem;
+  height: 12rem;
+  word-break: break-all;
+}
 
 /* Small devices (landscape phones, 576px and up) */
 @media (min-width: 576px) { 
@@ -25,6 +25,9 @@ div#tedit {max-width: 95vw;}
 @media (min-width: 768px) { 
   /* Custom rules for medium devices */
   div#tedit {min-width: 500px;}
+  textarea#etrackers {
+    height: 24rem;
+  }
 }
 
 /* Large devices (desktops, 992px and up) */

--- a/plugins/edit/edit.css
+++ b/plugins/edit/edit.css
@@ -1,58 +1,43 @@
-div#tedit 
-{
-	width: 405px; 
+div#tedit .row > div {
+  padding: 0;
 }
 
-div#tedit div.dlg-header 
-{
-	background-image: url(../../images/settings.gif)
+div#tedit div.dlg-header {
+  background-image: url(../../images/settings.gif);
 }
 
-div#tedit .text-wrapper
-{
-	border: 1px solid #D0D0D0; 
-	padding: 5px;
-	box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;		
+textarea#etrackers {
+  height: 150px;
+  word-break: break-all;
 }
 
-div#tedit textarea#etrackers 
-{
-	width: 100%; 
-	height: 120px; 
-	border: 0;
-	font-size: 11px; 
-	font-family: Tahoma, Arial, Helvetica, sans-serif; 
-	cursor: text; 
-	resize: none;
-	margin: 0;
-	padding: 0;
+/* X-Small devices (portrait phones, less than 576px) */
+/* No media query for `xs` since this is the default in Bootstrap */
+/* Custom rules for medium devices */
+div#tedit {max-width: 95vw;}
+
+/* Small devices (landscape phones, 576px and up) */
+@media (min-width: 576px) { 
+  /* Custom rules for small devices */
 }
 
-div#tedit fieldset label 
-{
-	display: inline-block; 
-	margin-top: 5px; 
-	margin-bottom: 5px; 
+/* Medium devices (tablets, 768px and up) */
+@media (min-width: 768px) { 
+  /* Custom rules for medium devices */
+  div#tedit {min-width: 500px;}
 }
 
-div#tedit fieldset input, div#tedit fieldset select
-{
-	padding: 5px;
-	margin: 0;
-	box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;	
+/* Large devices (desktops, 992px and up) */
+@media (min-width: 992px) { 
+  /* Custom rules for large devices */
 }
 
-div#tedit fieldset input[type='checkbox']
-{
-	margin: 8px 5px 5px 0;
+/* X-Large devices (large desktops, 1200px and up) */
+@media (min-width: 1200px) { 
+  /* Custom rules for x-large devices */
 }
 
-div#tedit #ecomment, div#tedit select
-{
-	width: 100%;
+/* XX-Large devices (larger desktops, 1400px and up) */
+@media (min-width: 1400px) { 
+  /* Custom rules for xx-large devices */
 }
-

--- a/plugins/edit/init.js
+++ b/plugins/edit/init.js
@@ -162,22 +162,44 @@ theWebUI.receiveEdit = function(d)
 
 plugin.onLangLoaded = function() 
 {
-	theDialogManager.make( "tedit", theUILang.EditTorrentProperties,
-		"<div class='cont fxcaret'>"+
-			"<fieldset>"+
-				"<input type='checkbox' name='eset_trackers' id='eset_trackers'/><label for='eset_trackers'>"+theUILang.Trackers+": </label>"+
-				"<div class='text-wrapper'><textarea id='etrackers'></textarea></div>"+
-				"<input type='checkbox' name='eset_comment' id='eset_comment'/><label for='eset_comment'>"+theUILang.Comment+": </label>"+
-                               	"<input type='text' id='ecomment' name='ecomment' class='TextboxLarge'/>"+
-                               	"<input type='checkbox' name='eset_private' id='eset_private'/><label for='eset_private'>"+theUILang.trkPrivate+": </label>"+
-                               	"<select id='eprivate'>"+
-	                               	"<option value='0'>"+theUILang.no+"</option>"+
-	                               	"<option value='1'>"+theUILang.yes+"</option>"+	                               	
-                               	"</select>"+
-			"</fieldset>"+
-		"</div>"+
-		"<div class='aright buttons-list'><input type='button' value='"+theUILang.ok+"' class='OK Button' id='editok' onclick='theWebUI.sendEdit(); return(false);'/><input type='button' value='"+theUILang.Cancel+"' class='Cancel Button'/></div>",
-		true);
+	theDialogManager.make("tedit", theUILang.EditTorrentProperties,
+		$("<div>").addClass("cont fxcaret").append(
+			$("<fieldset>").append(
+				$("<legend>").addClass("d-none d-md-block").text(theUILang.EditTorrentProperties),
+				$("<div>").addClass("m-0 row align-items-center").append(
+					$("<div>").addClass("col-md-3 d-flex flex-row align-items-center align-self-start").append(
+						$("<input>").attr({type: "checkbox", name: "eset_trackers", id: "eset_trackers"}),
+						$("<label>").attr({for: "eset_trackers"}).text(theUILang.Trackers + ": "),
+					),
+					$("<div>").addClass("col-md-9").append(
+						$("<textarea>").attr({id: "etrackers"}),
+					),
+					$("<div>").addClass("col-md-3 d-flex flex-row align-items-center").append(
+						$("<input>").attr({type: "checkbox", name: "eset_comment", id: "eset_comment"}),
+						$("<label>").attr({for: "eset_comment"}).text(theUILang.Comment + ": "),
+					),
+					$("<div>").addClass("col-md-9").append(
+						$("<input>").attr({type: "text", name: "ecomment", id: "ecomment"}),
+					),
+					$("<div>").addClass("col-3 d-flex flex-row align-items-center").append(
+						$("<input>").attr({type: "checkbox", name: "eset_private", id: "eset_private"}),
+						$("<label>").attr({for: "eset_private"}).text(theUILang.trkPrivate + ": "),
+					),
+					$("<div>").addClass("col-3").append(
+						$("<select>").attr({id: "eprivate"}).append(
+							$("<option>").val(0).text(theUILang.no),
+							$("<option>").val(1).text(theUILang.yes),
+						),
+					),
+				),
+			),
+		)[0].outerHTML +
+		$("<div>").addClass("buttons-list").append(
+			$("<button>").attr({id: "editok", onclick: "theWebUI.sendEdit(); return(false);"}).addClass("OK").text(theUILang.ok),
+			$("<button>").addClass("Cancel").text(theUILang.Cancel),
+		)[0].outerHTML,
+		true,
+	);
 }
 
 rTorrentStub.prototype.edittorrent = function()


### PR DESCRIPTION
Beside the rewriting of the dialog window, I also set some general CSS rules for `textarea` element in the `css/styles.css` file. Below are the screenshots:

1. Desktop screens:
![20240720114606](https://github.com/user-attachments/assets/ea41dab8-acf5-4770-a516-2ac019c27797)

2. Mobile screens:
![20240720114645](https://github.com/user-attachments/assets/ab89888e-fc56-474d-bf60-39d55b01096b)
