### PR TITLE
Prevent collapse menu from pushing content down

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -209,12 +209,18 @@ ul.CMenu li:hover ul.left {left: -150px}
 span.htkey {text-align:right; position: absolute; right: 16px; z-index:100}
 #sel {width: 0px; height: 0px; left: 0px; top: 0px; border: 1px dotted #000000; display: none; z-index: 1000}
 
-div#t {
-  height: auto;
+#t {
+  height: 36px;
   background: #F0F0F0 url(../images/t_bg.png) repeat-x center 0.25rem;
   border-bottom: 1px solid #D0D0D0;
   margin-bottom: 5px;
   white-space: nowrap;
+}
+#toggler-container {
+  min-height: 100%;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: space-between;
 }
 #top-menu {
   background-color: #F0F0F0;
@@ -223,6 +229,7 @@ div#t {
 }
 #top-menu .btn-group {
   flex-direction: column;
+  justify-content: center;
 }
 .dropdown-toggle span {
   /* Push dropdown triangle to the right end */
@@ -236,9 +243,17 @@ div#t {
   padding: 0.25rem 1rem;
   width: auto;
 }
-div#t button.navbar-toggler {
+.navbar-toggler {
   background-color: var(--btn-bg-color);
   width: 5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+}
+.navbar-toggler > div {
+  width: 16px;
+  height: 16px;
 }
 div#t a {padding: 3px;}
 #t .navbar-nav a:not(.dropdown-item):hover {
@@ -575,17 +590,8 @@ span#loadimg {padding: 20px; background: transparent url(../images/ajax-loader.g
 .buttons-group-row {margin: 0.25rem; gap: 0.25rem; display: flex; flex-direction: row;}
 
 .ie fieldset {padding: 5px}
-div.space {flex-grow: 1;}
 #servertime { text-align: center }
 #viewrows { text-align: center; }
-
-@media only screen and (min-width: 1280px) {
-  .desktop { display: inline-block; }
-}
-
-@media only screen and (max-width: 1279px) {
-  .desktop { display: none; }
-}
 
 /* Custom break point settings for responsiveness */
 
