### PR TITLE
filedrop plugin: support dropped links

### DIFF
--- a/plugins/filedrop/init.js
+++ b/plugins/filedrop/init.js
@@ -7,7 +7,62 @@ plugin.onLangLoaded = function()
 {
 	injectScript(plugin.path+"jquery.filedrop.js",function()
 	{
-		$("#maincont").filedrop(
+		$("#maincont").on("drop", function(event)
+		{
+			// Handle dropped URLs and dropped text containing URLs.
+			// The filedrop jQuery plugin only handles dropped files,
+			// not URLs. We have to do it in an event handler that
+			// gets called before filedrop's handler.
+
+			const items = [...event.originalEvent.dataTransfer.items];
+			// find text/uri-list; if not found, find text/plain
+			const uriList = items.find(item =>
+				item.kind === "string" &&
+				/^text\/uri-list(?![a-z-])/i.test(item.type)
+			) ?? items.find(item =>
+				item.kind === "string" &&
+				/^text\/plain(?![a-z-])/i.test(item.type)
+			);
+			if (uriList == null)
+				return true;  // not URL list; let filedrop handle this
+
+			const separator = /^text\/uri-list/i.test(uriList.type)
+				? /\r\n|\n|\r/  // line split text/uri-list
+				: /\s+/;        // word split text/plain
+			uriList.getAsString(async data => {
+				// add all magnet URLs and http/https URLs, which are
+				// assumed to be links to torrent files
+				for (let url of data.split(separator)) {
+					url = url.trim();
+					if (/^magnet:|^https?:\/\//i.test(url)) {
+						const data = await $.ajax({
+							url: plugin.path + '../../php/addtorrent.php',
+							method: "POST",
+							data: { url, json: 1 },
+							dataType: "json",
+						}).catch((_xhr, status, error) => {
+							console.error(
+								"filedrop: rTorrent API call error: " +
+								"url = %s | response status = %s | error = %o",
+								url, status, error);
+							return {};
+						});
+
+						const result = (typeof data === "object")
+							? (data.result ?? "Failed")
+							: "Failed";
+						noty(
+							`${url} : ${theUILang['addTorrent' + result]}`,
+							(result == "Success") ? "success" : "error");
+					}
+				}
+			});
+
+			// don't run filedrop event handler
+			event.stopImmediatePropagation();
+			return false;
+
+		}).filedrop(
 		{
 //			fallback_id:	'torrent_file',
 			paramname:	'torrent_file',

--- a/plugins/filedrop/init.js
+++ b/plugins/filedrop/init.js
@@ -30,11 +30,33 @@ plugin.onLangLoaded = function()
 				? /\r\n|\n|\r/  // line split text/uri-list
 				: /\s+/;        // word split text/plain
 			uriList.getAsString(async data => {
-				// add all magnet URLs and http/https URLs, which are
+				// find all magnet URLs and http/https URLs, which are
 				// assumed to be links to torrent files
-				for (let url of data.split(separator)) {
-					url = url.trim();
-					if (/^magnet:|^https?:\/\//i.test(url)) {
+				const urls = data.split(separator)
+					.map(item => item.trim())
+					.filter(item => /^magnet:|^https?:\/\//i.test(item));
+
+				// break URL list into chunks based on plugin configuration
+				const urlChunks = [];
+				if (plugin.queuefiles) {
+					for (let i = 0; i < urls.length; i += plugin.queuefiles)
+						urlChunks.push(urls.slice(i, i + plugin.queuefiles));
+				}
+				else {
+					if (plugin.maxfiles && urls.length > plugin.maxfiles) {
+						noty(theUILang.tooManyFiles + plugin.maxfiles, "error");
+						return;
+					}
+					urlChunks.push(urls);  // all URLs in one chunk
+				}
+
+				// send API calls to rTorrent one chunk at a time with
+				// delay between chunks
+				for (const [i, urls] of urlChunks.entries()) {
+					if (i != 0)
+						await new Promise(r => setTimeout(r, 200));
+
+					await Promise.all(urls.map(async url => {
 						const data = await $.ajax({
 							url: plugin.path + '../../php/addtorrent.php',
 							method: "POST",
@@ -54,7 +76,7 @@ plugin.onLangLoaded = function()
 						noty(
 							`${url} : ${theUILang['addTorrent' + result]}`,
 							(result == "Success") ? "success" : "error");
-					}
+					}));
 				}
 			});
 


### PR DESCRIPTION
Filedrop plugin doesn't support dropping links to torrents. Only torrent files are supported. It's not possible to drag a magnet link from another browser window. This adds support for dropping links.

Both magnet links and http/https links to a torrent file are supported. Additionally, dragging a text selection that contains one or more links is supported. Any non-URL text is ignored.