### PR TITLE
Define theme colors for dropdown menus

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -102,6 +102,15 @@ span {
   --header-bg-color: #F0F0F0;
   --header-border-color: #909090;
 }
+.dropdown-menu {
+  --bs-dropdown-border-color: var(--menu-border-color);
+  --bs-dropdown-bg: var(--menu-background-color);
+  --bs-dropdown-link-color: var(--menu-color);
+  --bs-dropdown-link-active-color: var(--menu-highlight-color);
+  --bs-dropdown-link-active-bg: var(--menu-highlight-background-color);
+  --bs-dropdown-link-hover-color: var(--menu-highlight-color);
+  --bs-dropdown-link-hover-bg: var(--menu-highlight-background-color);
+}
 category-list.rightalign-labelsize panel-label::part(size) {
   margin-left: auto;
 }
@@ -219,6 +228,14 @@ div#t {
   /* Push dropdown triangle to the right end */
   margin-right: auto;
 }
+#t .dropdown-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.25rem 1rem;
+  width: auto;
+}
 div#t button.navbar-toggler {
   background-color: var(--btn-bg-color);
   width: 5rem;
@@ -227,7 +244,7 @@ div#t a {padding: 3px;}
 #t .navbar-nav a:not(.dropdown-item):hover {
   filter: brightness(1.3);
 }
-#t .navbar-nav a:active {padding: 4px 2px 2px 4px;}
+#t .nav-link:active {padding: 4px 2px 2px 4px;}
 div#t div.TB_Separator {
   align-self: stretch;
   flex: 0 0 1px;
@@ -280,7 +297,7 @@ div#plugins {background: url(../images/plugin.png) 0px center}
 
 #pview_save_view_button { align-self: center; width: 38px; height: 19px; padding: 0px; line-height: 2px; font-size: 19px;  }
 
