### PR TITLE
Limit context menu on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -212,15 +212,22 @@ div#t {
   border-bottom: 1px solid #D0D0D0;
   z-index: 30;
 }
+#top-menu .btn-group {
+  flex-direction: column;
+}
+.dropdown-toggle span {
+  /* Push dropdown triangle to the right end */
+  margin-right: auto;
+}
 div#t button.navbar-toggler {
   background-color: var(--btn-bg-color);
   width: 5rem;
 }
 div#t a {padding: 3px;}
-div#t div.navbar-nav a:hover {
+#t .navbar-nav a:not(.dropdown-item):hover {
   filter: brightness(1.3);
 }
-div#t div.navbar-nav a:active {padding: 4px 2px 2px 4px;}
+#t .navbar-nav a:active {padding: 4px 2px 2px 4px;}
 div#t div.TB_Separator {
   align-self: stretch;
   flex: 0 0 1px;
@@ -595,8 +602,8 @@ div.dlg-window .buttons-list {
     border-bottom: none;
     z-index: auto;
   }
-  div#t div.navbar-nav a:hover {
-    background: transparent url(../images/tb_bg.gif) no-repeat scroll center center;
+  #t .navbar-nav a:not(.dropdown-item):hover {
+    background: transparent url(../images/tb_bg.gif) no-repeat scroll left center;
     filter: none;
   }
   div#t .nav-link {

--- a/index.html
+++ b/index.html
@@ -86,23 +86,27 @@
 				</button>	
 				<div class="collapse navbar-collapse px-1 py-2 py-md-0" id="top-menu">
 					<div class="navbar-nav flex-grow-1">
-						<a id="mnu_add" class="nav-link" href="#" onclick="theWebUI.showAdd(); return(false);" onfocus="this.blur()" uilangtitle="mnu_add">
-							<div id="add" class="nav-icon"></div>
-						</a>
+						<div class="d-flex flex-row align-items-center">
+							<a id="mnu_add" class="nav-link flex-grow-1" href="#" onclick="theWebUI.showAdd(); return(false);" onfocus="this.blur()" uilangtitle="mnu_add">
+								<div id="add" class="nav-icon"></div>
+							</a>
+							<div class="TB_Separator"></div>
+							<a id="mnu_remove" class="nav-link flex-grow-1" href="#" onclick="theWebUI.removeTorrent(); return(false);" onfocus="this.blur()" uilangtitle="mnu_remove">
+								<div id="remove" class="nav-icon"></div>
+							</a>
+						</div>
 						<div class="TB_Separator"></div>
-						<a id="mnu_remove" class="nav-link" href="#" onclick="theWebUI.removeTorrent(); return(false);" onfocus="this.blur()" uilangtitle="mnu_remove">
-							<div id="remove" class="nav-icon"></div>
-						</a>
-						<div class="TB_Separator"></div>
-						<a id="mnu_start" class="nav-link" href="#" onclick="theWebUI.start(); return(false);" onfocus="this.blur()" uilangtitle="mnu_start">
-							<div id="start" class="nav-icon"></div>
-						</a>
-						<a id="mnu_pause" class="nav-link" href="#" onclick="theWebUI.pause(); return(false);" onfocus="this.blur()" uilangtitle="mnu_pause">
-							<div id="pause" class="nav-icon"></div>
-						</a>
-						<a id="mnu_stop" class="nav-link" href="#" onclick="theWebUI.stop(); return(false);" onfocus="this.blur()" uilangtitle="mnu_stop">
-							<div id="stop" class="nav-icon"></div>
-						</a>
+						<div class="d-flex flex-row align-items-center">
+							<a id="mnu_start" class="nav-link flex-grow-1" href="#" onclick="theWebUI.start(); return(false);" onfocus="this.blur()" uilangtitle="mnu_start">
+								<div id="start" class="nav-icon"></div>
+							</a>
+							<a id="mnu_pause" class="nav-link flex-grow-1" href="#" onclick="theWebUI.pause(); return(false);" onfocus="this.blur()" uilangtitle="mnu_pause">
+								<div id="pause" class="nav-icon"></div>
+							</a>
+							<a id="mnu_stop" class="nav-link flex-grow-1" href="#" onclick="theWebUI.stop(); return(false);" onfocus="this.blur()" uilangtitle="mnu_stop">
+								<div id="stop" class="nav-icon"></div>
+							</a>
+						</div>
 						<div class="TB_Separator"></div>
 						<a id="mnu_settings" class="nav-link" href="#" onclick="theWebUI.showSettings(); return(false);" onfocus="this.blur()" uilangtitle="mnu_settings">
 							<div id="setting" class="nav-icon"></div>

