### PR TITLE
Covert clear log to a floating button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -492,6 +492,19 @@ div.tab {
 div#lcont {line-height: 1rem; background: #FFFFFF}
 div#lcont div.mono {font-family: monospace; line-height: 1rem; background: #F5F5F5; white-space: pre}
 div#lcont .std {padding: 2px}
+#clear_log {
+  position: fixed;
+  bottom: 4rem;
+  right: 2rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1.5rem;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  background-image: none;
+}
 
 div#gcont span.det-hdr {font-weight: bold;}
 div#gcont div.row.Header {font-size: 14px; font-weight: bold; background: #FCFCFC; padding: 0.5rem;}

--- a/index.html
+++ b/index.html
@@ -248,7 +248,13 @@
 						<div id="PeerList" class="table_tab"></div>
 						<div id="Speed" class="graph_tab"></div>
 						<div id="PluginList" class="table_tab"></div>
-						<div id="lcont" class="tab"></div>
+						<div id="lcont" class="tab">
+							<button type="button" id="clear_log" uilangtitle="ClearButton">
+								<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" class="bi bi-eraser" viewBox="0 0 16 16">
+									<path d="M8.086 2.207a2 2 0 0 1 2.828 0l3.879 3.879a2 2 0 0 1 0 2.828l-5.5 5.5A2 2 0 0 1 7.879 15H5.12a2 2 0 0 1-1.414-.586l-2.5-2.5a2 2 0 0 1 0-2.828zm2.121.707a1 1 0 0 0-1.414 0L4.16 7.547l5.293 5.293 4.633-4.633a1 1 0 0 0 0-1.414zM8.746 13.547 3.453 8.254 1.914 9.793a1 1 0 0 0 0 1.414l2.5 2.5a1 1 0 0 0 .707.293H7.88a1 1 0 0 0 .707-.293z"/>
+								</svg>
+							</button>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/js/common.js
+++ b/js/common.js
@@ -821,14 +821,6 @@ var theTabs = {
 				).on("click", (ev) => ev.target.blur()).addClass("nav-link").text(name),
 			)),
 		);
-		$("#tab_lcont").after(
-			$("<button>").attr(
-				{type:"button", id:"clear_log"}
-			).addClass('Button mx-2').text(theUILang.ClearButton).hide().on(
-				'click', () => $("#lcont").empty()
-			).on('focus', function() {
-				this.blur();
-			}));
 		this.show("gcont");
 		$('#gcont,#lcont').enableSysMenu();
 	},
@@ -875,15 +867,11 @@ var theTabs = {
                				        theWebUI.getTable(prefix).refreshRows();
                				theWebUI.setActiveView(id);
             				l.addClass("selected").css("z-index",1);
-	            			if(n=="lcont")
-		            			$("#clear_log").css("display","inline");
             			}
          			else
          			{
             				p.hide();
             				l.removeClass("selected").css("z-index",0);
-	            			if(n=="lcont")
-		            			$("#clear_log").hide();
             			}
          		}
       		}

--- a/js/webui.js
+++ b/js/webui.js
@@ -320,6 +320,7 @@ var theWebUI = {
 				theSearchEngines.run()
 			}
 		});
+		$("#clear_log").on("click", () => $("#clear_log").siblings().remove());
 
 		$(document).on( browser.isOpera ? 'keypress' : 'keydown', keyEvent);
 	},


### PR DESCRIPTION
![20241126205405](https://github.com/user-attachments/assets/afddade0-0c34-4c7e-b3d2-bc67556b663d)


- The tabs panel should be clean with only tabs, without anything else such buttons. This patch converts the clear log button to a rounded floating icon button on the bottom right corner of the log tab page, and simplifies the action of switching between detail tabs, without having to explicitly show/hiding the clear button by checking if we're switching to the log tab.