### PR TITLE
Allow wrapping in button groups on top toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
 				</button>	
 				<div class="collapse navbar-collapse px-1 py-2 py-md-0" id="top-menu">
 					<div class="navbar-nav flex-grow-1">
-						<div class="d-flex flex-row align-items-center">
+						<div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap">
 							<a id="mnu_add" class="nav-link flex-grow-1" href="#" onclick="theWebUI.showAdd(); return(false);" onfocus="this.blur()" uilangtitle="mnu_add">
 								<div id="add" class="nav-icon"></div>
 							</a>
@@ -96,7 +96,7 @@
 							</a>
 						</div>
 						<div class="TB_Separator"></div>
-						<div class="d-flex flex-row align-items-center">
+						<div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap">
 							<a id="mnu_start" class="nav-link flex-grow-1" href="#" onclick="theWebUI.start(); return(false);" onfocus="this.blur()" uilangtitle="mnu_start">
 								<div id="start" class="nav-icon"></div>
 							</a>

--- a/js/content.js
+++ b/js/content.js
@@ -18,12 +18,6 @@ function makeContent() {
 
 	$("#offcanvas-sidepanel-label").text("ruTorrent v" + theWebUI.version);
 
-	$("#query").on('keydown', function(e) {
-		if (e.keyCode === 13) {
-			theSearchEngines.run();
-		}
-	});
-
 	new DnD("HDivider", {
 		restrictY: true,
 		maskId: "HDivider",

--- a/plugins/_getdir/_getdir.css
+++ b/plugins/_getdir/_getdir.css
@@ -23,9 +23,4 @@
   color: highlighttext;
   background-color: highlight;
 }
-
-input.browseButton, button.browseButton {
-  width: 30px;
-  margin-left: 0.25rem;
-  margin-right: 0.25rem;
-}
+.browseButton {width: 30px;}


### PR DESCRIPTION
This patch address an issue that grouped buttons overflow on mobile if there are too many of them, for example the logoff plugin would add a log-off button before the add torrent button, so there will be four buttons in total in this group if the create plugin is also in use.

Besides, a duplicate event listener on the quick search text bar, and some duplicate CSS rules on the browse directory button were removed.