### PR TITLE
Use CSS to indicate the importance of whitespace rather than replacing with nbsp's

### DIFF
--- a/plugins/_getdir/_getdir.css
+++ b/plugins/_getdir/_getdir.css
@@ -18,6 +18,9 @@
   color: windowtext;
   padding: 0.15rem;
   text-wrap: nowrap;
+
+  /* whitespace here is deliberate, and should be shown as we set it */
+  white-space: pre;
 }
 .rmenuitem.active {
   color: highlighttext;

--- a/plugins/_getdir/init.js
+++ b/plugins/_getdir/init.js
@@ -121,7 +121,7 @@ theWebUI.rDirBrowser = class {
 
 	requestDir() {
 		$.ajax(
-			`plugins/_getdir/listdir.php?dir=${encodeURIComponent(this.edit.val().replace(/\u00a0/g, " "))}&time=${(new Date()).getTime()}${this.withFiles ? "&withfiles=1" : ""}`,
+			`plugins/_getdir/listdir.php?dir=${encodeURIComponent(this.edit.val())}&time=${(new Date()).getTime()}${this.withFiles ? "&withfiles=1" : ""}`,
 			{
 				success: (res) => {
 					this.frame.find(".filter-dir").val("").trigger("focus");
@@ -129,8 +129,8 @@ theWebUI.rDirBrowser = class {
 					this.frame.find(".rmenuobj").remove();
 					this.frame.append(
 						$("<div>").addClass("rmenuobj").append(
-							...res.directories.map(ele => $("<div>").addClass("rmenuitem").text(ele.replace(/ /g, "\u00a0") + "/")),
-							...(this.withFiles ? res.files : []).map(ele => $("<div>").addClass("rmenuitem").text(ele.replace(/ /g, "\u00a0"))),
+							...res.directories.map(ele => $("<div>").addClass("rmenuitem").text(ele + "/")),
+							...(this.withFiles ? res.files : []).map(ele => $("<div>").addClass("rmenuitem").text(ele)),
 						),
 					);
 					this.frame.find(".rmenuitem").on(


### PR DESCRIPTION
For your consideration, a CSS-only fix for the whitespace disappearing problem.

Closes #2779
Alternate fix for #2757
Partially reverts #2768