### PR TITLE
Apply flex window to main content division

### DIFF
--- a/css/stable.css
+++ b/css/stable.css
@@ -1,7 +1,6 @@
 .stable {
+  height: 100%;
   background-color: #FFFFFF;
-  border: 1px solid;
-  border-color: #D0D0D0 #FFFFFF #FFFFFF #D0D0D0;
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -19,9 +18,6 @@
   overflow: hidden;
   user-select: none;
   -moz-user-select: none;
-  border: 1px solid;
-  border-color: #FFFFFF #D0D0D0 #D0D0D0 #FFFFFF;
-  border-bottom: 0;
   z-index: 10;
 }
 .stable-head table {table-layout: fixed; width: 0}

--- a/css/style.css
+++ b/css/style.css
@@ -404,9 +404,8 @@ div.table_tab {
   -moz-user-input: enabled;
   user-select: none;
 }
-div#List,.main-table {border: 1px solid #A0A0A0;}
 
-div.cont {padding: 6px; font-size: 11px;}
+div.cont {padding: 6px;}
 
 .tabbar {
   flex: 0 0 18px;

--- a/css/style.css
+++ b/css/style.css
@@ -175,6 +175,7 @@ div#t {
   height: auto;
   background: #F0F0F0 url(../images/t_bg.png) repeat-x center 0.25rem;
   border-bottom: 1px solid #D0D0D0;
+  margin-bottom: 5px;
   white-space: nowrap;
 }
 #top-menu {
@@ -244,10 +245,26 @@ Input.TextboxLarge {border: 1px solid #B0B0B0; font-size: 11px;  padding: 2px; w
 #pview_save_view_button { align-self: center; width: 38px; height: 19px; padding: 0px; line-height: 2px; font-size: 19px;  }
 
 a {font-size: 11px;  color: #686868}
-table#maincont {margin: 5px 0 0 0; min-width: 600px;}
-table#maincont td.uicell {vertical-align: top; padding: 0 }
-
-#CatList { display: block; margin: 0; padding: 0; width: 0px; border: 1px solid #A0A0A0; background-color: #FFFFFF; overflow-y: auto; overflow-x: hidden; min-width: 160px; }
+#maincont {
+  height: calc(100vh - 36px - 5px - 25px - 5px);
+  width: 100vw;
+}
+#side-panel {
+  border: 1px solid #A0A0A0;
+  background-color: #FFFFFF;
+  min-width: 200px;
+  overflow: hidden auto;
+}
+#main-info {
+  flex: 0 0 auto;
+  overflow: hidden;
+}
+#list-table {
+  flex: 1 1 auto;
+  border: 1px solid #A0A0A0;
+  background-color: #FFFFFF;
+  overflow: hidden;
+}
 
 .stable-icon {background-image: url(../images/tstatus.png); background-repeat: no-repeat}
 .Status_Down {background-position: 0px 0px}
@@ -264,9 +281,14 @@ table#maincont td.uicell {vertical-align: top; padding: 0 }
 .Status_Checking {background-position: 0px -176px}
 .Status_RSS {background-position: 0px -208px}
 
-div#HDivider, div#VDivider { font-size: 0; }
-div#HDivider { width: 5px; height: 0px; padding: 0; margin: 0; cursor: e-resize; }
-div#VDivider { width: 100%; height: 5px; padding: 0; margin: 0; cursor: n-resize; }
+div#HDivider, div#VDivider {
+  align-self: stretch;
+  padding: 0;
+  margin: 0;
+  flex: 0 0 5px;
+}
+div#HDivider {cursor: e-resize;}
+div#VDivider {cursor: n-resize;}
 div#dividerDrag { width: 5px; height: 5px; padding: 0; margin: 0; background: #A0A0A0; position: absolute; display: none }
 
 div#stg {position: absolute; left: 0px; top: 50px; display: none; overflow: visible}
@@ -342,17 +364,30 @@ div.indent {padding-left: 16px}
 a {text-decoration: none}
 select.cols {border: 1px solid #808080; font-size: 11px;  padding: 2px; width: 120px}
 div#dragmask {width: 10px; height: 10px; left: 0px; top: 0px; position: absolute; z-index: 5000; display: none; border: 1px dotted #A0A0A0}
-div#tdetails {height: 50%; padding: 0 5px 0 0; background-color: #F5F5F5}
+div#tdetails {
+  background-color: #F5F5F5;
+  flex: 1 1 auto;
+}
 div#tdetails a.h {margin: 0}
