### PR TITLE
Apply flex layout to option-related plugins

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -338,6 +338,10 @@ div.op100l {width: 400px; float: left}
   background-color: var(--settings-background-color);
   overflow: hidden auto;
 }
+.stg_con legend {
+  position: sticky;
+  top: 0;
+}
 .ie9 .stg_con {position: static}
 .stg_con table {width: 100%}
 .stg_con td {font-weight: normal; height: 19px}

--- a/css/style.css
+++ b/css/style.css
@@ -42,6 +42,7 @@ textarea {
   padding: 0.25rem;
   resize: none;
   width: 100%;
+  height: 10rem;
 }
 label {
   cursor: pointer;

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -274,14 +274,12 @@ rPlugin.prototype.attachPageToOptions = function(dlg,name)
 	return(this);
 }
 
-rPlugin.prototype.removePageFromOptions = function(id)
-{
-	if(theOptionsSwitcher.current==id)
+rPlugin.prototype.removePageFromOptions = function(id) {
+	if (theOptionsSwitcher.current === id)
 		theOptionsSwitcher.run('st_gl');
-	$("#"+id).remove();
-	$("#hld_"+id).remove();
-	$(".lm ul li:last").addClass("last");
-	return(this);
+	$("#" + id).remove();
+	$("#hld_" + id).remove();
+	return this;
 }
 
 rPlugin.prototype.attachPageToTabs = function(dlg,name,idBefore)

--- a/plugins/autotools/autotools.css
+++ b/plugins/autotools/autotools.css
@@ -1,5 +1,0 @@
-#automove_browse_btn {width:30px}
-#autowatch_browse_btn {width:30px}
-#st_autotools {display: none;}
-#watch_start {margin: 4px 4px;}
-.ctrls_level2 {padding:0px 0px 0px 25px;}

--- a/plugins/autotools/init.js
+++ b/plugins/autotools/init.js
@@ -1,75 +1,68 @@
 plugin.loadLang();
 
-if(plugin.canChangeOptions())
-{
-	plugin.loadMainCSS();
+if (plugin.canChangeOptions()) {
 	plugin.addAndShowSettings = theWebUI.addAndShowSettings;
-	theWebUI.addAndShowSettings = function( arg )
-	{
-	        if(plugin.enabled)
-	        {
-			$$('enable_label').checked = ( theWebUI.autotools.EnableLabel == 1 );
+	theWebUI.addAndShowSettings = function(arg) {
+		if (plugin.enabled) {
+			$$('enable_label').checked = (theWebUI.autotools.EnableLabel === 1);
 			$$('label_template').value = theWebUI.autotools.LabelTemplate;
-			linked( $$('enable_label'), 0, ['label_template'] );
-			$$('enable_move').checked  = ( theWebUI.autotools.EnableMove  == 1 );
+			linked($$('enable_label'), 0, ['label_template']);
+			$$('enable_move').checked  = (theWebUI.autotools.EnableMove === 1);
 			$$('path_to_finished').value = theWebUI.autotools.PathToFinished;
 			$$('skip_move_for_files').value = theWebUI.autotools.SkipMoveForFiles;
-			linked( $$('enable_move'), 0, ['automove_filter', 'path_to_finished', 'skip_move_for_files', 'automove_browse_btn', 'fileop_type', 'auto_add_label', 'auto_add_name'] );
+			linked($$('enable_move'), 0, ['automove_filter', 'path_to_finished', 'skip_move_for_files', 'automove_browse_btn', 'fileop_type', 'auto_add_label', 'auto_add_name']);
 			$$('fileop_type').value = theWebUI.autotools.FileOpType;
-			$$('enable_watch').checked  = ( theWebUI.autotools.EnableWatch  == 1 );
+			$$('enable_watch').checked  = (theWebUI.autotools.EnableWatch === 1);
 			$$('path_to_watch').value = theWebUI.autotools.PathToWatch;
-			linked( $$('enable_watch'), 0, ['path_to_watch', 'autowatch_browse_btn', 'watch_start'] );
-			$$('watch_start').checked  = ( theWebUI.autotools.WatchStart  == 1 );
-			if(plugin.DirBrowser1)
+			linked($$('enable_watch'), 0, ['path_to_watch', 'autowatch_browse_btn', 'watch_start']);
+			$$('watch_start').checked  = (theWebUI.autotools.WatchStart === 1);
+			if (plugin.DirBrowser1)
 				plugin.DirBrowser1.hide();
-			if(plugin.DirBrowser2)
+			if (plugin.DirBrowser2)
 				plugin.DirBrowser2.hide();
 			$$('automove_filter').value = theWebUI.autotools.MoveFilter;
-			$$('auto_add_label').checked = ( theWebUI.autotools.AddLabel == 1 );
-			$$('auto_add_name').checked = ( theWebUI.autotools.AddName == 1 );			
+			$$('auto_add_label').checked = (theWebUI.autotools.AddLabel === 1);
+			$$('auto_add_name').checked = (theWebUI.autotools.AddName === 1);			
 		}
-		plugin.addAndShowSettings.call(theWebUI,arg);
+		plugin.addAndShowSettings.call(theWebUI, arg);
 	}
 
-	theWebUI.autotoolsWasChanged = function()
-	{
-		if( $$('enable_label').checked != ( theWebUI.autotools.EnableLabel == 1 ) )
+	theWebUI.autotoolsWasChanged = function() {
+		if ($$('enable_label').checked !== (theWebUI.autotools.EnableLabel === 1))
 			return true;
-		if( $$('label_template').value != theWebUI.autotools.LabelTemplate )
+		if ($$('label_template').value !== theWebUI.autotools.LabelTemplate)
 			return true;
-		if( $$('enable_move').checked  != ( theWebUI.autotools.EnableMove  == 1 ) )
+		if ($$('enable_move').checked !== (theWebUI.autotools.EnableMove === 1))
 			return true;
-		if( $$('path_to_finished').value != theWebUI.autotools.PathToFinished )
+		if ($$('path_to_finished').value !== theWebUI.autotools.PathToFinished)
 			return true;
-		if( $$('skip_move_for_files').value != theWebUI.autotools.SkipMoveForFiles )
+		if ($$('skip_move_for_files').value !== theWebUI.autotools.SkipMoveForFiles)
 			return true;
-		if( $$('enable_watch').checked  != ( theWebUI.autotools.EnableWatch  == 1 ) )
+		if ($$('enable_watch').checked !== ( theWebUI.autotools.EnableWatch === 1))
 			return true;
-		if( $$('path_to_watch').value != theWebUI.autotools.PathToWatch )
+		if ($$('path_to_watch').value !== theWebUI.autotools.PathToWatch)
 			return true;
-		if( $$('fileop_type').value != theWebUI.autotools.FileOpType )
+		if ($$('fileop_type').value !== theWebUI.autotools.FileOpType)
 			return true;
-		if( $$('watch_start').checked != ( theWebUI.autotools.WatchStart == 1 ) )
+		if ($$('watch_start').checked !== (theWebUI.autotools.WatchStart === 1))
 			return true;
-		if( $$('automove_filter').value != theWebUI.autotools.MoveFilter )
+		if ($$('automove_filter').value !== theWebUI.autotools.MoveFilter)
 			return true;
-		if( $$('auto_add_label').checked != ( theWebUI.autotools.AddLabel == 1 ) )
+		if ($$('auto_add_label').checked !== (theWebUI.autotools.AddLabel === 1))
 			return true;
-		if( $$('auto_add_name').checked != ( theWebUI.autotools.AddName == 1 ) )
+		if ($$('auto_add_name').checked !== (theWebUI.autotools.AddName === 1))
 			return true;
 		return false;
 	}
 
 	plugin.setSettings = theWebUI.setSettings;
-	theWebUI.setSettings = function()
-	{
+	theWebUI.setSettings = function() {
 		plugin.setSettings.call(this);
-		if( plugin.enabled && this.autotoolsWasChanged() )
-			this.request( "?action=setautotools" );
+		if (plugin.enabled && this.autotoolsWasChanged())
+			this.request("?action=setautotools");
 	}
 
-	rTorrentStub.prototype.setautotools = function()
-	{
+	rTorrentStub.prototype.setautotools = function() {
 		this.content = "enable_label=" + ( $$('enable_label').checked ? '1' : '0' ) +
 			"&label_template=" + $$('label_template').value +
 			"&enable_move=" + ( $$('enable_move').checked  ? '1' : '0' ) +
@@ -88,100 +81,104 @@ if(plugin.canChangeOptions())
 	}
 }
 
-plugin.onLangLoaded = function()
-{
-	if(this.canChangeOptions())
-	{
-		this.attachPageToOptions( $("<div>").attr("id","st_autotools").html(
-		"<fieldset>"+
-			"<legend>"+ theUILang.autotools +"</legend>"+
-			"<table>"+
-			"<tr>"+
-				"<td>"+
-					"<input type='checkbox' id='enable_label' checked='false' "+
-					"onchange='linked(this, 0, [\"label_template\"]);' />"+
-						"<label for='enable_label'>"+ theUILang.autotoolsEnableLabel +"</label>"+
-				"</td>"+
-				"<td class='alr'>"+
-					"<input type='text' id='label_template' class='TextboxNormal' maxlength='100' />"+
-				"</td>"+
-			"</tr>"+
-			"<tr>"+
-				"<td>"+
-					"<input type='checkbox' id='enable_move' checked='false' "+
-					"onchange='linked(this, 0, [\"automove_filter\", \"skip_move_for_files\", \"path_to_finished\", \"automove_browse_btn\", \"fileop_type\", \"auto_add_label\", \"auto_add_name\" ]);' />"+
-						"<label for='enable_move'>"+ theUILang.autotoolsEnableMove +"</label>"+
-				"</td>"+
-				"<td class='alr'>"+
-					"<input type='text' id='automove_filter' class='TextboxNormal' maxlength='200'/>" +				
-				"</td>"+
-			"</tr>"+
-			"<tr>"+
-				"<td>"+
-					"<label id='lbl_skip_move_for_files' for='skip_move_for_files' class='disabled' disabled='true'>"+
-					theUILang.autotoolsSkipMoveForFiles + "</label><br>"+
-				"</td>"+
-				"<td class='alr'>"+
-					"<input type='text' id='skip_move_for_files' class='TextBoxLarge' maxlength='30' />"+
-				"</td>"+
-
-			"</tr>"+
-			"<tr>"+
-				"<td class='ctrls_level2' colspan=2>"+
-					"<br><label id='lbl_path_to_finished' for='path_to_finished' class='disabled' disabled='true'>"+
-					theUILang.autotoolsPathToFinished +":</label><br>"+
-					"<input type='text' id='path_to_finished' class='TextboxLarge' maxlength='100' />"+
-					"<input type='button' id='automove_browse_btn' class='Button' value='...' />"+
-					"<br><label id='lbl_fileop_type' for='fileop_type' class='disabled' disabled='true'>"+theUILang.autotoolsFileOpType+":</label>"+
- 					"<select id='fileop_type' class='disabled' disabled='true'>"+
- 					"<option value='Move'>"+theUILang.autotoolsFileOpMove+"</option>"+
- 					"<option value='HardLink'>"+theUILang.autotoolsFileOpHardLink+"</option>"+
- 					"<option value='Copy'>"+theUILang.autotoolsFileOpCopy+"</option>"+
- 					"<option value='SoftLink'>"+theUILang.autotoolsFileOpSoftLink+"</option>"+
- 					"</select>"+
-					"<div class='checkbox'>" +
-						"<input type='checkbox' id='auto_add_label'/>"+
-						"<label id='lbl_auto_add_label' for='auto_add_label'>"+ theUILang.autotoolsAddLabel +"</label>"+
-					"</div>" +
-					"<div class='checkbox'>" +
-						"<input type='checkbox' id='auto_add_name'/>"+
-						"<label id='lbl_auto_add_name' for='auto_add_name'>"+ theUILang.autotoolsAddName +"</label>"+
-					"</div>"+
-				"</td>"+
-			"</tr>"+
-			"<tr>"+
-				"<td colspan=2>"+
-					"<input type='checkbox' id='enable_watch' checked='false' "+
-					"onchange='linked(this, 0, [\"path_to_watch\", \"autowatch_browse_btn\",\"watch_start\"]);' />"+
-						"<label for='enable_watch'>"+ theUILang.autotoolsEnableWatch +"</label>"+
-				"</td>"+
-			"</tr>"+
-			"<tr>"+
-				"<td class='ctrls_level2' colspan=2>"+
-					"<label id='lbl_path_to_watch' for='path_to_watch' class='disabled' disabled='true'>"+
-					theUILang.autotoolsPathToWatch +":</label><br>"+
-				"<input type='text' id='path_to_watch' class='TextboxLarge' maxlength='100' />"+
-				"<input type='button' id='autowatch_browse_btn' class='Button' value='...' />"+
-				"<br><input type='checkbox' id='watch_start' checked='false' disabled='true'/>"+
-				"<label id='lbl_watch_start' for='watch_start' class='disabled'>"+ theUILang.autotoolsWatchStart +"</label>"+
-				"</td>"+
-			"</tr>"+
-			"</table>"+
-		"</fieldset>")[0], theUILang.autotools );
-		if(thePlugins.isInstalled("_getdir"))
-		{
-			this.DirBrowser1 = new theWebUI.rDirBrowser( 'st_autotools', 'path_to_finished', 'automove_browse_btn', 'automove_browse_frame' );
-			this.DirBrowser2 = new theWebUI.rDirBrowser( 'st_autotools', 'path_to_watch', 'autowatch_browse_btn', 'autowatch_browse_frame' );
-		}
-		else
-		{
+plugin.onLangLoaded = function() {
+	if (this.canChangeOptions()) {
+		const stgAutoTools = $("<div>").attr({id:"st_autotools"}).append(
+			$("<fieldset>").append(
+				$("<legend>").text(theUILang.autotools),
+				$("<div>").addClass("row").append(
+					$("<div>").addClass("col-1 justify-content-md-end").append(
+						$("<input>").attr({type:"checkbox", id:"enable_label", onchange:"linked(this, 0, ['label_template']);"}),
+					),
+					$("<div>").addClass("col-11 col-md-5").append(
+						$("<label>").attr({for:"enable_label"}).text(theUILang.autotoolsEnableLabel),
+					),
+					$("<div>").addClass("col-11 offset-1 col-md-6 offset-md-0").append(
+						$("<input>").attr({type:"text", id:"label_template", maxlength:100}),
+					),
+				),
+				$("<div>").addClass("row").append(
+					$("<div>").addClass("col-1 justify-content-md-end").append(
+						$("<input>").attr({type:"checkbox", id:"enable_move", onchange:"linked(this, 0, ['automove_filter', 'skip_move_for_files', 'path_to_finished', 'automove_browse_btn', 'fileop_type', 'auto_add_label', 'auto_add_name']);"}),
+					),
+					$("<div>").addClass("col-11 col-md-5").append(
+						$("<label>").attr({for:"enable_move"}).text(theUILang.autotoolsEnableMove),
+					),
+					$("<div>").addClass("col-11 offset-1 col-md-6 offset-md-0").append(
+						$("<input>").attr({type:"text", id:"automove_filter", maxlength:200}),
+					),
+					$("<div>").addClass("col-11 col-md-5 offset-1").append(
+						$("<label>").attr({id:"lbl_skip_move_for_files", for:"skip_move_for_files"}).addClass("disabled").text(theUILang.autotoolsSkipMoveForFiles),
+					),
+					$("<div>").addClass("col-11 offset-1 col-md-6 offset-md-0").append(
+						$("<input>").attr({type:"text", id:"skip_move_for_files", maxlength:30}),
+					),
+					$("<div>").addClass("col-11 col-md-5 offset-1").append(
+						$("<label>").attr({id:"lbl_path_to_finished", for:"path_to_finished"}).addClass("disabled").text(theUILang.autotoolsPathToFinished + ": "),
+					),
+					$("<div>").addClass("col-11 offset-1 col-md-6 offset-md-0").append(
+						$("<input>").attr({type:"text", id:"path_to_finished", maxlength:100}),
+						$("<button>").attr({type:"button", id:"automove_browse_btn"}).addClass("browseButton").text("..."),
+					),
+					$("<div>").addClass("col-11 col-md-5 offset-1").append(
+						$("<label>").attr({id:"lbl_fileop_type", for:"fileop_type"}).addClass("disabled").text(theUILang.autotoolsFileOpType + ": "),
+					),
+					$("<div>").addClass("col-11 offset-1 col-md-6 offset-md-0").append(
+						$("<select>").attr({id:"fileop_type"}).addClass("disabled").append(
+							...[
+								["Move", theUILang.autotoolsFileOpMove],
+								["HardLink", theUILang.autotoolsFileOpHardLink],
+								["Copy", theUILang.autotoolsFileOpCopy],
+								["SoftLink", theUILang.autotoolsFileOpSoftLink],
+							].map(([value, text]) => $("<option>").val(value).text(text)),
+						),
+					),
+					$("<div>").addClass("col-11 offset-1 col-md-5 checkbox").append(
+						$("<input>").attr({type:"checkbox", id:"auto_add_label"}),
+						$("<label>").attr({id:"lbl_auto_add_label", for:"auto_add_label"}).text(theUILang.autotoolsAddLabel),
+					),
+					$("<div>").addClass("col-11 offset-1 col-md-6 offset-md-0 checkbox").append(
+						$("<input>").attr({type:"checkbox", id:"auto_add_name"}),
+						$("<label>").attr({id:"lbl_auto_add_name", for:"auto_add_name"}).text(theUILang.autotoolsAddName),
+					),
+				),
+				$("<div>").addClass("row").append(
+					$("<div>").addClass("col-1 justify-content-md-end").append(
+						$("<input>").attr({type:"checkbox", id:"enable_watch", onchange:"linked(this, 0, ['path_to_watch', 'autowatch_browse_btn', 'watch_start']);"}),
+					),
+					$("<div>").addClass("col-11 col-md-5").append(
+						$("<label>").attr({for:"enable_watch"}).text(theUILang.autotoolsEnableWatch),
+					),
+				),
+				$("<div>").addClass("row").append(
+					$("<div>").addClass("col-11 col-md-5 offset-1").append(
+						$("<label>").attr({id:"lbl_path_to_watch", for:"path_to_watch"}).addClass("disabled").text(theUILang.autotoolsPathToWatch + ": "),
+					),
+					$("<div>").addClass("col-11 offset-1 col-md-6 offset-md-0").append(
+						$("<input>").attr({type:"text", id:"path_to_watch", maxlength:100}),
+						$("<button>").attr({type:"button", id:"autowatch_browse_btn"}).addClass("browseButton").text("..."),
+					),
+					$("<div>").addClass("col-11 col-md-5 offset-1").append(
+						$("<input>").attr({type:"checkbox", id:"watch_start"}),
+						$("<label>").attr({id:"lbl_watch_start", for:"watch_start"}).addClass("disabled").text(theUILang.autotoolsWatchStart),
+					),
+				),
+			),
+		);
+		this.attachPageToOptions(
+			stgAutoTools.get(0),
+			theUILang.autotools,
+		);
+		if (thePlugins.isInstalled("_getdir")) {
+			this.DirBrowser1 = new theWebUI.rDirBrowser("stg", "path_to_finished", "automove_browse_btn", "automove_browse_frame");
+			this.DirBrowser2 = new theWebUI.rDirBrowser("stg", "path_to_watch", "autowatch_browse_btn", "autowatch_browse_frame");
+		} else {
 			$('#automove_browse_btn').remove();
 			$('#autowatch_browse_btn').remove();
 		}
 	}
 }
 
-plugin.onRemove = function()
-{
-	this.removePageFromOptions( "st_autotools" );
+plugin.onRemove = function() {
+	this.removePageFromOptions("st_autotools");
 }

--- a/plugins/autotools/init.js
+++ b/plugins/autotools/init.js
@@ -90,10 +90,10 @@ plugin.onLangLoaded = function() {
 					$("<div>").addClass("col-1 justify-content-md-end").append(
 						$("<input>").attr({type:"checkbox", id:"enable_label", onchange:"linked(this, 0, ['label_template']);"}),
 					),
-					$("<div>").addClass("col-11 col-md-5").append(
+					$("<div>").addClass("col-11").append(
 						$("<label>").attr({for:"enable_label"}).text(theUILang.autotoolsEnableLabel),
 					),
-					$("<div>").addClass("col-11 offset-1 col-md-6 offset-md-0").append(
+					$("<div>").addClass("col-11 offset-1").append(
 						$("<input>").attr({type:"text", id:"label_template", maxlength:100}),
 					),
 				),
@@ -101,22 +101,22 @@ plugin.onLangLoaded = function() {
 					$("<div>").addClass("col-1 justify-content-md-end").append(
 						$("<input>").attr({type:"checkbox", id:"enable_move", onchange:"linked(this, 0, ['automove_filter', 'skip_move_for_files', 'path_to_finished', 'automove_browse_btn', 'fileop_type', 'auto_add_label', 'auto_add_name']);"}),
 					),
-					$("<div>").addClass("col-11 col-md-5").append(
+					$("<div>").addClass("col-11").append(
 						$("<label>").attr({for:"enable_move"}).text(theUILang.autotoolsEnableMove),
 					),
-					$("<div>").addClass("col-11 offset-1 col-md-6 offset-md-0").append(
+					$("<div>").addClass("col-11 offset-1").append(
 						$("<input>").attr({type:"text", id:"automove_filter", maxlength:200}),
 					),
-					$("<div>").addClass("col-11 col-md-5 offset-1").append(
+					$("<div>").addClass("col-11 offset-1").append(
 						$("<label>").attr({id:"lbl_skip_move_for_files", for:"skip_move_for_files"}).addClass("disabled").text(theUILang.autotoolsSkipMoveForFiles),
 					),
-					$("<div>").addClass("col-11 offset-1 col-md-6 offset-md-0").append(
+					$("<div>").addClass("col-11 offset-1").append(
 						$("<input>").attr({type:"text", id:"skip_move_for_files", maxlength:30}),
 					),
-					$("<div>").addClass("col-11 col-md-5 offset-1").append(
+					$("<div>").addClass("col-11 offset-1").append(
 						$("<label>").attr({id:"lbl_path_to_finished", for:"path_to_finished"}).addClass("disabled").text(theUILang.autotoolsPathToFinished + ": "),
 					),
-					$("<div>").addClass("col-11 offset-1 col-md-6 offset-md-0").append(
+					$("<div>").addClass("col-11 offset-1").append(
 						$("<input>").attr({type:"text", id:"path_to_finished", maxlength:100}),
 						$("<button>").attr({type:"button", id:"automove_browse_btn"}).addClass("browseButton").text("..."),
 					),

--- a/plugins/create/create.css
+++ b/plugins/create/create.css
@@ -17,7 +17,7 @@ div#tcreate {min-width: 90vw;}
 @media (min-width: 576px) { 
   /* Custom rules for small devices */
   div#tcreate {min-width: 518px;}
-  div#tcreate textarea {resize: none; height: 16rem;}
+  div#tcreate textarea {height: 16rem;}
 }
 
 /* Medium devices (tablets, 768px and up) */

--- a/plugins/loginmgr/init.js
+++ b/plugins/loginmgr/init.js
@@ -1,5 +1,4 @@
 plugin.loadLang();
-plugin.loadMainCSS();
 
 if(plugin.canChangeOptions())
 {
@@ -62,41 +61,46 @@ if(plugin.canChangeOptions())
 	}
 }
 
-plugin.onLangLoaded = function()
-{
-	var s = '';
-	$.each( theWebUI.theAccounts, function(name,val)
-	{
-		s+="<fieldset>"+
-			"<legend>"+name+"</legend>"+
-			"<table>"+
-				"<tr>"+
-					"<td><input type='checkbox' id='"+name+"_lmenabled' onchange=\"linked(this, 0, ['"+name+"_lmlogin','"+name+"_lmpassword','"+name+"_lmauto']);\"/><label for='"+name+"_lmenabled' id='lbl_"+name+"_lmenabled'>"+theUILang.Enabled+"</label></td>"+
-				"</tr>"+
-				"<tr>"+
-					"<td><label id='lbl_"+name+"_lmlogin' for='"+name+"_lmlogin' class='disabled'>"+theUILang.accLogin+":</label></td>"+
-					"<td class=\"alr\"><input type='text' id='"+name+"_lmlogin' class='TextboxLarge' maxlength='32' disabled='true' /></td>"+
-				"</tr>"+
-				"<tr>"+
-					"<td><label id='lbl_"+name+"_lmpassword' for='"+name+"_lmpassword' class='disabled'>"+theUILang.accPassword+":</label></td>"+
-					"<td class=\"alr\"><input type='password' id='"+name+"_lmpassword' class='TextboxLarge' maxlength='64' disabled='true' /></td>"+
-				"</tr>"+
-				"<tr>"+
-					"<td><label id='lbl_"+name+"_lmauto' for='"+name+"_lmauto' class='disabled'>"+theUILang.accAuto+":</label></td>"+
-					"<td class=\"alr\"><select id='"+name+"_lmauto' class='TextboxLarge' maxlength='64' disabled='true'>"+
-						"<option value='0'>"+theUILang.acAutoNone+"</option>"+
-						"<option value='86400'>"+theUILang.acAutoDay+"</option>"+
-						"<option value='604800'>"+theUILang.acAutoWeek+"</option>"+
-						"<option value='2592000'>"+theUILang.acAutoMonth+"</option>"+
-					"</select></td>"+
-				"</tr>"+
-			"</table>"+
-		"</fieldset>";
-	});
-	this.attachPageToOptions($("<div>").attr("id","st_loginmgr").html(s)[0],theUILang.accAccounts);
+plugin.onLangLoaded = function() {
+	const s = Object.entries(theWebUI.theAccounts).map(([name, acct]) => $("<fieldset>").append(
+		$("<legend>").text(name),
+		$("<div>").addClass("row").append(
+			$("<div>").addClass("col-md-6").append(
+				$("<input>").attr({type:"checkbox", id:`${name}_lmenabled`, onchange:`linked(this, 0, ['${name}_lmlogin','${name}_lmpassword','${name}_lmauto'])`}),
+				$("<label>").attr({for:`${name}_lmenabled`, id:`lbl_${name}_lmenabled`}).text(theUILang.Enabled),
+			),
+			$("<div>").addClass("col-4 col-md-2").append(
+				$("<label>").attr({id:`lbl_${name}_lmauto`, for:`${name}_lmauto`}).addClass("disabled").text(theUILang.accAuto + ": "),
+			),
+			$("<div>").addClass("col-8 col-md-4").append(
+				$("<select>").attr({id:`${name}_lmauto`, maxlength:64}).append(
+					...[
+						[0, "acAutoNone"], [86400, "acAutoDay"], [604800, "acAutoWeek"], [2592000, "acAutoMonth"],
+					].map(([value, text]) => $("<option>").val(value).text(theUILang[text])),
+				),
+			),
+		),
+		$("<div>").addClass("row").append(
+			$("<div>").addClass("col-4 col-md-2").append(
+				$("<label>").attr({id:`lbl_${name}_lmlogin`, for:`${name}_lmlogin`}).addClass("disabled").text(theUILang.accLogin + ": "),
+			),
+			$("<div>").addClass("col-8 col-md-4").append(
+				$("<input>").attr({type:"text", id:`${name}_lmlogin`, maxlength:32}),
+			),
+			$("<div>").addClass("col-4 col-md-2").append(
+				$("<label>").attr({id:`lbl_${name}_lmpassword`, for:`${name}_lmpassword`}).addClass("disabled").text(theUILang.accPassword + ": "),
+			),
+			$("<div>").addClass("col-8 col-md-4").append(
+				$("<input>").attr({type:"password", id:`${name}_lmpassword`, maxlength:64}),
+			),
+		),
+	));
+	this.attachPageToOptions(
+		$("<div>").attr("id","st_loginmgr").append(...s)[0],
+		theUILang.accAccounts,
+	);
 }
 
-plugin.onRemove = function()
-{
+plugin.onRemove = function() {
 	this.removePageFromOptions("st_loginmgr");
 }

--- a/plugins/loginmgr/loginmgr.css
+++ b/plugins/loginmgr/loginmgr.css
@@ -1,1 +1,0 @@
-#st_loginmgr { overflow: auto }

--- a/plugins/unpack/init.js
+++ b/plugins/unpack/init.js
@@ -82,23 +82,20 @@ if(plugin.canChangeMenu())
 	}
 }
 
-if(plugin.canChangeOptions())
-{
+if (plugin.canChangeOptions()) {
 	plugin.addAndShowSettings = theWebUI.addAndShowSettings;
-	theWebUI.addAndShowSettings = function( arg )
-	{
-        	if(plugin.enabled && plugin.allStuffLoaded)
-	        {
+	theWebUI.addAndShowSettings = function(arg) {
+		if (plugin.enabled && plugin.allStuffLoaded) {
 			$('#unpack_enabled').prop('checked',(theWebUI.unpackData.enabled == 1));
 			$('#unpack_label').prop('checked',(theWebUI.unpackData.addLabel == 1));
 			$('#unpack_name').prop('checked',(theWebUI.unpackData.addName == 1));
 			$('#edit_unpack1').val( theWebUI.unpackData.path );
 			$('#edit_filter').val( theWebUI.unpackData.filter );
-			linked( $$('unpack_enabled'), 0, ['edit_filter'] );
-			if(plugin.btn)
+			linked($$('unpack_enabled'), 0, ['edit_filter', 'edit_unpack1', 'btn_unpack1']);
+			if (plugin.btn)
 				plugin.btn.hide();
 		}
-		plugin.addAndShowSettings.call(theWebUI,arg);
+		plugin.addAndShowSettings.call(theWebUI, arg);
 	}
 
 	theWebUI.unpackWasChanged = function()
@@ -155,59 +152,67 @@ plugin.onLangLoaded = function()
 		setTimeout(arguments.callee,1000);
 	else
 	{
-		theDialogManager.make( 'dlg_unpack', theUILang.unpack,
-			"<div class='cont fxcaret'>" +
-				"<fieldset>" +
-					"<div>" + theUILang.unpackPath + "</div>" +
-					"<input type='text' id='edit_unpack' class='TextboxLarge' maxlength='200'/>" +
-					"<input type='button' id='btn_unpack' class='Button' value='...' />" +
-				"</fieldset>" +
-			"</div>"+
-			"<div class='aright buttons-list'>" +
-				"<input type='button' value='" + theUILang.ok + "' class='OK Button' " +
-					" onclick='theWebUI.unpack(); return(false);' />" +
-				"<input type='button' value='"+ theUILang.Cancel + "' class='Cancel Button'/>" +
-			"</div>", true);
+		theDialogManager.make('dlg_unpack', theUILang.unpack,
+			$("<div>").addClass("cont fxcaret").append(
+				$("<fieldset>").append(
+					$("<legend>").text(theUILang.unpackPath),
+					$("<div>").addClass("row mx-1 my-5").append(
+						$("<div>").addClass("col-12 d-flex align-items-center").append(
+							$("<input>").attr({type:"text", id:"edit_unpack", maxlength:200}),
+							$("<button>").attr({type:"button", id:"btn_unpack"}).text("..."),
+						),
+					),
+				),
+			)[0].outerHTML +
+			$("<div>").addClass("buttons-list my-3").append(
+				$("<button>").attr({type:"button", onclick:"theWebUI.unpack(); return(false);"}).addClass("OK").text(theUILang.ok),
+				$("<button>").attr({type:"button"}).addClass("Cancel").text(theUILang.Cancel),
+			)[0].outerHTML,
+			true,
+		);
 
-		plugin.attachPageToOptions( $("<div>").attr("id","st_unpack").html(
-			"<div>"+
-				"<input id=\"unpack_enabled\" type=\"checkbox\""+
-					" onchange='linked(this, 0, [\"edit_filter\"]);' />"+
-				"<label for=\"unpack_enabled\">"+
-					theUILang.unpackEnabled+
-				"</label>"+
-				"<input type='text' id='edit_filter' class='TextboxMid' maxlength='200'/>" +
-			"</div>"+
-			"<fieldset>"+
-				"<legend>"+theUILang.unpackPath+"</legend>"+
-				"<input type='text' id='edit_unpack1' class='TextboxLarge' maxlength='200'/>" +
-				"<input type='button' id='btn_unpack1' class='Button' value='...' />" +
-			"</fieldset>"+
-			"<fieldset>"+
-				"<legend>"+theUILang.unpackTorrents+"</legend>"+
-				"<div class='checkbox'>" +
-					"<input type='checkbox' id='unpack_label'/>"+
-					"<label for='unpack_label'>"+ theUILang.unpackAddLabel +"</label>"+
-				"</div>" +
-				"<div class='checkbox'>" +
-					"<input type='checkbox' id='unpack_name'/>"+
-					"<label for='unpack_name'>"+ theUILang.unpackAddName +"</label>"+
-				"</div>"+
-			"</fieldset>"
-			)[0], theUILang.unpack );
+		plugin.attachPageToOptions(
+			$("<div>").attr({id:"st_unpack"}).append(
+				$("<fieldset>").append(
+					$("<legend>").text(theUILang.unpackPath),
+					$("<div>").addClass("row").append(
+						$("<div>").addClass("col-12 col-md-6").append(
+							$("<input>").attr({type:"checkbox", id:"unpack_enabled", onchange:"linked(this, 0, ['edit_filter', 'edit_unpack1', 'btn_unpack1']);"}),
+							$("<label>").attr({for:"unpack_enabled"}).text(theUILang.unpackEnabled),
+						),
+						$("<div>").addClass("col-12 col-md-6").append(
+							$("<input>").attr({type:"text", id:"edit_filter", maxlength:200}),
+						),
+						$("<div>").addClass("col-12").append(
+							$("<input>").attr({type:"text", id:"edit_unpack1", maxlength:200}),
+							$("<button>").attr({type:"button", id:"btn_unpack1"}).addClass("browseButton").text("..."),
+						),
+					),
+				),
+				$("<fieldset>").append(
+					$("<legend>").text(theUILang.unpackTorrents),
+					$("<div>").addClass("row").append(
+						...[
+							["unpack_label", theUILang.unpackAddLabel],
+							["unpack_name", theUILang.unpackAddName],
+						].map(([id, text]) => $("<div>").addClass("col-12 col-md-6").append(
+							$("<input>").attr({type:"checkbox", id:id}),
+							$("<label>").attr({for:id}).text(text),
+						)),
+					),
+				),
+			)[0],
+			theUILang.unpack,
+		);
 		$('#edit_unpack').val( theWebUI.unpackData.path );
-		if(thePlugins.isInstalled("_getdir"))
-		{
-			var btn = new theWebUI.rDirBrowser( 'dlg_unpack', 'edit_unpack', 'btn_unpack' );
-			theDialogManager.setHandler('dlg_unpack','afterHide',function()
-			{
+		if (thePlugins.isInstalled("_getdir")) {
+			const btn = new theWebUI.rDirBrowser('dlg_unpack', 'edit_unpack', 'btn_unpack');
+			theDialogManager.setHandler('dlg_unpack', 'afterHide', function() {
 				btn.hide();
 			});
-			if(plugin.canChangeOptions())
-				plugin.btn = new theWebUI.rDirBrowser( 'st_unpack', 'edit_unpack1', 'btn_unpack1' );
-		}
-		else
-		{
+			if (plugin.canChangeOptions())
+				plugin.btn = new theWebUI.rDirBrowser('stg', 'edit_unpack1', 'btn_unpack1');
+		} else {
 			$('#btn_unpack').remove();
 			$('#btn_unpack1').remove();
 		}

--- a/plugins/unpack/unpack.css
+++ b/plugins/unpack/unpack.css
@@ -1,15 +1,2 @@
-div#dlg_unpack {width: 325px; height: 150px; overflow: visible}
-
-div#dlg_unpack fieldset div {line-height: 16px}
-
-div#dlg_unpack label {width: 120px; vertical-align: middle; margin-top: 5px; margin-bottom: 5px; margin-left: 10px; }
-div#dlg_unpack input {vertical-align: middle; margin-top: 5px; margin-bottom: 5px;}
-
-div#dlg_unpack br {clear: left; line-height: 0}
-
-#btn_unpack {width:30px}
-#btn_unpack1 {width:30px}
-
+div#dlg_unpack .row > div {padding: 0 0.25rem; margin-bottom: 0.1rem;}
 div#dlg_unpack div.dlg-header {background-image: url(../../images/settings.gif)}
-
-div#st_unpack { display: none }

--- a/plugins/xmpp/init.js
+++ b/plugins/xmpp/init.js
@@ -1,13 +1,9 @@
 plugin.loadLang();
 
-if(plugin.canChangeOptions())
-{
-	plugin.loadMainCSS();
+if (plugin.canChangeOptions()) {
 	plugin.addAndShowSettings = theWebUI.addAndShowSettings;
-	theWebUI.addAndShowSettings = function( arg )
-	{
-	        if(plugin.enabled)
-	        {
+	theWebUI.addAndShowSettings = function(arg) {
+		if (plugin.enabled) {
 			$$('useEncryption').checked = ( theWebUI.xmpp.UseEncryption == 1 );
 			$$('advancedSettings').checked = ( theWebUI.xmpp.AdvancedSettings == 1);
 			$$('jabberHost').value = theWebUI.xmpp.JabberHost;
@@ -18,56 +14,37 @@ if(plugin.canChangeOptions())
 			$$('jabberPasswd').value = theWebUI.xmpp.JabberPasswd;
 			$$('message').value = theWebUI.xmpp.Message;
 		}
-		plugin.addAndShowSettings.call(theWebUI,arg);
+		plugin.addAndShowSettings.call(theWebUI, arg);
 	}
 
-	theWebUI.xmppWasChanged = function()
-	{
-		if( $$('useEncryption').checked != ( theWebUI.xmpp.UseEncryption == 1 ) )
-		{
+	theWebUI.xmppWasChanged = function() {
+		if ( $$('useEncryption').checked != ( theWebUI.xmpp.UseEncryption == 1 ) )
 			return true;
-		}
-		if( $$('jabberHost').value != theWebUI.xmpp.JabberHost )
-		{
+		if ( $$('jabberHost').value != theWebUI.xmpp.JabberHost )
 			return true;
-		}
-		if( $$('advancedSettings').checked  != ( theWebUI.xmpp.AdvansedSettings  == 1 ) )
-		{
+		if ( $$('advancedSettings').checked  != ( theWebUI.xmpp.AdvansedSettings  == 1 ) )
 			return true;
-		}
-		if( $$('jabberPort').value != theWebUI.xmpp.JabberPort)
-		{
+		if ( $$('jabberPort').value != theWebUI.xmpp.JabberPort)
 			return true;
-		}
-		if( $$('jabberJid').value != theWebUI.xmpp.JabberJID )
-		{
+		if ( $$('jabberJid').value != theWebUI.xmpp.JabberJID )
 			return true;
-		}
-		if( $$('jabberFor').value != theWebUI.xmpp.JabberFor )
-		{
+		if ( $$('jabberFor').value != theWebUI.xmpp.JabberFor )
 			return true;
-		}
-		if( $$('message').value != theWebUI.xmpp.Message )
-		{
+		if ( $$('message').value != theWebUI.xmpp.Message )
 			return true;
-		}
-		if( $$('jabberPasswd').value != theWebUI.xmpp.JabberPasswd )
-		{
+		if ( $$('jabberPasswd').value != theWebUI.xmpp.JabberPasswd )
 			return true;
-		}
 		return false;
 	}
 
 	plugin.setSettings = theWebUI.setSettings;
-	theWebUI.setSettings = function()
-	{
+	theWebUI.setSettings = function() {
 		plugin.setSettings.call(this);
-		if( plugin.enabled && this.xmppWasChanged() )
+		if ( plugin.enabled && this.xmppWasChanged() )
 			this.request( "?action=setxmpp" );
 	}
 
-	rTorrentStub.prototype.setxmpp = function()
-	{
+	rTorrentStub.prototype.setxmpp = function() {
 		this.content = "advancedSettings=" + ( $$('advancedSettings').checked ? '1' : '0' ) +
 			"&useEncryption=" + ( $$('useEncryption').checked  ? '1' : '0' ) +
 			"&jabberHost=" + $$('jabberHost').value +
@@ -82,64 +59,69 @@ if(plugin.canChangeOptions())
 	}
 }
 
-plugin.onLangLoaded = function()
-{
-	if(this.canChangeOptions())
-	{
-		this.attachPageToOptions( $("<div>").attr("id","st_xmpp").html(
-		"<fieldset>"+
-			"<legend>"+ theUILang.xmpp +"</legend>"+
-			"<table>"+
-			"<tr>"+
-				"<td>"+
-					"<label for='jabberJid'>"+ theUILang.xmppJabberJID +"</label>"+
-					"<input type='text' id='jabberJid' class='TextboxLarge' maxlength='100' />"+
-				"</td>"+
-			"</tr>"+
-			"<tr>"+
-				"<td>"+
-					"<label for='jabberPasswd'>"+ theUILang.xmppJabberPasswd +"</label>"+
-					"<input type='password' id='jabberPasswd' class='TextboxNormal' maxlength='100' />"+
-				"</td>"+
-			"</tr>"+
-			"<tr>"+
-				"<td>"+
-					"<label for='jabberFor'>"+ theUILang.xmppJabberFor +"</label>"+
-					"<input type='text' id='jabberFor' class='TextboxLarge' maxlength='100' />"+
-				"</td>"+
-			"</tr>"+
-			"<tr>"+
-				"<td>"+
-					"<label for='message'>"+ theUILang.xmppMessage +"</label>"+
-					"<textarea id='message'></textarea>"+
-				"</td>"+
-			"</tr>"+
-			"<tr>"+
-				"<td>"+
-					"<input type='checkbox' id='advancedSettings' checked='false' "+
-					"onchange='linked(this, 0, [\"jabberHost\", \"jabberPort\", \"useEncryption\"]);' />"+
-						"<label for='advancedSettings'>"+ theUILang.xmppAdvancedSettings +"</label>"+
-				"</td>"+
-			"</tr>"+
-			"<tr>"+
-				"<td class='ctrls_level2' colspan=2>"+
-					"<label id='lbl_jabberHost' for='jabberHost' class='disabled' disabled='true'>"+
-					theUILang.xmppJabberHost +":</label>"+
-					"<br><input type='text' id='jabberHost' class='TextboxNormal' maxlength='100' />"+
-					"<br><label id='lbl_jabberPort' for='jabberPort' class='disabled' disabled='true'>"+theUILang.xmppJabberPort+":</label>"+
-					"<br><input type='text' id='jabberPort' class='TextboxNormal' maxlength='100' />"+
-					"<div class='checkbox'>" +
-						"<input type='checkbox' id='useEncryption'/>"+
-						"<label id='lbl_useEncryption' for='useEncryption'>"+ theUILang.xmppUseEncryption +"</label>"+
-					"</div>" +
-				"</td>"+
-			"</tr>"+
-			"</table>"+
-		"</fieldset>")[0], theUILang.xmpp );
+plugin.onLangLoaded = function() {
+	if (this.canChangeOptions()) {
+		const stgXmpp = $("<div>").attr({id:"st_xmpp"}).append(
+			$("<fieldset>").append(
+				$("<legend>").text(theUILang.xmpp),
+				$("<div>").addClass("row").append(
+					...[
+						["jabberJid", theUILang.xmppJabberJID],
+						["jabberPasswd", theUILang.xmppJabberPasswd],
+						["jabberFor", theUILang.xmppJabberFor],
+					].flatMap(([id, text]) => {
+						return [
+							$("<div>").addClass("col-12 col-md-2").append(
+								$("<label>").attr({for:id}).text(text),
+							),
+							$("<div>").addClass("col-12 col-md-4").append(
+								$("<input>").attr({type:"text", id:id, maxlength:100}),
+							),
+						];
+					}),
+				),
+				$("<div>").addClass("row").append(
+					$("<div>").addClass("col-12 col-md-2 align-items-start").append(
+						$("<label>").attr({for:"message"}).text(theUILang.xmppMessage),
+					),
+					$("<div>").addClass("col-12 col-md-10").append(
+						$("<textarea>").attr({id:"message"}),
+					),
+				),
+			),
+			$("<fieldset>").append(
+				$("<legend>").text(theUILang.xmppAdvancedSettings),
+				$("<div>").addClass("row").append(
+					$("<div>").addClass("col-12").append(
+						$("<input>").attr({type:"checkbox", id:"advancedSettings", onchange:"linked(this, 0, ['jabberHost', 'jabberPort', 'useEncryption']);"}),
+						$("<label>").attr({for:"advancedSettings"}).text(theUILang.Enabled),
+					),
+					...[
+						["jabberHost", theUILang.xmppJabberHost], ["jabberPort", theUILang.xmppJabberPort],
+					].flatMap(([id, text]) => {
+						return [
+							$("<div>").addClass("col-12 col-md-2").append(
+								$("<label>").attr({id:`lbl_${id}`, for:id}).addClass("disabled").text(text + ": "),
+							),
+							$("<div>").addClass("col-12 col-md-4").append(
+								$("<input>").attr({type:"text", id:id, maxlength:100}),
+							),
+						];
+					}),
+					$("<div>").addClass("col-12 checkbox").append(
+						$("<input>").attr({type:"checkbox", id:"useEncryption"}),
+						$("<label>").attr({id:"lbl_useEncryption", for:"useEncryption"}).text(theUILang.xmppUseEncryption),
+					),
+				),
+			),
+		);
+		this.attachPageToOptions(
+			stgXmpp[0],
+			theUILang.xmpp,
+		);
 	}
 }
 
-plugin.onRemove = function()
-{
-	this.removePageFromOptions( "st_xmpp" );
+plugin.onRemove = function() {
+	this.removePageFromOptions("st_xmpp");
 }

--- a/plugins/xmpp/lang/cs.js
+++ b/plugins/xmpp/lang/cs.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/da.js
+++ b/plugins/xmpp/lang/da.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/de.js
+++ b/plugins/xmpp/lang/de.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Empfänger:";
  theUILang.xmppMessage			= "Nachricht:";
  theUILang.xmppJabberPasswd		= "Passwort:";
- theUILang.xmppAdvancedSettings		= "Erweitert:";
+ theUILang.xmppAdvancedSettings		= "Erweitert";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Verschlüsselung nutzen";

--- a/plugins/xmpp/lang/el.js
+++ b/plugins/xmpp/lang/el.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Παραλήπτης:";
  theUILang.xmppMessage			= "Μήνυμα:";
  theUILang.xmppJabberPasswd		= "Κωδικός:";
- theUILang.xmppAdvancedSettings		= "Προηγμένες:";
+ theUILang.xmppAdvancedSettings		= "Προηγμένες";
  theUILang.xmppJabberHost		= "Διακομιστής";
  theUILang.xmppJabberPort		= "Θύρα";
  theUILang.xmppUseEncryption		= "Χρήση κρυπτογράφησης";

--- a/plugins/xmpp/lang/en.js
+++ b/plugins/xmpp/lang/en.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/es.js
+++ b/plugins/xmpp/lang/es.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/fi.js
+++ b/plugins/xmpp/lang/fi.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/fr.js
+++ b/plugins/xmpp/lang/fr.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Destinataire :";
  theUILang.xmppMessage			= "Message :";
  theUILang.xmppJabberPasswd		= "Mot de passe :";
- theUILang.xmppAdvancedSettings		= "Paramètres avancés :";
+ theUILang.xmppAdvancedSettings		= "Paramètres avancés";
  theUILang.xmppJabberHost		= "Hôte ";
  theUILang.xmppJabberPort		= "Port ";
  theUILang.xmppUseEncryption		= "Utiliser le chiffrement";

--- a/plugins/xmpp/lang/hu.js
+++ b/plugins/xmpp/lang/hu.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/it.js
+++ b/plugins/xmpp/lang/it.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Ricevente:";
  theUILang.xmppMessage			= "Messaggio:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Avanzato:";
+ theUILang.xmppAdvancedSettings		= "Avanzato";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Usa cifratura";

--- a/plugins/xmpp/lang/ko.js
+++ b/plugins/xmpp/lang/ko.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "수신:";
  theUILang.xmppMessage			= "메시지:";
  theUILang.xmppJabberPasswd		= "암호:";
- theUILang.xmppAdvancedSettings		= "고급:";
+ theUILang.xmppAdvancedSettings		= "고급";
  theUILang.xmppJabberHost		= "호스트";
  theUILang.xmppJabberPort		= "포트";
  theUILang.xmppUseEncryption		= "암호화 사용";

--- a/plugins/xmpp/lang/lv.js
+++ b/plugins/xmpp/lang/lv.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/nl.js
+++ b/plugins/xmpp/lang/nl.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/no.js
+++ b/plugins/xmpp/lang/no.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Mottaker:";
  theUILang.xmppMessage			= "Melding:";
  theUILang.xmppJabberPasswd		= "Passord:";
- theUILang.xmppAdvancedSettings		= "Avansert:";
+ theUILang.xmppAdvancedSettings		= "Avansert";
  theUILang.xmppJabberHost		= "Vert";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Bruk kryptering";

--- a/plugins/xmpp/lang/pl.js
+++ b/plugins/xmpp/lang/pl.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Odbiorca:";
  theUILang.xmppMessage			= "Wiadomość:";
  theUILang.xmppJabberPasswd		= "Hasło:";
- theUILang.xmppAdvancedSettings		= "Zaawansowane:";
+ theUILang.xmppAdvancedSettings		= "Zaawansowane";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Używaj szyfrowania";

--- a/plugins/xmpp/lang/pt-br.js
+++ b/plugins/xmpp/lang/pt-br.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/pt-pt.js
+++ b/plugins/xmpp/lang/pt-pt.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Destinatário:";
  theUILang.xmppMessage			= "Mensagem:";
  theUILang.xmppJabberPasswd		= "Palavra-Chave:";
- theUILang.xmppAdvancedSettings		= "Avançado:";
+ theUILang.xmppAdvancedSettings		= "Avançado";
  theUILang.xmppJabberHost		= "Anfitrião";
  theUILang.xmppJabberPort		= "Porta";
  theUILang.xmppUseEncryption		= "Usar criptografia";

--- a/plugins/xmpp/lang/ru.js
+++ b/plugins/xmpp/lang/ru.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Кому:";
  theUILang.xmppMessage			= "Сообщение:";
  theUILang.xmppJabberPasswd		= "Пароль:";
- theUILang.xmppAdvancedSettings		= "Расширенные:";
+ theUILang.xmppAdvancedSettings		= "Расширенные";
  theUILang.xmppJabberHost		= "Хост";
  theUILang.xmppJabberPort		= "Порт";
  theUILang.xmppUseEncryption		= "Использовать шифрование";

--- a/plugins/xmpp/lang/sk.js
+++ b/plugins/xmpp/lang/sk.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/sr.js
+++ b/plugins/xmpp/lang/sr.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/sv.js
+++ b/plugins/xmpp/lang/sv.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/tr.js
+++ b/plugins/xmpp/lang/tr.js
@@ -14,7 +14,7 @@
  theUILang.xmppJabberFor		= "Alıcı:";
  theUILang.xmppMessage			= "İleti:";
  theUILang.xmppJabberPasswd		= "Parola:";
- theUILang.xmppAdvancedSettings		= "Gelişmiş:";
+ theUILang.xmppAdvancedSettings		= "Gelişmiş";
  theUILang.xmppJabberHost		= "Ana makine";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Şifreleme kullan";

--- a/plugins/xmpp/lang/uk.js
+++ b/plugins/xmpp/lang/uk.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Одержувач:";
  theUILang.xmppMessage			= "Повідомлення:";
  theUILang.xmppJabberPasswd		= "Пароль:";
- theUILang.xmppAdvancedSettings		= "Додатково:";
+ theUILang.xmppAdvancedSettings		= "Додатково";
  theUILang.xmppJabberHost		= "Сервер";
  theUILang.xmppJabberPort		= "Порт";
  theUILang.xmppUseEncryption		= "Використовувати шифрування";

--- a/plugins/xmpp/lang/vi.js
+++ b/plugins/xmpp/lang/vi.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/lang/zh-cn.js
+++ b/plugins/xmpp/lang/zh-cn.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "接收者:";
  theUILang.xmppMessage			= "信息:";
  theUILang.xmppJabberPasswd		= "密码:";
- theUILang.xmppAdvancedSettings		= "高级:";
+ theUILang.xmppAdvancedSettings		= "高级";
  theUILang.xmppJabberHost		= "主机";
  theUILang.xmppJabberPort		= "端口";
  theUILang.xmppUseEncryption		= "使用加密";

--- a/plugins/xmpp/lang/zh-tw.js
+++ b/plugins/xmpp/lang/zh-tw.js
@@ -13,7 +13,7 @@
  theUILang.xmppJabberFor		= "Recipient:";
  theUILang.xmppMessage			= "Message:";
  theUILang.xmppJabberPasswd		= "Password:";
- theUILang.xmppAdvancedSettings		= "Advanced:";
+ theUILang.xmppAdvancedSettings		= "Advanced";
  theUILang.xmppJabberHost		= "Host";
  theUILang.xmppJabberPort		= "Port";
  theUILang.xmppUseEncryption		= "Use encryption";

--- a/plugins/xmpp/xmpp.css
+++ b/plugins/xmpp/xmpp.css
@@ -1,2 +1,0 @@
-#st_xmpp {display: none;}
-.ctrls_level2 {padding:0px 0px 0px 25px;}


### PR DESCRIPTION
Apply flex layout to 4 plugins that add a page to the options window: 1) Accounts (loginmgr plugin); 2) Autotools; 3) XMPP; 4) Unpack. These changes are quite routine and just follow the previous patterns. Additionally, the unpack plugin also has a simple dialog window, and it's rewritten as well.