### PR TITLE
Fix task log copy formatting

### DIFF
--- a/plugins/_task/_task.css
+++ b/plugins/_task/_task.css
@@ -6,6 +6,7 @@
   overflow: auto;
   width: 580px;
   cursor: text;
+  user-select: text;
 }
 .tskconsole img {
   width: 100%;

--- a/plugins/_task/lang/cs.js
+++ b/plugins/_task/lang/cs.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/da.js
+++ b/plugins/_task/lang/da.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/de.js
+++ b/plugins/_task/lang/de.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnose";
  theUILang.tskBackground	= "Verstecken";
  theUILang.tskCopy		= "Kopieren";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Gestartet";
  theUILang.tskFinish		= "Fertiggestellt";
  theUILang.tskElapsed		= "Verstrichen";

--- a/plugins/_task/lang/el.js
+++ b/plugins/_task/lang/el.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Διαγνωστικά";
  theUILang.tskBackground	= "Απόκρυψη";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Εκκίνηση";
  theUILang.tskFinish		= "Ολοκλήρωση";
  theUILang.tskElapsed		= "Χρόνος που πέρασε";

--- a/plugins/_task/lang/en.js
+++ b/plugins/_task/lang/en.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/es.js
+++ b/plugins/_task/lang/es.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnosticos";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copiar";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/fi.js
+++ b/plugins/_task/lang/fi.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/fr.js
+++ b/plugins/_task/lang/fr.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostiques";
  theUILang.tskBackground	= "Cacher";
  theUILang.tskCopy		= "Copier";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Démarrée";
  theUILang.tskFinish		= "Terminée";
  theUILang.tskElapsed		= "Écoulée";

--- a/plugins/_task/lang/hu.js
+++ b/plugins/_task/lang/hu.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnosztika";
  theUILang.tskBackground	= "Elrejtés";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Elindult";
  theUILang.tskFinish		= "Végzett";
  theUILang.tskElapsed		= "Eltelt";

--- a/plugins/_task/lang/it.js
+++ b/plugins/_task/lang/it.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostiche";
  theUILang.tskBackground	= "Nascondi";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Avviato";
  theUILang.tskFinish		= "Terminato";
  theUILang.tskElapsed		= "Trascorso";

--- a/plugins/_task/lang/ko.js
+++ b/plugins/_task/lang/ko.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "진단";
  theUILang.tskBackground	= "숨기기";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "시작됨";
  theUILang.tskFinish		= "완료됨";
  theUILang.tskElapsed		= "경과";

--- a/plugins/_task/lang/lv.js
+++ b/plugins/_task/lang/lv.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/nl.js
+++ b/plugins/_task/lang/nl.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/no.js
+++ b/plugins/_task/lang/no.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostikk";
  theUILang.tskBackground	= "Skjul";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Startet";
  theUILang.tskFinish		= "Fullført";
  theUILang.tskElapsed		= "Forløpt";

--- a/plugins/_task/lang/pl.js
+++ b/plugins/_task/lang/pl.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostyka";
  theUILang.tskBackground	= "Ukryj";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Rozpoczęty";
  theUILang.tskFinish		= "Zakończony";
  theUILang.tskElapsed		= "Upłynęło";

--- a/plugins/_task/lang/pt-br.js
+++ b/plugins/_task/lang/pt-br.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/pt-pt.js
+++ b/plugins/_task/lang/pt-pt.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnóstico";
  theUILang.tskBackground	= "Ocultar";
  theUILang.tskCopy		= "Copiar";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Iniciado";
  theUILang.tskFinish		= "Terminado";
  theUILang.tskElapsed		= "Decorrido";

--- a/plugins/_task/lang/ru.js
+++ b/plugins/_task/lang/ru.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Диагностика";
  theUILang.tskBackground	= "Спрятать";
  theUILang.tskCopy		= "Копировать";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Старт";
  theUILang.tskFinish		= "Завершение";
  theUILang.tskElapsed		= "Затрачено";

--- a/plugins/_task/lang/sk.js
+++ b/plugins/_task/lang/sk.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/sr.js
+++ b/plugins/_task/lang/sr.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/sv.js
+++ b/plugins/_task/lang/sv.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostik";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/tr.js
+++ b/plugins/_task/lang/tr.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Tanılama";
  theUILang.tskBackground	= "Gizle";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Başlatıldı";
  theUILang.tskFinish		= "Bitti";
  theUILang.tskElapsed		= "Geçen";

--- a/plugins/_task/lang/uk.js
+++ b/plugins/_task/lang/uk.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Діагностика";
  theUILang.tskBackground	= "Приховати";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Початок";
  theUILang.tskFinish		= "Завершення";
  theUILang.tskElapsed		= "Минуло";

--- a/plugins/_task/lang/vi.js
+++ b/plugins/_task/lang/vi.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";

--- a/plugins/_task/lang/zh-cn.js
+++ b/plugins/_task/lang/zh-cn.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "诊断";
  theUILang.tskBackground	= "隐藏";
  theUILang.tskCopy		= "复制";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "已开始";
  theUILang.tskFinish		= "已完成";
  theUILang.tskElapsed		= "已用时间";

--- a/plugins/_task/lang/zh-tw.js
+++ b/plugins/_task/lang/zh-tw.js
@@ -12,6 +12,8 @@
  theUILang.tskErrors		= "Diagnostics";
  theUILang.tskBackground	= "Hide";
  theUILang.tskCopy		= "Copy";
+ theUILang.tskLogEmpty		= "Console log is empty.";
+ theUILang.tskSaveLog		= "Save Log";
  theUILang.tskStart		= "Started";
  theUILang.tskFinish		= "Finished";
  theUILang.tskElapsed		= "Elapsed";


### PR DESCRIPTION
- Preserve the break lines to maintain correct formatting while copying console log using copy button.
- Enable user select on the console log output.
- Add a button to save console log as a text file. This was planned for v5.1, but I thought since the two topics were so related, I would like to address them in one patch.

Related: 
https://github.com/Novik/ruTorrent/issues/2729
https://github.com/Novik/ruTorrent/issues/2708