### PR TITLE
Convert	recentTrackers->last_used to an array

### DIFF
--- a/plugins/create/init.js
+++ b/plugins/create/init.js
@@ -226,7 +226,7 @@ plugin.onLangLoaded = function() {
 		theDialogManager.setHandler("tcreate", "beforeShow", () => {
 			if (plugin.recentTrackers) {
 				const recent = plugin.recentTrackers;
-				$("#trackers").val(recent.last_used);
+				$("#trackers").val(recent.last_used.join("\r\n"));
 				$(`#piece_size option[value=${recent.piece_size || 1024}]`).prop("selected", true);
 				$("#start_seeding").prop("checked", iv(recent.start_seeding));
 				$("#private").prop("checked", iv(recent.private_torrent));


### PR DESCRIPTION
Previously, we were storing a string, and if a user created 20 torrents in a row, it would add 20 trailing carriage returns (\r) to the box.

We already do the logic of stripping empty lines for other purposes, reuse that here.

Add de-duplication of last used trackers (to match the list array).

Also eliminate $announce_list, because it's never used, and `grep -rn announce_list * | grep global` indicates no other function is using it without it being passed.