### PR TITLE
Fix side panel top and bottom empty space

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -319,7 +319,7 @@ a {color: #686868; text-decoration: none;}
 .offcanvas-header .btn-close {background-color: var(--btn-bg-color);}
 #offcanvas-sidepanel {
   border: 1px solid var(--container-border-color);
-  background-color: var(--container-bg-color);
+  background-color: var(--container-bg-color) !important;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -327,10 +327,11 @@ a {color: #686868; text-decoration: none;}
 .offcanvas-body {
   display: flex;
   flex-direction: column;
+  flex-grow: 1 !important;
+  overflow-y: auto !important;
 }
 #CatList {
   flex: 1 1 auto;
-  overflow: hidden auto;
 }
 #list-table {
   border: 1px solid var(--container-border-color);

--- a/css/style.css
+++ b/css/style.css
@@ -97,7 +97,8 @@ span {
   --menu-highlight-background-color: #cfdeef;
 
   --settings-background-color: #fafafa;
-
+  --container-bg-color: #ffffff;
+  --container-border-color: #a0a0a0;
   --btn-bg-color: #F0F0F0;
   --header-bg-color: #F0F0F0;
   --header-border-color: #909090;
@@ -317,14 +318,23 @@ a {color: #686868; text-decoration: none;}
 #maincont {height: calc(100dvh - 36px - 5px - 25px - 5px);}
 .offcanvas-header .btn-close {background-color: var(--btn-bg-color);}
 #offcanvas-sidepanel {
-  background-color: #FFFFFF;
+  border: 1px solid var(--container-border-color);
+  background-color: var(--container-bg-color);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 }
-#side-panel {
-  border: 1px solid #A0A0A0;
+.offcanvas-body {
+  display: flex;
+  flex-direction: column;
+}
+#CatList {
+  flex: 1 1 auto;
+  overflow: hidden auto;
 }
 #list-table {
-  border: 1px solid #A0A0A0;
-  background-color: #FFFFFF;
+  border: 1px solid var(--container-border-color);
+  background-color: var(--container-bg-color);
 }
 
 .stable-icon {background-image: url(../images/tstatus.png); background-repeat: no-repeat}
@@ -347,7 +357,7 @@ div#HDivider, div#VDivider {flex: 0 0 5px;}
 #stg {
   width: 95vw;
   height: 95vh;
-background-color: var(--settings-background-color);
+  background-color: var(--settings-background-color);
 }
 #stg_c {
   display: flex;
@@ -457,9 +467,9 @@ div#tdetails {
   background-color: #F5F5F5;
 }
 div#tdetails a.h {margin: 0}