@@ -610,9 +616,6 @@ div.dlg-window .buttons-list {
 /* Medium devices (tablets, 768px and up) */
 @media (min-width: 768px) { 
   /* Custom rules for medium devices */
-  div#t {
-    height: 36px;
-  }
   #top-menu {
     background-color: transparent;
     border-bottom: none;

--- a/index.html
+++ b/index.html
@@ -75,15 +75,17 @@
 		<div id="sel" class="position-absolute"></div>
 		<div id="sc"></div>
 		<div id="t" class="py-0 navbar navbar-expand-md">
-			<div class="px-0 container-fluid justify-content-between align-items-stretch">
-				<button class="d-md-none my-2 navbar-toggler h-auto" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-sidepanel" aria-controls="offcanvas-sidepanel">
-					<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-three-dots" viewBox="0 0 16 16">
-						<path d="M3 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3m5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3m5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3"/>
-					</svg>
-				</button>
-				<button class="navbar-toggler my-2 h-auto" type="button" data-bs-toggle="collapse" data-bs-target="#top-menu" aria-controls="top-menu" aria-expanded="false" aria-label="Toggle navigation">
-					<div class="navbar-toggler-icon"></div>
-				</button>	
+			<div class="h-100 px-0 container-fluid">
+				<div id="toggler-container" class="d-flex d-md-none">
+					<button class="d-md-none my-2 navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvas-sidepanel" aria-controls="offcanvas-sidepanel">
+						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-three-dots" viewBox="0 0 16 16">
+							<path d="M3 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3m5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3m5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3"/>
+						</svg>
+					</button>
+					<button class="navbar-toggler my-2" type="button" data-bs-toggle="collapse" data-bs-target="#top-menu" aria-controls="top-menu" aria-expanded="false" aria-label="Toggle navigation">
+						<div class="navbar-toggler-icon"></div>
+					</button>	
+				</div>
 				<div class="collapse navbar-collapse px-1 py-2 py-md-0" id="top-menu">
 					<div class="navbar-nav flex-grow-1">
 						<div class="d-flex flex-row align-items-center flex-wrap flex-md-nowrap">

--- a/js/content.js
+++ b/js/content.js
@@ -539,7 +539,9 @@ function makeContent() {
 			$("<legend>").text(theUILang.Listening_Port),
 			$("<div>").addClass("row").append(
 				$("<div>").addClass("col-md-6").append(
-					$("<input>").attr({type: "checkbox", id: "port_open", onclick: "linked(this, 0, ['port_range', 'port_random']);"}),
+					$("<input>")
+						.attr({type: "checkbox", id: "port_open"})
+						.on("click", (ev) => linked(ev.target, 0, ['port_range', 'port_random'])),
 					$("<label>").attr({for: "port_open"}).text(theUILang.Enable_port_open),
 				),
 				$("<div>").addClass("col-md-6").append(
@@ -595,7 +597,9 @@ function makeContent() {
 			$("<legend>").text(theUILang.Add_bittor_featrs),
 			$("<div>").addClass("row").append(
 				$("<div>").addClass("col-md-6").append(
-					$("<input>").attr({type: "checkbox", id: "dht", onchange: "linked(this, 0, ['dht_port']);"}),
+					$("<input>")
+						.attr({type: "checkbox", id: "dht"})
+						.on("change", (ev) => linked(ev.target, 0, ['dht_port'])),
 					$("<label>").attr({for: "dht"}).text(theUILang.En_DHT_ntw),
 				),
 				$("<div>").addClass("col-md-6").append(

--- a/plugins/theme/themes/Acid/style.css
+++ b/plugins/theme/themes/Acid/style.css
@@ -73,7 +73,7 @@ div.graph_tab {background-color: #272E36; color: #BDDBDB; font-weight: bold;}
 .graph_tab_legend { color: #FFF; background-color: #272E36; }
 .graph_tab_tooltip { color: #FFF; background-color: #272E36; border: 1px solid #BDDBDB; }
 
-div#t {background: #252525 url(./images/t_bg.png) repeat-x center center; border-bottom: 1px solid #252525;}
+#t {background: #252525 url(./images/t_bg.png) repeat-x center center; border-bottom: 1px solid #252525;}
 #top-menu {
   background-color: #252525;
   border-bottom: 1px solid #252525;

--- a/plugins/theme/themes/Blue/style.css
+++ b/plugins/theme/themes/Blue/style.css
@@ -42,7 +42,7 @@ panel-label[selected] {
   border-color: #D9E8FB;
 }
 
-div#t {background: #181818 url(./images/header_bg.gif) repeat-x center center; border-bottom: 1px solid #333333;}
+#t {background: #181818 url(./images/header_bg.gif) repeat-x center center; border-bottom: 1px solid #333333;}
 #top-menu {
   background-color: #181818;
   border-bottom: 1px solid #333333;
@@ -53,7 +53,7 @@ div#t .nav-link {
   color: #15428B;
   font-weight: normal;
 }
-div#t button.navbar-toggler {background-image: none;}
+.navbar-toggler {background-image: none;}
 
 div#t div#add {background: transparent url(./images/toolbar.png) no-repeat -24px center}
 div#t div#create {background: transparent url(./images/toolbar.png) no-repeat -48px center}

--- a/plugins/theme/themes/Dark/style.css
+++ b/plugins/theme/themes/Dark/style.css
@@ -78,12 +78,12 @@ ul.CMenu li a.sel {background: transparent url(./images/menusel.gif) no-repeat s
 
 #sel {border: 1px dotted #555555;}
 
-div#t {background: #181818 url(./images/t_bg.png) repeat-x center center; border-bottom: 1px solid #333333;}
+#t {background: #181818 url(./images/t_bg.png) repeat-x center center; border-bottom: 1px solid #333333;}
 #top-menu {
   background-color: #181818;
   border-bottom: 1px solid #333333;
 }
-div#t button.navbar-toggler {
+.navbar-toggler {
   background-image: none;
   border-color: #333333;
 }

--- a/plugins/theme/themes/DarkBetter/style.css
+++ b/plugins/theme/themes/DarkBetter/style.css
@@ -211,12 +211,12 @@ ul.CMenu li ul li a.dis:hover {background-color: #181818; color: #333333}
 
 #sel {border: 1px dotted #555555}
 
-div#t {background: #181818 url(./images/t_bg.png) repeat-x center center; border-bottom: 1px solid #333333;}
+#t {background: #181818 url(./images/t_bg.png) repeat-x center center; border-bottom: 1px solid #333333;}
 #top-menu {
   background-color: #181818;
   border-bottom: 1px solid #333333;
 }
-div#t button.navbar-toggler {
+.navbar-toggler {
   background-image: none;
   border-color: #333333;
 }

--- a/plugins/theme/themes/Excel/style.css
+++ b/plugins/theme/themes/Excel/style.css
@@ -44,12 +44,12 @@ panel-label[selected] {
 div#StatusBar { background: transparent url(./images/statbg.png) repeat-x 0 0; border-top: none; color: #034084 }
 .statuscell { border-color: #9EB6CE }
 
-div#t {background: none; border: none;}
+#t {background: none; border: none;}
 #top-menu {
   background-color: #B5D5FB;
   border-bottom: 1px solid #9EB6CE;
 }
-div#t button.navbar-toggler {
+.navbar-toggler {
   background-image: none;
 }
 

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -444,19 +444,18 @@ ul.CMenu li ul li a.dis:hover
 	border:1px dotted #555
 }
 
-div#t {
+#t {
 	background-color:#273238;
 	background-image:none;
 	border-bottom:none;
-	padding:4px 0 2px 5px;
-	height: auto;
+	height: 40px;
 }
 
 #top-menu {
   background-color: #273238;
   border-bottom: none;
 }
-div#t button.navbar-toggler {
+.navbar-toggler {
   background-image: none;
   border: none;
 }
@@ -1282,9 +1281,6 @@ span.det {
 
 @media (min-width: 768px) { 
   /* Custom rules for medium devices */
-	div#t {
-		height: 40px;
-	}
   div#t .nav-link {
     background-color: transparent;
   }

--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -133,12 +133,12 @@ ul.CMenu li:hover ul li a:hover { text-shadow:0px -1px 0px #000;}
 
 #sel {border: 1px dotted #555555;}
 
-div#t {background: #000 url(./images/headers.png) repeat-x 0px -252px; border-bottom: none;}
+#t {background: #000 url(./images/headers.png) repeat-x 0px -252px; border-bottom: none;}
 #top-menu {
   background-color: #000;
   border-bottom: none;
 }
-div#t button.navbar-toggler {
+.navbar-toggler {
   background-image: none;
   border-color: #0F0F0F;
 }


### PR DESCRIPTION
This patch tweaks the behavior of the top menu when it expands and collapse.

### Before
![Screen Recording 2024-10-30 235655](https://github.com/user-attachments/assets/7081c434-baeb-420f-bd54-054c7d221606)

### After
![Screen Recording 2024-10-30 235449](https://github.com/user-attachments/assets/58752108-9f77-412d-8875-57753c73e89f)

Currently on mobile, when opening the top menu, the main content will be pushed downwards. See how the "Name" header row goes downwards and upwards with the top menu when it expands and collapses. This creates resizing issues on mobile devices sometimes. Fix the position of main content and make top menu go above it looks more consistent on the overall layout.

Also, I try to reduce the specificity of CSS rules step by step, to make them cleaner and easier to maintain. Here in this patch, there are a few lines modified, too.

- On mobile, an open top menu will now go above the main content, instead of pushing the main content downward. This will prevent resizing issues.
- Remove some unused CSS rules.