-a {color: #686868;}
+a {color: #686868; text-decoration: none;}
 #maincont {height: calc(100dvh - 36px - 5px - 25px - 5px);}
 .offcanvas-header .btn-close {background-color: var(--btn-bg-color);}
 #offcanvas-sidepanel {
@@ -412,7 +429,6 @@ td.disabled, label.disabled, span.disabled, div.disabled {color: #C0C0C0; cursor
 div.indent {padding-left: 16px}
 #st_gl {display: block}
 #st_que, #st_sch, #st_dc {display: none}
-a {text-decoration: none}
 select.cols {border: 1px solid #808080; font-size: 11px;  padding: 2px; width: 120px}
 div#dragmask {width: 10px; height: 10px; left: 0px; top: 0px; position: absolute; z-index: 5000; display: none; border: 1px dotted #A0A0A0}
 div#tdetails {

--- a/js/content.js
+++ b/js/content.js
@@ -90,7 +90,7 @@ function makeContent() {
 						$("<div>").addClass("d-none col-md-3 d-md-flex justify-content-end").append(
 							$("<label>").attr({for: "dir_edit"}).text(theUILang.Base_directory + ": "),
 						),
-						$("<div>").addClass("col-md-9 d-flex flex-row").append(
+						$("<div>").addClass("col-md-9").append(
 							$("<input>").attr(
 								{type: "text", id: "dir_edit", name: "dir_edit", placeholder: theUILang.Base_directory}
 							).addClass("flex-grow-1"),
@@ -103,9 +103,7 @@ function makeContent() {
 								["torrents_start_stopped", theUILang.Dnt_start_down_auto],
 								["fast_resume", theUILang.doFastResume],
 								["randomize_hash", theUILang.doRandomizeHash],
-							].map(([id, label]) => $("<div>").attr({id: id + "_option"}).addClass(
-								"d-flex flex-row align-items-center"
-							).append(
+							].map(([id, label]) => $("<div>").attr({id: id + "_option"}).addClass("d-flex").append(
 									$("<input>").attr({type: "checkbox", name: id, id: id}),
 									$("<label>").attr({for: id}).text(label),
 								)
@@ -116,11 +114,11 @@ function makeContent() {
 						$("<div>").addClass("d-none col-md-3 d-md-flex justify-content-end").append(
 							$("<label>").attr({for: "tadd_label"}).text(theUILang.Label + ": "),
 						),
-						$("<div>").addClass("col-md-7 d-flex flex-row").append(
+						$("<div>").addClass("col-md-7").append(
 							$("<input>").attr({type: "text", id: "tadd_label", name: "tadd_label", placeholder: theUILang.Label}).addClass("flex-grow-1"),
 							$("<select>").attr({id: "tadd_label_select"}).addClass("flex-grow-1"),
 						),
-						$("<div>").addClass("col-md-2 d-flex").append(
+						$("<div>").addClass("col-md-2").append(
 							$("<button>").attr({type: "button", id: "tadd-return-select", name: "tadd-return-select"}).text(theUILang.Return_select_label),
 						),
 					),
@@ -131,13 +129,13 @@ function makeContent() {
 						$("<div>").addClass("d-none col-md-3 d-md-flex justify-content-end").append(
 							$("<label>").attr({for: "torrent_file"}).text(theUILang.Torrent_file + ": "),
 						),
-						$("<div>").addClass("col-md-6 d-flex").append(
+						$("<div>").addClass("col-md-6").append(
 							$("<input>")
 								.attr({type: "file", multiple: "multiple", name: "torrent_file[]", id: "torrent_file", accept: ".torrent"})
 								.on("change", (ev) => {$("#add_button").prop("disabled", ev.target.files.length === 0);})
 								.addClass("flex-shrink-1"),
 						),
-						$("<div>").addClass("col-md-3 d-flex").append(
+						$("<div>").addClass("col-md-3").append(
 							$("<input>").val(theUILang.add_button).attr({type: "submit", id: "add_button"}).addClass("Button").prop("disabled", true),
 						),
 					),
@@ -152,13 +150,13 @@ function makeContent() {
 						$("<div>").addClass("d-none col-md-3 d-md-flex justify-content-end").append(
 							$("<label>").attr({for: "url"}).text(theUILang.Torrent_URL + ": "),
 						),
-						$("<div>").addClass("col-md-6 d-flex").append(
+						$("<div>").addClass("col-md-6").append(
 							$("<input>")
 								.attr({type: "text", id: "url", name: "url", placeholder: theUILang.Torrent_URL})
 								.on("input", (ev) => {$('#add_url').prop('disabled', ev.target.value.trim() === '');})
 								.addClass("flex-grow-1"),
 						),
-						$("<div>").addClass("col-md-3 d-flex").append(
+						$("<div>").addClass("col-md-3").append(
 							$("<input>").val(theUILang.add_url).attr({type: "submit", id: "add_url"}).addClass("Button").prop("disabled", true),
 						),
 					),

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -393,7 +393,7 @@ rPlugin.prototype.addButtonToToolbar = function(id, name, onclick, idBefore, isD
 				newBtn
 					.addClass("dropdown-toggle")
 					.attr({"aria-expanded":false, "data-bs-toggle":"dropdown"}),
-				$("<ul>").addClass("dropdown-menu p-2").append(),
+				$("<ul>").addClass("dropdown-menu").append(),
 			);
 		}
 

--- a/plugins/create/init.js
+++ b/plugins/create/init.js
@@ -134,7 +134,7 @@ plugin.onLangLoaded = function() {
 			$("<div>").addClass("col-md-2").append(
 				$("<label>").attr({for: "piece_size", name: "lbl_piece_size", id: "lbl_piece_size"}).text(theUILang.PieceSize + ": "),
 			),
-			$("<div>").addClass("col-md-4 d-flex flex-row").append(
+			$("<div>").addClass("col-md-4").append(
 				$("<select>").attr({id: "piece_size", name: "piece_size"}).addClass("flex-grow-1").append(
 					...pieceSizeArray.map(ele => $("<option>").val(ele).text(
 						ele < 1024 ? ele + theUILang.KB : (ele / 1024) + theUILang.MB
@@ -145,7 +145,7 @@ plugin.onLangLoaded = function() {
 		if(plugin.hidePieceSize)
 			pieceSize = "";
 
-		var hybridTorrent = $("<div>").addClass("col-md-4 d-flex flex-row align-items-center").append(
+		var hybridTorrent = $("<div>").addClass("col-md-4").append(
 			$("<input>").attr({type: "checkbox", name: "hybrid", id: "hybrid"}),
 			$("<label>").attr({for: "hybrid", id: "lbl_hybrid"}).text(theUILang.HybridTorrent),
 		);
@@ -156,7 +156,7 @@ plugin.onLangLoaded = function() {
 			$("<fieldset>").append(
 				$("<legend>").text(theUILang.SelectSource),
 				$("<div>").addClass("row").append(
-					$("<div>").addClass("col-12 d-flex flex-row").append(
+					$("<div>").addClass("col-12").append(
 						$("<input>").attr({type: "text", id: "path_edit", name: "path_edit", autocomplete: "off"}).addClass("flex-grow-1"),
 					),
 				),
@@ -167,7 +167,7 @@ plugin.onLangLoaded = function() {
 					$("<div>").addClass("col-md-2 align-self-start").append(
 						$("<label>").attr({for: "trackers", name: "lbl_trackers", id: "lbl_trackers"}).text(theUILang.Trackers + ": "),
 					),
-					$("<div>").addClass("col-md-10 d-flex flex-row").append(
+					$("<div>").addClass("col-md-10").append(
 						$("<textarea>").attr({id: "trackers", name: "trackers"}).addClass("flex-grow-1"),
 					),
 				),
@@ -175,7 +175,7 @@ plugin.onLangLoaded = function() {
 					$("<div>").addClass("col-md-2").append(
 						$("<label>").attr({for: "comment", name: "lbl_comment", id: "lbl_comment"}).text(theUILang.Comment + ": "),
 					),
-					$("<div>").addClass("col-md-10 d-flex flex-row").append(
+					$("<div>").addClass("col-md-10").append(
 						$("<input>").attr({type: "text", id: "comment", name: "comment"}).addClass("flex-grow-1"),
 					),
 				),
@@ -183,7 +183,7 @@ plugin.onLangLoaded = function() {
 					$("<div>").addClass("col-md-2").append(
 						$("<label>").attr({for: "source", name: "lbl_source", id: "lbl_source"}).text(theUILang.source + ": "),
 					),
-					$("<div>").addClass("col-md-10 d-flex flex-row").append(
+					$("<div>").addClass("col-md-10").append(
 						$("<input>").attr({type: "text", id: "source", name: "source"}).addClass("flex-grow-1"),
 					),
 				),
@@ -192,11 +192,11 @@ plugin.onLangLoaded = function() {
 			$("<fieldset>").append(
 				$("<legend>").text(theUILang.Other),
 				$("<div>").addClass("row").append(
-					$("<div>").addClass("col-md-4 d-flex flex-row align-items-center").append(
+					$("<div>").addClass("col-md-4").append(
 						$("<input>").attr({type: "checkbox", name: "start_seeding", id: "start_seeding"}),
 						$("<label>").attr({for: "start_seeding", id: "lbl_start_seeding"}).text(theUILang.StartSeeding),
 					),
-					$("<div>").addClass("col-md-4 d-flex flex-row align-items-center").append(
+					$("<div>").addClass("col-md-4").append(
 						$("<input>").attr({type: "checkbox", name: "private", id: "private"}),
 						$("<label>").attr({for: "private", id: "lbl_private"}).text(theUILang.PrivateTorrent),
 					),

--- a/plugins/datadir/init.js
+++ b/plugins/datadir/init.js
@@ -138,22 +138,22 @@ plugin.onLangLoaded = function() {
 	const dlgDatadirContent = $("<div>").addClass("cont fxcaret").append(
 		$("<fieldset>").append(
 			$("<legend>").text(theUILang.DataDir),
-			$("<div>").addClass("row align-items-center").append(
+			$("<div>").addClass("row").append(
 				$("<div>").addClass("col-md-2 d-none d-md-flex justify-content-end").append(
 					$("<label>").attr({id: "lbl_datadir", for: "edit_datadir"}).text(theUILang.DataDir + ": "),
 				),
-				$("<div>").addClass("col-md-10 d-flex align-items-center").append(
+				$("<div>").addClass("col-md-10").append(
 					$("<input>").attr({type: "text", id: "edit_datadir"}).addClass("flex-grow-1"),
 				),
-				$("<div>").addClass("offset-md-2 col-md-10 d-flex align-items-center").append(
+				$("<div>").addClass("offset-md-2 col-md-10").append(
 					$("<input>").attr({type: "checkbox", id: "move_not_add_path"}),
 					$("<label>").attr({for: "move_not_add_path"}).text(theUILang.Dont_add_tname),
 				),
-				$("<div>").addClass("offset-md-2 col-md-10 d-flex align-items-center").append(
+				$("<div>").addClass("offset-md-2 col-md-10").append(
 					$("<input>").attr({type: "checkbox", id: "move_datafiles"}),
 					$("<label>").attr({for: "move_datafiles"}).text(theUILang.DataDirMove),
 				),
-				$("<div>").addClass("offset-md-2 col-md-10 d-flex align-items-center").append(
+				$("<div>").addClass("offset-md-2 col-md-10").append(
 					$("<input>").attr({type: "checkbox", id: "move_fastresume"}),
 					$("<label>").attr({for: "move_fastresume"}).text(theUILang.doFastResume),
 				),

--- a/plugins/theme/themes/Acid/style.css
+++ b/plugins/theme/themes/Acid/style.css
@@ -2,10 +2,11 @@ html, body { background-color: #1e2124; color: #BDDBDB }
 :root {
   --menu-color: #00FF00;
   --menu-background-color: #181818;
+  --menu-border-color: #a0a0a0;
 
   --menu-disabled-color: #c0c0c0;
+  --menu-disabled-background-color: #ffffff;
 
-  --menu-border-color: #333;
   --menu-highlight-color: #272E36;
   --menu-highlight-background-color: #BDDBDB;
 
@@ -13,6 +14,7 @@ html, body { background-color: #1e2124; color: #BDDBDB }
 
   --btn-bg-color: #D7D7D7;
   --header-bg-color: #1E2124;
+  --header-border-color: #909090;
 }
 button, input.Button {
   color: black;
@@ -170,8 +172,6 @@ span#loadimg { background: transparent url(./images/ajax-loader.gif) no-repeat c
 .Icon_File {background: transparent url(./images/file.gif) no-repeat left center}
 .Icon_Dir {background: transparent url(./images/dir.gif) no-repeat left center}
 .Icon_Share {background: transparent url(./images/dir.gif) no-repeat left center}
-
-div#tadd { background-color: #1e2124; border: 2px solid #909090; color: #BDDBDB;}
 
 #StatusBar { background-color: #1e2124; color: #ffffff; font-weight: bold }
 #st_up { background:url(./images/status_up.gif) 6px no-repeat; color: #BDDBDB; }

--- a/plugins/theme/themes/Blue/style.css
+++ b/plugins/theme/themes/Blue/style.css
@@ -2,16 +2,19 @@ html, body { background-color: #DFE8F6 }
 :root {
   --menu-color: #222222;
   --menu-background-color: #F0F0F0;
+  --menu-border-color: #718BB7;
 
   --menu-disabled-color: #808080;
+  --menu-disabled-background-color: #ffffff;
 
-  --menu-border-color: #718BB7;
   --menu-highlight-color: #222222;
   --menu-highlight-background-color: #D9E8FB;
 
   --settings-background-color: #DFE8F6;
 
+  --btn-bg-color: #F0F0F0;
   --header-bg-color: #D9E8FB;
+  --header-border-color: transparent;
 }
 #side-panel, category-list {
   border-color: #99BBE8;
@@ -94,11 +97,7 @@ ul.CMenu li a.exp {background: transparent url(./images/menu-parent.gif) no-repe
 
 ul.CMenu li.menuitem hr {background-color: #E0E0E0; color: #000000; border-bottom-width: 1px; border-bottom-color: #FFFFFF}
 
-.dlg-header {
-  background: var(--header-bg-color);
-  border: none;
-  color: #15428B;
-}
+.dlg-header {color: #15428B;}
 
 div#stg .lm { background-color: #FAFAFA; border: 1px solid #D0D0D0; }
 .lm li a.focus {background-color: #D9E8FB}

--- a/plugins/theme/themes/Dark/style.css
+++ b/plugins/theme/themes/Dark/style.css
@@ -2,10 +2,11 @@ html, body {background-color: #181818; color: #999999; }
 :root {
   --menu-color: #666666;
   --menu-background-color: #181818;
+  --menu-border-color: #333333;
 
   --menu-disabled-color: #333333;
+  --menu-disabled-background-color: #181818;
 
-  --menu-border-color: #333333;
   --menu-highlight-color: #111111;
   --menu-highlight-background-color: #888888;
 
@@ -155,8 +156,6 @@ select.cols {border: 1px solid #333333}
 div#dragmask {border: 1px dotted #333333}
 div#tdetails {background-color: #181818}
 div#tdcont {background: #181818; border: 1px solid #333333}
-
-div#tadd {background-color: #181818; border: 1px solid #333333}
 
 .tabbar li.nav-item a.nav-link {
   border: 1px solid #333333;

--- a/plugins/theme/themes/DarkBetter/style.css
+++ b/plugins/theme/themes/DarkBetter/style.css
@@ -2,10 +2,11 @@ html, body {background-color: #181818; color: #999999; }
 :root {
   --menu-color: #666666;
   --menu-background-color: #181818;
+  --menu-border-color: #333333;
 
   --menu-disabled-color: #333333;
+  --menu-disabled-background-color: #181818;
 
-  --menu-border-color: #333333;
   --menu-highlight-color: #111111;
   --menu-highlight-background-color: #888888;
 
@@ -224,7 +225,6 @@ div#t .nav-link {
   border-color: #333333;
   color: #686868;
 }
-div#t a:hover {background: #222;}
 div#t div.TB_Separator {background-color: #333333}
 div#t div#add {background: transparent url(./images/tb_add.svg) no-repeat center; background-size: 28px}
 div#t div#create {background: transparent url(./images/tb_create.svg) no-repeat center; background-size: 28px}

--- a/plugins/theme/themes/Excel/style.css
+++ b/plugins/theme/themes/Excel/style.css
@@ -1,7 +1,18 @@
 html, body { background-color: #DFE8F6; scrollbar-arrow-color: #586585; scrollbar-base-color: #e3e9f0; scrollbar-track-color: #7797c1; }
 :root {
+  --menu-color: #000000;
+  --menu-background-color: #f6f6f6;
+  --menu-border-color: #002d96;
+
+  --menu-disabled-color: #666666;
+  --menu-disabled-background-color: #f6f6f6;
+
+  --menu-highlight-color: #000000;
+  --menu-highlight-background-color: #ffeec2;
+
   --settings-background-color: #FFFFFF;
 
+  --btn-bg-color: #f1f1ec;
   --header-bg-color: #D9E8FB;
   --header-border-color: #9EB6CE;
 }
@@ -55,7 +66,7 @@ div#tdetails { background-color: transparent }
 div#stg .lm { background-color: #FAFAFA; border: 1px solid #D0D0D0; }
 .lm li a.focus {background-color: #D9E8FB}
 
-div.dlg-window { color: #000000; border-color: #9EB6CE; background-color: #FFFFFF }
+div.dlg-window { border-color: #9EB6CE; background-color: #FFFFFF }
 .dlg-header {color: #15428B;}
 .tabbar { background: transparent url(./images/tabbarbg.png) repeat-x 0 0 }
 .tabbar li.nav-item a.nav-link {

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -198,17 +198,19 @@ html,body
 :root {
 	--menu-color: #757571;
 	--menu-border-color: #333;
-	--menu-background-color: #181818;
+	--menu-background-color: #121212;
 
 	--menu-disabled-color: #333;
+	--menu-disabled-background-color: #ffffff;
 
-	--menu-highlight-color: #fff;
-	--menu-highlight-background-color: #888;
+	--menu-highlight-color: #d2d2d2;
+	--menu-highlight-background-color: #121212;
 
 	--settings-background-color: #222;
 
 	--btn-bg-color: #3498DB;
   --header-bg-color: #273238;
+  --header-border-color: transparent;
 }
 
 #offcanvas-sidepanel {
@@ -362,7 +364,6 @@ ul.CMenu li.menuitem:last-child
 
 ul.CMenu li a
 {
-	color:#757571;
 	background:transparent url(./images/menus.png) no-repeat 0 0
 }
 
@@ -589,11 +590,6 @@ div select {
 	padding:1px 4px
 }
 
-a
-{
-	color:#686868;
-}
-
 #pview_save_view_button {
 	width: 20px;
 	height: 20px;
@@ -738,7 +734,6 @@ a.dlg-close:link,a.dlg-close:visited
 }
 
 .dlg-header {
-	border: none;
 	text-transform: uppercase;
 	text-shadow: 0 -1px 0 #000;
 }

--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -1,13 +1,14 @@
 html, body {font-family: "Lucida Sans Unicode", "Lucida Grande", Tahoma, Arial, Helvetica, sans-serif;background-color: #000;color: #ffffff;text-shadow:0px -1px 0px #000;scrollbar-base-color:#181818; }
 :root {
   --menu-color: #757571;
-  --menu-background-color: transparent;
+  --menu-background-color: #121212;
+  --menu-border-color: #333333;
 
   --menu-disabled-color: #333333;
+  --menu-disabled-background-color: #121212;
 
-  --menu-border-color: #333333;
-  --menu-highlight-color: #fff;
-  --menu-highlight-background-color: #888888;
+  --menu-highlight-color: #ffffff;
+  --menu-highlight-background-color: #121212;
 
   --settings-background-color: #181818;
 
@@ -20,7 +21,6 @@ button, input[type=button], input[type=submit], .Button {
   border: 1px solid #000;
   background: var(--btn-bg-color) url(./images/headers.png) repeat-x 0px 0px;
   color:#AACF27;
-  cursor: pointer;
   font-weight: bold;
   text-shadow:0px -1px 0px #000;
   -moz-border-radius: 5px;


### PR DESCRIPTION
This patch adapts the dropdown menu to different themes. A more general way of theming was applied, so future theme maintenance can be a little bit easier. This change also prepares us for migrating the search engine menu to bootstrap dropdown menu.

- Override bootstrap color variables to redefine theme colors.
- Remove some redundant bootstrap utility class names.