### PR TITLE
Fix typo and final newline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
     "editor.tabSize": 2,
     "editor.insertSpaces": false,
     "editor.detectIndentation": true,
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
     "[css]": {
         "editor.insertSpaces": true
     }

--- a/plugins/create/init.js
+++ b/plugins/create/init.js
@@ -8,7 +8,7 @@ plugin.recentTrackers = {};
 function checkCreate() {
 	const path_edit = $("#path_edit").val().trim();
 	if (!path_edit.length) {
-		noty(theUILang.BadTorrentData, "error0");
+		noty(theUILang.BadTorrentData, "error");
 		return;
 	}
 	theDialogManager.hide('tcreate');


### PR DESCRIPTION
- Add missing final newline in `settings.json` file, and add settings for final newlines.
- Fix typo in "create" plugin.