### PR TITLE
Distribute WebUi space using flex layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -415,6 +415,7 @@ a {color: #686868; text-decoration: none;}
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  flex: 0 0 auto;
 }
 .offcanvas-body {
   display: flex;
@@ -426,6 +427,8 @@ a {color: #686868; text-decoration: none;}
   flex: 1 1 auto;
 }
 #list-table {
+  flex: 0 0 auto;
+  overflow: hidden;
   border: 1px solid var(--container-border-color);
   background-color: var(--container-bg-color);
 }
@@ -554,6 +557,7 @@ div#tdetails {
   flex-direction: column;
   align-items: stretch;
   flex: 1 1 auto;
+  overflow: hidden;
   background-color: #F5F5F5;
 }
 div#tdetails a.h {margin: 0}

--- a/css/style.css
+++ b/css/style.css
@@ -594,7 +594,16 @@ div#gcont div.row.Header {font-size: 14px; font-weight: bold; background: #FCFCF
 div#gcont div.row:not(.Header) {padding: 0 0.3rem; word-break: break-all;}
 div#gcont div.row > div {padding-top: 0.25rem; padding-bottom: 0.25rem;}
 
-div.graph_tab {background-color: #FFFFFF; overflow: hidden; display: block; -moz-user-focus: normal; -moz-user-input: enabled; line-height: 11px; color: #545454;}
+div.graph_tab {
+  height: 100%;
+  background-color: #FFFFFF;
+  overflow: hidden;
+  display: block;
+  -moz-user-focus: normal;
+  -moz-user-input: enabled;
+  line-height: 11px;
+  color: #545454;
+}
 .graph_tab_grid,.graph_tab_legend {display: none;}
 .graph_tab_grid { background-color: transparent; border: 2px solid #545454; }
 .graph_tab_legend { background-color: #F0F0F0; border: 0px none transparent; }

--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
 			</div>
 			<div id="HDivider" class="p-0 m-0"></div>
 			<div id="main-info" class="d-flex flex-column align-items-stretch flex-grow-1 flex-shrink-1 overflow-hidden">
-				<div id="list-table" class="flex-grow-1 flex-shrink-1 overflow-hidden">
+				<div id="list-table">
 					<div id="List"></div>
 				</div>
 				<div id="VDivider" class="p-0 m-0"></div>

--- a/js/webui.js
+++ b/js/webui.js
@@ -235,8 +235,8 @@ var theWebUI = {
 	},
 
 	assignEvents: function() {
-		window.addEventListener("resize", () => theWebUI.resize());
-		window.addEventListener("orientationchange", () => theWebUI.resize());
+		window.addEventListener("resize", theWebUI.resize);
+		window.addEventListener("orientationchange", theWebUI.resize);
 		$(document).on("dragstart", function(e) { return false; } );
 		$(document).on("selectstart", function(e) { return(e.fromTextCtrl); });
 		$(document).on("contextmenu", function(e) {
@@ -2266,6 +2266,8 @@ var theWebUI = {
 		if ($("#tdetails").css("display") !== "none") {
 			$("#list-table").css("flex-basis", h);
 			this.resizeGraph();
+		} else {
+			$("#list-table").css("flex-basis", "100%");
 		}
 	},
 
@@ -2291,16 +2293,15 @@ var theWebUI = {
 		bootstrap.Collapse.getInstance("#top-menu")?.hide();
 	},
 
-	update: function()
-   	{
-   	        if(theWebUI.systemInfo.rTorrent.started || !this.firstLoad)
+	update: function() {
+		if(theWebUI.systemInfo.rTorrent.started || !this.firstLoad)
 			theWebUI.getTorrents("list=1");
 		else
 			theWebUI.show();
-   	},
+	},
 
 	setVSplitter: function() {
-		let r = 1 - $("#tdetails").outerHeight() / $("#maincont").height();
+		let r = 1 - ($("#tdetails").outerHeight() + 5) / $("#maincont").height();
 		r = Math.floor(r * 1000) / 1000;
 		if ((theWebUI.settings["webui.vsplit"] !== r) && (r > 0) && (r < 1)) {
 			theWebUI.settings["webui.vsplit"] = r;
@@ -2324,8 +2325,7 @@ var theWebUI = {
 
 	toggleDetails: function() {
 		this.settings["webui.show_dets"] = !this.settings["webui.show_dets"];
-		$("#tdetails").toggleClass("d-flex d-none");
-		$("#VDivider").toggleClass("d-none");
+		$("#tdetails, #VDivider").toggle(this.settings["webui.show_dets"]);
 		this.resize();
 		this.save();
 	},
@@ -2336,12 +2336,8 @@ var theWebUI = {
 			return;
 		}
 		this.settings["webui.show_cats"] = !this.settings["webui.show_cats"];
-		if (this.settings["webui.show_cats"]) {
-			$("#offcanvas-sidepanel, #HDivider").show();
-		} else {
-			$("#offcanvas-sidepanel, #HDivider").hide();
-		}
-    this.resize();
+		$("#offcanvas-sidepanel, #HDivider").toggle(this.settings["webui.show_cats"]);
+		this.resize();
 		this.save();
 	},
 

--- a/js/webui.js
+++ b/js/webui.js
@@ -2233,37 +2233,40 @@ var theWebUI = {
 		if (offcanvas.css("display") === "none") {
 			// Senerio 1: when side panel is toggled off
 			$("#HDivider").hide();
-			$("#main-info").width($("#maincont").width());
 		} else {
 			// When side panel is toggled on
 			if ($(window).width() < 768) {
 				// Senerio 2: small screens and below
-				offcanvas.width("");
+				offcanvas.css("flex-basis", "");
 				$("#HDivider").hide();
-				$("#main-info").width($("#maincont").width());
 			} else {
 				// Senerio 3: medium screens and above
-				offcanvas.width(w);
+				offcanvas.css("flex-basis", w);
 				$("#HDivider").show();
-				$("#main-info").width($("#maincont").width() - 5 - w);
 			}
 		}
 		this.resizeGraph();
 	},
 
-	resizeTop: function(w, h) {
-		if (!h)
+	resizeTop: function(w, h) {  // TODO: rename function to `function(h)` in v6
+		// TODO: remove below in v6
+		if (w && h) {
+			// backward compatibility for those calling this function name with two parameters
+			noty("`theWebUI.resizeTop(w, h)` is deprecated. Please use `theWebUI.resizeTop(h)` instead.");
+		}
+		if (!w && !h)
 			return
+		if (w && !h)
+			h = w;
+		// TODO: remove above in v6
 		if (theWebUI.settings["webui.list_table_min_height"]) {
 			h = Math.max(h, ir(theWebUI.settings["webui.list_table_min_height"]));
 		}
+		h = Math.min(h, $("#main-info").height() - 5);
 		if ($("#tdetails").css("display") !== "none") {
-			$("#list-table").height(h);
-			$("#tdetails").height($("#main-info").height() - 5 - h);
-		} else {
-			$("#list-table").height($("#main-info").height());
+			$("#list-table").css("flex-basis", h);
+			this.resizeGraph();
 		}
-		this.resizeGraph();
 	},
 
 	resizeGraph: function() {

--- a/plugins/trafic/init.js
+++ b/plugins/trafic/init.js
@@ -115,14 +115,15 @@ class rTraficGraph extends rGraph {
     this.draw();
   }
 
-  resize(newWidth, newHeight) {
-    if (newWidth) newWidth -= 8;
-    if (this.plot && newHeight)
-      newHeight -=
-        iv($$(this.plot.getPlaceholder().attr("id") + "_ctrl").style.height) +
-        $("#tabbar").outerHeight();
-    super.resize(newWidth, newHeight);
-  }
+	resize(newWidth, newHeight) {
+		if (!newWidth) {
+			newWidth = $("#traf").width();
+		}
+		if (!newHeight) {
+			newHeight = $("#traf").height() - $("#traf_graph_ctrl").height();
+		}
+		super.resize(newWidth, newHeight);
+	}
 }
 
 if(plugin.canChangeTabs())
@@ -147,26 +148,24 @@ if(plugin.canChangeTabs())
 
 	plugin.resizeLeft = theWebUI.resizeLeft;
 	theWebUI.resizeLeft = function(w) {
+		plugin.resizeLeft.call(this, w);
 		if (plugin.enabled) {
 			if (plugin.allStuffLoaded) {
-				const tdcont = $("#tdcont");
-				this.trafGraph.resize(tdcont.width(), tdcont.height());
+				this.trafGraph.resize();
 			} else
 				setTimeout('theWebUI.resize()', 1000);
 		}
-		plugin.resizeLeft.call(this, w);
 	}
 
 	plugin.resizeTop = theWebUI.resizeTop;
 	theWebUI.resizeTop = function(w, h) {
+		plugin.resizeTop.call(this, w, h);
 		if (plugin.enabled) {
 			if (plugin.allStuffLoaded) {
-				const tdcont = $("#tdcont");
-				this.trafGraph.resize(tdcont.width(), tdcont.height());
+				this.trafGraph.resize();
 			} else
 				setTimeout('theWebUI.resize()', 1000);
 		}
-		plugin.resizeTop.call(this, w, h);
 	}
 
 	theWebUI.showTrafic = function(d)
@@ -323,10 +322,10 @@ plugin.onLangLoaded = function()
 		{
 			if(id=="traf")
 			{
-				if(theWebUI.activeView!="traf" || !theWebUI.trafGraph.xticks.length)
+				if(theWebUI.activeView!="traf" || !theWebUI.trafGraph.xticks.length) {
 					theWebUI.reqForTraficGraph();
-				else
-					theWebUI.trafGraph.resize();
+				}
+				theWebUI.trafGraph.resize();
 			}
 			else
 				plugin.onShow.call(this,id);

--- a/plugins/trafic/init.js
+++ b/plugins/trafic/init.js
@@ -332,8 +332,8 @@ plugin.onLangLoaded = function()
 				plugin.onShow.call(this,id);
 		};
 	 	this.attachPageToTabs(
-			$('<div>').attr("id","traf").append(
-				$("<div>").attr({id:"traf_graph_ctrl"}).addClass("graph_tab d-flex flex-row").append(
+			$('<div>').attr("id","traf").addClass("graph_tab").append(
+				$("<div>").attr({id:"traf_graph_ctrl"}).addClass("d-flex flex-row").append(
 					plugin.disableClearButton ? $() : $("<button>").attr({type:"button", onclick: "theWebUI.clearStats();return(false);"}).text(theUILang.ClearButton),
 					$("<select>").attr({
 						name:"tracker_mode",
@@ -352,7 +352,7 @@ plugin.onLangLoaded = function()
 						$("<option>").val("year").text(theUILang.perYear),
 					),
 				),
-				$("<div>").attr({id:"traf_graph"}).addClass("graph_tab"),
+				$("<div>").attr({id:"traf_graph"}),
 			)[0],
 			theUILang.traf,
 			"lcont",


### PR DESCRIPTION
- Resize category list, torrent list table and torrent detail tabs using `flex-basis` property. This reduces the amount of JS doing resizing work and lets CSS take over the space distribution.
- Add a deprecation warning for the old `theWebUI.resizeTop(w, h)` method and suggest using the new simplified `theWebUI.resizeTop(h)` method.
- Fix an error that occurs when traffic graph is shrinked down to less than 1px high.

Fixes https://github.com/Novik/ruTorrent/issues/2817