### PR TITLE
Persistent add and create torrent options

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -406,7 +406,7 @@ div#stg .lm {
   font-weight: bold;
   text-wrap: nowrap;
 }
-input.disabled {background-color: #FAFAFA; color: #C0C0C0; border: 1px solid #C0C0C0}
+input.disabled, button.disabled {background-color: #FAFAFA; color: #C0C0C0; border: 1px solid #C0C0C0}
 td.disabled, label.disabled, span.disabled, div.disabled {color: #C0C0C0; cursor: default}
 .ie7 fieldset div {padding: 0px}
 div.indent {padding-left: 16px}

--- a/js/content.js
+++ b/js/content.js
@@ -197,8 +197,7 @@ function makeContent() {
 		$("#tadd_label_select").show();
 	});
 
-	theDialogManager.setHandler('tadd','beforeShow',function()
-	{
+	theDialogManager.setHandler('tadd', 'beforeShow', function() {
 		$("#tadd_label").hide();
 		$("#tadd-return-select").hide();
 		$("#tadd_label_select").empty()
@@ -209,6 +208,20 @@ function makeContent() {
 		$("#torrent_file").val("");
 		$("#add_button").prop("disabled", true);
 		$("#tadd_label_select").trigger('change');
+		// toggle default add torrent options
+		[
+			"not_add_path", "torrents_start_stopped",
+			"fast_resume", "randomize_hash",
+		].forEach(ele => $$(ele).checked = !!theWebUI.settings["webui." + ele]);
+	});
+
+	// save add torrent options before closing dialog window
+	theDialogManager.setHandler("tadd", "beforeHide", () => {
+		[
+			"not_add_path", "torrents_start_stopped",
+			"fast_resume", "randomize_hash",
+		].forEach(ele => theWebUI.settings["webui." + ele] = $$(ele).checked);
+		theWebUI.save();
 	});
 
 	var makeAddRequest = function(frm) {

--- a/js/webui.js
+++ b/js/webui.js
@@ -178,6 +178,10 @@ var theWebUI =
 		"webui.show_open_status":	1,
 		"webui.show_view_panel": 1,
 		"webui.register_magnet":	0,
+		"webui.not_add_path":		0,
+		"webui.torrents_start_stopped":	0,
+		"webui.fast_resume":		0,
+		"webui.randomize_hash":	0,
 		...(() => {
 			const defaults = {};
 			const units = ['default', 'kb', 'mb', 'gb', 'tb', 'pb'];
@@ -734,8 +738,7 @@ var theWebUI =
 					if((/^webui\./).test(i))
 					{
 						needSave = true;
-						switch(i)
-						{
+						switch(i) {
 						        case "webui.effects":
 						        {
 								theDialogManager.setEffects( iv(nv)*200 );

--- a/php/cache.php
+++ b/php/cache.php
@@ -70,14 +70,14 @@ class rCache
 	}
 	public function get( &$rss )
 	{
-	        $fname = $this->getName($rss);
+		$fname = $this->getName($rss);
 		$ret = @file_get_contents($fname);
 		if($ret!==false)
 		{
 			$tmp = unserialize($ret);
 			if(is_array($tmp))
 			{
-			        $rss = $tmp;				
+				$rss = $tmp;				
 				$ret = true;
 			}
 			else
@@ -87,14 +87,14 @@ class rCache
 					(isset($rss->version) && !isset($tmp->version)) ||
 					(isset($tmp->version) && ($tmp->version==$rss->version))))
 				{
-				        $rss = $tmp;
+					$rss = $tmp;
 					$rss->modified = filemtime($fname);
 					$ret = true;
 				}
 				else
 					$ret = false;
 			}
-        	}
+		}
 		return($ret);
 	}
 	public function remove( $rss )

--- a/plugins/create/action.php
+++ b/plugins/create/action.php
@@ -10,6 +10,7 @@ class recentTrackers
 	public $hash = "rtrackers.dat";
 	public $modified = false;
 	public $list = array();
+	public $last_used = "";
 	public $piece_size = 1024;
 	public $start_seeding = false;
 	public $private_torrent = false;
@@ -39,6 +40,7 @@ class recentTrackers
 		$ret = array();
 		foreach( $this->list as $ann )
 			$ret['recent_trackers'][self::getTrackerDomain($ann)] = $ann;
+		$ret['last_used'] = $this->last_used;
 		$ret['piece_size'] = $this->piece_size;
 		$ret['start_seeding'] =  $this->start_seeding;
 		$ret['private_torrent'] = $this->private_torrent;
@@ -132,6 +134,7 @@ if(isset($_REQUEST['cmd']))
 					$announce_list = '';
 					if(isset($_REQUEST['trackers']))
 					{
+						$rt->last_used = $_REQUEST['trackers'];  // remember trackers last used
 						$arr = explode("\r",$_REQUEST['trackers']);
 						foreach( $arr as $key => $value )
 						{
@@ -151,6 +154,7 @@ if(isset($_REQUEST['cmd']))
 							}
 						}
 					}
+					// remember checkbox and dropdown options
 					$rt->piece_size = $_REQUEST['piece_size'];
 					$rt->start_seeding = $_REQUEST['start_seeding'];
 					$rt->private_torrent = $_REQUEST['private'];

--- a/plugins/create/action.php
+++ b/plugins/create/action.php
@@ -10,6 +10,10 @@ class recentTrackers
 	public $hash = "rtrackers.dat";
 	public $modified = false;
 	public $list = array();
+	public $piece_size = 1024;
+	public $start_seeding = false;
+	public $private_torrent = false;
+	public $hybrid_torrent = false;
 
 	static public function load()
 	{
@@ -34,7 +38,12 @@ class recentTrackers
 	{
 		$ret = array();
 		foreach( $this->list as $ann )
-			$ret[self::getTrackerDomain($ann)] = $ann;
+			$ret['recent_trackers'][self::getTrackerDomain($ann)] = $ann;
+		$ret['piece_size'] = $this->piece_size;
+		$ret['start_seeding'] =  $this->start_seeding;
+		$ret['private_torrent'] = $this->private_torrent;
+		$ret['hybrid_torrent'] = $this->hybrid_torrent;
+
 		return($ret);
 	}
 	public function strip()
@@ -131,8 +140,8 @@ if(isset($_REQUEST['cmd']))
 							{
 								$trackers[] = $value;
 								$rt->list[] = $value;
-                                                        }
-                                                        else
+							}
+							else
 							{
 								if(count($trackers)>0)
 								{
@@ -142,13 +151,18 @@ if(isset($_REQUEST['cmd']))
 							}
 						}
 					}
+					$rt->piece_size = $_REQUEST['piece_size'];
+					$rt->start_seeding = $_REQUEST['start_seeding'];
+					$rt->private_torrent = $_REQUEST['private'];
+					$rt->hybrid_torrent = $_REQUEST['hybrid'];
 					$rt->store();
+
 					if(count($trackers)>0)
 						$announce_list .= (' -a '.escapeshellarg(implode(',',$trackers)));
 					$piece_size = 262144;
 					if(isset($_REQUEST['piece_size']))
 						$piece_size = $_REQUEST['piece_size']*1024;
-	       				if(!$pathToCreatetorrent || ($pathToCreatetorrent==""))
+					if(!$pathToCreatetorrent || ($pathToCreatetorrent==""))
 						$pathToCreatetorrent = $useExternal;
 					if($useExternal=="mktorrent")
 						$piece_size = log($piece_size,2);

--- a/plugins/theme/themes/Acid/style.css
+++ b/plugins/theme/themes/Acid/style.css
@@ -119,7 +119,7 @@ div#stg .lm { background-color: #272E36; border: 1px solid #D0D0D0; }
 .lm li a.focus {background-color: #BDDBDB; color: #272E36;}
 .stg_con {background-color: #272E36}
 
-input.disabled {background-color: #272E36; }
+input.disabled, button.disabled {background-color: #272E36; }
 legend {color: #00FF00; font-weight: bold}
 
 #st_gl {background: #272E36; color: #BDDBDB;}

--- a/plugins/theme/themes/Dark/style.css
+++ b/plugins/theme/themes/Dark/style.css
@@ -148,7 +148,7 @@ div#stg .lm {background-color: #181818; border: 1px solid #333333}
 .lm li a.focus {background-color: #333333}
 .stg_con {background-color: #181818}
 * > fieldset {border: 1px solid #333333}
-input.disabled {background-color: #181818; color: #333333; border: 1px solid #333333}
+input.disabled, button.disabled {background-color: #181818; color: #333333; border: 1px solid #333333}
 td.disabled, label.disabled, span.disabled, div.disabled {color: #333333}
 legend {color: #888888}
 select.cols {border: 1px solid #333333}

--- a/plugins/theme/themes/DarkBetter/style.css
+++ b/plugins/theme/themes/DarkBetter/style.css
@@ -307,7 +307,7 @@ div#stg .lm {background-color: #181818; border: 1px solid #333333}
 .lm li a.focus {background-color: #333333}
 .stg_con {background-color: #181818}
 * > fieldset {border: 1px solid #333333}
-input.disabled {background-color: #181818; color: #333333; border: 1px solid #333333}
+input.disabled, button.disabled {background-color: #181818; color: #333333; border: 1px solid #333333}
 td.disabled, label.disabled, span.disabled, div.disabled {color: #333333}
 legend {color: #888888}
 select.cols {border: 1px solid #333333}

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -812,7 +812,7 @@ div#stg .lm
 	background:none
 }
 
-input.disabled {
+input.disabled, button.disabled {
 	background-color:#181818;
 	color:#333;
 	border:1px solid #333

--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -237,7 +237,7 @@ div#FileList, div#TrackerList, div#PeerList, div#Speed {background-color: #18181
 .lm li a.focus {background-color: #333333}
 .stg_con {background-color: #181818}
 * > fieldset {border: 1px solid #333333}
-input.disabled {background-color: #181818; color: #333333; border: 1px solid #333333}
+input.disabled, button.disabled {background-color: #181818; color: #333333; border: 1px solid #333333}
 td.disabled, label.disabled, span.disabled, div.disabled {color: #333333}
 legend {color: #888888}
 select.cols {border: 1px solid #333333}


### PR DESCRIPTION
This PR adds persistent options for add torrent and create torrent dialog windows. For add torrent, the 4 options will be saved to WebUI settings on close. For create torrent, the 4 options (piece size, start seeding, private torrent, hybrid torrent) will be saved to the plugin-specific cache file `rtrackers.dat`.

Related: https://github.com/Novik/ruTorrent/issues/2728