### PR TITLE
Apply flex layout to screenshots plugin

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -61,7 +61,7 @@ button, input[type=button], input[type=submit], .Button {
   padding: 1px 10px;
   background: #F0F0F0 url(../images/h.gif) repeat-x center bottom;
   width: 80px;
-  cursor: pointer;
+  text-wrap: nowrap;
 }
 button:disabled, input[type=button]:disabled, a.Button:disabled {
   opacity: 0.3;
@@ -442,11 +442,8 @@ div.cont {padding: 6px;}
 
 div#dlgLabel {max-width: 350px;}
 div#dlgLabel div.dlg-header {background-image: url(../images/label.gif)}
-div#padd {width: 250px; height: 120px}
+div#padd {width: 250px;}
 div#padd div.dlg-header {background-image: url(../images/props.gif)}
-div#padd div.content {width: 230px; margin: 5px; padding: 5px; line-height: 16px}
-div#padd div.content input {margin-top: 5px}
-#peerIP {width: 200px}
 div#dlgAbout {max-width: 300px;}
 div#dlgAbout div.dlg-header {background-image: url(../images/about.gif)}
 div#dlgHelp {max-width: 300px;}

--- a/js/content.js
+++ b/js/content.js
@@ -67,10 +67,22 @@ function makeContent() {
 			} catch(e) {}
 	}));
 	theDialogManager.make("padd",theUILang.peerAdd,
-		'<div class="content fxcaret">'+theUILang.peerAddLabel+'<br><input type="text" id="peerIP" class="Textbox" value="my.friend.addr:6881"/></div>'+
-		'<div class="aright buttons-list"><input type="button" class="OK Button" value="'+theUILang.ok+'" onclick="theWebUI.addNewPeer();theDialogManager.hide(\'padd\');return(false);" />'+
-			'<input type="button" class="Cancel Button" value="'+theUILang.Cancel+'"/></div>',
-		true);
+		$("<div>").addClass("cont fxcaret").append(
+			$("<fieldset>").append(
+				$("<legend>").text(theUILang.peerAddLabel),
+				$("<div>").addClass("row").append(
+					$("<div>").addClass("col-12").append(
+						$("<input>").attr({type:"text", id:"peerIP", placeholder:"my.friend.addr:6881"}),
+					),
+				),
+			),
+		)[0].outerHTML +
+		$("<div>").addClass("buttons-list").append(
+			$("<button>").attr({type:"button", onclick:"theWebUI.addNewPeer();theDialogManager.hide('padd');return(false);"}).addClass("OK").text(theUILang.ok),
+			$("<button>").attr({type:"button"}).addClass("Cancel").text(theUILang.Cancel),
+		)[0].outerHTML,
+		true,
+	);
 	theDialogManager.make("tadd",theUILang.torrent_add,
 		$("<div>").addClass("cont fxcaret").append(
 			$("<form>").attr(
@@ -347,10 +359,13 @@ function makeContent() {
 		}, 0);
 	});
 	theDialogManager.make("yesnoDlg","",
-		'<div class="content" id="yesnoDlg-content"></div>'+
-		'<div id="yesnoDlg-buttons" class="aright buttons-list"><input type="button" class="OK Button" value="'+theUILang.ok+'" id="yesnoOK">'+
-		'<input type="button" class="Button Cancel" value="'+theUILang.Cancel+'" id="yesnoCancel"></div>',
-		true);
+		$("<div>").attr({id:"yesnoDlg-content"}).addClass("cont")[0].outerHTML +
+		$("<div>").attr({id:"yesnoDlg-buttons"}).addClass("buttons-list").append(
+			$("<button>").attr({type:"button", id:"yesnoOK"}).addClass("OK").text(theUILang.ok),
+			$("<button>").attr({type:"button", id:"yesnoCancel"}).addClass("Cancel").text(theUILang.Cancel),
+		)[0].outerHTML,
+		true,
+	);
 
 	const stgPanel = $("<div>").addClass("lm").append(
 		$("<ul>").append(

--- a/plugins/_task/_task.css
+++ b/plugins/_task/_task.css
@@ -1,7 +1,19 @@
-.tskconsole {font-size: 11px; font-family: monospace; line-height: 11px; background: #F5F5F5; white-space: pre; overflow: scroll; height: 198px; width: 580px; cursor: text}
-div#tskConsole { height: 536px }
-div#tskConsole fieldset div {line-height: 16px }
-div#tsk_btns {background: transparent url(./images/ajax-loader.gif) no-repeat 5px 7px; padding-top: 5px}
+.tskconsole {
+  font-family: monospace;
+  line-height: 16px;
+  background: #F5F5F5;
+  white-space: pre;
+  overflow: scroll;
+  width: 580px;
+  cursor: text;
+}
+#tskcmdlog {
+  height: 36rem;
+}
+#tskcmderrors {
+  height: 12rem;
+}
+div#tsk_btns {background: transparent url(./images/ajax-loader.gif) no-repeat 5px 7px;}
 div#tskConsole div.dlg-header {background-image: url(../../images/settings.gif)}
 
-.konqueror div#tskConsole { height: 546px }
+.konqueror div.tskconsole { height: 546px }

--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -116,15 +116,11 @@ plugin.fromBackground = function( no )
 	plugin.onStart(this.foreground); 
 }
 