-div#tdcont {height: 200px; background: #FFFFFF; border: 1px solid #D0D0D0; padding: 0 2px 0 2px; overflow: hidden }
-
+div#tdcont {
+  flex: 1 1 auto;
+  background: #FFFFFF;
+  border: 1px solid #D0D0D0;
+  padding: 0 2px 0 2px;
+  overflow: auto;
+}
+div#tdcont > div {
+  height: 100%;
+}
 div.tab { height:100%; background: #F5F5F5; overflow: auto }
 div#lcont {font-size: 11px;  line-height: 11px; background: #FFFFFF}
 div#lcont div.mono {font-size: 11px; font-family: monospace; line-height: 11px; background: #F5F5F5; white-space: pre}
 div#lcont div.std {padding: 2px}
 
-div#gcont table {font-size: 11px;  line-height: 10px}
-div#gcont table td.Header {font-weight: bold; background: #FCFCFC}
+div#gcont span.det-hdr {font-weight: bold;}
+div#gcont div.row.Header {font-size: 14px; font-weight: bold; background: #FCFCFC; padding: 0.5rem;}
+div#gcont div.row:not(.Header) {padding: 0 0.3rem; word-break: break-all;}
+div#gcont div.row > div {padding-top: 0.25rem; padding-bottom: 0.25rem;}
 
 div.graph_tab {background-color: #FFFFFF; overflow: hidden; display: block; -moz-user-select: none; -moz-user-focus: normal; -moz-user-input: enabled; user-select: none; font-size: 11px;  line-height: 11px; color: #545454;}
 .graph_tab_grid,.graph_tab_legend {
@@ -372,7 +407,13 @@ div#List,.main-table {border: 1px solid #A0A0A0;}
 
 div.cont {padding: 6px; font-size: 11px;}
 
-.tabbar {height: 18px; margin: 0; padding: 0; list-style-type: none; text-align: left}
+.tabbar {
+  flex: 0 0 18px;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  text-align: left;
+}
 .tabbar li {margin: 0; padding: 0; display: inline; white-space: nowrap;}
 .tabbar li a {position: relative; top: 3px; text-decoration: none; border: 1px solid #D0D0D0; border-bottom: 0; margin: -5px 1px 0 1px; padding: 1px 5px; font-size: 11px;  -moz-border-radius-topleft: 5px; -moz-border-radius-topright: 5px; -webkit-border-top-left-radius:5px; -webkit-border-top-right-radius:5px; border-top-right-radius:5px; border-top-left-radius:5px; vertical-align: top; cursor: pointer}
 .tabbar li a:hover {border-top: 2px solid #FFC73C}
@@ -422,7 +463,7 @@ div#tadd {display: none; left: 100px; top: 100px; position: absolute; margin: 0 
   bottom: 0;
   border-top: 1px solid #A0A0A0;
   background-color: #FFFFFF;
-  margin-top: 4px;
+  margin-top: 5px;
   color: #000000;
   white-space: nowrap;
   overflow: hidden;
@@ -477,8 +518,6 @@ div#tadd {display: none; left: 100px; top: 100px; position: absolute; margin: 0 
 div.space {flex-grow: 1;}
 #servertime { text-align: center }
 #viewrows { text-align: center; }
-
-#bf {white-space:pre}
 
 @media only screen and (min-width: 1280px) {
   .desktop { display: inline-block; }

--- a/css/style.css
+++ b/css/style.css
@@ -264,6 +264,7 @@ a {font-size: 11px;  color: #686868}
   border: 1px solid #A0A0A0;
   background-color: #FFFFFF;
   overflow: hidden;
+  min-height: 300px;
 }
 
 .stable-icon {background-image: url(../images/tstatus.png); background-repeat: no-repeat}
@@ -289,7 +290,7 @@ div#HDivider, div#VDivider {
 }
 div#HDivider {cursor: e-resize;}
 div#VDivider {cursor: n-resize;}
-div#dividerDrag { width: 5px; height: 5px; padding: 0; margin: 0; background: #A0A0A0; position: absolute; display: none }
+div#HDivider:active, div#VDivider:active {cursor: grabbing;}
 
 div#stg {position: absolute; left: 0px; top: 50px; display: none; overflow: visible}
 div#stg_c {

--- a/index.html
+++ b/index.html
@@ -163,7 +163,6 @@
 				</category-list>
 			</div>
 			<div id="HDivider"></div>
-			<div id="dividerDrag"></div>
 			<div id="main-info" class="d-flex flex-column align-items-stretch">
 				<div id="list-table">
 					<div id="List" class="h-100"></div>

--- a/index.html
+++ b/index.html
@@ -114,146 +114,134 @@
 				</div>	
 			</div>
 		</div>
-		<table id="maincont" cellpadding="0" cellspacing="0" summary="layout table">
-			<tr>
-				<td class="uicell" rowspan="3">
-					<template id="panel-label-template">
-						<link href="./css/panel-label.css?v=430" rel="stylesheet" type="text/css" />
-						<div part="prefix" hidden></div>
-						<div part="icon"></div>
-						<div part="text"></div>
-						<div part="count">0</div>
-						<div part="size" style="display: none;"></div>
-					</template>
-					<template id="category-panel-template">
-						<link href="./css/category-panel.css?v=430" rel="stylesheet" type="text/css" />
-						<div part="heading">
-							<span class="text"></span><slot name="decorator" class="decorator"></slot>
-						</div>
-						<slot name="content"></slot>
-					</template>
-					<template id="pview-rename-dialog-template">
-						<div class="content">
-							<input type="text" onfocus="this.select()"/>
-						</div>
-						<div class="aright buttons-list" style="margin-top: 10px">
-							<button class="Button" value="confirm" uilang>ok</button>
-							<button class="Button Cancel" uilang>Cancel</button>
-						</div>
-					</template>
-					<category-list id="CatList">
-						<category-panel id="pview" uilangtext="pnlViews">
-							<input slot="decorator" class="Button" type="button" value="+" uilangtitle="SaveCurrentView" id="pview_save_view_button" />
-							<panel-label id="pview_all" icon="all" uilangtext="All" selected></panel-label>
-						</category-panel>
-						<category-panel id="pstate" uilangtext="pnlState">
-							<panel-label id="pstate_all" icon="all" uilangtext="All" selected></panel-label>
-							<panel-label id="-_-_-dls-_-_-" icon="down" uilangtext="Downloading"></panel-label>
-							<panel-label id="-_-_-com-_-_-" icon="completed" uilangtext="Finished"></panel-label>
-							<panel-label id="-_-_-act-_-_-" icon="up-down" uilangtext="Active"></panel-label>
-							<panel-label id="-_-_-iac-_-_-" icon="inactive" uilangtext="Inactive"></panel-label>
-							<panel-label id="-_-_-err-_-_-" icon="error" uilangtext="Error"></panel-label>
-						</category-panel>
-						<category-panel id="plabel" uilangtext="Labels">
-							<panel-label id="plabel_all" icon="all" uilangtext="All" selected></panel-label>
-							<panel-label id="-_-_-nlb-_-_-" icon="no-label" uilangtext="No_label"></panel-label>
-						</category-panel>
-						<category-panel id="psearch" uilangtext="mnu_search">
-							<panel-label id="psearch_all" icon="all" uilangtext="All" selected></panel-label>
-						</category-panel>
-					</category-list>
-				</td>
-				<td class="uicell" rowspan="3">
-					<div id="HDivider"></div><div id="dividerDrag"></div>
-				</td>
-				<td class="uicell">
-					<div id="List"></div>
-				</td>
-			</tr>
-			<tr>
-				<td class="uicell">
-					<div id="VDivider"></div>
-				</td>
-			</tr>
-			<tr>
-				<td class="uicell">
-					<div id="tdetails">
-						<ul id="tabbar" class="tabbar">
-						</ul>
-						<div id="tdcont">
-							<div id="gcont" class="tab">
-								<table cellpadding="5" cellspacing="2" width="100%" summary="layout table" id="mainlayout">
-									<tr>
-										<td colspan="6" class="Header"><span uilang>Transfer</span></td>
-									</tr>
-									<tr>
-										<td width="6%" nowrap><span uilang>Time_el</span>:</td><td width="11%" nowrap><span id="et" class="det"></span></td>
-										<td width="6%" nowrap><span uilang>Remaining</span>:</td><td width="11%" nowrap><span id="rm" class="det"></span></td>
-										<td width="6%" nowrap><span uilang>Share_ratio</span>:</td><td width="11%" nowrap><span id="ra" class="det"></span></td>
-									</tr>
-									<tr>
-										<td width="6%" nowrap><span uilang>Downloaded</span>:</td><td width="11%" nowrap><span id="dl" class="det"></span></td>
-										<td width="6%" nowrap><span uilang>Down_speed</span>:</td><td width="11%" nowrap><span id="ds" class="det"></span></td>
-										<td width="6%" nowrap><span uilang>Wasted</span>:</td><td width="11%" nowrap><span id="wa" class="det"></span></td>
-									</tr>
-									<tr>
-										<td nowrap><span uilang>Uploaded</span>:</td><td nowrap><span id="ul" class="det"></span></td>
-										<td nowrap><span uilang>Ul_speed</span>:</td><td nowrap><span id="us" class="det"></span></td>
-										<td nowrap>&nbsp;</td><td nowrap>&nbsp;</td>
-									</tr>
-									<tr>
-										<td nowrap><span uilang>Seeds</span>:</td><td nowrap><span id="se" class="det"></span></td>
-										<td nowrap><span uilang>Peers</span>:</td><td nowrap><span id="pe" class="det"></span></td>
-										<td nowrap>&nbsp;</td><td>&nbsp;</td>
-									</tr>
-									<tr>
-										<td colspan="6" class="Header"><span uilang>Tracker</span></td>
-									</tr>
-									<tr>
-										<td nowrap><span uilang>Track_URL</span>:</td>
-										<td colspan="5" nowrap><span id="tu" class="det"></span></td>
-									</tr>
-									<tr>
-										<td nowrap><span uilang>Track_status</span>:</td>
-										<td colspan="5" nowrap><span id="ts" class="det"></span></td>
-									</tr>
-									<tr>
-										<td colspan="6" class="Header"><span uilang>General</span></td>
-									</tr>
-									<tr>
-										<td nowrap><span uilang>Save_as</span></td>
-										<td colspan="5" nowrap><span id="bf" class="det"></span></td>
-									</tr>
-									<tr>
-										<td nowrap><span uilang>Free_Disk_Space</span>:</td>
-										<td colspan="5" nowrap><span id="dsk" class="det"></span></td>
-									</tr>
-									<tr>
-										<td nowrap><span uilang>Created_on</span>:</td>
-										<td colspan="5" nowrap><span id="co" class="det"></span></td>
-									</tr>
-									<tr>
-										<td nowrap><span uilang>Hash</span>:</td>
-										<td colspan="5" nowrap><span id="hs" class="det"></span></td>
-									</tr>
-									<tr>
-										<td nowrap><span uilang>Comment</span>:</td>
-										<td colspan="5"><span id="cmt" class="det"></span></td>
-									</tr>
-								</table>
-							</div>
-							<div id="FileList" class="table_tab"></div>
-							<div id="TrackerList" class="table_tab"></div>
-							<div id="PeerList" class="table_tab"></div>
-							<div id="Speed" class="graph_tab"></div>
-							<div id="PluginList" class="table_tab"></div>
-							<div id="lcont" class="tab"></div>
-						</div>
+		<div id="maincont" class="d-flex flex-row align-items-stretch">
+			<div id="side-panel">
+				<template id="panel-label-template">
+					<link href="./css/panel-label.css?v=430" rel="stylesheet" type="text/css" />
+					<div part="prefix" hidden></div>
+					<div part="icon"></div>
+					<div part="text"></div>
+					<div part="count">0</div>
+					<div part="size" style="display: none;"></div>
+				</template>
+				<template id="category-panel-template">
+					<link href="./css/category-panel.css?v=430" rel="stylesheet" type="text/css" />
+					<div part="heading">
+						<span class="text"></span><slot name="decorator" class="decorator"></slot>
 					</div>
-				</td>
-			</tr>
-		</table>
-		<div id="StatusBar" class="d-flex flex-row align-items-stretch justify-content-start">
+					<slot name="content"></slot>
+				</template>
+				<template id="pview-rename-dialog-template">
+					<div class="content">
+						<input type="text" onfocus="this.select()"/>
+					</div>
+					<div class="aright buttons-list" style="margin-top: 10px">
+						<button class="Button" value="confirm" uilang>ok</button>
+						<button class="Button Cancel" uilang>Cancel</button>
+					</div>
+				</template>
+				<category-list id="CatList">
+					<category-panel id="pview" uilangtext="pnlViews">
+						<input slot="decorator" class="Button" type="button" value="+" uilangtitle="SaveCurrentView" id="pview_save_view_button" />
+						<panel-label id="pview_all" icon="all" uilangtext="All" selected></panel-label>
+					</category-panel>
+					<category-panel id="pstate" uilangtext="pnlState">
+						<panel-label id="pstate_all" icon="all" uilangtext="All" selected></panel-label>
+						<panel-label id="-_-_-dls-_-_-" icon="down" uilangtext="Downloading"></panel-label>
+						<panel-label id="-_-_-com-_-_-" icon="completed" uilangtext="Finished"></panel-label>
+						<panel-label id="-_-_-act-_-_-" icon="up-down" uilangtext="Active"></panel-label>
+						<panel-label id="-_-_-iac-_-_-" icon="inactive" uilangtext="Inactive"></panel-label>
+						<panel-label id="-_-_-err-_-_-" icon="error" uilangtext="Error"></panel-label>
+					</category-panel>
+					<category-panel id="plabel" uilangtext="Labels">
+						<panel-label id="plabel_all" icon="all" uilangtext="All" selected></panel-label>
+						<panel-label id="-_-_-nlb-_-_-" icon="no-label" uilangtext="No_label"></panel-label>
+					</category-panel>
+					<category-panel id="psearch" uilangtext="mnu_search">
+						<panel-label id="psearch_all" icon="all" uilangtext="All" selected></panel-label>
+					</category-panel>
+				</category-list>
+			</div>
+			<div id="HDivider"></div>
+			<div id="dividerDrag"></div>
+			<div id="main-info" class="d-flex flex-column align-items-stretch">
+				<div id="list-table">
+					<div id="List" class="h-100"></div>
+				</div>
+				<div id="VDivider"></div>
+				<div id="tdetails" class="d-flex flex-column align-items-stretch">
+					<ul id="tabbar" class="tabbar"></ul>
+					<div id="tdcont">
+						<div id="gcont" class="tab">
+							<div id="mainlayout" class="container-fluid">
+								<div class="row Header">
+									<div class="col-12"><span uilang>Transfer</span></div>
+								</div>
+								<div class="row">
+									<div class="col-6 col-md-2"><span class="det-hdr" uilang>Time_el</span>:</div>
+									<div class="col-6 col-md-2"><span id="et" class="det"></span></div>
+									<div class="col-6 col-md-2"><span class="det-hdr" uilang>Remaining</span>:</div>
+									<div class="col-6 col-md-2"><span id="rm" class="det"></span></div>
+									<div class="col-6 col-md-2"><span class="det-hdr" uilang>Share_ratio</span>:</div>
+									<div class="col-6 col-md-2"><span id="ra" class="det"></span></div>
+								</div>
+								<div class="row">
+									<div class="col-6 col-md-2"><span class="det-hdr" uilang>Downloaded</span>:</div>
+									<div class="col-6 col-md-2"><span id="dl" class="det"></span></div>
+									<div class="col-6 col-md-2"><span class="det-hdr" uilang>Down_speed</span>:</div>
+									<div class="col-6 col-md-2"><span id="ds" class="det"></span></div>
+									<div class="col-6 col-md-2"><span class="det-hdr" uilang>Wasted</span>:</div>
+									<div class="col-6 col-md-2"><span id="wa" class="det"></span></div>
+								</div>
+								<div class="row">
+									<div class="col-6 col-md-2"><span class="det-hdr" uilang>Uploaded</span>:</div>
+									<div class="col-6 col-md-2"><span id="ul" class="det"></span></div>
+									<div class="col-6 col-md-2"><span class="det-hdr" uilang>Ul_speed</span>:</div>
+									<div class="col-6 col-md-2"><span id="us" class="det"></span></div>
+								</div>
+								<div class="row">
+									<div class="col-6 col-md-2"><span class="det-hdr" uilang>Seeds</span>:</div>
+									<div class="col-6 col-md-2"><span id="se" class="det"></span></div>
+									<div class="col-6 col-md-2"><span class="det-hdr" uilang>Peers</span>:</div>
+									<div class="col-6 col-md-2"><span id="pe" class="det"></span></div>
+								</div>
+								<div class="row Header">
+									<div class="col-12"><span uilang>Tracker</span></div>
+								</div>
+								<div class="row">
+									<div class="col-12 col-md-2"><span class="det-hdr" uilang>Track_URL</span>:</div>
+									<div class="col-12 col-md-10"><span id="tu" class="det"></span></div>
+									<div class="col-12 col-md-2"><span class="det-hdr" uilang>Track_status</span>:</div>
+									<div class="col-12 col-md-10"><span id="ts" class="det"></span></div>
+								</div>
+								<div class="row Header">
+									<div class="col-12"><span uilang>General</span></div>
+								</div>
+								<div class="row">
+									<div class="col-12 col-md-2"><span class="det-hdr" uilang>Save_as</span>:</div>
+									<div class="col-12 col-md-10"><span id="bf" class="det"></span></div>
+									<div class="col-12 col-md-2"><span class="det-hdr" uilang>Free_Disk_Space</span>:</div>
+									<div class="col-12 col-md-10"><span id="dsk" class="det"></span></div>
+									<div class="col-12 col-md-2"><span class="det-hdr" uilang>Created_on</span>:</div>
+									<div class="col-12 col-md-10"><span id="co" class="det"></span></div>
+									<div class="col-12 col-md-2"><span class="det-hdr" uilang>Hash</span>:</div>
+									<div class="col-12 col-md-10"><span id="hs" class="det"></span></div>
+									<div class="col-12 col-md-2"><span class="det-hdr" uilang>Comment</span>:</div>
+									<div class="col-12 col-md-10"><span id="cmt" class="det"></span></div>
+								</div>
+							</div>
+						</div>
+						<div id="FileList" class="table_tab"></div>
+						<div id="TrackerList" class="table_tab"></div>
+						<div id="PeerList" class="table_tab"></div>
+						<div id="Speed" class="graph_tab"></div>
+						<div id="PluginList" class="table_tab"></div>
+						<div id="lcont" class="tab"></div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div id="StatusBar" class="d-flex flex-row align-items-stretch justify-content-start w-100">
 			<div id="st_up" class="status-cell">
 				<div class="icon"></div>
 				<div class="sthdr d-none d-lg-block"><span uilang>Speed</span>:</div>

--- a/js/content.js
+++ b/js/content.js
@@ -27,12 +27,11 @@ function makeContent()
 		onRun : function(e) { $(document.body).css( "cursor", "e-resize" ); },
 		onFinish : function(e)
 		{
-		        var self = e.data;
+			var self = e.data;
 			var w = self.mask.offset().left-2;
-			theWebUI.resizeLeft(w,null);
+			theWebUI.resizeLeft(w);
 			w = $(window).width()-w-11;
 			theWebUI.resizeTop(w,null);
-      		        theWebUI.resizeBottom(w,null);
 			theWebUI.setHSplitter();
 			$(document.body).css( "cursor", "default" );
 		}
@@ -48,11 +47,10 @@ function makeContent()
 		onRun : function(e) { $(document.body).css( "cursor", "n-resize" ); },
 		onFinish : function(e)
 		{
-		        var self = e.data;
-		        var offs = self.mask.offset();
-      		        theWebUI.resizeTop(null,offs.top-($("#t").is(":visible") ?  $("#t").height() : -1)-8);
-      		        theWebUI.resizeBottom(null,$(window).height()-offs.top-$("#StatusBar").height()-14);
-      		        theWebUI.setVSplitter();
+			var self = e.data;
+			var offs = self.mask.offset();
+			theWebUI.resizeTop(null,offs.top-($("#t").is(":visible") ?  $("#t").height() : -1)-8);
+			theWebUI.setVSplitter();
 			$(document.body).css( "cursor", "default" );
 		}
 	});

--- a/js/content.js
+++ b/js/content.js
@@ -17,42 +17,36 @@ function makeContent()
 		);
 	});
 