--- a/js/webui.js
+++ b/js/webui.js
@@ -558,15 +558,6 @@ var theWebUI =
 // plugins
 //
 
-	showPluginsMenu: function()
-	{
-		theContextMenu.clear();
-		for( var item in thePlugins.topMenu )
-			thePlugins.get(thePlugins.topMenu[item].name).createPluginMenu();
-        	var offs = $("#plugins").offset();
-		theContextMenu.show(offs.left-5,offs.top+5+$("#plugins").height());
-	},
-
 	plgSelect: function(e, id)
 	{
 		if($type(id) && (e.which==3))

--- a/plugins/bulk_magnet/init.js
+++ b/plugins/bulk_magnet/init.js
@@ -105,14 +105,6 @@ plugin.showBulkAdd = function()
 	theDialogManager.show("dlgBulkAdd");
 }
 
-plugin.createPluginMenu = function()
-{
-	if(this.enabled)
-	{
-		theContextMenu.add([theUILang.bulkAdd, plugin.showBulkAdd]);
-	}
-}
-
 plugin.bulkAdd = function()
 {
 	theWebUI.request("?action=bulkadd",[plugin.wasAdded, plugin]);
@@ -149,7 +141,7 @@ plugin.wasAdded = function(data)
 }
 
 plugin.onLangLoaded = function() {
-	this.registerTopMenu(9);
+	this.registerTopMenu(9, theUILang.bulkAdd, plugin.showBulkAdd);
 	const dlgBulkAddContent = $("<div>").addClass("cont fxcaret").append(
 		$("<textarea>").attr({id:"bulkadd"}).on("input", (ev) => {
 			$('#dlgBulkAdd .OK').prop('disabled', ev.target.value.trim() === '');

--- a/plugins/extratio/init.js
+++ b/plugins/extratio/init.js
@@ -312,14 +312,8 @@ plugin.correctCSS = function()
 	}
 }
 
-plugin.createPluginMenu = function()
-{
-	if(this.enabled)
-		theContextMenu.add([theUILang.mnu_ratiorule, "theWebUI.showRatioRules()"]);
-}
-
 plugin.onLangLoaded = function() {
-	this.registerTopMenu(7);
+	this.registerTopMenu(7, theUILang.mnu_ratiorule, theWebUI.showRatioRules);
 	const dlgEditRatioRulesContent = $("<div>").addClass("cont fxcaret").append(
 		$("<div>").addClass("row").append(
 			$("<div>").addClass("col-md-6 d-flex flex-column align-items-center").append(

--- a/plugins/rssurlrewrite/init.js
+++ b/plugins/rssurlrewrite/init.js
@@ -8,7 +8,7 @@ theWebUI.maxRuleNo = 0;
 
 theWebUI.showRules = function()
 {
-	theWebUI.request("?action=getrules",[this.loadRules, this]);
+	theWebUI.request("?action=getrules",[theWebUI.loadRules, this]);
 }
 
 theWebUI.storeRuleParams = function()
@@ -250,14 +250,8 @@ if(plugin.canChangeMenu())
 	}
 }
 
-plugin.createPluginMenu = function()
-{
-	if(this.enabled)
-		theContextMenu.add([theUILang.mnu_rssurlrewrite, "theWebUI.showRules()"]);		
-}
-
 plugin.onLangLoaded = function() {
-	this.registerTopMenu(5);
+	this.registerTopMenu(5, theUILang.mnu_rssurlrewrite, theWebUI.showRules);
 	const dlgEditRulesContent = $("<div>").addClass("cont fxcaret").append(
 		$("<div>").addClass("row").append(
 			$("<div>").addClass("col-md-6 d-flex flex-column align-items-center").append(


### PR DESCRIPTION
I made the following changes to the top menu for now, including changing the Plugins button to a Bootstrap dropdown menu, and the grouping of some buttons. These changes could be breaking as well, if some third-party plugins call the `plugin.addButtonToToolbar()` or the `rPlugin.registerTopmenu()` functions.
The search engine button is more complex, so it stays unchanged for now.

- Replace plugins button with dropdown menu.
- Group buttons on top menu, sorting add torrent and remove torrent buttons into one group, and start, pause, and stop buttons into another group. Since the add torrent and remove buttons are grouped, the create torrent button will also go into the group because it will be inserted before the remove torrent button on plugin load.

Related: https://github.com/Novik/ruTorrent/issues/2734