-plugin.copyConsoleLog = function()
-{
-	let consoleLog = $('#tskcmdlog')[0].innerText;
-	if(consoleLog !== "")
-	{
-		navigator.clipboard.writeText(consoleLog);
-	}
-	else
-	{
+plugin.copyConsoleLog = function() {
+	const consoleLog = $('#tskcmdlog').text();
+	if (consoleLog !== "") {
+		copyToClipboard(consoleLog);
+	} else {
 		log("Console log is empty.");
 	}
 }
@@ -234,6 +230,10 @@ plugin.setConsoleControls = function(errPresent) {
 	if (plugin.foreground.status >= 0) {
 		$('#tsk_btns').css( "background", "none" );
 		$("#tskConsole-header").html(theUILang.tskCommandDone);
+		if ($('#tskcmdlog').text() === "") {
+			// hide copy log button if log output is empty
+			$("#tskCopy").hide();
+		};
 	}
 	else
 		$('#tsk_btns').css( "background", "transparent url(./plugins/_task/images/ajax-loader.gif) no-repeat 5px 7px" );
@@ -580,12 +580,18 @@ plugin.onLangLoaded = function() {
 			),
 		)[0].outerHTML +
 		$("<div>").attr({id:"tsk_btns"}).addClass("buttons-list").append(
-			$("<button>").attr({type:"button", id:"tskCopy"}).text(theUILang.tskCopy),
-			$("<button>").attr({type:"button", id:"tskBackground"}).text(theUILang.tskBackground),
-			$("<button>").attr({type:"button", id:"tskCancel"}).addClass("Cancel").text(theUILang.Cancel),
+			$("<button>").attr({type:"button", id:"tskCopy"})
+				.text(theUILang.tskCopy),
+			$("<button>").attr({type:"button", id:"tskBackground"})
+				.text(theUILang.tskBackground),
+			$("<button>").attr({type:"button", id:"tskCancel"})
+				.addClass("Cancel")
+				.text(theUILang.Cancel),
 		)[0].outerHTML,
 		true,
 	);
+	$("#tskCopy").on("click", plugin.copyConsoleLog);
+	$("#tskBackground").on("click", plugin.toBackground);
 
 	theDialogManager.setHandler('tskConsole','afterHide',function()
 	{
@@ -602,7 +608,5 @@ plugin.onLangLoaded = function() {
 		if(!plugin.cHeight)
 			plugin.cHeight = $('#tskcmderrors').parent().height();
 	});
-	$('#tskBackground').on('click', plugin.toBackground );
 	$(".tskconsole").enableSysMenu();
-	$("#tskCopy").on('click', plugin.copyConsoleLog);
 }

--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -229,27 +229,20 @@ plugin.kill = function()
 		plugin.callNotification("Finished");
 }
 
