### PR TITLE
Apply flex layout to RSS plugin

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -123,6 +123,8 @@ div.dlg-window {
   border-radius: 8px;
   display: none;
   max-width: 95vw;
+  max-height: 95vh;
+  overflow: auto;
 }
 div.dlg-window div.row {
   margin: 0.5rem 0;
@@ -134,6 +136,7 @@ div.dlg-window div.row > div {
   align-items: center;
   padding: 0 0.25rem;
   margin-bottom: 0.1rem;
+  overflow: auto;
 }
 div.fxcaret {overflow: auto}
 div.dlg-header {
@@ -142,9 +145,16 @@ div.dlg-header {
   border-bottom: 1px solid #909090;
   border-radius: 10px 10px 0 0;
 }
-a.dlg-close:link, a.dlg-close:visited {width: 14px; height: 14px; margin: 5px; background: transparent url(../images/close.png) no-repeat scroll left center; float: right; border: 0}
-a.dlg-close:hover {width: 14px; height: 14px; background: transparent url(../images/close.png) no-repeat scroll -14px center; float: right; border: 0}
-a.dlg-close:active {width: 14px; height: 14px; background: transparent url(../images/close.png) no-repeat scroll -28px center; float: right; border: 0}
+a.dlg-close:link, a.dlg-close:visited {
+  display: block;
+  position: absolute;
+  right: 5px;
+  height: 14px;
+  width: 14px;
+  background: transparent url(../images/close.png) no-repeat scroll left center;
+}
+a.dlg-close:hover {background-position-x: -14px;}
+a.dlg-close:active {background-position-x: -28px;}
 
 div#sc {width: 150px; right: 57px; top: 40px; position: absolute; display: none; border: 1px solid #808080; background-color: #E0E0E0; z-index: 100}
 div#sc ul {margin: 0; padding: 0; list-style: none}

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
 	<body>
 		<div id="preload" class="d-none"></div>
 		<div id="cover" class="w-100 h-100 position-absolute top-0 left-0">
-			<div id="msg" class="w-100 h-100 position-relative text-center">
+			<div id="msg" class="w-100 position-relative text-center">
 				<span id="loadimg">&nbsp;</span>
 				<span uilang>Loading</span>
 			</div>

--- a/js/objects.js
+++ b/js/objects.js
@@ -92,10 +92,14 @@ var theDialogManager =
 
 	make: function(id, name, content, isModal, noClose) {
 		$(document.body).append($("<div>").attr("id",id).addClass(
-			"dlg-window position-absolute overflow-hidden"
-		).html(content).
-			prepend($("<div>").attr("id",id+"-header").addClass("dlg-header fw-bold px-5 py-1").text(name)).
-			prepend($("<a>").addClass("dlg-close")));
+			"dlg-window position-absolute"
+		).append(
+			$("<div>").addClass("d-flex flex-row align-items-center justify-content-between position-sticky top-0").append(
+				$("<div>").attr("id",id+"-header").addClass("dlg-header fw-bold ps-5 pe-1 py-1 flex-grow-1").text(name),
+				$("<a>").attr({href:"#"}).addClass("dlg-close"),
+			),
+			$(content),
+		));
 		return(this.add(id,isModal,noClose));
 	},
 	add: function(id, isModal, noClose) {
@@ -105,7 +109,7 @@ var theDialogManager =
 		obj.css( { position: "absolute", display: "none", outline: "0px solid transparent" } ).
 			data("modal",isModal).data("nokeyclose",noClose);
 		if(!noClose)
-			obj.find(".dlg-close").attr("href","javascript:theDialogManager.hide('"+id+"');");
+			obj.find(".dlg-close").on("click", () => theDialogManager.hide(id));
 		var self = this;
 		var checkForButtons = function me(val)
 		{

--- a/plugins/rss/ie.css
+++ b/plugins/rss/ie.css
@@ -8,4 +8,3 @@ div#dlgEditFilters {height: 380px;}
 .rf fieldset {height: 310px;vertical-align: top;}
 div#dlgAddRSS {height: 133px}
 div#dlgEditRSS {height: 133px}
-.chk {margin: 0; padding: 0; height: 15px; overflow:hidden;}

--- a/plugins/rss/init.js
+++ b/plugins/rss/init.js
@@ -367,14 +367,15 @@ catlist.contextMenuEntries = function(panelId, labelId) {
 		: plugin.contextMenuEntries(panelId, labelId);
 }
 
-theWebUI.fillRSSGroups = function()
-{
-	var content = $("#rssGroupSet");
+theWebUI.fillRSSGroups = function() {
+	const content = $("#rssGroupSet");
 	content.children().remove();
-	var s = '';
-	for(var lbl in this.rssLabels)
-		s += ("<input type=checkbox id='grp_"+lbl+"'><label for='grp_"+lbl+"' id='lbl_grp_"+lbl+"'>"+this.rssLabels[lbl].name+"</label><br/>");
-	content.html(s);
+	content.append(
+		Object.entries(this.rssLabels).map(([rssHash, rssObj]) => $("<div>").addClass("col-12").append(
+			$("<input>").attr({type:"checkbox", id:`grp_${rssHash}`}),
+			$("<label>").attr({for:`grp_${rssHash}`, id:`lbl_grp_${rssHash}`}).text(rssObj["name"]),
+		),
+	));
 }
 
 theWebUI.RSSEditGroup = function()
@@ -1274,40 +1275,34 @@ rTorrentStub.prototype.getrsssettings = function()
 	this.rssCommon("mode=getsettings");
 }
 
-plugin.correctRatioFilterDialog = function()
-{
-	var rule = getCSSRule(".rf fieldset");
-	if(rule && thePlugins.get('ratio').allStuffLoaded)
-	{
-		$("#FLT_label").after( $("<div></div>").css({ padding: 0 }).
-			html("<label>"+theUILang.ratio+":</label><select id='FLT_ratio'><option value=''>"+theUILang.mnuRatioUnlimited+"</option></select>") );
-
-		$$('filterProps').style.height = "auto";
-		$("#FLT_label").parent().get(0).style.height = "auto";
-		$$('dlgEditFilters').style.height = "auto";	
-
-		theDialogManager.center("dlgEditFilters");
-	}
-	else
+plugin.correctRatioFilterDialog = function() {
+	if ($(".rf fieldset").length > 0 && thePlugins.get('ratio').allStuffLoaded) {
+		$("#FLT_label").parent().after(
+			$("<div>").addClass("col-12 col-md-3").append(
+				$("<label>").attr({for:"FLT_ratio"}).text(theUILang.ratio),
+			),
+			$("<div>").addClass("col-12 col-md-3").append(
+				$("<select>").attr({id:"FLT_ratio"}).append(
+					$("<option>").val("").text(theUILang.mnuRatioUnlimited),
+				),
+			),
+		);
+	} else
 		setTimeout(plugin.correctRatioFilterDialog,1000);
 }
 
-plugin.correctFilterDialog = function()
-{
-	var rule = getCSSRule(".rf fieldset");
-	if(rule && thePlugins.get('throttle').allStuffLoaded)
-	{
-		$("#FLT_label").after( $("<div></div>").css({ padding: 0 }).
-			html(  "<label>"+theUILang.throttle+":</label><select id='FLT_throttle'><option value=''>"+theUILang.mnuUnlimited+"</option></select><br/>" ) );
-		if(thePlugins.isInstalled('ratio'))
-			plugin.correctRatioFilterDialog();
-		else
-		{
-			$$('filterProps').style.height = "auto";
-			$("#FLT_label").parent().get(0).style.height = "auto";
-			$$('dlgEditFilters').style.height = "auto";	
-			theDialogManager.center("dlgEditFilters");
-		}
+plugin.correctFilterDialog = function() {
+	if ($(".rf fieldset").length > 0 && thePlugins.get('throttle').allStuffLoaded) {
+		$("#FLT_label").parent().after(
+			$("<div>").addClass("col-12 col-md-3").append(
+				$("<label>").attr({for:"FLT_throttle"}).text(theUILang.throttle),
+			),
+			$("<div>").addClass("col-12 col-md-3").append(
+				$("<select>").attr({id:"FLT_throttle"}).append(
+					$("<option>").val("").text(theUILang.mnuUnlimited),
+				),
+			),
+		);
 	}
 	else
 		setTimeout(plugin.correctFilterDialog,1000);
@@ -1324,102 +1319,225 @@ plugin.onLangLoaded = function()
 	);
 	$("#prss").prepend( $("<span>").attr({ id: "rsstimer", slot: "decorator" }));
 
-	this.attachPageToOptions( $("<div>").attr("id","st_rss").html(
-		"<fieldset>"+
-			"<legend>"+theUILang.rssFeeds+"</legend>"+
-			"<label for='rss_interval'>"+ theUILang.rssUpdateInterval + ' (' + theUILang.time_m.trim() +")</label>"+
-			"<input type='text' maxlength=4 id='rss_interval' class='TextboxShort'/><br/>"+
-			"<input type='checkbox' class='chk' id='rss_show_errors_delayed'/>"+
-			"<label for='rss_show_errors_delayed'>"+ theUILang.rssShowErrorsDelayed +"</label>"+
-		"</fieldset>"
-		)[0], theUILang.rssFeeds );
+	this.attachPageToOptions(
+		$("<div>").attr("id","st_rss").append(
+			$("<fieldset>").append(
+				$("<legend>").text(theUILang.rssFeeds),
+				$("<div>").addClass("row").append(
+					$("<div>").addClass("col-12 col-md-3").append(
+						$("<label>").attr({for:"rss_interval"}).text(`${theUILang.rssUpdateInterval} (${theUILang.time_m.trim()})`),
+					),
+					$("<div>").addClass("col-12 col-md-9").append(
+						$("<input>").attr({type:"text", id:"rss_interval", maxlength:4}),
+					),
+					$("<div>").addClass("col-12").append(
+						$("<input>").attr({type:"checkbox", id:"rss_show_errors_delayed"}),
+						$("<label>").attr({for:"rss_show_errors_delayed"}).text(theUILang.rssShowErrorsDelayed),
+					),
+				),
+			),
+		)[0],
+		theUILang.rssFeeds,
+	);
 	
-	theDialogManager.make( "dlgAddRSS", theUILang.addRSS,
-		"<div class='content'>"+
-			"<label>"+theUILang.feedURL+": </label>"+
-			"<input type='text' id='rssURL' class='TextboxLarge'/><br/>"+
-			"<label>"+theUILang.alias+": </label>"+
-			"<input type='text' id='rssLabel' class='TextboxLarge'/>"+
-		"</div>"+
-		"<div class='aright buttons-list'><input type='button' class='OK Button' value="+theUILang.ok+" onclick='theDialogManager.hide(\"dlgAddRSS\");theWebUI.addRSS();return(false);'/><input type='button' class='Cancel Button' value='"+theUILang.Cancel+"'/></div>",
-		true);
-	theDialogManager.make( "dlgAddRSSGroup", theUILang.addRSSGroup,
-		"<div class='content'>"+
-			"<label>"+theUILang.alias+": </label>"+
-			"<input type='hidden' id='rssGroupHash' value=''/>"+
-			"<input type='text' id='rssGroupLabel' class='TextboxLarge'/>"+
-			"<fieldset><legend>"+theUILang.addRSSGroupContent+"</legend>"+
-				"<div id='rssGroupSet'>"+
-				"</div>"+
-			"</fieldset>"+
-		"</div>"+
-		"<div class='aright buttons-list'><input type='button' class='OK Button' value="+theUILang.ok+" onclick='theWebUI.addRSSGroup();return(false);'/><input type='button' class='Cancel Button' value='"+theUILang.Cancel+"'/></div>",
-		true);
-	theDialogManager.make( "dlgEditRSS", theUILang.rssMenuEdit,
-		"<div class='content'>"+
-			"<label>"+theUILang.feedURL+": </label>"+
-			"<input type='text' id='editrssURL' class='TextboxLarge'/><br/>"+
-			"<label>"+theUILang.alias+": </label>"+
-			"<input type='text' id='editrssLabel' class='TextboxLarge'/>"+
-		"</div>"+
-		"<div class='aright buttons-list'><input type='button' class='OK Button' value="+theUILang.ok+" onclick='theDialogManager.hide(\"dlgEditRSS\");theWebUI.editRSS();return(false);'/><input type='button' class='Cancel Button' value='"+theUILang.Cancel+"'/></div>",
-		true);
-	theDialogManager.make( "dlgLoadTorrents", theUILang.torrent_add,
-		"<div class='content'>"+
-			"<label>"+theUILang.Base_directory+":</label><input type='text' id='RSSdir_edit' class='TextboxLarge'/><br/>"+
-			"<label></label><input type='checkbox' id='RSSnot_add_path'/>"+theUILang.Dont_add_tname+"<br/>"+
-			"<label></label><input type='checkbox' id='RSStorrents_start_stopped'/>"+theUILang.Dnt_start_down_auto+"<br/>"+
-			"<label>"+theUILang.Label+":</label><input type='text' id='RSS_label' class='TextboxLarge'/>"+
-		"</div>"+
-		"<div id='buttons' class='aright buttons-list'><input type='button' class='OK Button' value="+theUILang.ok+" onclick='theDialogManager.hide(\"dlgLoadTorrents\");theWebUI.RSSLoadTorrents();return(false);'/><input type='button' class='Cancel Button' value='"+theUILang.Cancel+"'/></div>",
-		true);
-	theDialogManager.make( "dlgEditFilters", theUILang.rssMenuManager,
-		"<div class='fxcaret'>"+
-			"<div class='lfc'>"+
-				"<div class='lf' id='filterList'>"+
-					"<ul id='fltlist'></ul>"+
-				"</div>"+
-				"<div id='FLTchk_buttons'>"+
-					"<input type='button' class='Button' value='"+theUILang.rssAddFilter+"' onclick='theWebUI.addNewFilter();return(false);'/>"+
-					"<input type='button' class='Button' value='"+theUILang.rssDelFilter+"' onclick='theWebUI.deleteCurrentFilter();return(false);'/>"+
-					"<input type='button' id='chkFilterBtn' class='Button' value='"+theUILang.rssCheckFilter+"' onclick='theWebUI.checkCurrentFilter();return(false);'/>"+
-				"</div>"+
-			"</div>"+
-			"<div class='rf' id='filterProps'>"+
-				"<fieldset id='filterPropsFieldSet'>"+
-					"<legend>"+theUILang.rssFiltersLegend+"</legend>"+
-					"<label>"+theUILang.rssFilter+":</label><input type='text' id='FLT_body' class='TextboxLarge'/><br/>"+
-					"<label>"+theUILang.rssExclude+":</label><input type='text' id='FLT_exclude' class='TextboxLarge'/><br/>"+
-					"<label></label><input type='checkbox' class='chk' id='FLTchktitle'/>"+theUILang.rssCheckTitle+"<br/>"+
-					"<label></label><input type='checkbox' class='chk' id='FLTchkdesc'/>"+theUILang.rssCheckDescription+"<br/>"+
-					"<label></label><input type='checkbox' class='chk' id='FLTchklink'/>"+theUILang.rssCheckLink+"<br/>"+
-					"<label>"+theUILang.rssStatus+":</label><select id='FLT_rss'><option value=''>"+theUILang.allFeeds+"</option></select><br/>"+
-					"<label>"+theUILang.Base_directory+":</label><input type='text' id='FLTdir_edit' class='TextboxLarge'/><br/>"+
-					"<label></label><input type='checkbox' class='chk' id='FLTnot_add_path'/>"+theUILang.Dont_add_tname+"<br/>"+
-					"<label></label><input type='checkbox' class='chk' id='FLTtorrents_start_stopped'/>"+theUILang.Dnt_start_down_auto+"<br/>"+
-					"<label>"+theUILang.rssMinInterval+":</label><select id='FLT_interval'>"+
-					        "<option value='-1'>"+theUILang.rssIntervalAlways+"</option>"+
-					        "<option value='0'>"+theUILang.rssIntervalOnce+"</option>"+
-					        "<option value='12'>"+theUILang.rssInterval12h+"</option>"+
-					        "<option value='24'>"+theUILang.rssInterval1d+"</option>"+
-					        "<option value='48'>"+theUILang.rssInterval2d+"</option>"+
-					        "<option value='72'>"+theUILang.rssInterval3d+"</option>"+
-					        "<option value='96'>"+theUILang.rssInterval4d+"</option>"+
-						"<option value='144'>"+theUILang.rssInterval6d+"</option>"+
-					        "<option value='168'>"+theUILang.rssInterval1w+"</option>"+
-					        "<option value='336'>"+theUILang.rssInterval2w+"</option>"+
-					        "<option value='504'>"+theUILang.rssInterval3w+"</option>"+
-					        "<option value='720'>"+theUILang.rssInterval1m+"</option>"+
-						"</select>"+
-						"<input type='button' class='Button' value='"+theUILang.rssClearFilter+"' onclick='theWebUI.rssClearFilter();return(false);'/><br/>"+
-					"<label>"+theUILang.Label+":</label><input type='text' id='FLT_label' class='TextboxLarge'/><br/>"+
-				"</fieldset>"+
-			"</div>"+
-		"</div>"+
-		"<div id='FLT_buttons' class='aright buttons-list'>"+
-			"<input type='button' class='OK Button' value='"+theUILang.ok+"' onclick='theDialogManager.hide(\"dlgEditFilters\");theWebUI.setFilters();return(false);'/>"+
-			"<input type='button' class='Cancel Button' value='"+theUILang.Cancel+"'/>"+
-		"</div>");
+	theDialogManager.make("dlgAddRSS", theUILang.addRSS,
+		$("<div>").addClass("cont fxcaret").append(
+			$("<div>").addClass("row").append(
+				...[
+					["rssURL", theUILang.feedURL],
+					["rssLabel", theUILang.alias],
+				].flatMap(([id, text]) => [
+					$("<div>").addClass("col-12 col-md-3").append(
+						$("<label>").attr({for:id}).text(text),
+					),
+					$("<div>").addClass("col-12 col-md-9").append(
+						$("<input>").attr({type:"text", id:id}),
+					),
+				]),
+			),
+		)[0].outerHTML +
+		$("<div>").addClass("buttons-list").append(
+			$("<button>").attr({type:"button", onClick: "theDialogManager.hide('dlgAddRSS');theWebUI.addRSS();return false;"}).addClass("OK").text(theUILang.ok),
+			$("<button>").attr({type:"button"}).addClass("Cancel").text(theUILang.Cancel),
+		)[0].outerHTML,
+		true,
+	);
+	theDialogManager.make("dlgAddRSSGroup", theUILang.addRSSGroup,
+		$("<div>").addClass("cont fxcaret").append(
+			$("<div>").addClass("row").append(
+				$("<div>").addClass("col-12 col-md-3").append(
+					$("<label>").attr({for:"rssGroupLabel"}).text(theUILang.alias + ": "),
+				),
+				$("<div>").addClass("col-12 col-md-9").append(
+					$("<input>").attr({type:"hidden", id:"rssGroupHash"}),
+					$("<input>").attr({type:"text", id:"rssGroupLabel"}),
+				),
+				$("<fieldset>").append(
+					$("<legend>").text(theUILang.addRSSGroupContent),
+					$("<div>").attr({id:"rssGroupSet"}).addClass("d-flex flex-column align-items-start overflow-y-auto"),
+					),
+				),
+			)[0].outerHTML +
+			$("<div>").addClass("buttons-list").append(
+				$("<button>").attr({type:"button"}).addClass("OK").text(theUILang.ok).on(
+					"click", () => {theWebUI.addRSSGroup(); return false;}
+				),
+				$("<button>").attr({type:"button"}).addClass("Cancel").text(theUILang.Cancel),
+			)[0].outerHTML,
+		true,
+	);
+	theDialogManager.make("dlgEditRSS", theUILang.rssMenuEdit,
+		$("<div>").addClass("cont fxcaret").append(
+			$("<div>").addClass("row").append(
+				...[
+					["editrssURL", theUILang.feedURL],
+					["editrssLabel", theUILang.alias],
+				].flatMap(([id, text]) => [
+					$("<div>").addClass("col-12 col-md-3").append(
+						$("<label>").attr({for:id}).text(text),
+					),
+					$("<div>").addClass("col-12 col-md-9").append(
+						$("<input>").attr({type:"text", id:id}),
+					),
+				]),
+			),
+		)[0].outerHTML +
+		$("<div>").addClass("buttons-list").append(
+			$("<button>").attr({type:"button"}).addClass("OK").text(theUILang.ok).on(
+				"click", () => {theDialogManager.hide("dlgEditRSS"); theWebUI.editRSS(); return false;}
+			),
+			$("<button>").attr({type:"button"}).addClass("Cancel").text(theUILang.Cancel),
+		)[0].outerHTML,
+		true,
+	);
+	theDialogManager.make("dlgLoadTorrents", theUILang.torrent_add,
+		$("<div>").addClass("cont fxcaret").append(
+			$("<div>").addClass("row").append(
+				$("<div>").addClass("col-12 col-md-3").append(
+					$("<label>").attr({for:"RSSdir_edit"}).text(theUILang.Base_directory),
+				),
+				$("<div>").addClass("col-12 col-md-9").append(
+					$("<input>").attr({type:"text", id:"RSSdir_edit"}),
+				),
+				$("<div>").addClass("col-12 col-md-9 offset-md-3").append(
+					$("<input>").attr({type:"checkbox", id:"RSSnot_add_path"}),
+					$("<label>").attr({for:"RSSnot_add_path"}).text(theUILang.Dont_add_tname),
+				),
+				$("<div>").addClass("col-12 col-md-9 offset-md-3").append(
+					$("<input>").attr({type:"checkbox", id:"RSStorrents_start_stopped"}),
+					$("<label>").attr({for:"RSStorrents_start_stopped"}).text(theUILang.Dnt_start_down_auto),
+				),
+				$("<div>").addClass("col-12 col-md-3").append(
+					$("<label>").attr({for:"RSS_label"}).text(theUILang.Label),
+				),
+				$("<div>").addClass("col-12 col-md-9").append(
+					$("<input>").attr({type:"text", id:"RSS_label"})
+				),
+			),
+		)[0].outerHTML +
+		$("<div>").attr({id:"buttons"}).addClass("buttons-list").append(
+			$("<button>").attr({type:"button", onClick: "theDialogManager.hide('dlgLoadTorrents');theWebUI.RSSLoadTorrents();return false;"}).addClass("OK").text(theUILang.ok),
+			$("<button>").attr({type:"button"}).addClass("Cancel").text(theUILang.Cancel),
+		)[0].outerHTML,
+		true,
+	);
+	theDialogManager.make("dlgEditFilters", theUILang.rssMenuManager,
+		$("<div>").addClass("cont fxcaret d-flex flex-column flex-md-row align-items-stretch align-items-md-start").append(
+			$("<div>").addClass("lfc flex-grow-0 flex-shrink-0 d-flex flex-column align-items-center").append(
+				$("<div>").attr({id:"filterList"}).addClass("lf p-2 m-2 align-self-stretch").append(
+					$("<ul>").attr({id:"fltlist"}).addClass("p-0 m-0"),
+				),
+				$("<div>").attr({id:"FLTchk_buttons"}).append(
+					...[
+						[theUILang.rssAddFilter, , "theWebUI.addNewFilter(); return false;"],
+						[theUILang.rssDelFilter, , "theWebUI.deleteCurrentFilter(); return false;"],
+						[theUILang.rssCheckFilter, "chkFilterBtn", "theWebUI.checkCurrentFilter(); return false;"],
+					].map(([text, id, onClick]) => $("<button>").attr(
+						{type:"button", id:id, onClick:onClick}
+					).text(text)),
+				),
+			),
+			$("<div>").attr({id:"filterProps"}).addClass("rf flex-grow-1 flex-shrink-1").append(
+				$("<fieldset>").attr({id:"filterPropsFieldSet"}).append(
+					$("<legend>").text(theUILang.rssFiltersLegend),
+					$("<div>").addClass("row").append(
+						...[
+							["text", "FLT_body", theUILang.rssFilter],
+							["text", "FLT_exclude", theUILang.rssExclude],
+							["checkbox", "FLTchktitle", theUILang.rssCheckTitle],
+							["checkbox", "FLTchkdesc", theUILang.rssCheckDescription],
+							["checkbox", "FLTchklink", theUILang.rssCheckLink],
+							["select", "FLT_rss", theUILang.rssStatus, ["", theUILang.allFeeds]],
+							["text", "FLTdir_edit", theUILang.Base_directory],
+							["checkbox", "FLTnot_add_path", theUILang.Dont_add_tname],
+							["checkbox", "FLTtorrents_start_stopped", theUILang.Dnt_start_down_auto],
+							["select", "FLT_interval", theUILang.rssMinInterval, [
+								[-1, theUILang.rssIntervalAlways],
+								[0, theUILang.rssIntervalOnce],
+								[12, theUILang.rssInterval12h],
+								[24, theUILang.rssInterval1d],
+								[48, theUILang.rssInterval2d],
+								[72, theUILang.rssInterval3d],
+								[96, theUILang.rssInterval4d],
+								[144, theUILang.rssInterval6d],
+								[168, theUILang.rssInterval1w],
+								[336, theUILang.rssInterval2w],
+								[504, theUILang.rssInterval3w],
+								[720, theUILang.rssInterval1m],
+							]],
+						].flatMap(([type, id, text, options]) => {
+							switch (type) {
+								case "text": {
+									return [
+										$("<div>").addClass("col-12 col-md-3").append(
+											$("<label>").attr({for:id}).text(text),
+										),
+										$("<div>").addClass("col-12 col-md-9").append(
+											$("<input>").attr({id:id, type:"text"})
+										),
+									];
+								};
+								case "checkbox": {
+									return [
+										$("<div>").addClass("col-12 col-md-9 offset-md-3").append(
+											$("<input>").attr({type:"checkbox", id:id}),
+											$("<label>").attr({for:id}).text(text),
+										),
+									];
+								}
+								case "select": {
+									return [
+										$("<div>").addClass("col-12 col-md-3").append(
+											$("<label>").attr({for:id}).text(text),
+										),
+										$("<div>").addClass("col-12 col-md-9").append(
+											$("<select>").attr({id:id}).append(
+												...options.map(([value, text]) => $("<option>").val(value).text(text)),
+											),
+										),
+									];
+								}
+								default: {
+									return;
+								}
+							}
+						}),
+						$("<div>").addClass("col-12 col-md-3").append(
+							$("<label>").attr({for:"FLT_label"}).text(theUILang.Label),
+						),
+						$("<div>").addClass("col-12 col-md-9").append(
+							$("<input>").attr({id:"FLT_label", type:"text"}),
+						),
+					)
+				),
+			),
+		)[0].outerHTML +
+		$("<div>").attr({id:"FLT_buttons"}).addClass("buttons-list").append(
+			$("<button>").attr({type:"button", onClick:"theWebUI.rssClearFilter();return false;"}).text(theUILang.rssClearFilter),
+			$("<button>").attr({type:"button", onClick:"theDialogManager.hide('dlgEditFilters');theWebUI.setFilters();return false;"}).addClass("OK").text(theUILang.ok),
+			$("<button>").attr({type:"button"}).addClass("Cancel").text(theUILang.Cancel),
+		)[0].outerHTML,
+	);
 	$("#gcont").append( $("<div>").attr("id","rsslayout").css( "display", "none" ));
 
 	if(thePlugins.isInstalled("_getdir"))
@@ -1434,11 +1552,9 @@ plugin.onLangLoaded = function()
 		plugin.editFilersBtn = new theWebUI.rDirBrowser( 'dlgEditFilters', 'FLTdir_edit', 'FLTBtn' );
 	}
 
-	if(thePlugins.isInstalled('throttle'))
-		this.correctFilterDialog();
-	else
-	if(thePlugins.isInstalled('ratio'))
-		this.correctRatioFilterDialog();
+	thePlugins.isInstalled('throttle') && this.correctFilterDialog();
+	thePlugins.isInstalled('ratio') && this.correctRatioFilterDialog();
+	theDialogManager.center("dlgEditFilters");
 };
 
 plugin.onRemove = function()

--- a/plugins/rss/rss.css
+++ b/plugins/rss/rss.css
@@ -1,56 +1,28 @@
-div#RSSList {border: 1px solid var(--menu-border-color); background-color: var(--menu-background-color); overflow: hidden; display: block; -moz-user-select: none; -moz-user-focus: normal; -moz-user-input: enabled}
+div#RSSList {border: 1px solid var(--menu-border-color); background-color: var(--menu-background-color); overflow: hidden; -moz-user-select: none; -moz-user-focus: normal; -moz-user-input: enabled}
 
-div#dlgAddRSS {width: 355px; height: 132px}
 div#dlgAddRSS div.dlg-header {background-image: url(./images/rss.gif)}
-div#dlgAddRSS div.content {width: 330px; margin: 5px; padding: 5px; line-height: 16px}
-div#dlgAddRSS div.content input {margin-top: 5px}
-div#dlgAddRSS label {width: 70px; display: block; float: left; margin-top: 5px; margin-bottom: 5px; margin-left: 10px; }
-div#dlgAddRSS label#nomargin { margin-top: 0px; margin-bottom: 0px; }
-div#dlgAddRSS input, div#dlgAddRSS select {margin-top: 5px; margin-bottom: 5px;}
-div#dlgAddRSS br {clear: left; line-height: 0}
-
-div#dlgEditRSS {width: 355px; height: 132px}
 div#dlgEditRSS div.dlg-header {background-image: url(./images/rss.gif)}
-div#dlgEditRSS div.content {width: 330px; margin: 5px; padding: 5px; line-height: 16px}
-div#dlgEditRSS div.content input {margin-top: 5px}
-div#dlgEditRSS label {width: 70px; display: block; float: left; margin-top: 5px; margin-bottom: 5px; margin-left: 10px; }
-div#dlgEditRSS label#nomargin { margin-top: 0px; margin-bottom: 0px; }
-div#dlgEditRSS input, div#dlgEditRSS select {margin-top: 5px; margin-bottom: 5px;}
-div#dlgEditRSS br {clear: left; line-height: 0}
-
-div#dlgLoadTorrents #RSSBtn {width: 30px;}
-div#dlgLoadTorrents {width: 380px; height: 170px; overflow: visible}
 div#dlgLoadTorrents div.dlg-header {background-image: url(../../images/world.gif)}
-div#dlgLoadTorrents div.content {margin: 5px; padding: 5px; line-height: 16px}
-div#dlgLoadTorrents div.content input {margin-top: 0px}
-div#dlgLoadTorrents label {width: 75px; display: block; float: left; margin-top: 0px; margin-bottom: 5px; margin-left: 5px; }
-div#dlgLoadTorrents input, div#dlgLoadTorrents select {margin-top: 2px; margin-bottom: 2px;}
-div#dlgLoadTorrents br {clear: left; line-height: 0}
-
-div#dlgEditFilters {width: 690px; height: 360px; font-size: 11px; font-family: Tahoma, Arial, Helvetica, sans-serif; overflow: visible}
 div#dlgEditFilters div.dlg-header {background-image: url(./images/rss.gif)}
-.lfc {float: left; }
-.lf {width: 245px; height: 230px; margin: 5px; margin-right: 0; padding: 5px; background-color: var(--menu-background-color); border: 1px solid var(--menu-border-color); overflow: auto}
-.lf ul {width: 100%; margin: 2px; padding: 0; list-style-position: inside; list-style: none; white-space: nowrap}
-.lf li input { margin: 0 5px 0 0; padding: 4px; } 
+#filterList {
+  height: 16rem;
+}
+.lf {background-color: var(--menu-background-color); border: 1px solid var(--menu-border-color); overflow: auto}
+.lf ul {
+  height: 100%;
+  list-style-position: inside;
+  list-style: none;
+  white-space: nowrap;
+}
 .lf li {margin: 0 ; padding: 0}
 .lf li input.TextboxFocus { width: 85%; background-color: var(--menu-highlight-background-color); }
 .lf li input.TextboxNormal { width: 85%; background-color: var(--menu-background-color) }
 .lf li input { border: 0; font-size: 11px; font-family: Tahoma, Verdana, Arial, Helvetica, sans-serif; cursor: default; font-weight: bold; }
 div#FLTchk_buttons {padding-top: 5px; width: 260px; text-align:center}
-.rf fieldset {margin: auto; height: 265px}
-.rf {float: right; width: 400px; height: 285px; margin: 4px; background-color: var(--settings-background-color); }
-.rf label {width: 75px; display: inline-block; margin-top: 5px; margin-bottom: 5px; margin-left: 10px; }
-.rf br {clear: left; line-height: 0}
-.rf select {width: 273px; margin-left: 5px; margin-bottom: 3px; }
-.rf input.TextboxLarge {margin: 3px; width: 273px;}
-.rf input#FLTdir_edit {margin: 3px; width: 220px;}
-.rf input.Button {margin: 3px;}
+.rf {background-color: var(--settings-background-color);}
 div#FLT_buttons {clear: both}
 
 #chkFilterBtn {width: 50px}
-#FLT_interval {width: 185px}
-#FLTBtn {width: 30px}
 
 #rsslayout { border: 0; display: none; margin: 5px; white-space: pre-line; }
 #rsslayout div { max-width: 700px; }
@@ -74,11 +46,21 @@ div#FLT_buttons {clear: both}
 #rsslayout .raw-details { font-size: smaller; float: right; padding: 0 0 0.5em 0.5em; max-width: 700px; }
 #rsslayout .raw-details summary { opacity: 0.5; text-align: right;}
 
-#dlgAddRSSGroup {width: 320px; height: 300px}
 #dlgAddRSSGroup div.dlg-header {background-image: url(./images/rss.gif)}
-div#dlgAddRSSGroup div.content {width: 302px; margin: 5px; padding: 5px; line-height: 16px}
-#rssGroupSet { overflow: auto; width: 275px; height: 160px }
 
 #tab_lcont.notification > a::after { color: gray; content: " ⚠"; }
 
 #rsstimer { font-weight: normal; }
+
+/* Medium devices (tablets, 768px and up) */
+@media (min-width: 768px) { 
+  #filterList {
+    height: 24rem;
+  }
+  #dlgEditFilters {
+    max-width: 750px;
+  }
+  #dlgLoadTorrents {
+    max-width: 500px;
+  }
+}


### PR DESCRIPTION
- Adjust the layout of the RSS plugin related components, including:
  1. an option page;
  2. a dialog to add rss feed and another dialog to edit it;
  3. a dialog to add rss group;
  4. a dialog to load torrents from rss;
  5. a dialog to edit rss filters;
- Modify the structure of the header of dialog windows, using flex as well.
- Restrict the max height of dialog windows and set the overflow property of the content to `auto` for very long dialog windows, such as the RSS manager dialog on mobile display.