### PR TITLE
Adjust task console log layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -636,11 +636,7 @@ div.dlg-window .buttons-list {
   div#tadd {min-width: 600px;}
   div.dlg-window .buttons-list {
     margin: 1rem 0.5rem;
-    gap: 0.25rem;
-    display: flex;
-    flex-direction: row;
     justify-content: end;
-    flex-wrap: nowrap;
   }
   div#stg {width: 660px;}
 }

--- a/plugins/_task/_task.css
+++ b/plugins/_task/_task.css
@@ -1,15 +1,29 @@
+#tskConsole {
+  width: 95vw;
+}
 .tskconsole {
   font-family: monospace;
-  line-height: 16px;
+  line-height: 1.5rem;
   background: #F5F5F5;
   white-space: pre;
   overflow: auto;
-  width: 580px;
   cursor: text;
   user-select: text;
 }
-.tskconsole img {
+.image-cont {
+  background-color: black;
+  cursor: default;
+}
+.image-cont > div {
+  height: 100%;
   width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+}
+.tskconsole img {
+  max-height: 100%;
+  max-width: 100%;
 }
 #tskcmdlog {
   height: 36rem;
@@ -20,4 +34,12 @@
 #tsk_btns {background: transparent url(./images/ajax-loader.gif) no-repeat 5px 7px;}
 #tskConsole-header {background-image: url(../../images/settings.gif)}
 
-.konqueror div.tskconsole { height: 546px }
+.konqueror .tskconsole { height: 546px }
+
+/* Medium devices (tablets, 768px and up) */
+@media (min-width: 768px) { 
+  /* Custom rules for medium devices */
+  #tskConsole {
+    width: unset;
+  }
+}

--- a/plugins/_task/_task.css
+++ b/plugins/_task/_task.css
@@ -10,9 +10,6 @@
   cursor: text;
   user-select: text;
 }
-.tskconsole:not(.image-cont) {
-  max-width: 580px;
-}
 .image-cont {
   background-color: black;
   cursor: default;
@@ -47,5 +44,8 @@
   /* Custom rules for medium devices */
   #tskConsole {
     width: unset;
+  }
+  .tskconsole {
+    width: 64rem;
   }
 }

--- a/plugins/_task/_task.css
+++ b/plugins/_task/_task.css
@@ -10,6 +10,9 @@
   cursor: text;
   user-select: text;
 }
+.tskconsole:not(.image-cont) {
+  max-width: 580px;
+}
 .image-cont {
   background-color: black;
   cursor: default;

--- a/plugins/_task/_task.css
+++ b/plugins/_task/_task.css
@@ -34,7 +34,10 @@
 #tskcmderrors {
   height: 12rem;
 }
-#tsk_btns {background: transparent url(./images/ajax-loader.gif) no-repeat 5px 7px;}
+#tsk_btns {
+  background: transparent url(./images/ajax-loader.gif) no-repeat 5px top;
+  padding-top: 2.5rem;
+}
 #tskConsole-header {background-image: url(../../images/settings.gif)}
 
 .konqueror .tskconsole { height: 546px }

--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -633,9 +633,5 @@ plugin.onLangLoaded = function() {
 		}
 		$("#tskCopy, #tskSaveLog").hide();
 	});
-	theDialogManager.setHandler('tskConsole', 'afterShow', function() {
-		if (!plugin.cHeight)
-			plugin.cHeight = $('#tskcmderrors').parent().height();
-	});
 	$(".tskconsole").enableSysMenu();
 }

