### PR TITLE
Fix create torrent from empty path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,12 @@
 .jsdtscope
 
 # VS Code
-.vscode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
 
 # ruTorrent
 conf/users/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "editor.tabSize": 2,
+    "editor.insertSpaces": false,
+    "editor.detectIndentation": true,
+    "[css]": {
+        "editor.insertSpaces": true
+    }
+}

--- a/plugins/create/action.php
+++ b/plugins/create/action.php
@@ -131,12 +131,12 @@ if(isset($_REQUEST['cmd']))
 		case "create":
 		{
 			$error = "Invalid parameters";
-		        if(isset($_REQUEST['path_edit']))
-		        {
-		        	$path_edit = trim($_REQUEST['path_edit']);
+			if(isset($_REQUEST['path_edit']) && strlen($_REQUEST['path_edit']))
+			{
+				$path_edit = trim($_REQUEST['path_edit']);
 				if(is_dir($path_edit))
 					$path_edit = FileUtil::addslash($path_edit);
-		        	if(rTorrentSettings::get()->correctDirectory($path_edit))
+				if(rTorrentSettings::get()->correctDirectory($path_edit))
 				{
 					$rt = recentTrackers::load();
 					$trackers = array();

--- a/plugins/create/init.js
+++ b/plugins/create/init.js
@@ -5,10 +5,14 @@ if(browser.isKonqueror)
 
 plugin.recentTrackers = {};
 
-theWebUI.checkCreate = function()
-{
+function checkCreate() {
+	const path_edit = $("#path_edit").val().trim();
+	if (!path_edit.length) {
+		noty(theUILang.BadTorrentData, "error0");
+		return;
+	}
 	theDialogManager.hide('tcreate');
-		var arr = $('#trackers').val().split("\n");
+	var arr = $('#trackers').val().split("\n");
 	var trk = '';
 	for( var i in arr )
 		trk+=(arr[i].trim()+'\r');
@@ -16,7 +20,7 @@ theWebUI.checkCreate = function()
 		{
 			"piece_size" : $('#piece_size').val(),
 			"trackers" : trk,
-			"path_edit" : $("#path_edit").val().trim(),
+			"path_edit" : path_edit,
 			"comment" : $("#comment").val().trim(),
 			"source" : $("#source").val().trim(),
 			"private" : $('#private').prop('checked') ? 1 : 0,
@@ -154,7 +158,7 @@ plugin.onLangLoaded = function() {
 
 		const tcreateContent = $("<div>").addClass("cont").append(
 			$("<fieldset>").append(
-				$("<legend>").text(theUILang.SelectSource),
+				$("<legend>").text(theUILang.SelectSource + " *"),
 				$("<div>").addClass("row").append(
 					$("<div>").addClass("col-12").append(
 						$("<input>").attr({type: "text", id: "path_edit", name: "path_edit", autocomplete: "off"}).addClass("flex-grow-1"),
@@ -215,7 +219,7 @@ plugin.onLangLoaded = function() {
 				.addClass("me-auto")
 				.on("click", theWebUI.deleteFromRecentTrackers)
 				.text(theUILang.deleteFromRecentTrackers),
-			$("<button>").attr({type:"button", id:"torrentCreate"}).text(theUILang.torrentCreate).on("click", theWebUI.checkCreate).addClass("OK"),
+			$("<button>").attr({type:"button", id:"torrentCreate"}).text(theUILang.torrentCreate).on("click", checkCreate).addClass("OK"),
 			$("<button>").attr({type:"button"}).addClass("Cancel").text(theUILang.Cancel),
 		);
 		theDialogManager.make("tcreate",theUILang.CreateNewTorrent,


### PR DESCRIPTION
- Check path length before proceeding with creating torrent files on both front-end and back-end.
- Move `checkCreate()` function to local scope to gradually reduce the size of `theWebUI`.
- Update `.gitignore` rules to include project code formatting styles.

Fixes: https://github.com/Novik/ruTorrent/issues/2784