### PR TITLE
fix settings background

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -347,11 +347,11 @@ div#HDivider, div#VDivider {flex: 0 0 5px;}
 #stg {
   width: 95vw;
   height: 95vh;
+background-color: var(--settings-background-color);
 }
 #stg_c {
   display: flex;
   flex-direction: row;
-  background-color: var(--settings-background-color);
 }
 #stg-pages {
   padding: 0 0.5rem;

--- a/plugins/theme/themes/Acid/style.css
+++ b/plugins/theme/themes/Acid/style.css
@@ -106,7 +106,7 @@ div#side-panel ul li.sel {background-color: #BDDBDB; border-color: #BDDBDB; colo
 
 .stable-icon {background-image: url(./images/tstatus.png); }
 
-#stg { background-color: #1E2124; color: #BDDBDB; border: 2px solid #909090; }
+#stg { background-color: #272E36; color: #BDDBDB; border: 2px solid #909090; }
 div#stg .lm { background-color: #272E36; border: 1px solid #D0D0D0; }
 
 .lm li div > div {


### PR DESCRIPTION
After commit feba8353413e60728bd2b0f1dc90ccd410ea0db6 background goes beyond the window border in the lower corners of the settings.

Before (left) After (right)

* Standard
![Standard](https://github.com/user-attachments/assets/669411b4-4231-4744-9be1-1be0f8e3354b)

* Acid
![Acid](https://github.com/user-attachments/assets/5c5c2539-e764-4063-9ee4-323730a22421)

* Blue
![Blue](https://github.com/user-attachments/assets/3eb114ba-df98-474c-b307-4376e91c565f)

* DarkBetter
![DarkBetter](https://github.com/user-attachments/assets/51c45c95-70ac-4adc-9379-5d3725dd7bb4)

* MaterialDesign
![MaterialDesign](https://github.com/user-attachments/assets/48b12c47-5b35-4c43-8fe1-f8fe79527042)

* Oblivion
![Oblivion](https://github.com/user-attachments/assets/7ee18ec1-d892-48ab-9ce0-a20c21ff0cf8)