-div#tdcont {
-  background: #FFFFFF;
-  border: 1px solid #D0D0D0;
+#tdcont {
+  background: var(--container-bg-color);
+  border: 1px solid var(--container-border-color);
 }
 div.tab {
   height:100%;

--- a/index.html
+++ b/index.html
@@ -137,45 +137,43 @@
 					<h4 class="offcanvas-title" id="offcanvas-sidepanel-label"></h4>
 					<button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#offcanvas-sidepanel" aria-label="Close"></button>
 				</div>
-				<div class="p-1 p-md-0 mh-100 offcanvas-body overflow-x-hidden flex-grow-1 flex-shrink-1">
-					<div id="side-panel" class="w-100 overflow-x-hidden overflow-y-auto">
-						<template id="panel-label-template">
-							<link href="./css/panel-label.css?v=51B4" rel="stylesheet" type="text/css" />
-							<div part="prefix" hidden></div>
-							<div part="icon"></div>
-							<div part="text"></div>
-							<div part="count">0</div>
-							<div part="size" style="display: none;"></div>
-						</template>
-						<template id="category-panel-template">
-							<link href="./css/category-panel.css?v=51B4" rel="stylesheet" type="text/css" />
-							<div part="heading">
-								<span class="text"></span><slot name="decorator" class="decorator"></slot>
-							</div>
-							<slot name="content"></slot>
-						</template>
-						<category-list id="CatList">
-							<category-panel id="pview" uilangtext="pnlViews">
-								<input slot="decorator" class="Button" type="button" value="+" uilangtitle="SaveCurrentView" id="pview_save_view_button" />
-								<panel-label id="pview_all" icon="all" uilangtext="All" selected></panel-label>
-							</category-panel>
-							<category-panel id="pstate" uilangtext="pnlState">
-								<panel-label id="pstate_all" icon="all" uilangtext="All" selected></panel-label>
-								<panel-label id="-_-_-dls-_-_-" icon="down" uilangtext="Downloading"></panel-label>
-								<panel-label id="-_-_-com-_-_-" icon="completed" uilangtext="Finished"></panel-label>
-								<panel-label id="-_-_-act-_-_-" icon="up-down" uilangtext="Active"></panel-label>
-								<panel-label id="-_-_-iac-_-_-" icon="inactive" uilangtext="Inactive"></panel-label>
-								<panel-label id="-_-_-err-_-_-" icon="error" uilangtext="Error"></panel-label>
-							</category-panel>
-							<category-panel id="plabel" uilangtext="Labels">
-								<panel-label id="plabel_all" icon="all" uilangtext="All" selected></panel-label>
-								<panel-label id="-_-_-nlb-_-_-" icon="no-label" uilangtext="No_label"></panel-label>
-							</category-panel>
-							<category-panel id="psearch" uilangtext="mnu_search">
-								<panel-label id="psearch_all" icon="all" uilangtext="All" selected></panel-label>
-							</category-panel>
-						</category-list>
-					</div>
+				<div class="p-1 p-md-0 offcanvas-body">
+					<template id="panel-label-template">
+						<link href="./css/panel-label.css?v=51B4" rel="stylesheet" type="text/css" />
+						<div part="prefix" hidden></div>
+						<div part="icon"></div>
+						<div part="text"></div>
+						<div part="count">0</div>
+						<div part="size" style="display: none;"></div>
+					</template>
+					<template id="category-panel-template">
+						<link href="./css/category-panel.css?v=51B4" rel="stylesheet" type="text/css" />
+						<div part="heading">
+							<span class="text"></span><slot name="decorator" class="decorator"></slot>
+						</div>
+						<slot name="content"></slot>
+					</template>
+					<category-list id="CatList">
+						<category-panel id="pview" uilangtext="pnlViews">
+							<input slot="decorator" class="Button" type="button" value="+" uilangtitle="SaveCurrentView" id="pview_save_view_button" />
+							<panel-label id="pview_all" icon="all" uilangtext="All" selected></panel-label>
+						</category-panel>
+						<category-panel id="pstate" uilangtext="pnlState">
+							<panel-label id="pstate_all" icon="all" uilangtext="All" selected></panel-label>
+							<panel-label id="-_-_-dls-_-_-" icon="down" uilangtext="Downloading"></panel-label>
+							<panel-label id="-_-_-com-_-_-" icon="completed" uilangtext="Finished"></panel-label>
+							<panel-label id="-_-_-act-_-_-" icon="up-down" uilangtext="Active"></panel-label>
+							<panel-label id="-_-_-iac-_-_-" icon="inactive" uilangtext="Inactive"></panel-label>
+							<panel-label id="-_-_-err-_-_-" icon="error" uilangtext="Error"></panel-label>
+						</category-panel>
+						<category-panel id="plabel" uilangtext="Labels">
+							<panel-label id="plabel_all" icon="all" uilangtext="All" selected></panel-label>
+							<panel-label id="-_-_-nlb-_-_-" icon="no-label" uilangtext="No_label"></panel-label>
+						</category-panel>
+						<category-panel id="psearch" uilangtext="mnu_search">
+							<panel-label id="psearch_all" icon="all" uilangtext="All" selected></panel-label>
+						</category-panel>
+					</category-list>
 				</div>
 			</div>
 			<div id="HDivider" class="p-0 m-0"></div>

--- a/plugins/theme/themes/Acid/style.css
+++ b/plugins/theme/themes/Acid/style.css
@@ -11,7 +11,8 @@ html, body { background-color: #1e2124; color: #BDDBDB }
   --menu-highlight-background-color: #BDDBDB;
 
   --settings-background-color: #272E36;
-
+  --container-bg-color: #272E36;
+  --container-border-color: #a0a0a0;
   --btn-bg-color: #D7D7D7;
   --header-bg-color: #1E2124;
   --header-border-color: #909090;
@@ -100,7 +101,7 @@ div#t div#setting {background: transparent url(./images/toolbar.png) no-repeat -
 div#t div#help {background: transparent url(./images/quest.gif) no-repeat 0px center}
 div#t div#go {background: transparent url(./images/go.gif) no-repeat 0px center; }
 
-#offcanvas-sidepanel { background-color: #272E36; color: #BDDBDB;}
+#offcanvas-sidepanel { color: #BDDBDB;}
 div#side-panel ul li { border: 1px solid #272E36; font-weight: bold; }
 div#side-panel ul li.sel {background-color: #BDDBDB; border-color: #BDDBDB; color: #272E36;}
 
@@ -133,7 +134,6 @@ legend {color: #00FF00; font-weight: bold}
 a { color: #00ff00; font-weight: bold;}
 
 div#tdetails {background-color: #1E2124}
-div#tdcont {background: #272E36; }
 div.tab { background: #272E36; }
 div#lcont { background: #272E36; font-weight: bold; color: #BDDBDB;}
 

--- a/plugins/theme/themes/Blue/style.css
+++ b/plugins/theme/themes/Blue/style.css
@@ -11,7 +11,8 @@ html, body { background-color: #DFE8F6 }
   --menu-highlight-background-color: #D9E8FB;
 
   --settings-background-color: #DFE8F6;
-
+  --container-bg-color: #ffffff;
+  --container-border-color: #99bbe8;
   --btn-bg-color: #F0F0F0;
   --header-bg-color: #D9E8FB;
   --header-border-color: transparent;
@@ -24,7 +25,7 @@ category-panel {
   --heading-background-color: #d9e8fb;
   --heading-border-color: #8db2e3;
 }
-#side-panel, category-list {
+category-list {
   border-color: #99BBE8;
 }
 
@@ -84,9 +85,6 @@ button, input.Button { background-image: url(./images/btn-sprite.gif); backgroun
 
 input[type="text"], input[type="password"], input[type="file"], select, textarea { background: #FFFFFF url(./images/text-bg.gif) repeat-x 0 0; border:1px solid #B5B8C8; }
 input[type="text"][disabled],input[type="password"][disabled],input[type="file"][disabled], select[disabled], textarea[disabled] { border: 1px solid #C0C0C0; background: #F0F0F0; color: #C0C0C0}
-
-
-div#tdcont { background: #FFFFFF; border: 1px solid #99BBE8; }
 
 #StatusBar { border-color: #99BBE8; background-color: #FFFFFF; color: #000000; }
 .statuscell { border-color: #99BBE8;}

--- a/plugins/theme/themes/Dark/style.css
+++ b/plugins/theme/themes/Dark/style.css
@@ -11,7 +11,8 @@ html, body {background-color: #181818; color: #999999; }
   --menu-highlight-background-color: #888888;
 
   --settings-background-color: #181818;
-
+  --container-bg-color: #181818;
+  --container-border-color: #333333;
   --btn-bg-color: #999999;
   --header-bg-color: #181818;
   --header-border-color: #333333;
@@ -40,9 +41,8 @@ button:not([disabled]):hover:active, input.Button:not([disabled]):hover:active {
 
 #offcanvas-sidepanel {
   color: #686868;
-  background-color: #181818;
 }
-#side-panel, category-list {
+category-list {
   background-color: #181818;
   border: 1px solid #333333;
 }
@@ -125,7 +125,6 @@ div#List {border: 1px solid #333333;}
 
 div#modalbg {background-color: #181818;}
 
-div#list-table {border: 1px solid #333333; background-color: #181818}
 div#FileList, div#TrackerList, div#PeerList, div#Speed {background-color: #181818}
 
 #stg { background-color: #181818; color: #888888; border: 1px solid #333333}
@@ -152,7 +151,6 @@ legend {color: #888888}
 select.cols {border: 1px solid #333333}
 div#dragmask {border: 1px dotted #333333}
 div#tdetails {background-color: #181818}
-div#tdcont {background: #181818; border: 1px solid #333333}
 
 .tabbar li.nav-item a.nav-link {
   border: 1px solid #333333;

--- a/plugins/theme/themes/DarkBetter/style.css
+++ b/plugins/theme/themes/DarkBetter/style.css
@@ -11,7 +11,8 @@ html, body {background-color: #181818; color: #999999; }
   --menu-highlight-background-color: #888888;
 
   --settings-background-color: #181818;
-
+  --container-bg-color: #181818;
+  --container-border-color: #333333;
   --btn-bg-color: #D6D6D6;
   --header-bg-color: #181818;
   --header-border-color: #333333;
@@ -67,9 +68,8 @@ button:hover:active, input.Button:not([disabled]):hover:active {
 select, input[type=file], input[type=text], input[type=number], input[type=password] {border: 1px solid #333333;}
 #offcanvas-sidepanel {
   color: #686868;
-  background-color: #181818;
 }
-#side-panel, category-list {
+category-list {
   border: 1px solid #333333;
   background-color: #181818;
 }
@@ -282,7 +282,6 @@ div#List {border: 1px solid #333333}
 
 div#modalbg {background-color: #181818}
 
-div#list-table {border: 1px solid #333333; background-color: #181818}
 div#FileList, div#TrackerList, div#PeerList, div#Speed {background-color: #181818}
 
 #stg {background-color: #181818; color: #888888; border: 1px solid #333333}
@@ -309,7 +308,6 @@ legend {color: #888888}
 select.cols {border: 1px solid #333333}
 div#dragmask {border: 1px dotted #333333}
 div#tdetails {background-color: #181818}
-div#tdcont {background: #181818; border: 1px solid #333333}
 
 div#tadd {background-color: #181818; border: 1px solid #333333}
 .tabbar li.nav-item a.nav-link {

--- a/plugins/theme/themes/Excel/style.css
+++ b/plugins/theme/themes/Excel/style.css
@@ -11,7 +11,8 @@ html, body { background-color: #DFE8F6; scrollbar-arrow-color: #586585; scrollba
   --menu-highlight-background-color: #ffeec2;
 
   --settings-background-color: #FFFFFF;
-
+  --container-bg-color: #d2e0f0;
+  --container-border-color: #9eb6ce;
   --btn-bg-color: #f1f1ec;
   --header-bg-color: #D9E8FB;
   --header-border-color: #FFFFFF;
@@ -24,7 +25,7 @@ category-panel {
   --heading-background-color: linear-gradient(0deg, rgba(158,182,206,1) 0%, rgba(230,235,243,1) 100%);
   --heading-border-color: transparent;
 }
-#side-panel, category-list {
+category-list {
   border-top-style: none;
   border-color: #9EB6CE;
   background-color: #FFFFFF;
@@ -42,7 +43,7 @@ panel-label[selected] {
   --badge-background-color: #FFFFFF;
 }
 
-div#StatusBar { background: transparent url(./images/statbg.png) repeat-x 0 0; border-top: none; color: #034084 }
+#StatusBar { background: transparent url(./images/statbg.png) repeat-x 0 0; border-top: none; color: #034084 }
 .statuscell { border-color: #9EB6CE }
 
 #t {background: none; border: none;}
@@ -57,10 +58,10 @@ div#StatusBar { background: transparent url(./images/statbg.png) repeat-x 0 0; b
 input[type="text"], input[type="password"], input[type="file"], select, textarea { background-color: #FFFFFF; border:1px solid #B5B8C8; }
 input[type="text"][disabled],input[type="password"][disabled],input[type="file"][disabled], select[disabled], textarea[disabled] { border: 1px solid #C0C0C0; color: #C0C0C0}
 
-div#tdcont, div.tab, div#lcont { background-color: #d2e0f0; color: #034084 }
+div.tab, div#lcont { background-color: #d2e0f0; color: #034084 }
 div.graph_tab { background-color: #d2e0f0; color: #034084; border-color: #ffffff }
 div#gcont div.row.Header {background-color: #e4edf6;}
-div#tdcont { border-color: #9EB6CE }
+#tdcont { color: #034084 }
 div#tdetails { background-color: transparent }
 
 .stg_con { background-color: #FFFFFF }

--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -207,7 +207,8 @@ html,body
 	--menu-highlight-background-color: #121212;
 
 	--settings-background-color: #222;
-
+  --container-bg-color: #181818;
+  --container-border-color: #1b1b1b;
 	--btn-bg-color: #3498DB;
   --header-bg-color: #273238;
   --header-border-color: transparent;
@@ -223,9 +224,8 @@ category-panel {
 
 #offcanvas-sidepanel {
   color: #EEE;
-  background-color: #1A2329;
 }
-#side-panel, category-list
+category-list
 {
 	border:none;
 	background-color:#1A2329;
@@ -701,11 +701,6 @@ div#modalbg {
 	background-color:#181818
 }
 
-#list-table {
-	border: none;
-	background-color:#181818
-}
-
 div#FileList,div#TrackerList,div#PeerList,div#Speed
 {
 	background-color:#181818
@@ -827,12 +822,6 @@ div#tdetails {
 	color:#888;
 	border-top-right-radius:6px;
 	border-top-left-radius:6px
-}
-
-div#tdcont {
-	background:#181818;
-	border:none;
-	padding:0
 }
 
 table#maincont td.uicell {

--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -11,7 +11,8 @@ html, body {font-family: "Lucida Sans Unicode", "Lucida Grande", Tahoma, Arial, 
   --menu-highlight-background-color: #121212;
 
   --settings-background-color: #181818;
-
+  --container-bg-color: #181818;
+  --container-border-color: #333333;
   --btn-bg-color: #515151;
   --header-bg-color: #222222;
   --header-border-color: #333333;
@@ -44,9 +45,8 @@ button:not([disabled]):hover:active, input.Button:not([disabled]):hover:active {
 
 #offcanvas-sidepanel {
   color: #626262;
-  background-color: #212121;
 }
-#side-panel, category-list {
+category-list {
   border:none;
   background-color: #212121;
   border-right: 1px solid #1b1b1b;
@@ -218,7 +218,6 @@ div.graph_tab {color:#FFF; background-color: #181818}
 
 div#modalbg {background-color: #181818;}
 
-#list-table {margin-right:6px;border-top: 1px solid #333; border-right: 1px solid #070707; border-left: 1px solid #1b1b1b; border-bottom: 1px solid #000000; background-color: #181818;}
 div#FileList, div#TrackerList, div#PeerList, div#Speed {background-color: #181818}
 
 .lm li div > div {
@@ -241,7 +240,6 @@ legend {color: #888888}
 select.cols {border: 1px solid #333333}
 div#dragmask {border: 1px dotted #333333}
 div#tdetails {padding:0px;margin:0px;background-color: #181818;color:#888888;-moz-border-radius-topleft:5px; -webkit-border-top-left-radius:5px;-moz-border-radius-topright:5px;-webkit-border-top-right-radius:5px;border-top-right-radius:5px;border-top-left-radius:5px;}
-div#tdcont {background: #181818; border-top: none; border-right: 1px solid #070707; border-left: 1px solid #1b1b1b; border-bottom: 1px solid #000000;}
 
 /*TABBED MENU */
 .tabbar {


### PR DESCRIPTION
> Side panel comparison v4.3 (left) vs v 5.1 (right)
> Minor issues with MaterialDesign and Oblivion
>
> * MaterialDesign
>
> ![MaterialDesign5](https://github.com/user-attachments/assets/b7116cb7-b5a3-4221-a51b-e98af9282230)
>
> * Oblivion
>
> ![Oblivion3](https://github.com/user-attachments/assets/d3e8b6c0-4831-4a90-b3a3-07e2aa33e999)
>
> _Originally posted by @koblack in https://github.com/Novik/ruTorrent/issues/2721#issuecomment-2453578083_

**After - Empty spaces are now gone:**
* Oblivion:
![20241115193540](https://github.com/user-attachments/assets/cd0e04ab-3b35-4a43-a7e6-3583a1133867)
* MaterialDesign:
![20241115193646](https://github.com/user-attachments/assets/da1952b0-3a0a-4f1a-90bd-6e8030d490a9)


With the aim of fixing empty spaces above/below the panel list in Oblivion and MaterialDesign themes, this patch also simplifies the DOM structure of the side panel, and replaces part of hard-coded color schemes with CSS variables.

- Simplify DOM structure of the offcanvas side panel, reducing a previously redundant level of `<div>`.
- Fix extra white spaces existing above and below the side panel list in some themes such as Oblivion.
- Define container background color and border color using variables, which are applied to the top menu, the side panel, and the list table.
