### PR TITLE
tracklabels plugin: check favicon mime type

### DIFF
--- a/plugins/tracklabels/action.php
+++ b/plugins/tracklabels/action.php
@@ -87,6 +87,8 @@ if ($png_name !== null) {
 			@$client->fetchComplex($url);
 			if ($client->status == 200)
 				file_put_contents($ico_name, $client->results);
+			if (strpos(mime_content_type($ico_name), "image/")===false)
+				@unlink($ico_name);
 			try_send_image($ico_name, 'image/x-icon');
 		}
 	}


### PR DESCRIPTION
Some trackers return text instead of favicon. This fixes missing icons:

![favicon](https://github.com/user-attachments/assets/b339cd27-a198-40eb-97c2-64c115c8ac09)