--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -249,7 +249,7 @@ plugin.kill = function()
 plugin.setConsoleControls = function(errPresent) {
 	$('#tskBackground').prop( 'disabled', !plugin.canDetachTask() );
 	if (plugin.foreground.status >= 0) {
-		$('#tsk_btns').css( "background", "none" );
+		$('#tsk_btns').css({background:"none", paddingTop:0});
 		$("#tskConsole-header").html(theUILang.tskCommandDone);
 		if ($('#tskcmdlog').text() === "") {
 			// hide copy log button if log output is empty
@@ -259,7 +259,7 @@ plugin.setConsoleControls = function(errPresent) {
 		};
 	}
 	else
-		$('#tsk_btns').css( "background", "transparent url(./plugins/_task/images/ajax-loader.gif) no-repeat 5px 7px" );
+		$('#tsk_btns').css({background: "", paddingTop:""});
 	if (errPresent) {
 		$('#tskcmderrors').show();
 		$('#tskcmderrors_set').show();

--- a/plugins/screenshots/init.js
+++ b/plugins/screenshots/init.js
@@ -129,7 +129,7 @@ if(plugin.canChangeMenu())
 	plugin.onTaskShowInterface = function(task)
 	{
 	        $('.scplay').hide();
-	        $('#tskcmdlog').addClass('scframe_cont');
+	        $('#tskcmdlog').addClass('image-cont');
 	}
 
 	plugin.onTaskShowLog = function(task,line,id,ndx)
@@ -144,10 +144,6 @@ if(plugin.canChangeMenu())
 					$('.scframe').hide();
 				$('#'+id).append("<div class='scframe' id='scframe"+ndx+"'><img src='plugins/screenshots/action.php?cmd=ffmpeggetimage&no="+task.no+
 					"&fno="+line+"&file="+encodeURIComponent($('#scimgfile').val())+"' /></div>");
-				$('#scframe'+ndx+' img').on('load', function()
-				{
-					plugin.centerFrame(ndx);
-				});
 			}
 			return('');
 		}
@@ -171,7 +167,7 @@ if(plugin.canChangeMenu())
 	plugin.onTaskHideInterface = function(task)
 	{
 	        $('.scplay').hide();
-		$('#tskcmdlog').removeClass('scframe_cont');
+		$('#tskcmdlog').removeClass('image-cont');
 		if(plugin.playTimer)
 		{
 			window.clearInterval(plugin.playTimer);
@@ -221,18 +217,6 @@ if(plugin.canChangeMenu())
 	}
 }
 
-plugin.centerFrame = function(no)
-{
-	var img = $('#scframe'+no+' img');
-	if(img.height())
-	{
-		var delta = ($('#tskcmdlog').height()-img.height())/2;
-		if(delta>0)
-			img.parent().css("top",delta);
-	}
-}
-
-
 plugin.getCurrentFrame = function()
 {
 	return($('.scframe:visible').length ? iv($('.scframe:visible').attr("id").substr(7)) : 0);
@@ -251,7 +235,6 @@ plugin.setCurrentFrame = function(no)
 		no = 0;
 	$('.scframe:visible').hide();
 	$('#scframe'+no).show();
-	plugin.centerFrame(no);
 	plugin.setPlayControls();
 }
 

--- a/plugins/screenshots/screenshots.css
+++ b/plugins/screenshots/screenshots.css
@@ -1,11 +1,3 @@
-.scframe {
-  position: relative;
-  text-align: center;
-  width: 100%;
-  padding: 0;
-  cursor: default;
-}
-.scframe img { width: 100%; vertical-align: middle; }
 .scplay {
   display: none;
   text-wrap: nowrap;
@@ -13,6 +5,3 @@
   padding: 0;
 }
 #sclast {margin-right: auto;}
-
-.scframe_cont { overflow: auto; background-color: black; margin: 0 auto; }
-#st_screenshots { overflow: auto }

--- a/plugins/spectrogram/init.js
+++ b/plugins/spectrogram/init.js
@@ -53,7 +53,7 @@ if (plugin.canChangeMenu()) {
 	plugin.onTaskFinished = function(task,onBackground) {
 		if (!onBackground) {
 			if (plugin.gotImage) {
-				$('#tskcmdlog').addClass('soxframe_cont');
+				$('#tskcmdlog').addClass('image-cont');
 				$('#tskcmdlog').empty();
 				$('#tskcmdlog').append(
 					$("<div>").attr({id:"soxframe"}).addClass("soxframe").append(
@@ -63,7 +63,6 @@ if (plugin.canChangeMenu()) {
 						}),
 					),
 				);
-				$('#soxframe img').on('load', () => plugin.setConsoleSize(this));
 				$("#soxtaskno").val(task.no);
 				$("#soxsave").on('click', () => {
 					$("#soximgcmd").val("soxgetimage");
@@ -77,34 +76,11 @@ if (plugin.canChangeMenu()) {
 
 	plugin.onTaskShowInterface = function(task) {
 		plugin.gotImage = false;
-		plugin.saveConsoleSize();
 	}
 
 	plugin.onTaskHideInterface = function(task) {
-		plugin.setConsoleSize(null);
 		$('.soxplay').hide();
-		$('#tskcmdlog').removeClass('soxframe_cont');
-	}
-
-	plugin.saveConsoleSize = function() {
-		if (!plugin.consoleWidth) {
-			plugin.consoleWidth = $('#tskConsole').width();
-			plugin.deltaWidth = $('#tskConsole').width() - $('#tskcmdlog').width();
-		} else
-			plugin.setConsoleSize(null);
-	}
-
-	plugin.setConsoleSize = function(img) {
-		if (plugin.consoleWidth && plugin.deltaWidth) {
-			if (img) {
-				$('#tskConsole').width(img.naturalWidth+plugin.deltaWidth+window.scrollbarWidth);
-				$('#tskcmdlog').width(img.naturalWidth+window.scrollbarWidth);
-			} else {
-				$('#tskcmdlog').width(plugin.consoleWidth-plugin.deltaWidth);
-				$('#tskConsole').width(plugin.consoleWidth);
-			}
-			theDialogManager.center('tskConsole');
-		}
+		$('#tskcmdlog').removeClass('image-cont');
 	}
 }
 


### PR DESCRIPTION
### Before

Screenshots on mobile has overflow flaws.

> ![Screenshot_20241021_091054_Chrome](https://github.com/user-attachments/assets/64d45972-2827-47b6-93f7-013b222f1f19)

_Originally posted by @koblack in https://github.com/Novik/ruTorrent/issues/2748#issuecomment-2425825286_

### After

- Cleaned up the CSS rules on the task console window and its image frames to make it display within screen limitation on mobile. 
- Merge some of the rules for the screenshots plugin and the spectrogram plugin, since they have something in common.
- Using CSS to position images frames in the center, instead of the old method that was using JavaScript to dynamically position them centrally.

![20241101151138](https://github.com/user-attachments/assets/190cc8e7-4d4f-4e66-8b5c-c413a24a4a5f)
