### PR TITLE
Use bootstrap dropdown on recent trackers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -123,6 +123,9 @@ span {
   --bs-dropdown-link-hover-color: var(--menu-highlight-color);
   --bs-dropdown-link-hover-bg: var(--menu-highlight-background-color);
 }
+a.dropdown-item {
+  width: auto;
+}
 category-list.rightalign-labelsize panel-label::part(size) {
   margin-left: auto;
 }
@@ -255,7 +258,6 @@ span.htkey {text-align:right; position: absolute; right: 16px; z-index:100}
   align-items: center;
   justify-content: space-between;
   padding: 0.25rem 1rem;
-  width: auto;
 }
 .navbar-toggler {
   background-color: var(--btn-bg-color);

--- a/js/plugins.js
+++ b/js/plugins.js
@@ -378,7 +378,7 @@ rPlugin.prototype.addButtonToToolbar = function(id, name, onclick, idBefore, isD
 		let newBtn = $("<a>")
 			.attr({id:`mnu_${id}`, href:"#", title:`${name}...`})
 			.on({
-				click: $type(onclick) === "function" ? () => onclick() : () => eval(onclick),
+				click: $type(onclick) === "function" ? onclick : () => eval(onclick),
 				focus: (ev) => ev.target.blur(),
 			})
 			.addClass("nav-link top-menu-item")

--- a/plugins/create/action.php
+++ b/plugins/create/action.php
@@ -59,7 +59,18 @@ class recentTrackers
 	public function strip()
 	{
 		global $recentTrackersMaxCount;
-		$this->last_used = array_values( array_unique($this->last_used) );
+		for ($i = count($this->last_used) - 1; $i >= 0; $i--)
+		# remove trailing white spaces and preserve those in between from last used array
+		{ 
+			if( strlen(trim($this->last_used[$i])) < 1 )
+			{
+				array_pop($this->last_used);
+			}
+			else
+			{
+				break;
+			}
+		}
 		$this->list = array_values( array_unique($this->list) );
 		$cnt = count($this->list);
 		$arr = array_values($this->list);
@@ -143,8 +154,8 @@ if(isset($_REQUEST['cmd']))
 					$trackers = array();
 					if(isset($_REQUEST['trackers']))
 					{
-						$arr = explode("\r", $_REQUEST['trackers']);
-						foreach( $arr as $key => $value )
+						$trackers = explode("\r", $_REQUEST['trackers']);
+						foreach( $trackers as $key => $value )
 						{
 							$value = trim($value);
 							if(strlen($value) === 0)
@@ -152,7 +163,6 @@ if(isset($_REQUEST['cmd']))
 								continue;
 							}
 
-							$trackers[] = $value;
 							$rt->list[] = $value;
 						}
 					}

--- a/plugins/create/action.php
+++ b/plugins/create/action.php
@@ -124,7 +124,8 @@ if(isset($_REQUEST['cmd']))
 				}
 				$newList = array_diff($rt->list,$trk);
 				if( $newList !== $rt->list )
-					$ret = $rt->delete($newList);
+					$rt->delete($newList);
+				$ret = $rt->get();
 			}
 			break;
 		}

--- a/plugins/create/create.css
+++ b/plugins/create/create.css
@@ -2,7 +2,12 @@
 #tcreate-header {background-image: url(./images/create16.gif)}
 #tcreate textarea {resize: none; height: 8rem;}
 
-#recentTrackers {width: 130px;}
+#recentTrackers {
+  width: 130px;
+  display: flex;
+  align-items: center;
+}
+#recentTrackers::after {margin-left: auto;}
 #deleteFromRecentTrackers {text-align: left;}
 
 /* Custom break point settings for responsiveness */

