### PR TITLE
Fix rss group not showing

### DIFF
--- a/plugins/rssurlrewrite/init.js
+++ b/plugins/rssurlrewrite/init.js
@@ -93,7 +93,7 @@ function checkCurrentRule() {
 
 theWebUI.showRules = function()
 {
-	theWebUI.request("?action=getrules",[theWebUI.loadRules, this]);
+	theWebUI.request("?action=getrules",[theWebUI.loadRules, theWebUI]);
 }	
 
 theWebUI.storeRuleParams = function()
@@ -118,9 +118,9 @@ theWebUI.loadRules = function( rle )
 	list.empty();
 	$('#RLS_rss option').remove();	
 	$('#RLS_rss').append("<option value=''>"+theUILang.allFeeds+"</option>");
-	for(var lbl in this.rssGroups)
+	for(var lbl in theWebUI.rssGroups)
 		$('#RLS_rss').append("<option value='"+lbl+"'>"+this.rssGroups[lbl].name+"</option>");
-	for(var lbl in this.rssLabels)
+	for(var lbl in theWebUI.rssLabels)
 		$('#RLS_rss').append("<option value='"+lbl+"'>"+this.rssLabels[lbl].name+"</option>");
 	plugin.rules = rle;
 	plugin.maxRuleNo = 0;


### PR DESCRIPTION
This is a hotfix commit for RSS groups not showing up when opening the RSS rules manager dialog window. This hotfix is also applicable to the develop branch, so it should be cherry-picked on to it after merged into the master branch.

Fixes: https://github.com/Novik/ruTorrent/issues/2832