### PR TITLE
Apply flex layout to three of the remaining plugins

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -137,7 +137,6 @@ div.dlg-window div.row > div {
   align-items: center;
   padding: 0 0.25rem;
   margin-bottom: 0.1rem;
-  overflow: auto;
 }
 div.fxcaret {overflow: auto}
 div.dlg-header {

--- a/css/style.css
+++ b/css/style.css
@@ -46,7 +46,8 @@ textarea {
 }
 label {
   cursor: pointer;
-  margin: 0.15rem 0.25rem;
+  margin: 0.15rem;
+  overflow: hidden;
 }
 input[type=checkbox], input[type=radio] {margin: 0.25rem;}
 select, input[type=file], input[type=text], input[type=number], input[type=password] {
@@ -123,7 +124,7 @@ div.dlg-window {
   border: 2px solid #909090;
   border-radius: 8px;
   display: none;
-  max-width: 95vw !important;
+  max-width: 95vw;
   max-height: 95vh;
 }
 div.dlg-window div.row {

--- a/css/style.css
+++ b/css/style.css
@@ -10,12 +10,9 @@ div, td, label, fieldset, textarea, select, input, button, .Button {
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
 }
-table {
+table, tbody, td, tfoot, th, thead, tr {
   /* prevent collision with bootstrap */
-  border-collapse: initial;
-}
-tbody, td, tfoot, th, thead, tr {
-  /* prevent collision with bootstrap */
+  border-collapse: collapse;
   border-color: initial;
   border-style: initial;
   border-width: 1px;
@@ -53,7 +50,7 @@ input[type=checkbox], input[type=radio] {margin: 0.25rem;}
 select, input[type=file], input[type=text], input[type=number], input[type=password] {
   border: 1px solid #B0B0B0;
   border-radius: 3px;
-  margin: 0.25rem;
+  margin: 0.25rem auto;
   padding: 0.25rem;
   width: 100%;
 }
@@ -375,8 +372,9 @@ div#stg .lm {
   text-wrap: nowrap;
   text-align: right;
   font-weight: bold;
+  padding-right: 0.5rem;
 }
-.stg_con thead td {
+.stg_con th {
   text-align: center;
   font-weight: bold;
   text-wrap: nowrap;

--- a/css/style.css
+++ b/css/style.css
@@ -115,6 +115,7 @@ div#modalbg {left: 0px; top: 0px; z-index: 500; display: none; opacity: 0.5; bac
 
 div.aright {text-align: right}
 div.dlg-window {
+  position: absolute;
   left: 0px;
   top: 0px;
   background-color: #FAFAFA;
@@ -122,9 +123,8 @@ div.dlg-window {
   border: 2px solid #909090;
   border-radius: 8px;
   display: none;
-  max-width: 95vw;
+  max-width: 95vw !important;
   max-height: 95vh;
-  overflow: auto;
 }
 div.dlg-window div.row {
   margin: 0.5rem 0;
@@ -289,7 +289,7 @@ div#HDivider {cursor: e-resize;}
 div#VDivider {cursor: n-resize;}
 div#HDivider:hover, div#VDivider:hover {background: #A0A0A0;}
 
-div#stg {position: absolute; left: 0px; top: 50px; display: none; overflow: visible}
+div#stg {width: 95vw;}
 div#stg_c {
   display: flex;
   flex-direction: row;
@@ -297,9 +297,10 @@ div#stg_c {
 div#stg-pages {
   padding: 0 0.5rem;
   height: 550px;
-  width: 550px;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
+  overflow-x: auto;
 }
 div#stg-header { background-image: url(../images/settings.gif); }
 
@@ -358,7 +359,7 @@ div#stg .lm {
 .ie .lm li a {margin: 0 0 0 -5px; padding: 0}
 .stg_con {
   display: none;
-  flex: 1 1 auto;
+  margin-bottom: auto;
   background-color: var(--settings-background-color);
   overflow: hidden auto;
 }
@@ -586,6 +587,7 @@ div.dlg-window .buttons-list {
     justify-content: end;
     flex-wrap: nowrap;
   }
+  div#stg {width: 660px;}
 }
 
 /* Large devices (desktops, 992px and up) */

--- a/css/style.css
+++ b/css/style.css
@@ -371,6 +371,16 @@ div#stg .lm {
 .stg_con table {width: 100%}
 .stg_con td {font-weight: normal; height: 19px}
 .stg_con td.alr {text-align: right}
+.stg_con td:first-child {
+  text-wrap: nowrap;
+  text-align: right;
+  font-weight: bold;
+}
+.stg_con thead td {
+  text-align: center;
+  font-weight: bold;
+  text-wrap: nowrap;
+}
 input.disabled {background-color: #FAFAFA; color: #C0C0C0; border: 1px solid #C0C0C0}
 td.disabled, label.disabled, span.disabled, div.disabled {color: #C0C0C0; cursor: default}
 .ie7 fieldset div {padding: 0px}
@@ -507,14 +517,8 @@ div#tadd {display: none; left: 100px; top: 100px; position: absolute; margin: 0 
   min-width: 3rem;
 }
 .speedEdit { width: 320px }
-.decimalDigitEdit input[type=number] {padding: 1px; margin: 0;}
-.decimalDigitEdit > .row:not(:last-child) {
-  border-bottom: 1px dotted #D0D0D0;
-}
-.decimalDigitEdit > .row:first-of-type > div,
-.decimalDigitEdit > .row > div:first-of-type {
-  font-weight: bold;
-  justify-content: center;
+#decimalDigitEdit input[type=number] {
+  min-width: 2rem;
 }
 .optionColumn {
   display: flex;

--- a/js/content.js
+++ b/js/content.js
@@ -617,30 +617,36 @@ function makeContent() {
 		),
 		$("<fieldset>").append(
 			$("<legend>").text(theUILang.DecimalPlacesSizes),
-			$("<div>").addClass("decimalDigitEdit").append(
-				$("<div>").addClass("row").append(
-					...[
-						"", "Default", "KB", "MB", "GB", "TB", "PB",
-					].map((unit) => $("<div>").addClass(
-						unit !== "" ? "col" : "col-12 col-md-3"						
-					).text(unit !== "" ? theUILang[unit] : "")),
+			$("<div>").attr({id:"decimalDigitEdit"}).addClass("row").append(
+				$("<div>").addClass("col-12 overflow-x-auto").append(
+					$("<table>").append(
+						$("<thead>").append(
+							$("<tr>").append(
+								...[
+									"", "Default", "KB", "MB", "GB", "TB", "PB",
+								].map((unit) => $("<td>").text(theUILang[unit] ?? "")),
+							),
+						),
+						$("<tbody>").append(
+							...Object.entries({
+								catlist: theUILang.CatListSizeDecimalPlaces,
+								table: theUILang.TableSizeDecimalPlaces,
+								details: theUILang.DetailsSizeDecimalPlaces,
+								other: theUILang.OtherSizeDecimalPlaces,
+							}).map(([context, name]) => $('<tr>').append(
+								$("<td>").text(name + ": "),
+								...["default", "kb", "mb", "gb", "tb", "pb"].map(unit => $("<td>").append(
+									$("<input>").attr({
+										type: "number",
+										id: "webui.size_decimal_places." + context + "." + unit,
+										maxlength: 1,
+										min: 0,
+									}),
+								)),
+							)),
+						),
+					),
 				),
-				...Object.entries({
-					catlist: theUILang.CatListSizeDecimalPlaces,
-					table: theUILang.TableSizeDecimalPlaces,
-					details: theUILang.DetailsSizeDecimalPlaces,
-					other: theUILang.OtherSizeDecimalPlaces,
-				}).map(([context, name]) => $('<div>').addClass("row").append(
-					$("<div>").addClass("col-12 col-md-3").text(name + ": "),
-					...["default", "kb", "mb", "gb", "tb", "pb"].map(unit => $("<div>").addClass("col").append(
-						$("<input>").attr({
-							type: "number",
-							id: "webui.size_decimal_places." + context + "." + unit,
-							maxlength: 1,
-							min: 0,
-						}),
-					)),
-				)),				
 			),
 		),
 	);

--- a/js/content.js
+++ b/js/content.js
@@ -695,7 +695,7 @@ function makeContent() {
 	);
 
 	theDialogManager.make("stg",theUILang.ruTorrent_settings,
-		$("<div>").attr({id: "stg_c"}).addClass("fxcaret cont").append(
+		$("<div>").attr({id: "stg_c"}).addClass("cont").append(
 			stgPanel,
 			$("<div>").attr({id: "stg-pages"}).append(
 				stgGlCont, stgDlCont, stgConCont, stgBtCont, stgFmtCont, stgAoCont,

--- a/js/objects.js
+++ b/js/objects.js
@@ -91,9 +91,7 @@ var theDialogManager =
 	modalState: false,
 
 	make: function(id, name, content, isModal, noClose) {
-		$(document.body).append($("<div>").attr("id",id).addClass(
-			"dlg-window position-absolute"
-		).append(
+		$(document.body).append($("<div>").attr("id",id).addClass("dlg-window").append(
 			$("<div>").addClass("d-flex flex-row align-items-center justify-content-between position-sticky top-0").append(
 				$("<div>").attr("id",id+"-header").addClass("dlg-header fw-bold ps-5 pe-1 py-1 flex-grow-1").text(name),
 				$("<a>").attr({href:"#"}).addClass("dlg-close"),

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -767,7 +767,7 @@ plugin.onLangLoaded = function() {
 					$("<input>").attr({type:"checkbox", id:id}),
 					$("<label>").attr({for:id}).text(text),
 				)),
-				$("<div>").addClass("col-12 col-md-3justify-content-md-end").append(
+				$("<div>").addClass("col-12 col-md-3 justify-content-md-end").append(
 					$("<label>").attr({for:"teglabel"}).text(theUILang.Label + ":"),
 				),
 				$("<div>").addClass("col-12 col-md-9").append(

--- a/plugins/ratio/init.js
+++ b/plugins/ratio/init.js
@@ -257,22 +257,22 @@ plugin.onLangLoaded = function() {
 						...Array.from(Array(theWebUI.maxRatio).keys()).map(i => $("<tr>").append(
 							$("<td>").addClass("alr").append($("<strong>").text((i + 1) + ".")),
 							$("<td>").append(
-								$("<input>").attr({type:"text", id:`rat_name${i}`}).addClass("w-auto"),
+								$("<input>").attr({type:"text", id:`rat_name${i}`}).addClass("ratio-name"),
 							),
 							$("<td>").append(
-								$("<input>").attr({type:"text", id:`rat_min${i}`}),
+								$("<input>").attr({type:"text", id:`rat_min${i}`}).addClass("ratio-condition"),
 							),
 							$("<td>").append(
-								$("<input>").attr({type:"text", id:`rat_max${i}`}),
+								$("<input>").attr({type:"text", id:`rat_max${i}`}).addClass("ratio-condition"),
 							),
 							$("<td>").append(
-								$("<input>").attr({type:"text", id:`rat_upload${i}`, maxlength:6}),
+								$("<input>").attr({type:"text", id:`rat_upload${i}`, maxlength:6}).addClass("ratio-condition"),
 							),
 							$("<td>").addClass("ratio_time").append(
-								$("<input>").attr({type:"text", id:`rat_time${i}`, maxlength:6}),
+								$("<input>").attr({type:"text", id:`rat_time${i}`, maxlength:6}).addClass("ratio-condition"),
 							),
 							$("<td>").append(
-								$("<select>").attr({id:`rat_action${i}`}).addClass("w-auto").append(
+								$("<select>").attr({id:`rat_action${i}`}).addClass("ratio-action").append(
 									$("<option>").val(0).text(theUILang.ratioStop),
 									$("<option>").val(1).text(theUILang.ratioStopAndRemove),
 									$("<option>").val(2).text(theUILang.ratioErase),

--- a/plugins/ratio/init.js
+++ b/plugins/ratio/init.js
@@ -242,15 +242,15 @@ plugin.onLangLoaded = function() {
 				$("<table>").append(
 					$("<thead>").append(
 						$("<tr>").append(
-							$("<td>").text(theUILang.Num_No),
+							$("<th>").text(theUILang.Num_No),
 							...[
 								theUILang.ratioName, theUILang.minRatio + ", %",
 								theUILang.maxRatio + ", %", theUILang.ratioUpload + "," + theUILang.GB,
-							].map(th => $("<td>").attr({align:"center"}).append($("<strong>").text(th))),
-							$("<td>").attr({align:"center"}).addClass("ratio_time").append(
-								$("<strong>").text(theUILang.maxTime + ", " + theUILang.time_h.substr(0, theUILang.time_h.length - 1)),
+							].map(th => $("<th>").text(th)),
+							$("<th>").addClass("ratio_time")
+								.text(theUILang.maxTime + ", " + theUILang.time_h.substr(0, theUILang.time_h.length - 1),
 							),
-							$("<td>").attr({align:"center"}).append($("<strong>").text(theUILang.ratioAction)),
+							$("<th>").text(theUILang.ratioAction),
 						),
 					),
 					$("<tbody>").append(

--- a/plugins/ratio/init.js
+++ b/plugins/ratio/init.js
@@ -242,7 +242,7 @@ plugin.onLangLoaded = function() {
 				$("<table>").append(
 					$("<thead>").append(
 						$("<tr>").append(
-							$("<td>").append($("<strong>").text(theUILang.Num_No)),
+							$("<td>").text(theUILang.Num_No),
 							...[
 								theUILang.ratioName, theUILang.minRatio + ", %",
 								theUILang.maxRatio + ", %", theUILang.ratioUpload + "," + theUILang.GB,
@@ -255,7 +255,7 @@ plugin.onLangLoaded = function() {
 					),
 					$("<tbody>").append(
 						...Array.from(Array(theWebUI.maxRatio).keys()).map(i => $("<tr>").append(
-							$("<td>").addClass("alr").append($("<strong>").text((i + 1) + ".")),
+							$("<td>").text((i + 1) + "."),
 							$("<td>").append(
 								$("<input>").attr({type:"text", id:`rat_name${i}`}).addClass("ratio-name"),
 							),

--- a/plugins/ratio/init.js
+++ b/plugins/ratio/init.js
@@ -234,47 +234,86 @@ theWebUI.isCorrectRatio = function(i)
         	(theWebUI.ratios[i].name!=""));
 }
 
-plugin.onLangLoaded = function() 
-{
-	var s = 
-		"<fieldset>"+
-			"<legend>"+theUILang.ratios+"</legend>"+
-			"<div id='st_ratio_h'>"+
-			"<table>"+
-				"<tr>"+
-					"<td><b>"+theUILang.Num_No+"</b></td>"+
-					"<td align=center><b>"+theUILang.ratioName+"</b></td>"+
-					"<td align=center><b>"+theUILang.minRatio+",%</b></td>"+
-					"<td align=center><b>"+theUILang.maxRatio+",%</b></td>"+
-					"<td align=center><b>"+theUILang.ratioUpload+","+theUILang.GB+"</b></td>"+
-					"<td class='ratio_time' align=center><b>"+theUILang.maxTime+","+theUILang.time_h.substr(0,theUILang.time_h.length-1)+"</b></td>"+
-					"<td align=center><b>"+theUILang.ratioAction+"</b></td>"+
-				"</tr>";
-	for(var i=0; i<theWebUI.maxRatio; i++)
-		s +=
-			"<tr>"+
-				"<td class='alr'><b>"+(i+1)+".</b></td>"+
-				"<td><input type='text' id='rat_name"+i+"' class='TextboxShort'/></td>"+
-				"<td><input type='text' id='rat_min"+i+"' class='Textbox num1'/></td>"+
-				"<td><input type='text' id='rat_max"+i+"' class='Textbox num1'/></td>"+
-				"<td><input type='text' id='rat_upload"+i+"' class='Textbox num1' maxlength='6'/></td>"+
-				"<td class='ratio_time'><input type='text' id='rat_time"+i+"' class='Textbox num1' maxlength='6'/></td>"+
-				"<td><select id='rat_action"+i+"'><option value='0'>"+theUILang.ratioStop+"</option><option value='1'>"+theUILang.ratioStopAndRemove+"</option><option value='2'>"+theUILang.ratioErase+"</option><option value='3'>"+theUILang.ratioEraseData+"</option><option value='4'>"+theUILang.ratioEraseData+" ("+theUILang.All+")</option></select></td>"+
-			"</tr>";
-	s+="</table></div></fieldset>";	
+plugin.onLangLoaded = function() {
+	const s = $("<fieldset>").append(
+		$("<legend>").text(theUILang.ratios),
+		$("<div>").attr({id:"st_ratio_h"}).addClass("row").append(
+			$("<div>").addClass("col-12").append(
+				$("<table>").append(
+					$("<thead>").append(
+						$("<tr>").append(
+							$("<td>").append($("<strong>").text(theUILang.Num_No)),
+							...[
+								theUILang.ratioName, theUILang.minRatio + ", %",
+								theUILang.maxRatio + ", %", theUILang.ratioUpload + "," + theUILang.GB,
+							].map(th => $("<td>").attr({align:"center"}).append($("<strong>").text(th))),
+							$("<td>").attr({align:"center"}).addClass("ratio_time").append(
+								$("<strong>").text(theUILang.maxTime + ", " + theUILang.time_h.substr(0, theUILang.time_h.length - 1)),
+							),
+							$("<td>").attr({align:"center"}).append($("<strong>").text(theUILang.ratioAction)),
+						),
+					),
+					$("<tbody>").append(
+						...Array.from(Array(theWebUI.maxRatio).keys()).map(i => $("<tr>").append(
+							$("<td>").addClass("alr").append($("<strong>").text((i + 1) + ".")),
+							$("<td>").append(
+								$("<input>").attr({type:"text", id:`rat_name${i}`}).addClass("w-auto"),
+							),
+							$("<td>").append(
+								$("<input>").attr({type:"text", id:`rat_min${i}`}),
+							),
+							$("<td>").append(
+								$("<input>").attr({type:"text", id:`rat_max${i}`}),
+							),
+							$("<td>").append(
+								$("<input>").attr({type:"text", id:`rat_upload${i}`, maxlength:6}),
+							),
+							$("<td>").addClass("ratio_time").append(
+								$("<input>").attr({type:"text", id:`rat_time${i}`, maxlength:6}),
+							),
+							$("<td>").append(
+								$("<select>").attr({id:`rat_action${i}`}).addClass("w-auto").append(
+									$("<option>").val(0).text(theUILang.ratioStop),
+									$("<option>").val(1).text(theUILang.ratioStopAndRemove),
+									$("<option>").val(2).text(theUILang.ratioErase),
+									$("<option>").val(3).text(theUILang.ratioEraseData),
+									$("<option>").val(4).text(theUILang.ratioEraseData + " (" + theUILang.All + ")"),
+								),
+							),
+						)),
+					),
+				),
+			),
+			// Default ratio group selector
+			$("<div>").addClass("col-12 col-md-6").append(
+				$("<label>").attr({for:"ratDefault"}).text(theUILang.ratioDefault),
+			),
+			$("<div>").addClass("col-12 col-md-6").append(
+				$("<select>").attr({id:"ratDefault"}).append(
+					$("<option>").val(0).text(theUILang.dontSet),
+					...Array.from(Array(theWebUI.maxRatio).keys()).map(i => $("<option>").val(i).text(i + 1)),
+				),
+			),
+		),
+	);
 	// Table to put the default ratio group selector beside the UL Legend
-	s+="<table><tr><td>";	
-	// Legend explaining how UL column works
-	s+="<div id='st_legend'><fieldset><legend>"+theUILang.ratioUpload+","+theUILang.GB+"</legend><table>";
-	s+="<tr><label>"+theUILang.minRatio+": 0.01"+theUILang.GB+" = 10"+theUILang.MB+"</label><br></tr>";
-	s+="<tr><label>"+theUILang.maxRatio+": 999999"+theUILang.GB+" = 1"+theUILang.PB+"</label></tr>";
-	s+="</table></fieldset></div></td>";
-	// Default ratio group selector
-	s+="<td><div class='aright'><label>"+theUILang.ratioDefault+":</label><select id='ratDefault'><option value='0'>"+theUILang.dontSet+"</option>";
-	for(var i=1; i<=theWebUI.maxRatio; i++)
-		s+="<option value='"+i+"'>"+i+"</option>";
-	s+="</select></div></td></tr></table>";
-	this.attachPageToOptions($("<div>").attr("id","st_ratio").html(s).get(0),theUILang.ratios);
+	const t = $("<fieldset>").append(
+		$("<legend>").text(theUILang.ratioUpload + ", " + theUILang.GB),
+		$("<div>").addClass("row").append(
+			$("<div>").addClass("col-12").append(
+				$("<span>").text(theUILang.minRatio + ": 0.01" + theUILang.GB + " = 10" + theUILang.MB),
+			),
+			$("<div>").addClass("col-12").append(
+				$("<span>").text(theUILang.maxRatio + ": 999999" + theUILang.GB + " = 1" + theUILang.PB),
+			),
+		),
+	);
+	this.attachPageToOptions(
+		$("<div>").attr({id:"st_ratio"}).append(
+			s, t,
+		)[0],
+		theUILang.ratios,
+	);
 }
 
 plugin.onRemove = function()

--- a/plugins/ratio/init.js
+++ b/plugins/ratio/init.js
@@ -237,8 +237,8 @@ theWebUI.isCorrectRatio = function(i)
 plugin.onLangLoaded = function() {
 	const s = $("<fieldset>").append(
 		$("<legend>").text(theUILang.ratios),
-		$("<div>").attr({id:"st_ratio_h"}).addClass("row").append(
-			$("<div>").addClass("col-12").append(
+		$("<div>").addClass("row").append(
+			$("<div>").addClass("col-12 overflow-x-auto").append(
 				$("<table>").append(
 					$("<thead>").append(
 						$("<tr>").append(

--- a/plugins/ratio/ratio.css
+++ b/plugins/ratio/ratio.css
@@ -1,0 +1,9 @@
+#st_ratio .ratio-name {
+  width: 8rem;
+}
+#st_ratio .ratio-condition {
+  min-width: 4rem;
+}
+#st_ratio .ratio-action {
+  width: 10rem;
+}

--- a/plugins/ratio/ratio.css
+++ b/plugins/ratio/ratio.css
@@ -1,6 +1,0 @@
-#st_ratio {display: none;}
-#st_ratio_h table {width: 400px; border-collapse: collapse;}
-#st_ratio_h table tr td {padding: 0px;}
-#st_ratio_h {width: 420px; overflow: auto; height: 260px; }
-#st_legend fieldset { width: 200px; }
-input.num1 {text-align: right; width: 33px;}

--- a/plugins/scheduler/init.js
+++ b/plugins/scheduler/init.js
@@ -80,49 +80,39 @@ if(plugin.canChangeMenu() && (theWebUI.systemInfo.rTorrent.iVersion >= 0x805))
 	}
 }
 
-if(plugin.canChangeOptions())
-{
+if (plugin.canChangeOptions()) {
 	plugin.loadMainCSS();
 
 	plugin.addAndShowSettings = theWebUI.addAndShowSettings;
-	theWebUI.addAndShowSettings = function(arg) 
-	{
-		if(plugin.enabled)
-		{
-			var tbl = $$('sch_graph');
-			for(var i=0; i<7; i++)
-			{
-				for(var j=1; j<25; j++)
-				{
-					cell = tbl.rows[i].cells[j];
-					cell.setAttribute("clr",theWebUI.scheduleTable.week[i][j-1]);
+	theWebUI.addAndShowSettings = function(arg) {
+		if (plugin.enabled) {
+			for (let day = 0; day < 7; day++) {
+				for (let hour = 0; hour < 24; hour++) {
+					$(`.day-${day}.hour-${hour}`).attr("clr", theWebUI.scheduleTable.week[day][hour]);
 				}
 			}
 			$$('sch_enable').checked = theWebUI.scheduleTable.enabled;
-			for(var i=0; i<3; i++)
-			{
-				$$('restrictedUL'+(i+1)).value = theWebUI.scheduleTable.UL[i];
-				$$('restrictedDL'+(i+1)).value = theWebUI.scheduleTable.DL[i];
+			for (let i = 0; i < 3; i++) {
+				$$('restrictedUL' + ( i + 1 )).value = theWebUI.scheduleTable.UL[i];
+				$$('restrictedDL' + ( i + 1 )).value = theWebUI.scheduleTable.DL[i];
 			}
 			theWebUI.linkedSch($$('sch_enable'), ['restrictedUL1', 'restrictedDL1', 'restrictedUL2', 'restrictedDL2', 'restrictedUL3', 'restrictedDL3']);
 		}
 		plugin.addAndShowSettings.call(theWebUI,arg);
 	}
 
-	theWebUI.schedulerWasChanged = function() 
-	{
-		if($$('sch_enable').checked != theWebUI.scheduleTable.enabled)
-			return(true);
-		for(var i=0; i<3; i++)
-			if(($$('restrictedUL'+(i+1)).value!=theWebUI.scheduleTable.UL[i]) ||
-				($$('restrictedDL'+(i+1)).value!=theWebUI.scheduleTable.DL[i]))
-					return(true);
-		var tbl = $$('sch_graph');
-		for(var i=0; i<7; i++)
-			for(var j=1; j<25; j++)
-				if(tbl.rows[i].cells[j].getAttribute("clr")!=theWebUI.scheduleTable.week[i][j-1])
-					return(true);
-		return(false);
+	theWebUI.schedulerWasChanged = function() {
+		if ($$('sch_enable').checked != theWebUI.scheduleTable.enabled)
+			return true;
+		for (var i = 0; i < 3; i++)
+			if (($$('restrictedUL' + (i + 1)).value != theWebUI.scheduleTable.UL[i]) ||
+				($$('restrictedDL' + (i + 1)).value != theWebUI.scheduleTable.DL[i]))
+					return true;
+		for (let day = 0; day < 7; day++)
+			for (let hour = 1; hour < 25; hour++)
+				if ($(`.day-${day}.hour-${hour}`).attr("clr") !== theWebUI.scheduleTable.week[day][hour])
+					return true;
+		return false;
 	}
 
 	plugin.setSettings = theWebUI.setSettings;
@@ -133,25 +123,19 @@ if(plugin.canChangeOptions())
 			this.request("?action=setschedule");
 	}
 
-	rTorrentStub.prototype.setschedule = function()
-	{
+	rTorrentStub.prototype.setschedule = function() {
 		this.content = "dummy=1";
-		var tbl = $$('sch_graph');
-		for(var i=0; i<7; i++)
-		{
-			for(var j=1; j<25; j++)
-			{
-				var cell = tbl.rows[i].cells[j];
-				this.content += ('&day_'+i+'_'+(j-1)+'='+cell.getAttribute("clr"));
+		for (let day = 0; day < 7; day++) {
+			for (let hour = 0; hour < 24; hour++) {
+				this.content += ('&day_' + day + '_' + hour + '=' + $(`.day-${day}.hour-${hour}`).attr("clr"));
 			}
 		}
-		for(var i=0; i<3; i++)
-		{
+		for (let i = 0; i < 3; i++) {
 			this.content += ('&UL'+i+'='+$$('restrictedUL'+(i+1)).value);
 			this.content += ('&DL'+i+'='+$$('restrictedDL'+(i+1)).value);
 		}
 		this.content += ('&enabled='+($$('sch_enable').checked ? '1' : '0'));
-	        this.contentType = "application/x-www-form-urlencoded";
+		this.contentType = "application/x-www-form-urlencoded";
 		this.mountPoint = "plugins/scheduler/action.php";
 		this.dataType = "script";
 	}
@@ -187,34 +171,32 @@ if(plugin.canChangeOptions())
 		}
 	}
 
-	theWebUI.linkedSch = function(obj, lst) 
-	{
-		linked(obj,0,lst);
-		var tbl = $$('sch_graph');
-		var isChecked = $$('sch_enable').checked;
-		for(var i=0; i<7; i++)
-		{
-			var cell = tbl.rows[i].cells[0];
-			cell.className = isChecked ? 'sch_week' : 'sch_week disabled';
-			for(var j=1; j<25; j++)
-			{
-				cell = tbl.rows[i].cells[j];
-				var clr = schClasses[cell.getAttribute("clr")];
-				cell.className = isChecked ? clr : clr+"dis";
+	theWebUI.linkedSch = function(obj, lst) {
+		linked(obj, 0, lst);
+		const isChecked = $$('sch_enable').checked;
+		isChecked
+			// enable/disable day of week column
+			? $("span.sch-week").removeClass("disabled")
+			: $("span.sch-week").addClass("disabled");
+		for (let day = 0; day < 7; day++) {
+			for (let hour = 0; hour < 24; hour++) {
+				const cell = $(`.day-${day}.hour-${hour}`);
+				const clr = schClasses[cell.attr("clr")];
+				isChecked
+					? cell.addClass(clr).removeClass(clr + "dis")
+					: cell.removeClass(clr).addClass(clr + "dis");
 			}
 		}
-		tbl = $$('sch_legend');
-		for(var i=0; i<2; i++)
-		{
-	        	for(var j=0; j<6; j++)
-		        {
-			        var cell = tbl.rows[i].cells[j];
+		const legendTbl = $$('sch_legend');
+		for (var i=0; i<2; i++) {
+			for (var j=0; j<6; j++) {
+				var cell = legendTbl.rows[i].cells[j];
 				var clr = schClasses[cell.getAttribute("clr")];
-				if(clr!=null)
+				if (clr!=null)
 					cell.className = isChecked ? clr : clr+"dis";
 				else
 					cell.className = isChecked ? '' : "disabled";
-		        }
+			}
 		}
 		isChecked ? $("#sch_desc").removeClass("disabled") : $("#sch_desc").addClass("disabled");
 	}
@@ -234,21 +216,25 @@ plugin.onLangLoaded = function() {
 						}),
 						$("<label>").attr({for:"sch_enable"}).text(theUILang.schedulerOn),
 					),
-					$("<div>").addClass("col-12 overflow-x-auto").append(
-						$("<table>").attr({id:"sch_graph"}).append(
-							...Array.from(Array(7).keys()).map(week => $("<tr>").append(
-								$("<td>").addClass("sch_week disabled").text(theUILang.schShortWeek[week]),
-								...Array.from(Array(24).keys()).map(hour => {
-									const day = theWebUI.scheduleTable.week[week][hour];
-									return $("<td>").attr({
-										clr: day,
-										onmouseover: `theWebUI.schMouseOver("${week}","${hour}")`,
-										onmouseout: "theWebUI.schMouseOut();",
-										onclick: `theWebUI.schClick(this, "${week}","${hour}");`,
-									}).addClass(schClasses[day] + "dis");
-								}),
-							)),
-						),
+					$("<div>").attr({id:"sch_graph"}).addClass("col-12 row").append(
+						...Array.from(Array(7).keys()).flatMap(day => [
+							$("<div>").addClass("col-2 col-md-1").append(
+								$("<span>").addClass("sch-week").text(theUILang.schShortWeek[day]),
+							),
+							$("<div>").addClass("col-10 col-md-11 row flex-grow-1 mb-1 mb-md-0").append(
+								...["am", "pm"].map(_ => $("<div>").addClass("col-12 col-md-6 align-items-stretch").append(
+									...Array.from(Array(12).keys()).map(hour => {
+										const clr = theWebUI.scheduleTable.week[day][hour];
+										return $("<span>").attr({
+											clr,
+											onmouseover: `theWebUI.schMouseOver("${day}","${hour}")`,
+											onmouseout: "theWebUI.schMouseOut();",
+											onclick: `theWebUI.schClick(this, "${day}","${hour}");`,
+										}).addClass(`${schClasses[clr]}dis day-${day} hour-${hour}`);
+									}),
+								)),
+							),
+						])
 					),
 					$("<div>").addClass("col-12").append(
 						$("<div>").attr({id:"sch_desc"}).addClass("p-2 flex-grow-1 disabled").html("&nbsp;"),

--- a/plugins/scheduler/init.js
+++ b/plugins/scheduler/init.js
@@ -234,7 +234,7 @@ plugin.onLangLoaded = function() {
 						}),
 						$("<label>").attr({for:"sch_enable"}).text(theUILang.schedulerOn),
 					),
-					$("<div>").addClass("col-12").append(
+					$("<div>").addClass("col-12 overflow-x-auto").append(
 						$("<table>").attr({id:"sch_graph"}).append(
 							...Array.from(Array(7).keys()).map(week => $("<tr>").append(
 								$("<td>").addClass("sch_week disabled").text(theUILang.schShortWeek[week]),

--- a/plugins/scheduler/init.js
+++ b/plugins/scheduler/init.js
@@ -216,88 +216,112 @@ if(plugin.canChangeOptions())
 					cell.className = isChecked ? '' : "disabled";
 		        }
 		}
-		$$('sch_desc').className = isChecked ? '' : "disabled";
+		isChecked ? $("#sch_desc").removeClass("disabled") : $("#sch_desc").addClass("disabled");
 	}
 }
 
-plugin.onLangLoaded = function() 
-{
-        if(this.canChangeOptions())
-        {
-		var s = 
-			"<div>"+
-				"<input id='sch_enable' type='checkbox' onchange=\"theWebUI.linkedSch(this, ['restrictedUL1', 'restrictedDL1', 'restrictedUL2', 'restrictedDL2', 'restrictedUL3', 'restrictedDL3']);\" />"+
-				"<label for='sch_enable'>"+
-					theUILang.schedulerOn+
-				"</label>"+
-			"</div>"+
-			"<fieldset>"+
-				"<legend>"+theUILang.schedulerGraph+"</legend>"+
-			"<table id='sch_graph'>";
-		for(var i=0; i<7; i++)
-		{
-			s += "<tr><td class='sch_week disabled'>"+theUILang.schShortWeek[i]+"</td>";
-			for(var j=0; j<24; j++)
-			{
-				var day = theWebUI.scheduleTable.week[i][j];
-				s+="<td class='"+schClasses[day]+"dis' clr='"+day+"' onmouseover='theWebUI.schMouseOver("+i+","+j+");' onmouseout='theWebUI.schMouseOut();' onclick='theWebUI.schClick(this,"+i+","+j+");'></td>";
-			}
-			s += "</tr>";
-		}
-		s+="</table><div id='sch_desc' class='disabled'>&nbsp;</div>";
-		s+="<table id='sch_legend'>"+
-			"<tr>"+
-			"<td clr='0' class='sch_fastdis' onmouseover='theWebUI.schLegendMouseOver(0);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schUnlimited+"</td>"+
-			"<td clr='1' class='sch_stopdis' onmouseover='theWebUI.schLegendMouseOver(1);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schTurnOff+"</td>"+
-			"<td clr='2' class='sch_seeddis' onmouseover='theWebUI.schLegendMouseOver(2);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schSeedingOnly+"</td>"+
-			"</tr>"+
-			"<tr>"+
-			"<td clr='3' class='sch_res1dis' onmouseover='theWebUI.schLegendMouseOver(3);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schLimited+"1</td>"+
-			"<td clr='4' class='sch_res2dis' onmouseover='theWebUI.schLegendMouseOver(4);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schLimited+"2</td>"+
-			"<td clr='5' class='sch_res3dis' onmouseover='theWebUI.schLegendMouseOver(5);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schLimited+"3</td>"+
-			"</tr>"+
-		"</table></fieldset><div id='st_scheduler_h'>";
-
-		s+="<fieldset>"+
-			"<legend>"+theUILang.schLimited+"1</legend>"+
-			"<table>"+
-				"<tr>"+
-					"<td><label id='lbl_restrictedUL1' for='restrictedUL1' class='disabled'>"+theUILang.schLimitedUL+" ("+theUILang.KB + "/" + theUILang.s+"):</label></td>"+
-					"<td class=\"alr\"><input type='text' id='restrictedUL1' class='TextboxNum' maxlength='6' disabled='1'/></td>"+
-				"</tr>"+
-				"<tr>"+
-					"<td><label id='lbl_restrictedDL1' for='restrictedDL1' class='disabled'>"+theUILang.schLimitedDL+" ("+theUILang.KB + "/" + theUILang.s+"):</label></td>"+
-					"<td class=\"alr\"><input type='text' id='restrictedDL1' class='TextboxNum' maxlength='6' disabled='1'/></td>"+
-				"</tr>"+
-			"</table>"+
-		   "</fieldset>"+
-		   "<fieldset>"+
-			"<legend>"+theUILang.schLimited+"2</legend>"+
-			"<table>"+
-				"<tr>"+
-					"<td><label id='lbl_restrictedUL2' for='restrictedUL2' class='disabled'>"+theUILang.schLimitedUL+" ("+theUILang.KB + "/" + theUILang.s+"):</label></td>"+
-					"<td class=\"alr\"><input type='text' id='restrictedUL2' class='TextboxNum' maxlength='6' disabled='1'/></td>"+
-				"</tr>"+
-				"<tr>"+
-					"<td><label id='lbl_restrictedDL2' for='restrictedDL2' class='disabled'>"+theUILang.schLimitedDL+" ("+theUILang.KB + "/" + theUILang.s+"):</label></td>"+
-					"<td class=\"alr\"><input type='text' id='restrictedDL2' class='TextboxNum' maxlength='6' disabled='1'/></td>"+
-				"</tr>"+
-			"</table>"+
-		   "</fieldset>"+
-		   "<fieldset>"+
-			"<legend>"+theUILang.schLimited+"3</legend>"+
-			"<table>"+
-				"<tr>"+
-					"<td><label id='lbl_restrictedUL3' for='restrictedUL3' class='disabled'>"+theUILang.schLimitedUL+" ("+theUILang.KB + "/" + theUILang.s+"):</label></td>"+
-					"<td class=\"alr\"><input type='text' id='restrictedUL3' class='TextboxNum' maxlength='6' disabled='1'/></td>"+
-				"</tr>"+
-				"<tr>"+
-					"<td><label id='lbl_restrictedDL3' for='restrictedDL3' class='disabled'>"+theUILang.schLimitedDL+" ("+theUILang.KB + "/" + theUILang.s+"):</label></td>"+
-					"<td class=\"alr\"><input type='text' id='restrictedDL3' class='TextboxNum' maxlength='6' disabled='1'/></td>"+
-				"</tr>"+
-			"</table>"+
-		   "</fieldset>";
-		this.attachPageToOptions($("<div>").attr("id","st_scheduler").html(s+"</div>")[0],theUILang.scheduler);
+plugin.onLangLoaded = function() {
+	if (this.canChangeOptions()) {
+		const s = $("<div>").attr({id:"st_scheduler"}).append(
+			$("<fieldset>").append(
+				$("<legend>").text(theUILang.schedulerGraph),
+				$("<div>").addClass("row").append(
+					$("<div>").addClass("col-12").append(
+						$("<input>").attr({
+							type: "checkbox",
+							id: "sch_enable",
+							onchange:"theWebUI.linkedSch(this, ['restrictedUL1', 'restrictedDL1', 'restrictedUL2', 'restrictedDL2', 'restrictedUL3', 'restrictedDL3']);",
+						}),
+						$("<label>").attr({for:"sch_enable"}).text(theUILang.schedulerOn),
+					),
+					$("<div>").addClass("col-12").append(
+						$("<table>").attr({id:"sch_graph"}).append(
+							...Array.from(Array(7).keys()).map(week => $("<tr>").append(
+								$("<td>").addClass("sch_week disabled").text(theUILang.schShortWeek[week]),
+								...Array.from(Array(24).keys()).map(hour => {
+									const day = theWebUI.scheduleTable.week[week][hour];
+									return $("<td>").attr({
+										clr: day,
+										onmouseover: `theWebUI.schMouseOver("${week}","${hour}")`,
+										onmouseout: "theWebUI.schMouseOut();",
+										onclick: `theWebUI.schClick(this, "${week}","${hour}");`,
+									}).addClass(schClasses[day] + "dis");
+								}),
+							)),
+						),
+					),
+					$("<div>").addClass("col-12").append(
+						$("<div>").attr({id:"sch_desc"}).addClass("p-2 flex-grow-1 disabled").html("&nbsp;"),
+					),
+					$("<div>").addClass("col-12").append(
+						$("<table>").attr({id:"sch_legend"}).html(
+							"<tr>"+
+								"<td clr='0' class='sch_fastdis' onmouseover='theWebUI.schLegendMouseOver(0);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schUnlimited+"</td>"+
+								"<td clr='1' class='sch_stopdis' onmouseover='theWebUI.schLegendMouseOver(1);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schTurnOff+"</td>"+
+								"<td clr='2' class='sch_seeddis' onmouseover='theWebUI.schLegendMouseOver(2);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schSeedingOnly+"</td>"+
+							"</tr>"+
+							"<tr>"+
+								"<td clr='3' class='sch_res1dis' onmouseover='theWebUI.schLegendMouseOver(3);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schLimited+"1</td>"+
+								"<td clr='4' class='sch_res2dis' onmouseover='theWebUI.schLegendMouseOver(4);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schLimited+"2</td>"+
+								"<td clr='5' class='sch_res3dis' onmouseover='theWebUI.schLegendMouseOver(5);' onmouseout='theWebUI.schMouseOut();'></td><td class='disabled'>"+theUILang.schLimited+"3</td>"+
+							"</tr>"
+						),
+					),
+				),
+			),
+			$("<fieldset>").append(
+				$("<legend>").text(theUILang.schLimited + " 1"),
+				$("<div>").addClass("row").append(
+					...[
+						["restrictedUL1", theUILang.schLimitedUL],
+						["restrictedDL1", theUILang.schLimitedDL],
+					].flatMap(([id, text]) => [
+						$("<div>").addClass("col-12 col-md-4").append(
+							$("<label>").attr({id:`lbl_${id}`, for:id}).addClass("disabled").text(text + " ("+theUILang.KB + "/" + theUILang.s+"):"),
+						),
+						$("<div>").addClass("col-12 col-md-8").append(
+							$("<input>").attr({type:"text", id:id, maxlength:6}).addClass("TextboxNum").prop("disabled", true),
+						),
+					]),
+				),
+			),
+			$("<fieldset>").append(
+				$("<legend>").text(theUILang.schLimited + " 2"),
+				$("<div>").addClass("row").append(
+					...[
+						["restrictedUL2", theUILang.schLimitedUL],
+						["restrictedDL2", theUILang.schLimitedDL],
+					].flatMap(([id, text]) => [
+						$("<div>").addClass("col-12 col-md-4").append(
+							$("<label>").attr({id:`lbl_${id}`, for:id}).addClass("disabled").text(text + " ("+theUILang.KB + "/" + theUILang.s+"):"),
+						),
+						$("<div>").addClass("col-12 col-md-8").append(
+							$("<input>").attr({type:"text", id:id, maxlength:6}).addClass("TextboxNum").prop("disabled", true),
+						),
+					]),
+				),
+			),
+			$("<fieldset>").append(
+				$("<legend>").text(theUILang.schLimited + " 3"),
+				$("<div>").addClass("row").append(
+					...[
+						["restrictedUL3", theUILang.schLimitedUL],
+						["restrictedDL3", theUILang.schLimitedDL],
+					].flatMap(([id, text]) => [
+						$("<div>").addClass("col-12 col-md-4").append(
+							$("<label>").attr({id:`lbl_${id}`, for:id}).addClass("disabled").text(text + " ("+theUILang.KB + "/" + theUILang.s+"):"),
+						),
+						$("<div>").addClass("col-12 col-md-8").append(
+							$("<input>").attr({type:"text", id:id, maxlength:6}).addClass("TextboxNum").prop("disabled", true),
+						),
+					]),
+				),
+			),
+		);
+		this.attachPageToOptions(
+			s[0],
+			theUILang.scheduler,
+		);
 	}
 }
 

--- a/plugins/scheduler/scheduler.css
+++ b/plugins/scheduler/scheduler.css
@@ -1,7 +1,4 @@
-#st_scheduler {display: none;}
-#st_scheduler_h {width: 450px; height: 300px; overflow: auto}
-
-#sch_graph {width: 415px; border: 0; border-collapse:collapse; table-layout: fixed; margin-left: 10px}
+#sch_graph {border: 0; border-collapse:collapse; table-layout: fixed;}
 #sch_graph td {height: 16px; padding: 0; white-space: nowrap; }
 .sch_fast {background: #00A800; border: 1px solid black; width: 15px;}
 .sch_res1 {background: #8DAA8D; border: 1px solid black; width: 15px;}
@@ -18,7 +15,5 @@
 
 .sch_week {border: 0; width: 22px; text-align: left}
 
-#sch_desc {width: 390px; margin-left: 5px; padding: 5px; white-space: nowrap}
-
-#sch_legend {width: 390px; border: 0; table-layout: fixed; margin-left: 10px; border-collapse:collapse; }
+#sch_legend {border: 0; table-layout: fixed; border-collapse:collapse;}
 #sch_legend td { padding: 3px; height: 16px }

--- a/plugins/scheduler/scheduler.css
+++ b/plugins/scheduler/scheduler.css
@@ -1,19 +1,33 @@
-#sch_graph {border: 0; border-collapse:collapse; table-layout: fixed;}
-#sch_graph td {height: 16px; padding: 0; white-space: nowrap; }
-.sch_fast {background: #00A800; border: 1px solid black; width: 15px;}
-.sch_res1 {background: #8DAA8D; border: 1px solid black; width: 15px;}
-.sch_res2 {background: #8DCC8D; border: 1px solid black; width: 15px;}
-.sch_res3 {background: #8DFF8D; border: 1px solid black; width: 15px;}
-.sch_stop {background: #FFFFFF; border: 1px solid black; width: 15px;}
-.sch_seed {background: #FFC0C0; border: 1px solid black; width: 15px;}
-.sch_fastdis {background: #636363; border: 1px solid black; width: 15px;}
-.sch_res1dis {background: #9E9E9E; border: 1px solid black; width: 15px;}
-.sch_res2dis {background: #B2B2B2; border: 1px solid black; width: 15px;}
-.sch_res3dis {background: #D0D0D0; border: 1px solid black; width: 15px;}
-.sch_stopdis {background: #FFFFFF; border: 1px solid black; width: 15px;}
-.sch_seeddis {background: #D2D2D2; border: 1px solid black; width: 15px;}
+.sch-week {
+  margin-left: auto;
+  font-weight: bold;
+}
+#sch_graph div {
+  margin: 0;
+}
+#sch_graph div.row > div {
+  margin: 0;
+  padding: 0;
+}
+#sch_graph div.row > div span {
+  border: 1px solid var(--menu-border-color);
+  height: 1.5rem;
+  flex-grow: 1;
+  text-align: center;
+}
+.day-half {width: 1rem;}
+.sch_fast {background: #00A800;}
+.sch_res1 {background: #8DAA8D;}
+.sch_res2 {background: #8DCC8D;}
+.sch_res3 {background: #8DFF8D;}
+.sch_stop {background: #FFFFFF;}
+.sch_seed {background: #FFC0C0;}
+.sch_fastdis {background: #636363;}
+.sch_res1dis {background: #9E9E9E;}
+.sch_res2dis {background: #B2B2B2;}
+.sch_res3dis {background: #D0D0D0;}
+.sch_stopdis {background: #FFFFFF;}
+.sch_seeddis {background: #D2D2D2;}
 
-.sch_week {border: 0; width: 22px; text-align: left}
-
-#sch_legend {border: 0; table-layout: fixed; border-collapse:collapse;}
-#sch_legend td { padding: 3px; height: 16px }
+#sch_legend {border: 0; table-layout: auto;}
+#sch_legend td {padding: 3px; height: 16px; min-width: 2rem;}

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -428,11 +428,6 @@ div select {
 	padding:1px 4px
 }
 
-#st_throttle_h
-{
-	height:360px !important
-}
-
 a
 {
 	color:#686868;

--- a/plugins/throttle/init.js
+++ b/plugins/throttle/init.js
@@ -220,12 +220,12 @@ plugin.onLangLoaded = function() {
 								theUILang.Num_No, theUILang.channelName,
 								theUILang.UL + " (" + theUILang.KB + "/" + theUILang.s + ")",
 								theUILang.DL + " (" + theUILang.KB + "/" + theUILang.s + ")",
-							].map(th => $("<td>").append($("<strong>").text(th))),
+							].map(th => $("<td>").text(th)),
 						),
 					),
 					$("<tbody>").append(
 						...Array.from(Array(theWebUI.maxThrottle).keys()).map(i => $("<tr>").append(
-							$("<td>").addClass("alr").append(
+							$("<td>").append(
 								$("<strong>").text((i + 1) + "."),
 							),
 							$("<td>").append(

--- a/plugins/throttle/init.js
+++ b/plugins/throttle/init.js
@@ -1,5 +1,4 @@
 plugin.loadLang();
-plugin.loadMainCSS();
 
 plugin.config = theWebUI.config;
 theWebUI.config = function()
@@ -213,7 +212,7 @@ plugin.onLangLoaded = function() {
 	const s = $("<fieldset>").append(
 		$("<legend>").text(theUILang.throttles),
 		$("<div>").addClass("row").append(
-			$("<div>").addClass("col-12 overflow-auto").append(
+			$("<div>").addClass("col-12 overflow-x-auto").append(
 				$("<table>").append(
 					$("<thead>").append(
 						$("<tr>").append(

--- a/plugins/throttle/init.js
+++ b/plugins/throttle/init.js
@@ -209,33 +209,54 @@ theWebUI.isCorrectThrottle = function(i)
 		(theWebUI.throttles[i].down>=0));
 }
 
-plugin.onLangLoaded = function() 
-{
-	var s = 
-		"<fieldset>"+
-			"<legend>"+theUILang.throttles+"</legend>"+
-			"<div id='st_throttle_h'>"+
-			"<table>"+
-				"<tr>"+
-					"<td><b>"+theUILang.Num_No+"</b></td>"+
-					"<td><b>"+theUILang.channelName+"</b></td>"+
-					"<td><b>"+theUILang.UL+" ("+theUILang.KB+"/"+theUILang.s+")</b></td>"+
-					"<td><b>"+theUILang.DL+" ("+theUILang.KB+"/"+theUILang.s+")</b></td>"+
-				"</tr>";
-	for(var i=0; i<theWebUI.maxThrottle; i++)
-		s +=
-			"<tr>"+
-			        "<td class='alr'><b>"+(i+1)+".</b></td>"+
-				"<td><input type='text' id='thr_name"+i+"' class='TextboxLarge'/></td>"+
-				"<td><input type='text' id='thr_up"+i+"' class='Textbox num' maxlength='6'/></td>"+
-				"<td><input type='text' id='thr_down"+i+"' class='Textbox num' maxlength='6'/></td>"+
-			"</tr>";
-	s+="</table></div></fieldset>";
-	s+="<div class='aright'><label>"+theUILang.channelDefault+":</label><select id='chDefault'><option value='0'>"+theUILang.dontSet+"</option>";
-	for(var i=1; i<=theWebUI.maxThrottle; i++)
-		s+="<option value='"+i+"'>"+i+"</option>";
-	s+="</select></div>";
-	this.attachPageToOptions($("<div>").attr("id","st_throttle").html(s).get(0),theUILang.throttles);
+plugin.onLangLoaded = function() {
+	const s = $("<fieldset>").append(
+		$("<legend>").text(theUILang.throttles),
+		$("<div>").addClass("row").append(
+			$("<div>").addClass("col-12 overflow-auto").append(
+				$("<table>").append(
+					$("<thead>").append(
+						$("<tr>").append(
+							...[
+								theUILang.Num_No, theUILang.channelName,
+								theUILang.UL + " (" + theUILang.KB + "/" + theUILang.s + ")",
+								theUILang.DL + " (" + theUILang.KB + "/" + theUILang.s + ")",
+							].map(th => $("<td>").append($("<strong>").text(th))),
+						),
+					),
+					$("<tbody>").append(
+						...Array.from(Array(theWebUI.maxThrottle).keys()).map(i => $("<tr>").append(
+							$("<td>").addClass("alr").append(
+								$("<strong>").text((i + 1) + "."),
+							),
+							$("<td>").append(
+								$("<input>").attr({type:"text", id:`thr_name${i}`}),
+							),
+							$("<td>").append(
+								$("<input>").attr({type:"text", id:`thr_up${i}`, maxlength:6}).addClass("num"),
+							),
+							$("<td>").append(
+								$("<input>").attr({type:"text", id:`thr_down${i}`, maxlength:6}).addClass("num"),
+							),
+						),),
+					),
+				),
+			),
+			$("<div>").addClass("col-12 col-md-6").append(
+				$("<label>").attr({for:"chDefault"}).text(theUILang.channelDefault + ":"),
+			),
+			$("<div>").addClass("col-12 col-md-6").append(
+				$("<select>").attr({id:"chDefault"}).append(
+					$("<option>").val(0).text(theUILang.dontSet),
+					...Array.from(Array(theWebUI.maxThrottle).keys()).map(i => $("<option>").val(i).text(i + 1)),
+				),
+			),
+		),
+	);
+	this.attachPageToOptions(
+		$("<div>").attr("id","st_throttle").append(s)[0],
+		theUILang.throttles,
+	);
 }
 
 plugin.onRemove = function()

--- a/plugins/throttle/throttle.css
+++ b/plugins/throttle/throttle.css
@@ -1,5 +1,0 @@
-#st_throttle {display: none;}
-#st_throttle_h table {width: 400px}
-#st_throttle_h {width: 420px; overflow: auto; height: 260px}
-#st_throttle_h table td input {margin: 0 2px; padding: 0 4px}
-


### PR DESCRIPTION
In this pull request, three of the four remaining plugins were rewritten for the responsive UI. I modified the setting dialog layout a bit, so that the tables on the setting pages of these three plugins can overflow and scroll within the fixed parent box. These tables remained as HTML `<table>`, although previously most HTML `<table>`s that served as layout boxes were rewritten to `<div>`s to provide a smoother layout; these ones are real tables. As I consider again about the `<table>`s, I think the table that sets decimal sizes on the "Format" page, which was changed into a flex `<div>`, should also be reverted to an HTML `<table>`.

Changes on the last plugin screenshots are on the way, too.