### PR TITLE
Fix s-table header dragging

### DIFF
--- a/css/stable.css
+++ b/css/stable.css
@@ -1,5 +1,4 @@
 .stable {
-  position: relative;  /* Need to be positioned for drag masks to be positioned properly */
   height: 100%;
   background-color: #FFFFFF;
   overflow: hidden;
@@ -11,6 +10,7 @@
 }
 .stable td {font: menu; white-space: nowrap; padding: 1px}
 .stable-head {
+  position: relative;  /* Need to be positioned for drag masks to be positioned properly */
   width: 100%;
   flex: 0 0 auto;
   background: #F5F5F5;

--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@
 			<div id="HDivider" class="p-0 m-0"></div>
 			<div id="main-info" class="d-flex flex-column align-items-stretch flex-grow-1 flex-shrink-1 overflow-hidden">
 				<div id="list-table" class="flex-grow-1 flex-shrink-1 overflow-hidden">
-					<div id="List" class="h-100"></div>
+					<div id="List"></div>
 				</div>
 				<div id="VDivider" class="p-0 m-0"></div>
 				<div id="tdetails">


### PR DESCRIPTION
### Current
Scroll an s-table horizontally to some point and drag a header cell. The drop target box (whatever it is called) wouldn't appear.
![Screen Recording 2024-10-29 181903](https://github.com/user-attachments/assets/9719c63e-b8ab-4c15-b005-215dcee63469)

### Expected
Scroll the table to the left-end would produce the expected effect for all scenarios.
![Screen Recording 2024-10-29 182013](https://github.com/user-attachments/assets/6d9a13ef-6cc1-4fd0-8f03-380d9e1216c5)