--- a/plugins/create/init.js
+++ b/plugins/create/init.js
@@ -38,11 +38,13 @@ function addTrackerToBox(ev) {
 	const ann = $(ev.target).data("tracker");
 	$("#deleteFromRecentTrackers").prop("disabled", false);
 	const val = $('#trackers').val();
-	if (val.includes(ann)) return;  // do nothing if selected tracker is already in the box
+	if (val.includes(ann)) {
+		// only trim trailing white spaces if selected tracker is already in the box
+		$('#trackers').val(val.trim()).focus();
+		return;
+	}
 	$('#trackers').val(
-		[...val.split(/\r?\n/), ann]  // split by "\r\n" or "\n"
-			.filter(tracker => tracker.trim().length)  // remove empty lines
-			.join("\r\n")
+		[...val.split(/\r?\n/), ann].join("\r").trim()
 	).trigger("focus");
 }
 

--- a/plugins/create/init.js
+++ b/plugins/create/init.js
@@ -4,6 +4,7 @@ if(browser.isKonqueror)
 	plugin.loadCSS("konqueror");
 
 plugin.recentTrackers = {};
+plugin.deleteFromRecentTrackers = "";
 
 function checkCreate() {
 	const path_edit = $("#path_edit").val().trim();
@@ -33,6 +34,18 @@ function checkCreate() {
 	);
 }
 
+function addTrackerToBox(ev) {
+	const ann = $(ev.target).data("tracker");
+	$("#deleteFromRecentTrackers").prop("disabled", false);
+	const val = $('#trackers').val();
+	if (val.includes(ann)) return;  // do nothing if selected tracker is already in the box
+	$('#trackers').val(
+		[...val.split(/\r?\n/), ann]  // split by "\r\n" or "\n"
+			.filter(tracker => tracker.trim().length)  // remove empty lines
+			.join("\r\n")
+	).trigger("focus");
+}
+
 plugin.onTaskFinished = function(task,fromBackground)
 {
 	if(!fromBackground)
@@ -60,53 +73,44 @@ rTorrentStub.prototype.rtdelete = function()
 	this.dataType = "json";
 }
 