-plugin.setConsoleControls = function( errPresent )
-{
+plugin.setConsoleControls = function(errPresent) {
 	$('#tskBackground').prop( 'disabled', !plugin.canDetachTask() );
-	if(plugin.foreground.status>=0)
-	{
+	if (plugin.foreground.status >= 0) {
 		$('#tsk_btns').css( "background", "none" );
 		$("#tskConsole-header").html(theUILang.tskCommandDone);
 	}
 	else
 		$('#tsk_btns').css( "background", "transparent url(./plugins/_task/images/ajax-loader.gif) no-repeat 5px 7px" );
-	if(errPresent)
-	{
-		$('#tskcmdlog').height(plugin.cHeight-18).parent().height(plugin.cHeight);
+	if (errPresent) {
 		$('#tskcmderrors').show();
 		$('#tskcmderrors_set').show();
-	}
-	else
-	{
+	} else {
 		$('#tskcmderrors').hide();
 		$('#tskcmderrors_set').hide();
-		$('#tskcmdlog').height(plugin.cHeight*2+3).parent().height(plugin.cHeight*2+21);
 	}
 }
 
@@ -574,24 +567,26 @@ plugin.onGetTasks = function(d)
 	}		
 }
 
-plugin.onLangLoaded = function()
-{
-	theDialogManager.make("tskConsole",theUILang.tskCommand,
-		"<div class='fxcaret'>"+
-			"<fieldset id='tskcmdlog_set'>"+
-				"<legend>"+theUILang.tskConsole+"</legend>"+
-				"<div class='tskconsole' id='tskcmdlog'></div>"+
-			"</fieldset>"+
-			"<fieldset id='tskcmderrors_set'>"+
-				"<legend>"+theUILang.tskErrors+"</legend>"+
-				"<div class='tskconsole' id='tskcmderrors'></div>"+
-			"</fieldset>"+
-		"</div>"+
-		"<div class='aright buttons-list' id='tsk_btns'>"+
-			"<input type='button' id='tskCopy' class='Button' value='"+theUILang.tskCopy+"'/>"+
-			"<input type='button' id='tskBackground' class='Button' value='"+theUILang.tskBackground+"'/>"+
-			"<input type='button' id='tskCancel' class='Cancel Button' value='"+theUILang.Cancel+"'/>"+
-		"</div>",true);
+plugin.onLangLoaded = function() {
+	theDialogManager.make("tskConsole", theUILang.tskCommand,
+		$("<div>").addClass("cont fxcaret").append(
+			$("<fieldset>").attr({id:"tskcmdlog_set"}).append(
+				$("<legend>").text(theUILang.tskConsole),
+				$("<div>").attr({id:"tskcmdlog"}).addClass("tskconsole"),
+			),
+			$("<fieldset>").attr({id:"tskcmderrors_set"}).append(
+				$("<legend>").text(theUILang.tskErrors),
+				$("<div>").attr({id:"tskcmderrors"}).addClass("tskconsole"),
+			),
+		)[0].outerHTML +
+		$("<div>").attr({id:"tsk_btns"}).addClass("buttons-list").append(
+			$("<button>").attr({type:"button", id:"tskCopy"}).text(theUILang.tskCopy),
+			$("<button>").attr({type:"button", id:"tskBackground"}).text(theUILang.tskBackground),
+			$("<button>").attr({type:"button", id:"tskCancel"}).addClass("Cancel").text(theUILang.Cancel),
+		)[0].outerHTML,
+		true,
+	);
+
 	theDialogManager.setHandler('tskConsole','afterHide',function()
 	{
 		if( plugin.foreground.no )

--- a/plugins/bulk_magnet/bulk_magnet.css
+++ b/plugins/bulk_magnet/bulk_magnet.css
@@ -1,4 +1,6 @@
 div#dlgBulkAdd {width: 395px}
 div#dlgBulkAdd div.dlg-header {background-image: url(../../images/world.gif)}
-div#dlgBulkAdd .container {padding: 5px; margin-bottom: 10px;}
-div#dlgBulkAdd textarea {box-sizing: border-box; width: 100%; height: 200px; padding: 5px; white-space: nowrap} 
+div#dlgBulkAdd textarea {
+  height: 200px;
+  white-space: nowrap;
+}

--- a/plugins/bulk_magnet/init.js
+++ b/plugins/bulk_magnet/init.js
@@ -152,14 +152,15 @@ plugin.onLangLoaded = function()
 {
 	this.registerTopMenu(9);
 	theDialogManager.make( "dlgBulkAdd", theUILang.bulkAdd,
-		"<div class='container'>"+
-			"<textarea id='bulkadd'></textarea>"+
-			theUILang.bulkAddDescription+
-		"</div>"+
-		"<div class='aright buttons-list'>"+
-			"<input type='button' class='OK Button' disabled='disabled' value='"+theUILang.ok+"'/>"+
-			"<input type='button' class='Cancel Button' value='"+theUILang.Cancel+"'/>"+
-		"</div>");
+		$("<div>").addClass("cont fxcaret").append(
+			$("<textarea>").attr({id:"bulkadd"}),
+			$("<span>").text(theUILang.bulkAddDescription),
+		)[0].outerHTML +
+		$("<div>").addClass("buttons-list").append(
+			$("<button>").attr({type:"button"}).addClass("OK").prop("disabled", true).text(theUILang.ok),
+			$("<button>").attr({type:"button"}).addClass("Cancel").text(theUILang.Cancel),
+		)[0].outerHTML,
+	);
 	var text = $$('bulkadd');
 	theDialogManager.setHandler('dlgBulkAdd','beforeShow',function()
 	{

--- a/plugins/geoip/init.js
+++ b/plugins/geoip/init.js
@@ -216,10 +216,22 @@ plugin.onLangLoaded = function()
 	if(plugin.retrieveComments)
 	{
 		theDialogManager.make("cadd",theUILang.peerComment,
-			'<div class="content fxcaret">'+theUILang.peerCommentLabel+'<br><input type="text" id="peerComment" class="Textbox" maxlength="64"/></div>'+
-			'<div class="aright buttons-list"><input type="button" class="OK Button" value="'+theUILang.ok+'" onclick="theWebUI.addNewComment();theDialogManager.hide(\'cadd\');return(false);" />'+
-				'<input type="button" class="Cancel Button" value="'+theUILang.Cancel+'"/></div>',
-			true);
+			$("<div>").addClass("cont fxcaret").append(
+				$("<fieldset>").append(
+					$("<legend>").text(theUILang.peerCommentLabel),
+					$("<div>").addClass("row").append(
+						$("<div>").addClass("col-12").append(
+							$("<input>").attr({type:"text", id:"peerComment", maxlength:64}),
+						),
+					),
+				),
+			)[0].outerHTML +
+			$("<div>").addClass("buttons-list").append(
+				$("<button>").attr({type:"button", onclick:"theWebUI.addNewComment();theDialogManager.hide('cadd');return(false);"}).addClass("OK").text(theUILang.ok),
+				$("<button>").attr({type:"button"}).addClass("Cancel").text(theUILang.Cancel),
+			)[0].outerHTML,
+			true,
+		);
 		theDialogManager.setHandler('cadd','beforeShow',function()
 		{
 			var peer = theWebUI.peers[theWebUI.getTable("prs").getFirstSelected()];

--- a/plugins/history/history.css
+++ b/plugins/history/history.css
@@ -1,0 +1,3 @@
+#notifPerms {
+  width: auto;
+}

--- a/plugins/history/init.js
+++ b/plugins/history/init.js
@@ -1,4 +1,5 @@
 plugin.loadLang();
+plugin.loadMainCSS();
 plugin.mark = 0;
 plugin.hstTimeout = null;
 

--- a/plugins/screenshots/init.js
+++ b/plugins/screenshots/init.js
@@ -257,62 +257,73 @@ plugin.setCurrentFrame = function(no)
 	plugin.setPlayControls();
 }
 
-plugin.onLangLoaded = function()
-{
+plugin.onLangLoaded = function() {
 	if(!thePlugins.get("_task").allStuffLoaded)
 		setTimeout(arguments.callee,1000);
-	else
-	{
+	else {
 		if(!explorerIsInstalled)
-			plugin.attachPageToOptions($("<div>").attr("id","st_screenshots").html(
-				"<fieldset>"+
-					"<legend>"+theUILang.exFFMPEG+"</legend>"+
-					"<table>"+
-					"<tr><td><input type=\"checkbox\" id=\"exusewidth\" onchange=\"linked(this, 0, ['exfrmwidth']);\"/><label id='lbl_exfrmwidth' for='exfrmwidth' class='disabled'>"+
-						theUILang.exFrameWidth+'</label></td><td class="alr"><input type="text" id="exfrmwidth" class="TextboxShort" disabled="true"/></td></tr>'+
-					"<tr><td>"+theUILang.exFramesCount+'</td><td class="alr"><input type="text" id="exfrmcount" class="TextboxShort"/></td></tr>'+
-					"<tr><td>"+theUILang.exStartOffset+', '+theUILang.time_s+'</td><td class="alr"><input type="text" id="exfrmoffs" class="TextboxShort"/></td></tr>'+
-					"<tr><td>"+theUILang.exBetween+', '+theUILang.time_s+'</td><td class="alr"><input type="text" id="exfrminterval" class="TextboxShort"/></td></tr>'+
-					"<tr><td>"+theUILang.exPlayInterval+', '+theUILang.time_s+'</td><td class="alr"><input type="text" id="explayinterval" class="TextboxShort"/></td></tr>'+
-					"<tr><td>"+theUILang.exImageFormat+'</td><td class="alr"><select id="exformat" class="TextboxShort">'+
-						"<option value='0'>JPEG</option>"+
-						"<option value='1'>PNG</option>"+
-						'</select></td></tr>'+
-					"</table>"+
-				"</fieldset>"
-				)[0],theUILang.exFFMPEG);
+			plugin.attachPageToOptions(
+				$("<div>").attr("id","st_screenshots").append(
+					$("<fieldset>").append(
+						$("<legend>").text(theUILang.exFFMPEG),
+						$("<div>").addClass("row").append(
+							$("<div>").addClass("col-12 col-md-6").append(
+								$("<input>").attr({type:"checkbox", id:"exusewidth", onchange:"linked(this, 0, ['exfrmwidth']);"}),
+								$("<label>").attr({for:"exfrmwidth", id:"lbl_exfrmwidth"}).addClass("disabled").text(theUILang.exFrameWidth),
+							),
+							$("<div>").addClass("col-12 col-md-6").append(
+								$("<input>").attr({type:"text", id:"exfrmwidth"}).prop("disabled", true),
+							),
+							...[
+								["exfrmcount", theUILang.exFramesCount],
+								["exfrmoffs", theUILang.exStartOffset + ", " + theUILang.time_s],
+								["exfrminterval", theUILang.exBetween + ", " + theUILang.time_s],
+								["explayinterval", theUILang.exPlayInterval + ", " + theUILang.time_s],
+							].flatMap(([id, text]) => [
+								$("<div>").addClass("col-12 col-md-6").append(
+									$("<label>").attr({for:id}).text(text),
+								),
+								$("<div>").addClass("col-12 col-md-6").append(
+									$("<input>").attr({type:"text", id:id}),
+								),
+							]),
+							$("<div>").addClass("col-12 col-md-6").append(
+								$("<label>").attr({for:"exformat"}).text(theUILang.exImageFormat),
+							),
+							$("<div>").addClass("col-12 col-md-6").append(
+								$("<select>").attr({id:"exformat"}).append(
+									$("<option>").val(0).text("JPEG"),
+									$("<option>").val(1).text("PNG"),
+								),
+							),
+						),
+					),
+				)[0],
+				theUILang.exFFMPEG,
+			);
 		$('#tsk_btns').prepend(
-			"<input type='button' class='Button scplay' id='scfirst' value='<<'>"+
-			"<input type='button' class='Button scplay' id='scprev' value='<'>"+
-			"<input type='button' class='Button scplay' id='scplay' value='►'>"+
-			"<input type='button' class='Button scplay' id='scnext' value='>'>"+
-			"<input type='button' class='Button scplay' id='sclast' value='>>'>&nbsp;&nbsp;&nbsp;&nbsp;"+
-			"<input type='button' class='Button scplay' id='scsave' value='"+theUILang.exSave+"'>"+
-			"<input type='button' class='Button scplay' id='scsaveall' value='"+theUILang.exSaveAll+"'>"
-			 );
-		$("#scfirst").on('click', function()
-		{
+			...[
+				["scfirst", "<<"], ["scprev", "<"],
+				["scplay", "►"], ["scnext", ">"], ["sclast", ">>"],
+				["scsave", theUILang.exSave], ["scsaveall", theUILang.exSaveAll],
+			].map(([id, text]) => $("<button>").attr({type:"button", id:id}).addClass("scplay").text(text)),
+		);
+		$("#scfirst").on('click', function() {
 			plugin.setCurrentFrame(0);
 		});
-		$("#sclast").on('click', function()
-		{
+		$("#sclast").on('click', function() {
 			plugin.setCurrentFrame($('.scframe').length-1);
 		});
-		$("#scprev").on('click', function()
-		{
+		$("#scprev").on('click', function() {
 			plugin.setCurrentFrame( plugin.getCurrentFrame()-1 );
 		});
 		$("#scnext").on('click', plugin.setNextFrame );
-		$("#scplay").on('click', function()
-		{
-		        if(plugin.playTimer)
-			{
+		$("#scplay").on('click', function() {
+			if (plugin.playTimer) {
 				window.clearInterval(plugin.playTimer);
 				plugin.playTimer = null;
 				plugin.setPlayControls();
-			}
-			else
-			{
+			} else {
 				plugin.playTimer = window.setInterval( plugin.setNextFrame, iv(plugin.ffmpegSettings.explayinterval)*1000 );
 				plugin.setNextFrame();
 			}
@@ -325,14 +336,12 @@ plugin.onLangLoaded = function()
 				'<input type="hidden" name="fno" id="scimgno" value="0">'+
 				'<input type="hidden" name="file" id="scimgfile" value="frame">'+
 			'</form>').width(0).height(0));
-		$("#scsave").on('click', function()
-		{
+		$("#scsave").on('click', function() {
 			$("#scimgno").val(plugin.getCurrentFrame());
 			$("#scimgcmd").val("ffmpeggetimage");
 			$('#scgetimg').trigger('submit');
 		});
-		$("#scsaveall").on('click', function()
-		{
+		$("#scsaveall").on('click', function() {
 			$("#scimgcmd").val("ffmpeggetall");
 			$('#scgetimg').trigger('submit');
 		});

--- a/plugins/screenshots/screenshots.css
+++ b/plugins/screenshots/screenshots.css
@@ -1,12 +1,18 @@
-.scframe { position: relative; left: 0px; top: 0px; text-align: center; width: 100%; padding: 0; vertical-align: middle; }
+.scframe {
+  position: relative;
+  text-align: center;
+  width: 100%;
+  padding: 0;
+  cursor: default;
+}
 .scframe img { width: 100%; vertical-align: middle; }
-.scplay { display: none }
-
-#scfirst { width: 40px }
-#scprev { width: 40px }
-#scplay { width: 40px }
-#scnext { width: 40px }
-#sclast { width: 40px }
+.scplay {
+  display: none;
+  text-wrap: nowrap;
+  width: 50px;
+  padding: 0;
+}
+#sclast {margin-right: auto;}
 
 .scframe_cont { overflow: auto; background-color: black; margin: 0 auto; }
 #st_screenshots { overflow: auto }


### PR DESCRIPTION
Apply flex layout to other dialog windows
- Apply flex layout to screenshots plugin.
- Apply flex layout to screenshots plugin.
- Apply flex layout to other dialog windows including: Add Peer Window, Yes-or-No Window, Magnet Link Bulk Add Window, Peer Comment Window.
- Prevent button textes from wrapping, and set enable button width to auto on the history plugin option page.
- Switch to rutorrent's copyToClipboard() function for browser compatibility. Hide the copy button on task complete if the log output is empty. Hope it could fix this error: https://github.com/Novik/ruTorrent/pull/2666#issuecomment-2284822387