### PR TITLE
Change various s-table methods

### DIFF
--- a/css/stable.css
+++ b/css/stable.css
@@ -9,6 +9,11 @@
   -moz-user-input: enabled;
 }
 .stable td {font: menu; white-space: nowrap; padding: 1px}
+.stable td:first-child div {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
 .stable-head {
   position: relative;  /* Need to be positioned for drag masks to be positioned properly */
   width: 100%;
@@ -30,10 +35,23 @@
 }
 .stable-body table {table-layout: fixed; width: 0; }
 .stable-body tr {cursor: pointer}
-.stable-body td {height: 16px; border-bottom: 1px solid #E0E0E0; overflow: hidden; vertical-align: top}
-.stable-icon {width: 16px; height: 16px; margin-right: -6px; margin: 0 5px; padding: 0 !important; float: left}
+.stable-body td {border-bottom: 1px solid #E0E0E0; overflow: hidden;}
+.stable-icon {
+  display: inline-block;
+  width: 1.35rem;
+  height: 1.35rem;
+  margin: 0 0.25rem;
+  padding: 0 !important;
+  flex: 0 0 auto;
+  background: url(../images/tstatus.png) no-repeat;
+}
 .stable-lpad {width: 5px; height: 16px; margin: 0; padding: 0; float: left; }
-.stable-body td div {font-size: 11px; overflow: hidden; height: 16px !important;}
+.stable-body td div {
+  font-size: 11px;
+  overflow: hidden;
+  height: 16px !important;
+  margin: 0 2px !important;
+}
 .konqueror .stable-body td div { margin: 0 0px 0 0px !important }
 .stable-body td div { margin: 0 2px 0 2px !important}
 .stable-body tr.selected td {background: #CFDEEF}
@@ -48,10 +66,36 @@
 .stable-scrollpos {width: 80%; height: 16px; left: 10%; top: 50%; position: absolute; padding: 0 5px; margin-top: -8px; background: #FFFFFF; color: #AAAAAA; font-size: 11px; font-weight: bold; text-align: center; overflow: hidden; display: none; white-space: nowrap}
 .stable-resize-header {	position: absolute; background-color: #A0A0A0; width: 1px; top: 0px; font: menu; visibility: hidden; overflow: hidden; z-index: 100; }
 
-.stable-head .rowcover { position: absolute; left: 0; top: 0; height: 20px; width: 1000px; background: transparent; display: none; }
+.rowcover {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 20px;
+  width: 100%;
+  background: transparent;
+  display: none;
+}
 
 .meter-value { float: left; background-color: #99D699; border: 1px inset #BBBBBB; border-bottom: none;}
 .meter-text { position: relative; text-align: center; float: left; width: 100%; height: 0px; overflow: visible; font-size: 11px; z-index: 1; }
 
 .meter-value-start-color { background-color: #FFFF00 }
 .meter-value-end-color { background-color: #99D699 }
+
+.Status_Down {background-position: 0px 0px}
+.Status_Up {background-position: 0px -16px}
+.Status_Incompleted {background-position: 0px -32px}
+.Status_Paused {background-position: 0px -48px}
+.Status_Error_Down {background-position: 0px -64px}
+.Status_Error_Up {background-position: 0px -80px}
+.Status_Error {background-position: 0px -96px}
+.Status_Completed {background-position: 0px -112px}
+.Status_Queued_Down {background-position: 0px -128px}
+.Status_Queued_Up {background-position: 0px -144px}
+.Status_Up_Down {background-position: 0px -160px}
+.Status_Checking {background-position: 0px -176px}
+.Status_RSS {background-position: 0px -208px}
+
+.Icon_File {background: transparent url(../images/file.gif) no-repeat left center}
+.Icon_Dir {background: transparent url(../images/dir.gif) no-repeat left center}
+.Icon_Share {background: transparent url(../images/share.gif) no-repeat left center}

--- a/css/style.css
+++ b/css/style.css
@@ -432,21 +432,6 @@ a {color: #686868; text-decoration: none;}
   background-color: var(--container-bg-color);
 }
 
-.stable-icon {background-image: url(../images/tstatus.png); background-repeat: no-repeat}
-.Status_Down {background-position: 0px 0px}
-.Status_Up {background-position: 0px -16px}
-.Status_Incompleted {background-position: 0px -32px}
-.Status_Paused {background-position: 0px -48px}
-.Status_Error_Down {background-position: 0px -64px}
-.Status_Error_Up {background-position: 0px -80px}
-.Status_Error {background-position: 0px -96px}
-.Status_Completed {background-position: 0px -112px}
-.Status_Queued_Down {background-position: 0px -128px}
-.Status_Queued_Up {background-position: 0px -144px}
-.Status_Up_Down {background-position: 0px -160px}
-.Status_Checking {background-position: 0px -176px}
-.Status_RSS {background-position: 0px -208px}
-
 div#HDivider, div#VDivider {flex: 0 0 5px;}
 
 #stg {
@@ -651,10 +636,6 @@ div.table_tab {
 span#loadimg {padding: 20px; background: transparent url(../images/ajax-loader.gif) no-repeat center center; }
 .webkit div#msg {position: fixed;}
 .konqueror div#msg {position: fixed;}
-
-.Icon_File {background: transparent url(../images/file.gif) no-repeat left center}
-.Icon_Dir {background: transparent url(../images/dir.gif) no-repeat left center}
-.Icon_Share {background: transparent url(../images/share.gif) no-repeat left center}
 
 #tadd-header {background-image: url(../images/world.gif)}
 

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -284,7 +284,7 @@ catlist.switchLabel = function(panelId, targetId, toggle=false, range=false)
 			tegList.show();
 		}
 		table.scrollTo(0);
-		table.calcSize().resizeColumn();
+		table.resizeColumn();
 	} else if (tegList.is(":visible")) {
 		// switch away from extsearch view
 		tegList.hide();

--- a/plugins/theme/themes/DarkBetter/style.css
+++ b/plugins/theme/themes/DarkBetter/style.css
@@ -168,10 +168,8 @@ div#preload {
     background-image: url(./images/tb_moved.svg);
     background-image: url(./images/tb_search.svg);
     background-image: url(./images/tb_rss.svg);
-    background-image: url(./images/rb_rss_group.svg);
+    background-image: url(./images/tb_rss_group.svg);
     background-image: url(./images/tb_setting.svg);
-    background-image: url(./images/tb_rss.svg);
-    background-image: url(./images/t_error.svg);
     background-image: url(./images/close.svg);
     background-image: url(./images/yellow.svg);
     background-image: url(./images/red.svg);
@@ -180,27 +178,21 @@ div#preload {
     background-image: url(./images/pnl_close.svg);
     background-image: url(./images/file.svg);
     background-image: url(./images/dir.svg);
-    background-image: url(./images/dir.svg);
     background-image: url(./images/t_down.svg);
     background-image: url(./images/t_up.svg);
     background-image: url(./images/t_inactive.svg);
     background-image: url(./images/t_paused.svg);
+    background-image: url(./images/t_error.svg);
     background-image: url(./images/t_error_down.svg);
     background-image: url(./images/t_error_up.svg);
-    background-image: url(./images/t_error.svg);
     background-image: url(./images/t_completed.svg);
     background-image: url(./images/t_queued_down.svg);
     background-image: url(./images/t_queued_up.svg);
     background-image: url(./images/t_active.svg);
     background-image: url(./images/t_all.svg);
-    background-image: url(./images/rb_rss.svg);
-    background-image: url(./images/pnl_open.svg);
     background-image: url(./images/quest.svg);
     background-image: url(./images/go.svg);
     background-image: url(./images/plugin.svg);
-    background-image: url(./images/yellow.svg);
-    background-image: url(./images/red.svg);
-    background-image: url(./images/green.svg);
 }
 div#cover {background: #181818}
 div#msg {background: #181818; border-top: 1px solid #333333; border-bottom: 1px solid #333333}


### PR DESCRIPTION
- Adjust s-table's `createRow()` method to use jQuery to create table rows. This is more readable than generating table rows
  with HTML strings.
- Rewrite `toggleColumn` to use jQuery's `toggle()` method to toggle table cell display and use jQuery's selector function to replace a for loop.
- Deprecate `calcSize()` method with a deprecation warning since we're unifying behaviors on different browsers. This method will be removed in the next major version update.