### PR TITLE
DarkBetter theme fix missing icon for active torrents

### DIFF
--- a/plugins/theme/themes/DarkBetter/style.css
+++ b/plugins/theme/themes/DarkBetter/style.css
@@ -125,7 +125,7 @@ panel-label[icon="queued-down"] {
 panel-label[icon="queued-up"] {
   --status-image: url(../plugins/theme/themes/DarkBetter/images/t_queued_up.svg);
 }
-panel-label[icon="active"] {
+panel-label[icon="up-down"] {
   --status-image: url(../plugins/theme/themes/DarkBetter/images/t_active.svg);
 }
 panel-label[icon="all"] {


### PR DESCRIPTION
DarkBetter theme fix missing icon for active torrents.

before/after
![image](https://github.com/user-attachments/assets/9a5ec898-b245-4057-a9bc-0c072bf7f1b8)