-	new DnD("HDivider",
+	$("#query").on('keydown', function(e)
 	{
-		left : function() { return(60); },
-		right : function() { return( $(window).width()-20 ); },
-		restrictY : true,
-		maskId : "dividerDrag",
-		onStart : function(e) { return(theWebUI.settings["webui.show_cats"]); },
-		onRun : function(e) { $(document.body).css( "cursor", "e-resize" ); },
-		onFinish : function(e)
+		if(e.keyCode == 13)
 		{
-			var self = e.data;
-			var w = self.mask.offset().left-2;
-			theWebUI.resizeLeft(w);
-			w = $(window).width()-w-11;
-			theWebUI.resizeTop(w,null);
-			theWebUI.setHSplitter();
-			$(document.body).css( "cursor", "default" );
+			theSearchEngines.run();
 		}
 	});
 
-	new DnD("VDivider",
-	{
-		top : function() { return(60); },
-		bottom : function() { return( $(window).height()-60 ); },
-		restrictX : true,
-		maskId : "dividerDrag",
-		onStart : function(e) { return(theWebUI.settings["webui.show_dets"]); },
-		onRun : function(e) { $(document.body).css( "cursor", "n-resize" ); },
-		onFinish : function(e)
-		{
-			var self = e.data;
-			var offs = self.mask.offset();
-			theWebUI.resizeTop(null,offs.top-($("#t").is(":visible") ?  $("#t").height() : -1)-8);
+	new DnD("HDivider", {
+		restrictY: true,
+		maskId: "HDivider",
+		onStart: function(e) {return $("#side-panel").css("display") !== "none";},
+		onRun: function(e) {
+			theWebUI.resizeLeft(parseFloat(e.data.mask.css("left")));
+		},
+		onFinish: function(e) {
+			$("#HDivider").attr({style:""});
+			theWebUI.setHSplitter();
+		},
+	});
+
+	new DnD("VDivider", {
+		restrictX: true,
+		maskId: "VDivider",
+		onStart: function(e) {return $("#tdetails").css("display") !== "none";},
+		onRun: function(e) {theWebUI.resizeTop(null, parseFloat(e.data.mask.css("top")) - $("#t").outerHeight() - 5);},
+		onFinish: function(e) {
+			$("#VDivider").attr({style:""});
 			theWebUI.setVSplitter();
-			$(document.body).css( "cursor", "default" );
-		}
+		},
 	});
 
 	$(document.body).append($("<iframe name='uploadfrm'/>").css({visibility: "hidden"}).attr( { name: "uploadfrm" } ).width(0).height(0).on('load', function()

--- a/js/objects.js
+++ b/js/objects.js
@@ -4,78 +4,79 @@
  */
 
 // Drag & Drop object 
-function DnD( id, options )
-{
-	this.obj = $('#'+id);
-	var headers = this.obj.find(".dlg-header");
-	var header = headers.length>0 ? $(headers[0]) : this.obj;
-	this.options = options || {};
-	if(!this.options.left)
-		this.options.left = function() { return(0); };
-	if(!this.options.top)
-		this.options.top = function() { return(0); };
-	if(!this.options.right)
-		this.options.right = function() { return($(window).width()); };
-	if(!this.options.bottom)
-		this.options.bottom = function() { return($(window).height()); };
-	if(!this.options.onStart)
-		this.options.onStart = function() { return(true); }
-	if(!this.options.onRun)
-		this.options.onRun = function() {}
-	if(!this.options.onFinish)
-		this.options.onFinish = function() {}
-	if(!this.options.maskId)
-		this.options.maskId = 'dragmask';
-	this.detachedMask = (this.options.maskId!=id);
-	this.mask = $('#'+this.options.maskId);
-	header.off( "mousedown" );
-	header.on( "mousedown", this, this.start );
-}
-
-DnD.prototype.start = function( e )
-{
-	var self = e.data;
-	if(self.options.onStart(e))
-	{
-		var offs = self.obj.offset();
-		theDialogManager.bringToTop(self.obj.attr("id"))
-		theDialogManager.bringToTop(self.mask.attr("id"))
-		if(self.detachedMask)
-		{
-			self.mask.css( { left: offs.left, top: offs.top, width: self.obj.width(), height: self.obj.height() } );
-			self.mask.show();
-		}
-		self.delta = { x: e.clientX-offs.left, y: e.clientY-offs.top };
-		$(document).on("mousemove",self,self.run); 
-		$(document).on("mouseup",self,self.finish);
-	}	
-	return(false);
-}
-
-DnD.prototype.run = function( e )
-{
-	var self = e.data;
-	if(!self.options.restrictX)
-		self.mask.css( { left: Math.min(Math.max(self.options.left(), e.clientX),self.options.right())-self.delta.x } ); 
-	if(!self.options.restrictY)
-		self.mask.css( { top: Math.min(Math.max(self.options.top(), e.clientY),self.options.bottom())-self.delta.y } );
-	self.options.onRun(e);
-	return(false);
-}
-
-DnD.prototype.finish = function( e )
-{
-	var self = e.data;
-	self.options.onFinish(e);
-	if(self.detachedMask)
-	{
-		var offs = self.mask.offset();
-		self.mask.hide();
-		self.obj.css( { left: offs.left, top: offs.top } );
+class DnD {
+	constructor(id, options) {
+		this.obj = $('#' + id);
+		const headers = this.obj.find(".dlg-header");
+		const header = headers.length > 0 ? $(headers[0]) : this.obj;
+		this.options = options || {};
+		if (!this.options.left)
+			this.options.left = function() {return 0;};
+		if (!this.options.top)
+			this.options.top = function() {return 0;};
+		if (!this.options.right)
+			this.options.right = function() {return ($(window).width());};
+		if (!this.options.bottom)
+			this.options.bottom = function() {return ($(window).height());};
+		if (!this.options.onStart)
+			this.options.onStart = function() {return true;};
+		if (!this.options.onRun)
+			this.options.onRun = function() {};
+		if (!this.options.onFinish)
+			this.options.onFinish = function() {};
+		if (!this.options.maskId)
+			this.options.maskId = 'dragmask';
+		this.detachedMask = this.options.maskId !== id;
+		this.mask = $('#' + this.options.maskId);
+		header.off("mousedown");
+		header.on("mousedown", this, this.start);
 	}
-	$(document).off("mousemove",self.run); 
-	$(document).off("mouseup",self.finish);
-	return(false);
+
+	start(e) {
+		const self = e.data;
+		if (self.options.onStart(e)) {
+			const offs = self.obj.offset();
+			theDialogManager.bringToTop(self.obj.attr("id"));
+			theDialogManager.bringToTop(self.mask.attr("id"));
+			if (self.detachedMask) {
+				self.mask.css({left: offs.left, top: offs.top, width: self.obj.width(), height: self.obj.height()});
+				self.mask.show();
+			}
+			self.delta = {x: e.clientX - offs.left, y: e.clientY - offs.top};
+			$(document).on("mousemove", self, self.run);
+			$(document).on("mouseup", self, self.finish);
+		}
+		return false;
+	}
+
+	run(e) {
+		const self = e.data;
+		if (!self.options.restrictX) {
+			self.mask.css({
+				left: Math.min(Math.max(self.options.left(), e.clientX), self.options.right()) - self.delta.x
+			});
+		}
+		if (!self.options.restrictY) {
+			self.mask.css({
+				top: Math.min(Math.max(self.options.top(), e.clientY), self.options.bottom()) - self.delta.y
+			});
+		}
+		self.options.onRun(e);
+		return false;
+	}
+
+	finish(e) {
+		const self = e.data;
+		self.options.onFinish(e);
+		if (self.detachedMask) {
+			const offs = self.mask.offset();
+			self.mask.hide();
+			self.obj.css({left: offs.left, top: offs.top});
+		}
+		$(document).off("mousemove", self.run);
+		$(document).off("mouseup", self.finish);
+		return false;
+	}
 }
 
 // Dialog manager

--- a/js/stable.js
+++ b/js/stable.js
@@ -127,7 +127,7 @@ dxSTable.prototype.create = function(ele, styles, aName)
 	this.dCont.appendChild(this.dHead);
 	this.dCont.appendChild(this.dBody);
 
-	this.tHead = $("<table>").prop({cellSpacing: 0, cellPadding: 0}).width(100).get(0);
+	this.tHead = $("<table>").prop({cellSpacing: 0, cellPadding: 0}).get(0);
 	this.tHead.tb = $("<tbody>").get(0);
 	this.dHead.appendChild(this.tHead);
 	this.tHead.appendChild(this.tHead.tb);
@@ -400,8 +400,6 @@ dxSTable.prototype.resizeColumn = function()
 //				this.tBody.rows[j].cells[i].style.textAlign = c.style.textAlign;
 		}
 	}
-	this.tBody.tb.style.width = this.tHead.offsetWidth + "px";
-	this.tBody.style.width = this.tHead.offsetWidth + "px";
 
 	(($type(this.onresize) === "function") && needCallHandler) && this.onresize();
 }
@@ -1619,21 +1617,11 @@ dxSTable.prototype.syncDOM = function()
 	const wantsCustomRefresh = p.resizeHeight || onlyNeedsScroll;
 	const sortRefreshed = !this.noSort && needsSort && /* Sort returns 0 on success */ !this.Sort();
 
-	if (wantsCustomRefresh)
-	{
-		if (p.resizeHeight)
-			this.dCont.style.height = p.resizeHeight + "px";
-		if (p.resizeWidth)
-			this.dCont.style.width = p.resizeWidth + "px";
-
+	if (wantsCustomRefresh) {
 		this.refreshRows(p.resizeHeight, onlyNeedsScroll);
-	}
-	else if (needsRefresh && !sortRefreshed)
-	{
+	} else if (needsRefresh && !sortRefreshed) {
 		this.refreshRows();
-	}
-	else if (p.dirtySelection && !needsRefresh)
-	{
+	} else if (p.dirtySelection && !needsRefresh) {
 		this.refreshSelection();
 	}
 

--- a/js/webui.js
+++ b/js/webui.js
@@ -2259,22 +2259,28 @@ var theWebUI =
 		return(false);
 	},
 
-	resizeLeft: function( w, h )
-	{
-	        if(w!==null)
-	        {
-			$("#CatList").width( w );
-			$("#VDivider").width( $(window).width()-w-10 );
-		}
-		if(h!==null)
-		{
-			$("#CatList").height( h );
+	resizeLeft: function(w) {
+		if (w === null)
+			return;
+		w = Math.max(w, parseFloat($("#side-panel").css("min-width")));
+		if ($("#side-panel").css("display") !== "none") {
+			$("#side-panel").width(w);
+			$("#main-info").width($("#maincont").width() - 5 - w);
+		} else {
+			$("#main-info").width(100);
 		}
 	},
 
-	resizeTop : function( w, h )
-	{
-		this.getTable("trt").resize(w,h);
+	resizeTop: function(w, h) {
+		if (h === null)
+			return
+		h = Math.max(h, parseFloat($("#list-table").css("min-height")));
+		if ($("#tdetails").css("display") !== "none") {
+			$("#list-table").height(h);
+			$("#tdetails").height($("#maincont").height() - 5 - h);
+		} else {
+			$("#list-table").height(100);
+		}
 	},
 
 	resizeBottom : function( w, h )
@@ -2303,28 +2309,11 @@ var theWebUI =
 		}
 	},
 
-	resize: function()
-	{
-		var ww = $(window).width();
-		var wh = $(window).height();
-       		var w = Math.floor(ww * (1 - theWebUI.settings["webui.hsplit"])) - 5;
-	        var th = ($("#t").is(":visible") ? $("#t").height() : -1)+$("#StatusBar").height()+12;
-		$("#StatusBar").width(ww);
-		if(theWebUI.settings["webui.show_cats"])
-		{
-			theWebUI.resizeLeft( w, wh-th );
-			w = ww - w;
-		}
-		else
-		{
-			$("#VDivider").width( ww-10 );
-			w = ww;
-		}
-		w-=11;
-		theWebUI.resizeTop( w, Math.floor(wh * (theWebUI.settings["webui.show_dets"] ? theWebUI.settings["webui.vsplit"] : 1))-th-7 );
-		if(theWebUI.settings["webui.show_dets"])
-			theWebUI.resizeBottom( w, Math.floor(wh * (1 - theWebUI.settings["webui.vsplit"])) );
-		$("#HDivider").height( wh-th+2 );
+	resize: function() {
+		const w = $("#maincont").width() * (1 - theWebUI.settings["webui.hsplit"]) - 5;
+		theWebUI.resizeLeft(w);
+		const h = $("#maincont").height() * theWebUI.settings["webui.vsplit"];
+		theWebUI.resizeTop(null, h);
 	},
 
 	update: function()
@@ -2335,25 +2324,20 @@ var theWebUI =
 			theWebUI.show();
    	},
 
-	setVSplitter : function()
-	{
-		var r = 1 - ($("#tdetails").height() / $(window).height());
-		r = Math.floor(r * Math.pow(10, 3)) / Math.pow(10, 3);
-		if((theWebUI.settings["webui.vsplit"] != r) && (r>0) && (r<1))
-		{
+	setVSplitter: function() {
+		let r = 1 - $("#tdetails").outerHeight() / $("#maincont").height();
+		r = Math.floor(r * 1000) / 1000;
+		if ((theWebUI.settings["webui.vsplit"] !== r) && (r > 0) && (r < 1)) {
 			theWebUI.settings["webui.vsplit"] = r;
 			theWebUI.save();
 		}
 	},
 
-	setHSplitter : function()
-	{
-		var r = 1 - ($("#CatList").width()+5)/$(window).width();
-		r = Math.floor(r * Math.pow(10, 3)) / Math.pow(10, 3);
-		if((theWebUI.settings["webui.hsplit"] != r) && (r>0) && (r<1))
-		{
+	setHSplitter: function() {
+		let r = 1 - $("#side-panel").outerWidth() / $("#maincont").width();
+		r = Math.floor(r * 1000) / 1000;
+		if ((theWebUI.settings["webui.hsplit"] !== r) && (r > 0) && (r < 1)) {
 			theWebUI.settings["webui.hsplit"] = r;
-			theWebUI.resize();
 			theWebUI.save();
 		}
 	},
@@ -2361,6 +2345,7 @@ var theWebUI =
 	toggleMenu: function() {
 		$("#t").toggle();
 		theWebUI.resize();
+		theWebUI.save()
 	},
 
 	toggleDetails: function() {

--- a/js/webui.js
+++ b/js/webui.js
@@ -467,12 +467,14 @@ var theWebUI =
 		theTabs.show(tab);
 		this.activeView = tab;
 
-		if (!this.settings["webui.show_cats"])
-			$("#side-panel").hide();
-		if (!this.settings["webui.show_dets"]) {
-			$("#tdetails").hide();
-			if (!theWebUI.systemInfo.rTorrent.started)
-				this.toggleDetails();
+		if (!this.settings["webui.show_cats"]) {
+			$("#side-panel").addClass("d-none");
+			$("#HDivider").addClass("d-none");
+		}
+		if (!this.settings["webui.show_dets"] || !theWebUI.systemInfo.rTorrent.started) {
+			$("#tdetails").addClass("d-none");
+			$("#tdetails").removeClass("d-flex");
+			$("#VDivider").addClass("d-none")
 		}
 		theDialogManager.setEffects( iv(this.settings["webui.effects"])*200 );
 //		this.setStatusUpdate();
@@ -2267,8 +2269,9 @@ var theWebUI =
 			$("#side-panel").width(w);
 			$("#main-info").width($("#maincont").width() - 5 - w);
 		} else {
-			$("#main-info").width(100);
+			$("#main-info").width($("#maincont").width());
 		}
+		this.resizeGraph();
 	},
 
 	resizeTop: function(w, h) {
@@ -2279,37 +2282,23 @@ var theWebUI =
 			$("#list-table").height(h);
 			$("#tdetails").height($("#maincont").height() - 5 - h);
 		} else {
-			$("#list-table").height(100);
+			$("#list-table").height($("#maincont").height());
 		}
+		this.resizeGraph();
 	},
 
-	resizeBottom : function( w, h )
-	{
-        	if(w!==null)
-        	{
-			$("#tdetails").width( w );
-			w-=8;
-		}
-		if(h!==null)
-        	{
-			$("#tdetails").height( h );
-			h-=($("#tabbar").outerHeight());
-			$("#tdcont").height( h );
-			h-=2;
-        	}
-        	if(theWebUI.configured)
-        	{
-	        	this.getTable("fls").resize(w,h);
-			this.getTable("trk").resize(w,h);
-			this.getTable("prs").resize(w,h);
-			var table = this.getTable("plg");
-			if(table)
-				table.resize(w,h);
-			this.speedGraph.resize(w,h);
-		}
+	resizeGraph: function() {
+		// Resize graphs in #tdetails
+		const tdcont = $("#tdcont");
+		this.speedGraph.resize(tdcont.width(), tdcont.height());
 	},
 
 	resize: function() {
+		if ($("#t").css("display") === "none") {
+			$("#maincont").height($(window).height() - 30); // 25px for #StatusBar, 5px for margin top
+		} else {
+			$("#maincont").css({height:""});
+		}
 		const w = $("#maincont").width() * (1 - theWebUI.settings["webui.hsplit"]) - 5;
 		theWebUI.resizeLeft(w);
 		const h = $("#maincont").height() * theWebUI.settings["webui.vsplit"];
@@ -2329,7 +2318,7 @@ var theWebUI =
 		r = Math.floor(r * 1000) / 1000;
 		if ((theWebUI.settings["webui.vsplit"] !== r) && (r > 0) && (r < 1)) {
 			theWebUI.settings["webui.vsplit"] = r;
-			theWebUI.save();
+			this.save();
 		}
 	},
 
@@ -2338,30 +2327,29 @@ var theWebUI =
 		r = Math.floor(r * 1000) / 1000;
 		if ((theWebUI.settings["webui.hsplit"] !== r) && (r > 0) && (r < 1)) {
 			theWebUI.settings["webui.hsplit"] = r;
-			theWebUI.save();
+			this.save();
 		}
 	},
 
 	toggleMenu: function() {
 		$("#t").toggle();
-		theWebUI.resize();
-		theWebUI.save()
+		this.resize();
 	},
 
 	toggleDetails: function() {
-		theWebUI.settings["webui.show_dets"] = !theWebUI.settings["webui.show_dets"];
-		$("#tdetails").toggle();
-		$("#VDivider").toggle();
-		theWebUI.resize();
-		theWebUI.save();
+		this.settings["webui.show_dets"] = !this.settings["webui.show_dets"];
+		$("#tdetails").toggleClass("d-flex d-none");
+		$("#VDivider").toggleClass("d-none");
+		this.resize();
+		this.save();
 	},
 
 	toggleCategories: function() {
-		theWebUI.settings["webui.show_cats"] = !theWebUI.settings["webui.show_cats"];
-		$("#side-panel").toggle();
-		$("#HDivider").toggle();
-    theWebUI.resize();
-		theWebUI.save();
+		this.settings["webui.show_cats"] = !this.settings["webui.show_cats"];
+		$("#side-panel").toggleClass("d-none");
+		$("#HDivider").toggleClass("d-none");
+    this.resize();
+		this.save();
 	},
 
 	showAdd: function()

--- a/js/webui.js
+++ b/js/webui.js
@@ -467,12 +467,11 @@ var theWebUI =
 		theTabs.show(tab);
 		this.activeView = tab;
 
-		if(!this.settings["webui.show_cats"])
-			$("#CatList").hide();
-		if(!this.settings["webui.show_dets"])
-		{
+		if (!this.settings["webui.show_cats"])
+			$("#side-panel").hide();
+		if (!this.settings["webui.show_dets"]) {
 			$("#tdetails").hide();
-			if(!theWebUI.systemInfo.rTorrent.started)
+			if (!theWebUI.systemInfo.rTorrent.started)
 				this.toggleDetails();
 		}
 		theDialogManager.setEffects( iv(this.settings["webui.effects"])*200 );
@@ -769,7 +768,7 @@ var theWebUI =
 							}
 							case "webui.show_cats":
 							{
-								$("#CatList").toggle();
+								$("#side-panel").toggle();
 								needResize = true;
 								break;
 							}
@@ -2359,25 +2358,24 @@ var theWebUI =
 		}
 	},
 
-	toggleMenu: function()
-	{
+	toggleMenu: function() {
 		$("#t").toggle();
-  		theWebUI.resize();
+		theWebUI.resize();
 	},
 
-	toggleDetails: function()
-	{
+	toggleDetails: function() {
 		theWebUI.settings["webui.show_dets"] = !theWebUI.settings["webui.show_dets"];
 		$("#tdetails").toggle();
-      		theWebUI.resize();
+		$("#VDivider").toggle();
+		theWebUI.resize();
 		theWebUI.save();
 	},
 
-	toggleCategories: function()
-	{
-	        theWebUI.settings["webui.show_cats"] = !theWebUI.settings["webui.show_cats"];
-		$("#CatList").toggle();
-      		theWebUI.resize();
+	toggleCategories: function() {
+		theWebUI.settings["webui.show_cats"] = !theWebUI.settings["webui.show_cats"];
+		$("#side-panel").toggle();
+		$("#HDivider").toggle();
+    theWebUI.resize();
 		theWebUI.save();
 	},
 

--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -485,25 +485,6 @@ theTabs.onShow = function(id)
 		plugin.tasksOnShow.call(this,id);
 };
 
-plugin.resizeBottom = theWebUI.resizeBottom;
-theWebUI.resizeBottom = function( w, h )
-{
-	plugin.resizeBottom.call(theWebUI,w,h);
-	if(theWebUI.configured)
-	{
-	       	if(w!==null)
-			w-=8;
-		if(h!==null)
-       		{
-			h-=($("#tabbar").outerHeight());
-			h-=2;
-        	}
-		var table = this.getTable("tasks");
-		if(table)
-			table.resize(w,h);
-	}
-}
-
 plugin.canDetachTask = function()
 {
 	return( !(plugin.foreground.options && plugin.foreground.options.nohide) &&

--- a/plugins/chunks/init.js
+++ b/plugins/chunks/init.js
@@ -116,20 +116,16 @@ rTorrentStub.prototype.getchunksParseXML = function(xml)
 	return(ret);
 }
 
-plugin.resizeBottom = theWebUI.resizeBottom;
-theWebUI.resizeBottom = function( w, h )
-{
-	if(plugin.enabled) 
-	{
-	        if(theWebUI.configured)
-	        {
-	        	if(h)
-		        	$('#cCont').height(h-50);
-		}
-		else
-			setTimeout( 'theWebUI.resize()', 1000 );
+plugin.resizeTop = theWebUI.resizeTop;
+theWebUI.resizeTop = function(w, h) {
+	if (plugin.enabled) {
+		if (theWebUI.configured) {
+			if (h)
+				$('#cCont').height(h - 50);
+		} else
+			setTimeout('theWebUI.resize()', 1000);
 	}
-	plugin.resizeBottom.call(this,w,h);
+	plugin.resizeTop.call(this, w, h);
 }
 
 plugin.onLangLoaded = function() 

--- a/plugins/history/init.js
+++ b/plugins/history/init.js
@@ -374,25 +374,6 @@ if(plugin.canChangeTabs() || plugin.canChangeColumns())
 			plugin.onShow.call(this,id);
 	}
 
-	plugin.resizeBottom = theWebUI.resizeBottom;
-	theWebUI.resizeBottom = function( w, h )
-	{
-		plugin.resizeBottom.call(theWebUI,w,h);
-        	if(w!==null)
-			w-=8;
-		if(h!==null)
-        	{
-			h-=($("#tabbar").outerHeight());
-			h-=2;
-        	}
-        	if(theWebUI.configured)
-        	{
-			var table = this.getTable("hst");
-			if(table)
-				table.resize(w,h);
-		}
-	}
-
 	if(plugin.canChangeMenu())
 	{
 		dxSTable.prototype.historySelect = function(e,id)

--- a/plugins/rss/init.js
+++ b/plugins/rss/init.js
@@ -206,10 +206,7 @@ theWebUI.config = function()
 	this.rssArray = [];
 	this.filters = [];	
 	$("#List").after(
-		$("<div>")
-		.attr("id","RSSList")
-		.addClass('main-table')
-		.css("display","none")
+		$("<div>").attr("id","RSSList").css("display","none"),
 	);
 	this.tables["rss"] =  
 	{

--- a/plugins/rutracker_check/init.js
+++ b/plugins/rutracker_check/init.js
@@ -80,11 +80,24 @@ theWebUI.updateDetails = function()
 plugin.onLangLoaded = function()
 {
 	$("#mainlayout").append( 
-		"<tr id='chkinfo1'><td colspan='6' class='Header'>"+theUILang.chkHdr+"</td></tr>"+
-		"<tr id='chkinfo2'><td nowrap>"+theUILang.checkedAt+":</td>"+
-			"<td><span id='chktime' class='det'></span></td>"+
-			"<td nowrap>"+theUILang.checkedResult+":</td>"+
-			"<td colspan=3><span id='chkresult' class='det'></span></td></tr>" );
+		$("<div>").addClass("row Header").append(
+			$("<div>").attr({id:"chkinfo1"}).addClass("col-12").text(theUILang.chkHdr),
+		),
+		$("<div>").addClass("row").append(
+			$("<div>").attr({id:"chkinfo2"}).addClass("col-12 col-md-2").append(
+				$("<span>").addClass("det-hdr").text(theUILang.checkedAt + ": "),
+			),
+			$("<div>").addClass("col-12 col-md-10").append(
+				$("<span>").attr({id:"chktime"}).addClass("det"),
+			),
+			$("<div>").addClass("col-12 col-md-2").append(
+				$("<span>").addClass("det-hdr").text(theUILang.checkedResult + ": "),
+			),
+			$("<div>").addClass("col-12 col-md-10").append(
+				$("<span>").attr({id:"chkresult"}).addClass("det"),
+			),
+		),
+	);
 }
 
 plugin.onRemove = function()

--- a/plugins/theme/themes/Acid/stable.css
+++ b/plugins/theme/themes/Acid/stable.css
@@ -1,4 +1,4 @@
-.stable-head { background: #272E36; border-color: #A0A0A0 #A0A0A0 #A0A0A0 #A0A0A0; }
+.stable-head {background: #272E36;}
 .stable-head table tr {background: transparent url(./images/header.gif) repeat-x scroll center top}
 .stable-head table tr td { border-color: #A0A0A0 #A0A0A0 #A0A0A0 #A0A0A0; background: transparent url(./images/blank.gif) no-repeat scroll right center; color: #00ff00; font-weight: bold;}
 .stable-head div.resz {background: transparent url(./images/s.gif) no-repeat scroll left center; }

--- a/plugins/theme/themes/Acid/style.css
+++ b/plugins/theme/themes/Acid/style.css
@@ -94,9 +94,9 @@ div#t div#setting {background: transparent url(./images/toolbar.png) no-repeat -
 div#t div#help {background: transparent url(./images/quest.gif) no-repeat 0px center}
 div#t div#go {background: transparent url(./images/go.gif) no-repeat 0px center; }
 
-category-list#CatList { background-color: #272E36; color: #BDDBDB;}
-div#CatList ul li { border: 1px solid #272E36; font-weight: bold; }
-div#CatList ul li.sel {background-color: #BDDBDB; border-color: #BDDBDB; color: #272E36;}
+#side-panel { background-color: #272E36; color: #BDDBDB;}
+div#side-panel ul li { border: 1px solid #272E36; font-weight: bold; }
+div#side-panel ul li.sel {background-color: #BDDBDB; border-color: #BDDBDB; color: #272E36;}
 
 .stable-icon {background-image: url(./images/tstatus.png); }
 
@@ -124,8 +124,8 @@ div#tdcont {background: #272E36; }
 div.tab { background: #272E36; }
 div#lcont { background: #272E36; font-weight: bold; color: #BDDBDB;}
 
-div#gcont table {color: #BDDBDB; font-weight: bold;}
-div#gcont table td.Header {background: #323A46;}
+div#gcont {color: #BDDBDB; font-weight: bold;}
+div#gcont div.Header {background: #323A46;}
 
 .tabbar {background-color: #1e2124;}
 .tabbar li a:hover {border-top: 2px solid #00FF00;}

--- a/plugins/theme/themes/Blue/style.css
+++ b/plugins/theme/themes/Blue/style.css
@@ -11,7 +11,7 @@ html, body { background-color: #DFE8F6 }
 
   --settings-background-color: #272E36;
 }
-#CatList, category-list {
+#side-panel, category-list {
   border-color: #99BBE8;
 }
 

--- a/plugins/theme/themes/Dark/stable.css
+++ b/plugins/theme/themes/Dark/stable.css
@@ -1,4 +1,4 @@
-.stable-head { background: #181818; border-color: #181818 #333333 #333333 #181818;}
+.stable-head {background: #181818;}
 .stable-head table tr {background: transparent url(./images/header.gif) repeat-x scroll center top}
 .stable-head table tr td { border-color: #181818 #333333 #333333 #181818; }
 .stable-head div.resz {border: 1px solid #FF0000; background: transparent url(./images/s.gif) no-repeat scroll left center;}

--- a/plugins/theme/themes/Dark/stable.css
+++ b/plugins/theme/themes/Dark/stable.css
@@ -1,4 +1,3 @@
-.stable {border: 1px solid; border-color: #333333 #181818 #181818 #333333}
 .stable-head { background: #181818; border-color: #181818 #333333 #333333 #181818;}
 .stable-head table tr {background: transparent url(./images/header.gif) repeat-x scroll center top}
 .stable-head table tr td { border-color: #181818 #333333 #333333 #181818; }

--- a/plugins/theme/themes/Dark/style.css
+++ b/plugins/theme/themes/Dark/style.css
@@ -26,7 +26,7 @@ button:not([disabled]):hover:active, input.Button:not([disabled]):hover:active {
   filter: brightness(1.3);
 }
 
-#CatList, category-list {
+#side-panel, category-list {
   border: 1px solid #333333;
   background-color: #181818;
 }
@@ -117,7 +117,7 @@ a {color: #686868}
 
 div.tab {background: #181818}
 div#lcont {background: #181818}
-div#gcont table td.Header {background: #181818}
+div#gcont div.Header {background: #181818;}
 div.graph_tab {background-color: #181818}
 .graph_tab_legend { color: #FFF; background-color: #181818; }
 .graph_tab_tooltip { color: #FFF; background-color: #606060; border: 1px solid #606060; }
@@ -125,7 +125,7 @@ div#List {border: 1px solid #333333;}
 
 div#modalbg {background-color: #181818;}
 
-div#List {border: 1px solid #333333; background-color: #181818}
+div#list-table {border: 1px solid #333333; background-color: #181818}
 div#FileList, div#TrackerList, div#PeerList, div#Speed {background-color: #181818}
 
 div#stg { background-color: #181818; color: #888888; border: 1px solid #333333}

--- a/plugins/theme/themes/DarkBetter/stable.css
+++ b/plugins/theme/themes/DarkBetter/stable.css
@@ -1,4 +1,3 @@
-.stable {border: 1px solid; border-color: #333333 #181818 #181818 #333333}
 .stable-head {background: #181818; border-color: #181818 #333333 #333333 #181818}
 .stable-head table tr {background: transparent url(./images/header.gif) repeat-x scroll center top}
 .stable-head table tr td {border-color: #181818 #333333 #333333 #181818}

--- a/plugins/theme/themes/DarkBetter/stable.css
+++ b/plugins/theme/themes/DarkBetter/stable.css
@@ -1,4 +1,4 @@
-.stable-head {background: #181818; border-color: #181818 #333333 #333333 #181818}
+.stable-head {background: #181818;}
 .stable-head table tr {background: transparent url(./images/header.gif) repeat-x scroll center top}
 .stable-head table tr td {border-color: #181818 #333333 #333333 #181818}
 .stable-head div.resz {border: 1px solid #FF0000; background: transparent url(./images/s.gif) no-repeat scroll left center}

--- a/plugins/theme/themes/DarkBetter/style.css
+++ b/plugins/theme/themes/DarkBetter/style.css
@@ -56,8 +56,7 @@ input.Button:not([disabled]):hover:active {
   -webkit-box-shadow: inset 0px 0px 8px 0px #474747;
 }
 
-#CatList,
-category-list {
+#side-panel, category-list {
   border: 1px solid #333333;
   background-color: #181818;
 }
@@ -282,7 +281,7 @@ a {color: #686868}
 
 div.tab {background: #181818}
 div#lcont {background: #181818}
-div#gcont table td.Header {background: #181818}
+div#gcont div.Header {background: #181818;}
 div.graph_tab {background-color: #181818}
 .graph_tab_legend { color: #FFF; background-color: #181818; }
 .graph_tab_tooltip { color: #FFF; background-color: #606060; border: 1px solid #606060; }
@@ -290,7 +289,7 @@ div#List {border: 1px solid #333333}
 
 div#modalbg {background-color: #181818}
 
-div#List {border: 1px solid #333333; background-color: #181818}
+div#list-table {border: 1px solid #333333; background-color: #181818}
 div#FileList, div#TrackerList, div#PeerList, div#Speed {background-color: #181818}
 
 div#stg {background-color: #181818; color: #888888; border: 1px solid #333333}

--- a/plugins/theme/themes/Excel/stable.css
+++ b/plugins/theme/themes/Excel/stable.css
@@ -1,5 +1,8 @@
 #list-table { border-color: #9eb6ce }
-.stable-head { border-style: none none none none; color: #000000; background: transparent url(./images/header.gif) repeat-x scroll center top }
+.stable-head {
+  color: #000000;
+  background: transparent url(./images/header.gif) repeat-x scroll center top;
+}
 .stable-head table tr {background: transparent url(./images/header.gif) repeat-x scroll center top }
 .stable-head table tr td { border-color: #f8d79b #f2993c #f2993c #f8d79b }
 

--- a/plugins/theme/themes/Excel/stable.css
+++ b/plugins/theme/themes/Excel/stable.css
@@ -1,4 +1,4 @@
-.stable, div#List { border-color: #9eb6ce }
+#list-table { border-color: #9eb6ce }
 .stable-head { border-style: none none none none; color: #000000; background: transparent url(./images/header.gif) repeat-x scroll center top }
 .stable-head table tr {background: transparent url(./images/header.gif) repeat-x scroll center top }
 .stable-head table tr td { border-color: #f8d79b #f2993c #f2993c #f8d79b }

--- a/plugins/theme/themes/Excel/style.css
+++ b/plugins/theme/themes/Excel/style.css
@@ -2,7 +2,7 @@ html, body { background-color: #DFE8F6; scrollbar-arrow-color: #586585; scrollba
 :root {
   --settings-background-color: #FFFFFF;
 }
-#CatList, category-list {
+#side-panel, category-list {
   border-top-style: none;
   border-color: #9EB6CE;
   background: local transparent url(./images/cbg.png) repeat-y 0 0;
@@ -49,7 +49,7 @@ input[type="text"][disabled],input[type="password"][disabled],input[type="file"]
 
 div#tdcont, div.tab, div#lcont { background-color: #d2e0f0; color: #034084 }
 div.graph_tab { background-color: #d2e0f0; color: #034084; border-color: #ffffff }
-div#gcont table td.Header { background-color: #e4edf6 }
+div#gcont div.Header {background-color: #e4edf6;}
 div#tdcont { border-color: #9EB6CE }
 div#tdetails { background-color: transparent }
 

--- a/plugins/theme/themes/Excel/style.css
+++ b/plugins/theme/themes/Excel/style.css
@@ -26,7 +26,6 @@ panel-label {
 panel-label[selected] {
   --badge-background-color: #FFFFFF;
 }
-div#HDivider { width: 5px }
 
 .stable {border: none;}
 

--- a/plugins/theme/themes/Excel/style.css
+++ b/plugins/theme/themes/Excel/style.css
@@ -27,8 +27,6 @@ panel-label[selected] {
   --badge-background-color: #FFFFFF;
 }
 
-.stable {border: none;}
-
 div#StatusBar { background: transparent url(./images/statbg.png) repeat-x 0 0; border-top: none; color: #034084 }
 .statuscell { border-color: #9EB6CE }
 

--- a/plugins/theme/themes/MaterialDesign/stable.css
+++ b/plugins/theme/themes/MaterialDesign/stable.css
@@ -6,12 +6,10 @@
     src: local('Ubuntu'), url(./font/ubuntu.woff) format('woff');
 }
 
-.stable { border: 1px solid; border-color: #333333 #181818 #181818 #333333; }
 .stable td { padding: 2px; }
 
 .stable-head { color: #626262; background: #181818 url(./images/headers.png) repeat-x 0px -91px; border: none; text-shadow: 0px 1px 0px #000; font-family: Ubuntu; }
 div#tdcont .stable-head { border: none; }
-div#tdcont .stable { border: none; }
 .stable-head table tr { background: transparent; border: none; }
 .stable-head table tr td { border: none; font-family: Ubuntu; height: 18px; line-height: 18px; cursor: pointer; }
 .stable-head div.resz { border: 1px solid #FF0000; background: transparent url(./images/s.gif) no-repeat scroll left center; }

--- a/plugins/theme/themes/MaterialDesign/stable.css
+++ b/plugins/theme/themes/MaterialDesign/stable.css
@@ -8,8 +8,12 @@
 
 .stable td { padding: 2px; }
 
-.stable-head { color: #626262; background: #181818 url(./images/headers.png) repeat-x 0px -91px; border: none; text-shadow: 0px 1px 0px #000; font-family: Ubuntu; }
-div#tdcont .stable-head { border: none; }
+.stable-head {
+  color: #626262;
+  background: #181818 url(./images/headers.png) repeat-x 0px -91px;
+  text-shadow: 0px 1px 0px #000;
+  font-family: Ubuntu;
+}
 .stable-head table tr { background: transparent; border: none; }
 .stable-head table tr td { border: none; font-family: Ubuntu; height: 18px; line-height: 18px; cursor: pointer; }
 .stable-head div.resz { border: 1px solid #FF0000; background: transparent url(./images/s.gif) no-repeat scroll left center; }

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -37,7 +37,7 @@ html,body
 	--settings-background-color: #222;
 }
 
-#CatList, category-list
+#side-panel, category-list
 {
 	border:none;
 	background-color:#1A2329;
@@ -504,29 +504,25 @@ div#lcont
 	font-family:'Roboto'
 }
 
-div#gcont table td.Header
-{
+div#gcont div.Header {
 	background:transparent url(./images/status_icons.png) no-repeat 0 -286px;
 	font-family:'Roboto';
 	color:#D4D6C9;
-	padding-left:17px
+	padding-left:17px;
 }
 
-div#gcont table tr
-{
+div#gcont div.row {
 	background:#181818 url(./images/headers.png) repeat-x 0 -93px;
 	font-family:'Roboto';
-	color:#D4D6C9
+	color:#D4D6C9;
 }
 
-div#gcont table tr td
-{
+div#gcont div.row > div {
 	background:#181818 url(./images/headers.png) repeat-x 0 -38px
 }
 
-div#gcont table
-{
-	font-family:'Roboto'
+div#gcont {
+	font-family:'Roboto';
 }
 
 div.graph_tab
@@ -554,10 +550,8 @@ div#modalbg {
 	background-color:#181818
 }
 
-div#List,.main-table
-{
+#list-table {
 	margin-right:6px;
-	border:none;
 	background-color:#181818
 }
 

--- a/plugins/theme/themes/Oblivion/stable.css
+++ b/plugins/theme/themes/Oblivion/stable.css
@@ -1,8 +1,6 @@
-.stable {border: 1px solid; border-color: #333333 #181818 #181818 #333333;}
 .stable td {padding:2px;}
 .stable-head {color:#626262;background: #181818 url(./images/headers.png) repeat-x 0px -91px; border:none; text-shadow:0px 1px 0px #000;font-family:inherit;}
 div#tdcont .stable-head {border:none;}
-div#tdcont .stable {border:none;}
 .stable-head table tr {background: transparent;border:none;}
 .stable-head table tr td { border:none; font-family:inherit;height:18px;line-height:18px;cursor:pointer;}
 .stable-head div.resz {border: 1px solid #FF0000; background: transparent url(./images/s.gif) no-repeat scroll left center;}

--- a/plugins/theme/themes/Oblivion/stable.css
+++ b/plugins/theme/themes/Oblivion/stable.css
@@ -1,6 +1,10 @@
 .stable td {padding:2px;}
-.stable-head {color:#626262;background: #181818 url(./images/headers.png) repeat-x 0px -91px; border:none; text-shadow:0px 1px 0px #000;font-family:inherit;}
-div#tdcont .stable-head {border:none;}
+.stable-head {
+  color: #626262;
+  background: #181818 url(./images/headers.png) repeat-x 0px -91px;
+  text-shadow:0px 1px 0px #000;
+  font-family: inherit;
+}
 .stable-head table tr {background: transparent;border:none;}
 .stable-head table tr td { border:none; font-family:inherit;height:18px;line-height:18px;cursor:pointer;}
 .stable-head div.resz {border: 1px solid #FF0000; background: transparent url(./images/s.gif) no-repeat scroll left center;}

--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -30,7 +30,7 @@ button:not([disabled]):hover:active, input.Button:not([disabled]):hover:active {
   background: #000 url(./images/headers.png) repeat-x 0px -8px;
 }
 
-#CatList, category-list {
+#side-panel, category-list {
   border:none;
   background-color: #212121;
   border-right: 1px solid #1b1b1b;
@@ -187,18 +187,28 @@ input[type="number"][disabled],input[type="text"][disabled], input[type="passwor
 
 div.tab {background: #181818;font-family: inherit;}
 div#lcont {background: #181818;font-family: inherit;}
-div#gcont table td.Header {background: transparent url(./images/status_icons.png) no-repeat 0px -286px;font-family: inherit;color:#D4D6C9;padding-left:17px;}
-
-div#gcont table tr {background: #181818 url(./images/headers.png) repeat-x 0px -93px;font-family: inherit;color:#D4D6C9}
-div#gcont table tr td{background: #181818 url(./images/headers.png) repeat-x 0px -38px;}
-div#gcont table {font-family:inherit;}
+div#gcont {font-family:inherit;}
+div#gcont div.Header {
+  background: transparent url(./images/status_icons.png) no-repeat 0px -286px;
+  font-family: inherit;
+  color: #D4D6C9;
+  padding-left: 17px;
+}
+div#gcont div.row {
+  background: #181818 url(./images/headers.png) repeat-x 0px -93px;
+  font-family: inherit;
+  color: #D4D6C9;
+}
+div#gcont div.row > div {
+  background: #181818 url(./images/headers.png) repeat-x 0px -38px;
+}
 div.graph_tab {color:#FFF; background-color: #181818}
 .graph_tab_legend { color: #FFF; background-color: #181818; }
 .graph_tab_tooltip { color: #FFF; background-color: #606060; border: 1px solid #606060; }
 
 div#modalbg {background-color: #181818;}
 
-div#List {margin-right:6px;border-top: 1px solid #333; border-right: 1px solid #070707; border-left: 1px solid #1b1b1b; border-bottom: 1px solid #000000; background-color: #181818;}
+#list-table {margin-right:6px;border-top: 1px solid #333; border-right: 1px solid #070707; border-left: 1px solid #1b1b1b; border-bottom: 1px solid #000000; background-color: #181818;}
 div#FileList, div#TrackerList, div#PeerList, div#Speed {background-color: #181818}
 
 .dlg-window { background-color: #222222; box-shadow: 2px 2px 5px #888;}

--- a/plugins/trafic/init.js
+++ b/plugins/trafic/init.js
@@ -148,17 +148,28 @@ if(plugin.canChangeTabs())
 		}
 	}
 
-	plugin.resizeBottom = theWebUI.resizeBottom;
-	theWebUI.resizeBottom = function( w, h )
-	{
-		if(plugin.enabled) 
-		{
-		        if(plugin.allStuffLoaded)
-				this.trafGraph.resize(w,h);
-			else
-				setTimeout( 'theWebUI.resize()', 1000 );
+	plugin.resizeLeft = theWebUI.resizeLeft;
+	theWebUI.resizeLeft = function(w) {
+		if (plugin.enabled) {
+			if (plugin.allStuffLoaded) {
+				const tdcont = $("#tdcont");
+				this.trafGraph.resize(tdcont.width(), tdcont.height());
+			} else
+				setTimeout('theWebUI.resize()', 1000);
 		}
-		plugin.resizeBottom.call(this,w,h);
+		plugin.resizeLeft.call(this, w);
+	}
+
+	plugin.resizeTop = theWebUI.resizeTop;
+	theWebUI.resizeTop = function(w, h) {
+		if (plugin.enabled) {
+			if (plugin.allStuffLoaded) {
+				const tdcont = $("#tdcont");
+				this.trafGraph.resize(tdcont.width(), tdcont.height());
+			} else
+				setTimeout('theWebUI.resize()', 1000);
+		}
+		plugin.resizeTop.call(this, w, h);
 	}
 
 	theWebUI.showTrafic = function(d)


### PR DESCRIPTION
Changes are made to the main content division, including:

- apply flex layout to the main content division, reducing the amount of resizing work previously done by JavaScript and incline CSS styles;
- modify drag-n-drop behaviors on the vertical divider and the horizontal divider, making the side panel and the torrent detail resize immediately when dragging, rather than resize on releasing the mouse button;
- remove some lines of JavaScript codes in resizing, and let CSS takes some part of sizing, and this should make things easier to understand and maintain.