-theWebUI.showCreate = function()
-{
+function showCreate() {
 	if( $("#trackers").val().trim().length < 1 )
 		$("#deleteFromRecentTrackers").prop("disabled", true);
 	else
 		$("#deleteFromRecentTrackers").prop("disabled", false);
-	$('#start_seeding').prop('disabled',!theWebUI.systemInfo.rTorrent.started);
-	if(theWebUI.systemInfo.rTorrent.started)
+	if (theWebUI.systemInfo.rTorrent.started) {
+		$('#start_seeding').prop('disabled', false);
 		$('#lbl_start_seeding').removeClass('disabled');
-	else
+	} else {
+		$('#start_seeding').prop('disabled', true);
 		$('#lbl_start_seeding').addClass('disabled');
+	}
 	theDialogManager.show('tcreate');
 }
 
-plugin.getRecentTrackers = function( data )
-{
+plugin.getRecentTrackers = function(data) {
 	plugin.recentTrackers = data;
-	$("#recentTrackers").prop(
-		"disabled",
-		(!plugin.recentTrackers?.recent_trackers || !propsCount(plugin.recentTrackers.recent_trackers)),
-	);
-}
-
-theWebUI.addTrackerToBox = function(ann)
-{
-	$("#deleteFromRecentTrackers").prop("disabled", false);
-	const val = $('#trackers').val();
-	if (val.includes(ann)) return;  // do nothing if selected tracker is already in the box
-	$('#trackers').val(
-		[...val.split(/\r?\n/), ann]  // split by "\r\n" or "\n"
-			.filter(tracker => tracker.trim().length)  // remove empty lines
-			.join("\r\n")
-	).trigger("focus");
-}
-
-theWebUI.showRecentTrackers = function() {
-	if (plugin.recentTrackers?.recent_trackers && propsCount(plugin.recentTrackers.recent_trackers)) {
-		theContextMenu.clear();
-		for( var domain in plugin.recentTrackers.recent_trackers )
-			theContextMenu.add([domain,"theWebUI.addTrackerToBox('"+addslashes(plugin.recentTrackers.recent_trackers[domain])+"')"]);
-		var offs = $("#recentTrackers").offset();
-		theContextMenu.show(offs.left,offs.top-theContextMenu.obj.height()-5);
+	if (data?.recent_trackers && propsCount(data.recent_trackers)) {
+		const rtList = $("#recentTrackers + ul").empty();
+		Object.entries(data.recent_trackers).forEach(([domain, tracker]) => {
+			rtList.append(
+				$("<li>").append(
+					$("<a>")
+						.attr({href:"#"})
+						.addClass("dropdown-item")
+						.data("tracker", tracker)
+						.on("click", addTrackerToBox)
+						.text(domain),
+				),
+			);
+		});
+		$("#recentTrakcers").prop("disabled", false);
+	} else {
+		$("#recentTrackers").prop("disabled", true);
 	}
 }
 
-theWebUI.deleteFromRecentTrackers = function()
-{
+function deleteFromRecentTrackers() {
 	$("#deleteFromRecentTrackers").prop("disabled", true);
 	var trklist = $('#trackers').val();
 	if(!trklist)
@@ -117,8 +121,7 @@ theWebUI.deleteFromRecentTrackers = function()
 	for( var i in arr )
 		trk+=(arr[i].trim()+'\r');
 	plugin.deleteFromRecentTrackers = trk;
-	theWebUI.request('?action=rtdelete');
-	theWebUI.request('?action=rtget',[plugin.getRecentTrackers, plugin]);
+	theWebUI.request('?action=rtdelete', [plugin.getRecentTrackers, plugin]);
 }
 
 plugin.onLangLoaded = function() {
@@ -130,7 +133,7 @@ plugin.onLangLoaded = function() {
 		$('#tsk_btns').prepend(
 			$("<button>").attr({type:"button", id:"xcsave"}).text(theUILang.torrentSave).hide(),
 		);
-		plugin.addButtonToToolbar("create",theUILang.mnu_create,"theWebUI.showCreate()","remove");
+		plugin.addButtonToToolbar("create", theUILang.mnu_create, showCreate, "remove");
 		plugin.addSeparatorToToolbar("remove");
 
 		const pieceSizeArray = [32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536];
@@ -209,15 +212,17 @@ plugin.onLangLoaded = function() {
 			),
 		);
 		const tcreateButtons = $("<div>").addClass("buttons-list").append(
-			$("<button>")
-				.attr({type:"button", id:"recentTrackers"})
-				.addClass("menuitem")
-				.on("click", theWebUI.showRecentTrackers)
-				.text(theUILang.recentTrackers + "..."),
+			$("<div>").addClass("btn-group").append(
+				$("<button>")
+					.attr({type:"button", id:"recentTrackers", "aria-expanded":"false", "data-bs-toggle":"dropdown"})
+					.addClass("dropdown-toggle")
+					.text(theUILang.recentTrackers + "..."),
+				$("<ul>").addClass("dropdown-menu"),
+			),
 			$("<button>")
 				.attr({type:"button", id:"deleteFromRecentTrackers"})
 				.addClass("me-auto")
-				.on("click", theWebUI.deleteFromRecentTrackers)
+				.on("click", deleteFromRecentTrackers)
 				.text(theUILang.deleteFromRecentTrackers),
 			$("<button>").attr({type:"button", id:"torrentCreate"}).text(theUILang.torrentCreate).on("click", checkCreate).addClass("OK"),
 			$("<button>").attr({type:"button"}).addClass("Cancel").text(theUILang.Cancel),


### PR DESCRIPTION
- Get recent trackers and previous create torrent settings on plugin load, and update the dropdown menu immediately. This replaces previous mechanism of showing recent trackers with a context menu.
- Move some utility functions from `theWebUI` object to the plugin itself. This reduuces the size of `theWebUI` object, and avoids potential function naming conflicts.
- Return new data immediately with the `rtdelete` request. This saves the need for another request to fetch the new data after deleting some trackers from recent ones.