### PR TITLE
Read dir content without trailing slash

### DIFF
--- a/plugins/_getdir/init.js
+++ b/plugins/_getdir/init.js
@@ -120,12 +120,8 @@ theWebUI.rDirBrowser = class {
 	}
 
 	requestDir() {
-		const path = this.edit.val();
-		if (path.length > 0 && !path.endsWith("/")) {
-			this.edit.val(path.slice(0, path.lastIndexOf("/") + 1));
-		}
 		$.ajax(
-			`plugins/_getdir/listdir.php?dir=${encodeURIComponent(this.edit.val())}&time=${(new Date()).getTime()}${this.withFiles ? "&withfiles=1" : ""}`,
+			`plugins/_getdir/listdir.php?dir=${encodeURIComponent(this.edit.val().replace(/\u00a0/g, " "))}&time=${(new Date()).getTime()}${this.withFiles ? "&withfiles=1" : ""}`,
 			{
 				success: (res) => {
 					this.frame.find(".filter-dir").val("").trigger("focus");
@@ -133,8 +129,8 @@ theWebUI.rDirBrowser = class {
 					this.frame.find(".rmenuobj").remove();
 					this.frame.append(
 						$("<div>").addClass("rmenuobj").append(
-							...res.directories.map(ele => $("<div>").addClass("rmenuitem").text(ele + "/")),
-							...(this.withFiles ? res.files : []).map(ele => $("<div>").addClass("rmenuitem").text(ele)),
+							...res.directories.map(ele => $("<div>").addClass("rmenuitem").text(ele.replace(/ /g, "\u00a0") + "/")),
+							...(this.withFiles ? res.files : []).map(ele => $("<div>").addClass("rmenuitem").text(ele.replace(/ /g, "\u00a0"))),
 						),
 					);
 					this.frame.find(".rmenuitem").on(

--- a/plugins/_getdir/listdir.php
+++ b/plugins/_getdir/listdir.php
@@ -11,7 +11,6 @@ if(isset($requestedDir) && strlen($requestedDir))
 {
 	$dir = rawurldecode($requestedDir);
 	rTorrentSettings::get()->correctDirectory($dir);
-	$dir = FileUtil::addslash($dir);
 
 	if(
 			(strpos($dir,$topDirectory)!==0) ||
@@ -24,13 +23,11 @@ if(isset($requestedDir) && strlen($requestedDir))
 else
 {
 	$dir = User::isLocalMode() ? $theSettings->directory : $topDirectory;
-	if(strpos(FileUtil::addslash($dir),$topDirectory)!==0)
+	if (strpos($dir, $topDirectory) !== 0)
 		$dir = $topDirectory;
-
-	if(strrpos($dir, '/') != strlen($dir) - 1)
-		$dir = FileUtil::addslash($dir);
 }
 
+$dir = FileUtil::addslash($dir);
 $items = array_diff(scandir($dir), (($dir == $topDirectory) ? ["..", "."] : ["."]));
 $directories = array_filter($items, function ($item) {
 	global $dir;


### PR DESCRIPTION
- Send path to server as is and try reading path as directory with or without trailing slash first. If path is not a directory, fall back to default top directory.
- Fix an issue that white spaces not displaying properly. Related: https://github.com/Novik/ruTorrent/issues/2757