### PR TITLE
Use flex display on dialog windows

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -101,6 +101,8 @@ span {
   --btn-bg-color: #F0F0F0;
   --header-bg-color: #F0F0F0;
   --header-border-color: #909090;
+  --dialog-bg-color: #FAFAFA;
+  --dialog-border-color: #909090;
 }
 .dropdown-menu {
   --bs-dropdown-border-color: var(--menu-border-color);
@@ -133,32 +135,31 @@ div#modalbg {left: 0px; top: 0px; z-index: 500; display: none; opacity: 0.5; bac
 .konqueror div#modalbg { background: none; }
 .ie div#modalbg { filter:alpha(opacity=50); }
 
-div.aright {text-align: right}
-div.dlg-window {
+.dlg-window {
   position: absolute;
   left: 0px;
   top: 0px;
-  background-color: #FAFAFA;
+  background-color: var(--dialog-bg-color);
   color: #000000;
-  border: 2px solid #909090;
+  border: 2px solid var(--dialog-border-color);
   border-radius: 8px;
   outline: 0px solid transparent;
-  display: none;
+  display: flex;
+  flex-direction: column;
   max-width: 95vw;
   max-height: 95vh;
 }
-div.dlg-window div.row {
+.dlg-window .row {
   margin: 0.5rem 0;
   padding: 0;
 }
-div.dlg-window div.row > div {
+.dlg-window .row > div {
   display: flex;
   flex-direction: row;
   align-items: center;
   padding: 0 0.25rem;
   margin-bottom: 0.1rem;
 }
-div.fxcaret {overflow: auto}
 .dlg-header {
   display: flex;
   flex-direction: row;
@@ -343,15 +344,17 @@ a {color: #686868; text-decoration: none;}
 
 div#HDivider, div#VDivider {flex: 0 0 5px;}
 
-div#stg {width: 95vw;}
-div#stg_c {
+#stg {
+  width: 95vw;
+  height: 95vh;
+}
+#stg_c {
   display: flex;
   flex-direction: row;
   background-color: var(--settings-background-color);
 }
-div#stg-pages {
+#stg-pages {
   padding: 0 0.5rem;
-  height: 550px;
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
@@ -369,7 +372,7 @@ div#stg .lm {
 }
 .ie div#stg .lm {width: 125px; position: static;}
 .ie9 div#stg .lm {position: static}
-.ie div#stg {width: 605px;}
+.ie #stg {width: 605px;}
 
 .lm li {
   margin: 0 0.5rem;
@@ -485,7 +488,11 @@ div.table_tab {
   -moz-user-input: enabled;
 }
 
-div.cont {padding: 6px;}
+.cont {
+  padding: 6px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
 
 .tabbar li.nav-item a.nav-link {
   padding: 0.3rem;
@@ -521,8 +528,6 @@ div.cont {padding: 6px;}
 
 #yesnoDlg {width: 280px; height: auto; min-height: 100px}
 #yesnoDlg-header {background-image: url(../images/error.gif)}
-#yesnoDlg div.content {width: 260px; margin: 5px; padding: 5px; line-height: 16px}
-#yesnoDlg div.content input {margin-top: 5px}
 
 span#loadimg {padding: 20px; background: transparent url(../images/ajax-loader.gif) no-repeat center center; }
 .webkit div#msg {position: fixed;}
@@ -599,7 +604,7 @@ span#loadimg {padding: 20px; background: transparent url(../images/ajax-loader.g
 /* No media query for `xs` since this is the default in Bootstrap */
 /* Custom rules for medium devices */
 div#tadd {max-width: 95vw;}
-div.dlg-window .buttons-list {
+.dlg-window .buttons-list {
   margin: 0.5rem;
   gap: 0.25rem;
   display: flex;
@@ -634,11 +639,14 @@ div.dlg-window .buttons-list {
   div#VDivider {cursor: n-resize;}
   div#HDivider:hover, div#VDivider:hover {background: #A0A0A0;}
   div#tadd {min-width: 600px;}
-  div.dlg-window .buttons-list {
+  .dlg-window .buttons-list {
     margin: 1rem 0.5rem;
     justify-content: end;
   }
-  div#stg {width: 660px;}
+  #stg {
+    width: 660px;
+    height: 600px;
+  }
 }
 
 /* Large devices (desktops, 992px and up) */

--- a/js/content.js
+++ b/js/content.js
@@ -61,7 +61,7 @@ function makeContent() {
 			} catch(e) {}
 	}));
 
-	const paddContent = $("<div>").addClass("cont fxcaret").append(
+	const paddContent = $("<div>").addClass("cont").append(
 		$("<fieldset>").append(
 			$("<legend>").text(theUILang.peerAddLabel),
 			$("<div>").addClass("row").append(
@@ -80,7 +80,7 @@ function makeContent() {
 		true,
 	);
 	theDialogManager.make("tadd",theUILang.torrent_add,
-		$("<div>").addClass("cont fxcaret").append(
+		$("<div>").addClass("cont").append(
 			$("<form>").attr(
 				{action: "addtorrent.php", id: "addtorrent", method: "post", enctype: "multipart/form-data", target: "uploadfrm"}
 			).append(
@@ -251,7 +251,7 @@ function makeContent() {
 	   	return makeAddRequest(this);
 	});
 
-	const dlgPropsContent = $("<div>").addClass("cont fxcaret").append(
+	const dlgPropsContent = $("<div>").addClass("cont").append(
 		$("<fieldset>").append(
 			$("<legend>").text(theUILang.Bandwidth_sett),
 			$("<div>").addClass("row").append(
@@ -343,7 +343,7 @@ function makeContent() {
 		),
 	);
 
-	const dlgLabelContent = $("<div>").addClass("cont fxcaret").append(
+	const dlgLabelContent = $("<div>").addClass("cont").append(
 		$("<div>").addClass("row").append(
 			$("<div>").addClass("col-12").append(
 				$("<label>").attr({for:"txtLabel"}).text(theUILang.Enter_label_prom + ": "),

--- a/js/objects.js
+++ b/js/objects.js
@@ -108,13 +108,18 @@ var theDialogManager = {
 	divider: 0,
 	modalState: false,
 
+	/**
+	 * Create a new dialog window.
+	 * @param {string} id The HTML `id` of the dialog window.
+	 * @param {string} name The title shown in the header of the dialog window.
+	 * @param {string | Object | Object[]} content Content of the dialog window,
+	 * including the buttons in the footer. Can be an HTML string, a jQuery object,
+	 * or an array of jQuery objects.
+	 * @param {boolean} isModal The modal state of the dialog window, default is `false`.
+	 * @param {boolean} noClose Whether to disable the close button, default is `false`.
+	 * @returns {Object}
+	 */
 	make: function(id, name, content, isModal, noClose) {
-		// id: HTML `id` of dialog window
-		// name: Title shown in the header of the dialog window
-		// content: Content of the dialog window, including the buttons in the footer.
-		//          Can be an HTML string, a jQuery object, or an array of jQuery objects.
-		// isMocal: Modal state of the dialog window, default is false.
-		// noClose: Disable the close button, default is false.
 		if ($type(content) === "string") {
 			content = $(content);
 		}
@@ -125,7 +130,7 @@ var theDialogManager = {
 					$("<a>").attr({href:"#"}).addClass("dlg-close"),
 				),
 				content,
-			),
+			).hide(),
 		);
 		return this.add(id, isModal, noClose);
 	},
@@ -203,9 +208,7 @@ var theDialogManager = {
 		// An offcanvas is a modal under the hood and will intercept focus events
 		// from other elements, and make other text inputs unfocusable and uneditable.
 		if ($(window).width() < 768) {
-			const panel = bootstrap.Offcanvas.getInstance($("#offcanvas-sidepanel")[0]);
-			if (panel)
-				panel.hide();
+			bootstrap.Offcanvas.getOrCreateInstance(document.querySelector("#offcanvas-sidepanel")).hide();
 		}
 
 		const obj = $('#' + id);

--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -591,7 +591,7 @@ plugin.onGetTasks = function(d)
 }
 
 plugin.onLangLoaded = function() {
-	const tskConsoleContent = $("<div>").addClass("cont fxcaret").append(
+	const tskConsoleContent = $("<div>").addClass("cont").append(
 		$("<fieldset>").attr({id:"tskcmdlog_set"}).append(
 			$("<legend>").text(theUILang.tskConsole),
 			$("<div>").attr({id:"tskcmdlog"}).addClass("tskconsole"),

--- a/plugins/bulk_magnet/init.js
+++ b/plugins/bulk_magnet/init.js
@@ -142,7 +142,7 @@ plugin.wasAdded = function(data)
 
 plugin.onLangLoaded = function() {
 	this.registerTopMenu(9, theUILang.bulkAdd, plugin.showBulkAdd);
-	const dlgBulkAddContent = $("<div>").addClass("cont fxcaret").append(
+	const dlgBulkAddContent = $("<div>").addClass("cont").append(
 		$("<textarea>").attr({id:"bulkadd"}).on("input", (ev) => {
 			$('#dlgBulkAdd .OK').prop('disabled', ev.target.value.trim() === '');
 		}),

--- a/plugins/create/init.js
+++ b/plugins/create/init.js
@@ -152,7 +152,7 @@ plugin.onLangLoaded = function() {
 		if(plugin.hideHybrid)
 			hybridTorrent = "";
 
-		const tcreateContent = $("<div>").addClass("cont fxcaret").append(
+		const tcreateContent = $("<div>").addClass("cont").append(
 			$("<fieldset>").append(
 				$("<legend>").text(theUILang.SelectSource),
 				$("<div>").addClass("row").append(

--- a/plugins/datadir/init.js
+++ b/plugins/datadir/init.js
@@ -135,7 +135,7 @@ rTorrentStub.prototype.setdatadir = function()
 }
 
 plugin.onLangLoaded = function() {
-	const dlgDatadirContent = $("<div>").addClass("cont fxcaret").append(
+	const dlgDatadirContent = $("<div>").addClass("cont").append(
 		$("<fieldset>").append(
 			$("<legend>").text(theUILang.DataDir),
 			$("<div>").addClass("row").append(

--- a/plugins/edit/init.js
+++ b/plugins/edit/init.js
@@ -161,7 +161,7 @@ theWebUI.receiveEdit = function(d)
 }
 
 plugin.onLangLoaded = function() {
-	const teditContent = $("<div>").addClass("cont fxcaret").append(
+	const teditContent = $("<div>").addClass("cont").append(
 		$("<fieldset>").append(
 			$("<legend>").addClass("d-none d-md-block").text(theUILang.EditTorrentProperties),
 			$("<div>").addClass("m-0 row align-items-center").append(

--- a/plugins/extratio/init.js
+++ b/plugins/extratio/init.js
@@ -314,7 +314,7 @@ plugin.correctCSS = function()
 
 plugin.onLangLoaded = function() {
 	this.registerTopMenu(7, theUILang.mnu_ratiorule, theWebUI.showRatioRules);
-	const dlgEditRatioRulesContent = $("<div>").addClass("cont fxcaret").append(
+	const dlgEditRatioRulesContent = $("<div>").addClass("cont").append(
 		$("<div>").addClass("row").append(
 			$("<div>").addClass("col-md-6 d-flex flex-column align-items-center").append(
 				$("<div>").attr({id: "ratioRuleList"}).addClass("flex-grow-1 align-self-stretch").append(

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -750,7 +750,7 @@ plugin.shutdownOldVersion = function()
 }
 
 plugin.onLangLoaded = function() {
-	const tegLoadTorrentsContent = $("<div>").addClass("fxcaret cont").append(
+	const tegLoadTorrentsContent = $("<div>").addClass("cont").append(
 		$("<div>").addClass("row").append(
 			$("<div>").addClass("col-12 col-md-3 justify-content-md-end").append(
 				$("<label>").attr({for:"tegdir_edit"}).text(theUILang.Base_directory + ":"),

--- a/plugins/geoip/geoip.css
+++ b/plugins/geoip/geoip.css
@@ -253,6 +253,4 @@
 
 div#cadd {width: 250px; height: 120px}
 div#cadd div.dlg-header {background-image: url(../../images/props.gif)}
-div#cadd div.content {width: 230px; margin: 5px; padding: 5px; line-height: 16px}
-div#cadd div.content input {margin-top: 5px}
 #peerComment {width: 200px}

--- a/plugins/geoip/init.js
+++ b/plugins/geoip/init.js
@@ -213,7 +213,7 @@ if(plugin.canChangeMenu() && plugin.retrieveComments)
 
 plugin.onLangLoaded = function() {
 	if (plugin.retrieveComments) {
-		const caddContent = $("<div>").addClass("cont fxcaret").append(
+		const caddContent = $("<div>").addClass("cont").append(
 			$("<fieldset>").append(
 				$("<legend>").text(theUILang.peerCommentLabel),
 				$("<div>").addClass("row").append(

--- a/plugins/mediainfo/mediainfo.css
+++ b/plugins/mediainfo/mediainfo.css
@@ -1,3 +1,2 @@
 div#dlg_info {width: 600px; height: 450px}
 div#dlg_info div.dlg-header {background-image: url(./images/mediainfo16.png)}
-div#dlg_info div.content {width: 595px; height: 420px; padding: 2px; overflow: auto; line-height: 10px}

--- a/plugins/rss/init.js
+++ b/plugins/rss/init.js
@@ -1340,7 +1340,7 @@ plugin.onLangLoaded = function()
 		theUILang.rssFeeds,
 	);
 	
-	const dlgAddRSSContent = $("<div>").addClass("cont fxcaret").append(
+	const dlgAddRSSContent = $("<div>").addClass("cont").append(
 		$("<div>").addClass("row").append(
 			...[
 				["rssURL", theUILang.feedURL],
@@ -1364,7 +1364,7 @@ plugin.onLangLoaded = function()
 		true,
 	);
 
-	const dlgAddRSSGroupContent = $("<div>").addClass("cont fxcaret").append(
+	const dlgAddRSSGroupContent = $("<div>").addClass("cont").append(
 		$("<div>").addClass("row").append(
 			$("<div>").addClass("col-12 col-md-3 text-nowrap").append(
 				$("<label>").attr({for:"rssGroupLabel"}).text(theUILang.alias + ": "),
@@ -1388,7 +1388,7 @@ plugin.onLangLoaded = function()
 		true,
 	);
 
-	const dlgEditRSSContent = $("<div>").addClass("cont fxcaret").append(
+	const dlgEditRSSContent = $("<div>").addClass("cont").append(
 		$("<div>").addClass("row").append(
 			...[
 				["editrssURL", theUILang.feedURL],
@@ -1446,7 +1446,7 @@ plugin.onLangLoaded = function()
 		true,
 	);
 
-	const dlgEditFiltersContent = $("<div>").addClass("cont fxcaret d-flex flex-column flex-md-row align-items-stretch align-items-md-start").append(
+	const dlgEditFiltersContent = $("<div>").addClass("cont d-flex flex-column flex-md-row align-items-stretch align-items-md-start").append(
 		$("<div>").addClass("lfc flex-grow-0 flex-shrink-0 d-flex flex-column align-items-center").append(
 			$("<div>").attr({id:"filterList"}).addClass("lf p-2 m-2 align-self-stretch").append(
 				$("<ul>").attr({id:"fltlist"}).addClass("p-0 m-0"),

--- a/plugins/rssurlrewrite/init.js
+++ b/plugins/rssurlrewrite/init.js
@@ -265,7 +265,7 @@ if(plugin.canChangeMenu())
 
 plugin.onLangLoaded = function() {
 	this.registerTopMenu(5, theUILang.mnu_rssurlrewrite, theWebUI.showRules);
-	const dlgEditRulesContent = $("<div>").addClass("cont fxcaret").append(
+	const dlgEditRulesContent = $("<div>").addClass("cont").append(
 		$("<div>").addClass("row").append(
 			$("<div>").addClass("col-md-6 d-flex flex-column align-items-center").append(
 				$("<div>").addClass("lf_rur align-self-stretch").append(

--- a/plugins/theme/themes/Acid/style.css
+++ b/plugins/theme/themes/Acid/style.css
@@ -15,6 +15,8 @@ html, body { background-color: #1e2124; color: #BDDBDB }
   --btn-bg-color: #D7D7D7;
   --header-bg-color: #1E2124;
   --header-border-color: #909090;
+  --dialog-bg-color: #1E2124;
+  --dialog-border-color: #909090;
 }
 button, input.Button {
   color: black;
@@ -61,7 +63,7 @@ panel-label[selected] {
 div#preload {background-image: url(./images/toolbar.png); background-image: url(./images/tstatus.png); background-image: url(./images/t_bg.png); background-image: url(./images/r_bg.gif); background-image: url(./images/i_bg.gif); background-image: url(./images/asc.gif); background-image: url(./images/desc.gif); background-image: url(./images/file.gif); background-image: url(./images/dir.gif); background-image: url(./images/pnl_open.gif); background-image: url(./images/pnl_close.gif)}
 div#cover {background: #272E36}
 div#msg {background: #272E36; border-top: 1px solid #D0D0D0; border-bottom: 1px solid #D0D0D0; color: #00ff00;}
-div.dlg-window { background-color: #1e2124; color: #BDDBDB }
+.dlg-window { color: #BDDBDB }
 
 div#modalbg {background-color: #181818;}
 
@@ -104,7 +106,7 @@ div#side-panel ul li.sel {background-color: #BDDBDB; border-color: #BDDBDB; colo
 
 .stable-icon {background-image: url(./images/tstatus.png); }
 
-div#stg { background-color: #1E2124; color: #BDDBDB; border: 2px solid #909090; }
+#stg { background-color: #1E2124; color: #BDDBDB; border: 2px solid #909090; }
 div#stg .lm { background-color: #272E36; border: 1px solid #D0D0D0; }
 
 .lm li div > div {
@@ -154,7 +156,6 @@ div#gcont div.row.Header {background: #323A46;}
 }
 
 .dlg-header {color: #00FF00;}
-div.content {color: #BDDBDB;}
 
 /* Dialog window icons */
 #stg-header {background-image: url(./images/settings.gif);}

--- a/plugins/theme/themes/Blue/style.css
+++ b/plugins/theme/themes/Blue/style.css
@@ -15,6 +15,8 @@ html, body { background-color: #DFE8F6 }
   --btn-bg-color: #F0F0F0;
   --header-bg-color: #D9E8FB;
   --header-border-color: transparent;
+  --dialog-bg-color: #FAFAFA;
+  --dialog-border-color: #909090;
 }
 #side-panel, category-list {
   border-color: #99BBE8;

--- a/plugins/theme/themes/Dark/style.css
+++ b/plugins/theme/themes/Dark/style.css
@@ -15,6 +15,8 @@ html, body {background-color: #181818; color: #999999; }
   --btn-bg-color: #999999;
   --header-bg-color: #181818;
   --header-border-color: #333333;
+  --dialog-bg-color: #181818;
+  --dialog-border-color: #333333;
 }
 button, input.Button {
   color: #111111;
@@ -131,7 +133,7 @@ div#modalbg {background-color: #181818;}
 div#list-table {border: 1px solid #333333; background-color: #181818}
 div#FileList, div#TrackerList, div#PeerList, div#Speed {background-color: #181818}
 
-div#stg { background-color: #181818; color: #888888; border: 1px solid #333333}
+#stg { background-color: #181818; color: #888888; border: 1px solid #333333}
 
 div#stg .lm {background-color: #181818; border: 1px solid #333333}
 
@@ -172,7 +174,7 @@ div#tdcont {background: #181818; border: 1px solid #333333}
 }
 
 div#dlgProps textarea#prop-trackers {background: #181818; border: 1px solid #333333}
-div.dlg-window {background-color: #181818; color: #888888; border: 1px solid #333333;}
+.dlg-window {color: #888888;}
 
 div.tab {background-color: #181818}
 

--- a/plugins/theme/themes/DarkBetter/style.css
+++ b/plugins/theme/themes/DarkBetter/style.css
@@ -15,6 +15,8 @@ html, body {background-color: #181818; color: #999999; }
   --btn-bg-color: #D6D6D6;
   --header-bg-color: #181818;
   --header-border-color: #333333;
+  --dialog-bg-color: #181818;
+  --dialog-border-color: #333333;
 }
 button, input.Button {
   background: -webkit-gradient(
@@ -289,7 +291,7 @@ div#modalbg {background-color: #181818}
 div#list-table {border: 1px solid #333333; background-color: #181818}
 div#FileList, div#TrackerList, div#PeerList, div#Speed {background-color: #181818}
 
-div#stg {background-color: #181818; color: #888888; border: 1px solid #333333}
+#stg {background-color: #181818; color: #888888; border: 1px solid #333333}
 
 div#stg .lm {background-color: #181818; border: 1px solid #333333}
 
@@ -331,7 +333,7 @@ div#tadd {background-color: #181818; border: 1px solid #333333}
 }
 div#dlgProps textarea#prop-trackers {background: #181818; border: 1px solid #333333}
 
-div.dlg-window {background-color: #181818; color: #888888; border: 1px solid #333333}
+.dlg-window {color: #888888;}
 
 div.tab {background-color: #181818}
 

--- a/plugins/theme/themes/Excel/style.css
+++ b/plugins/theme/themes/Excel/style.css
@@ -14,7 +14,9 @@ html, body { background-color: #DFE8F6; scrollbar-arrow-color: #586585; scrollba
 
   --btn-bg-color: #f1f1ec;
   --header-bg-color: #D9E8FB;
-  --header-border-color: #9EB6CE;
+  --header-border-color: #FFFFFF;
+  --dialog-bg-color: #D9E8FB;
+  --dialog-border-color: #FFFFFF;
 }
 #side-panel, category-list {
   border-top-style: none;
@@ -66,7 +68,7 @@ div#tdetails { background-color: transparent }
 div#stg .lm { background-color: #FAFAFA; border: 1px solid #D0D0D0; }
 .lm li a.focus {background-color: #D9E8FB}
 
-div.dlg-window { border-color: #9EB6CE; background-color: #FFFFFF }
+.dlg-window { color: #000000; }
 .dlg-header {color: #15428B;}
 .tabbar { background: transparent url(./images/tabbarbg.png) repeat-x 0 0 }
 .tabbar li.nav-item a.nav-link {

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -211,6 +211,8 @@ html,body
 	--btn-bg-color: #3498DB;
   --header-bg-color: #273238;
   --header-border-color: transparent;
+  --dialog-bg-color: #222222;
+  --dialog-border-color: #333333;
 }
 
 #offcanvas-sidepanel {
@@ -1042,14 +1044,13 @@ div#dlgProps textarea#prop-trackers
 	border:1px solid #333
 }
 
-div.dlg-window {
-	background-color: #222;
+.dlg-window {
 	box-shadow: 0 19px 38px rgba(0,0,0,0.60);
 	color: #fff;
-	border-top: 1px solid #333;
-	border-right: 1px solid #1b1b1b;
-	border-left: 1px solid #1b1b1b;
-	border-bottom: 1px solid #000;
+	border-top-color: #333;
+	border-right-color: #1b1b1b;
+	border-left-color: #1b1b1b;
+	border-bottom-color: #000;
 }
 
 #stg_c
@@ -1277,7 +1278,7 @@ span.det {
 .sthdr { color: #FFF; }
 .stval { color: #FFF; }
 .tickLabel { color: #FFF; }
-.fxcaret legend { color: #FFF; }
+.dlg-window legend { color: #FFF; }
 
 @media (min-width: 768px) { 
   /* Custom rules for medium devices */

--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -15,6 +15,8 @@ html, body {font-family: "Lucida Sans Unicode", "Lucida Grande", Tahoma, Arial, 
   --btn-bg-color: #515151;
   --header-bg-color: #222222;
   --header-border-color: #333333;
+  --dialog-bg-color: #222222;
+  --dialog-border-color: #333333;
 }
 
 button, input[type=button], input[type=submit], .Button {
@@ -273,7 +275,7 @@ div#tdcont {background: #181818; border-top: none; border-right: 1px solid #0707
 
 /* DIALOGS */
 div#dlgProps textarea#prop-trackers {background: #222222; border: 1px solid #333333}
-div.dlg-window {background-color: #222222; box-shadow: 2px 2px 5px #888; color: #fff; border-top: 1px solid #333; border-right: 1px solid #1b1b1b; border-left: 1px solid #1b1b1b; border-bottom: 1px solid #000000;	}
+.dlg-window {box-shadow: 2px 2px 5px #888; color: #fff; border-top-color: #333; border-right-color: #1b1b1b; border-left-color: #1b1b1b; border-bottom-color: #000000;}
 .dlg-header {background: linear-gradient(0deg, rgba(11,11,11,1), rgba(44,44,44,1) 100%);}
 .dlg-header > div:first-child {
   padding-left: 3rem;

--- a/plugins/unpack/init.js
+++ b/plugins/unpack/init.js
@@ -150,7 +150,7 @@ plugin.onLangLoaded = function() {
 	if(!plg.allStuffLoaded)
 		setTimeout(arguments.callee,1000);
 	else {
-		const dlgUnpackContent = $("<div>").addClass("cont fxcaret").append(
+		const dlgUnpackContent = $("<div>").addClass("cont").append(
 			$("<fieldset>").append(
 				$("<legend>").text(theUILang.unpackPath),
 				$("<div>").addClass("row").append(


### PR DESCRIPTION
> I can't vertically scroll the RSS Manager on mobile, so everything below the heading "RatioGroup" is invisible. This includes the RatioGroup selection box, the Channel heading and selection box, as well as the Reset, OK, and Cancel buttons.

_Originally posted by @Airman8 in https://github.com/Novik/ruTorrent/issues/2721#issuecomment-2453454764_

This PR address this issue mentioned above. It's based on the previous PR (https://github.com/Novik/ruTorrent/pull/2762), with a few minor adjustments added. The previous PR was planned for v5.2 in the beginning, but now it seems we'd better include this in the v5.1 stable release.

- Use flex display for dialog contents, and enable overflowing on the Y-axis if content height exceeds the max-height of windows.
- Define background color and border colors using CSS variables.
- Remove unused CSS rules.