### PR TITLE
Fix add tracker from recent list error

### DIFF
--- a/plugins/create/init.js
+++ b/plugins/create/init.js
@@ -84,10 +84,11 @@ theWebUI.addTrackerToBox = function(ann)
 	$("#deleteFromRecentTrackers").prop("disabled", false);
 	const val = $('#trackers').val();
 	if (val.includes(ann)) return;  // do nothing if selected tracker is already in the box
-	if(val.length)
-		val+='\r\n';
-	$('#trackers').val( val+ann );
-	$('#trackers').trigger('focus');
+	$('#trackers').val(
+		[...val.split(/\r?\n/), ann]  // split by "\r\n" or "\n"
+			.filter(tracker => tracker.trim().length)  // remove empty lines
+			.join("\r\n")
+	).trigger("focus");
 }
 
 theWebUI.showRecentTrackers = function() {


### PR DESCRIPTION
This is a complementary commit to the previously merged PR: https://github.com/Novik/ruTorrent/pull/2750. The error appears when trying to add tracker announces from the recent list. Perhaps I was too sleepy when doing the last commit... Anyway, the error should be fixed now, and the algorithm is also improved.