### PR TITLE
Control alternate row color using CSS

### DIFF
--- a/css/stable.css
+++ b/css/stable.css
@@ -4,6 +4,10 @@
   --header-border-color: #d0d0d0;
   --header-asc-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAGCAYAAAARx7TFAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAU0lEQVQImYXOsQ0AMQgDQFIgZRxG9G60zECTBdJQ+6t8EfR6JDfWSUbkOgC8uwYyk5/wgL03q6pDAIwIZibXWm8OHABoZjLnFFVtC+4u4+9ZAOMBnF07zgszHpwAAAAASUVORK5CYII=);
   --col-resize-sep-bg-color: #a0a0a0;
+  --row-odd-bg-color: #f3f3f3;
+  --row-even-bg-color: #ffffff;
+  --row-active-bg-color: #cfdeef;
+  --row-highlight-brightness: 1;
   height: 100%;
   background-color: #FFFFFF;
   overflow: hidden;
@@ -100,9 +104,11 @@
   margin: 0 2px !important;
 }
 .konqueror .stable-body td div { margin: 0 0px 0 0px !important }
-.stable-body tr.selected td {background: #CFDEEF}
-.stable-body tr.odd td {background: #F3F3F3}
-.stable-body tr.even td {background: #FFFFFF}
+.stable-body tr.selected td {background: var(--row-active-bg-color) !important;}
+.stable-body tr:hover td {filter: brightness(var(--row-highlight-brightness));}
+.stable-body tr td {background: var(--row-even-bg-color);}
+.alternate .stable-body tr:nth-child(odd) td {background: var(--row-odd-bg-color);}
+.alternate .stable-body tr:nth-child(even) td {background: var(--row-even-bg-color);}
 .stable-move-header {position: absolute; background: transparent url(../images/header_move.gif) repeat-x scroll center top rgba(255,255,255,0.7); top: 0px; font: menu; padding: 2px 12px 2px 4px; line-height: 12px; visibility: visible; border: 1px solid #0099FF; overflow: hidden; }
 .webkit .stable-move-header {background: rgba(255,255,255,0.7);}
 .opera .stable-move-header {background: rgba(255,255,255,0.7);}

--- a/js/stable.js
+++ b/js/stable.js
@@ -53,7 +53,6 @@ var dxSTable = function()
 	this.secRev = 0;
 	this.tHeadCols = new Array();
 	this.tBodyCols = new Array();
-	this.colorEvenRows = false;
 	this.cancelSort = false;
 	this.cancelMove = false;
 	this.colMove = new dxSTable.ColumnMove(this);
@@ -208,7 +207,6 @@ dxSTable.prototype.create = function(ele, styles, aName)
 	}
 	this.init();
 	this.resizeColumn();
-
 	this.created = true;
 }
 
@@ -1064,7 +1062,7 @@ dxSTable.prototype.createRow = function(cols, sId, icon, attr) {
 	Object.assign(attrs, attr || {});
 	const data = this.rowdata[sId]?.fmtdata || {};
 
-	const row = $("<tr>").attr(attrs).addClass(this.colorEvenRows ? ((this.rows & 1) ? "odd" : "even") : "");
+	const row = $("<tr>").attr(attrs);
 	for (let i = 0; i < this.cols; i++) {
 		const index = this.colOrder[i];
 		const cdat = this.colsdata[i];
@@ -1224,23 +1222,15 @@ dxSTable.prototype.unhideRow = function(sId)
 	}
 }
 
-dxSTable.prototype.refreshSelection = function() 
-{
-        if(this.created)
-        {
+dxSTable.prototype.refreshSelection = function() {
+	if (this.created) {
 		var rows = this.tBody.getElementsByTagName("tbody")[0].rows, l = rows.length;
-		for(var i = 0; i < l; i++) 
-		{
+		for (var i = 0; i < l; i++) {
 			if(this.rowSel[rows[i].id] == true) 
-				rows[i].className = "selected";
-			else 
-			{
-				if(!this.colorEvenRows) 
-					rows[i].className = "even";
-				else 
-					rows[i].className = (i & 1) ? "odd" : "even";
-			}
-      		}
+				rows[i].classList.add("selected");
+			else
+				rows[i].classList.remove("selected");
+		}
 	}
 }
 

--- a/js/webui.js
+++ b/js/webui.js
@@ -391,7 +391,6 @@ var theWebUI = {
 			table.obj.ondblclick = table.ondblclick;
 			table.obj.onselect = table.onselect;
 			table.obj.ondelete = table.ondelete;
-			table.obj.colorEvenRows = theWebUI.settings["webui.alternate_color"];
 			table.obj.maxRows = iv(theWebUI.settings["webui.fullrows"]);
 			table.obj.noDelayingDraw = iv(theWebUI.settings["webui.no_delaying_draw"]);
 			if($type(theWebUI.settings["webui."+ndx+".sindex"]))
@@ -466,6 +465,7 @@ var theWebUI = {
 				}
 			}
 		});
+		$(".stable").toggleClass("alternate", !!theWebUI.settings["webui.alternate_color"]);
 		table = this.getTable("plg");
 		if(table)
 		{
@@ -722,13 +722,8 @@ var theWebUI = {
 								theDialogManager.setEffects( iv(nv)*200 );
 								break;
 							}
-							case "webui.alternate_color":
-							{
-								$.each(theWebUI.tables, function(ndx,table)
-								{
-							  		table.obj.colorEvenRows = nv;
-						     			table.obj.refreshSelection();
-								});
+							case "webui.alternate_color": {
+								$(".stable").toggleClass("alternate", !!nv);
 								break;
 							}
 							case "webui.show_cats": {

--- a/plugins/theme/themes/Acid/stable.css
+++ b/plugins/theme/themes/Acid/stable.css
@@ -4,15 +4,17 @@
   --header-border-color: #a0a0a0;
   --header-asc-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAGCAYAAAARx7TFAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAfElEQVQImV2OQQqCYBhE3xctau9RxAt0BLeuvErnbKlYKCH/DyUtXouMpIGB4TEMg8rWjY3/bMdGLa2JREXllu+/oaZ2ZmZgoKMjHqFHAyBUSkozmZGRaZmgB25ABk9GFBYmEktaYOBXmIEXcFiX4hLSr4UrcAeenzOejTe+01J0omVRDQAAAABJRU5ErkJggg==);
   --col-resize-sep-bg-color: #a0a0a0;
+  --row-odd-bg-color: #323a46;
+  --row-even-bg-color: #272e36;
+  --row-active-bg-color: #bddbdb;
+  --row-highlight-brightness: 1;
 }
 .stable-head td {color: #00ff00; font-weight: bold;}
 .stable-head div.resz {background: transparent url(./images/s.gif) no-repeat scroll left center; }
 .stable-body td { border-bottom: 1px solid #E0E0E0; color: #BDDBDB; font-weight: bold;}
 
 .stable-body {background: #272E36;}
-.stable-body tr.selected td {background: #BDDBDB; color: #272E36;}
-.stable-body tr.odd td {background: #323A46;}
-.stable-body tr.even td {background: #272E36;}  
+.stable-body tr.selected td {color: #272E36;}
 .stable-move-header {position: absolute; background: transparent url(./images/header_move.gif) repeat-x scroll center top rgba(255,255,255,0.7); border: 1px solid #0099FF; }
 
 .stable-separator-header { background: #0099FF; }

--- a/plugins/theme/themes/Blue/stable.css
+++ b/plugins/theme/themes/Blue/stable.css
@@ -4,6 +4,10 @@
   /* --header-border-color: undefined - inherit from standard theme; */
   --header-asc-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAFCAYAAACXU8ZrAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAMUlEQVQImWN0+O/AgAwUJ/b+v59fzIgsxoSuAJnGUIQugcxnwqYAXSHj43e/sSpABgAAzBbHU/fvogAAAABJRU5ErkJggg==);
   --col-resize-sep-bg-color: #a0a0a0;
+  /* --row-odd-bg-color: undefined - inherit from standard theme; */
+  /* --row-even-bg-color: undefined - inherit from standard theme; */
+  /* --row-active-bg-color: undefined - inherit from standard theme; */
   border-color:  #8DB2E3 #FFFFFF #FFFFFF #8DB2E3;
+  --row-highlight-brightness: 1;
 }
 .stable-body tr.selected td {background: #D9E8FB}

--- a/plugins/theme/themes/Dark/stable.css
+++ b/plugins/theme/themes/Dark/stable.css
@@ -4,15 +4,17 @@
   --header-border-color: #333333;
   /* --header-asc-icon: undefined - inherit from standard theme; */
   --col-resize-sep-bg-color: #a0a0a0;
+  --row-odd-bg-color: #333333;
+  --row-even-bg-color: #191919;
+  --row-active-bg-color: #888888;
+  --row-highlight-brightness: 1;
 }
 .stable-head div.resz {border: 1px solid #FF0000; background: transparent url(./images/s.gif) no-repeat scroll left center;}
 .stable-body {background: window; background-color: #181818; }
 .stable-body td {border-bottom: 1px solid #333333; }
 
 .stable-body {background: #181818}
-.stable-body tr.selected td {background: #888888; color:#111111}
-.stable-body tr.odd td {background: #333333}
-.stable-body tr.even td {background: #191919}
+.stable-body tr.selected td {color:#111111}
 .stable-move-header { background: transparent url(./images/header_move.gif) repeat-x scroll center top; border: 1px solid #0099FF;}
 
 .stable-move-header { background: transparent url(./images/header_move.gif) repeat-x scroll center top rgba(128,128,128,0.7); border: 1px solid #0099FF; }

--- a/plugins/theme/themes/DarkBetter/stable.css
+++ b/plugins/theme/themes/DarkBetter/stable.css
@@ -4,15 +4,17 @@
   --header-border-color: #333333;
   --header-asc-icon: url("data:image/svg+xml,%3csvg version='1' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3e%3cpath fill='%232196F3' d='M43 17.1L39.9 14 24 29.9 8.1 14 5 17.1 24 36z'/%3e%3c/svg%3e");
   --col-resize-sep-bg-color: #a0a0a0;
+  --row-odd-bg-color: #333333;
+  --row-even-bg-color: #191919;
+  --row-active-bg-color: #888888;
+  --row-highlight-brightness: 1;
 }
 .stable-head div.resz {border: 1px solid #FF0000; background: transparent url(./images/s.gif) no-repeat scroll left center}
 .stable-body {background: window; background-color: #181818}
 .stable-body td {border-bottom: 1px solid #333333}
 
 .stable-body {background: #181818}
-.stable-body tr.selected td {background: #888888; color:#111111}
-.stable-body tr.odd td {background: #333333}
-.stable-body tr.even td {background: #191919}
+.stable-body tr.selected td {color:#111111}
 .stable-move-header {background: transparent url(./images/header_move.gif) repeat-x scroll center top; border: 1px solid #0099FF}
 
 .stable-move-header {background: transparent url(./images/header_move.gif) repeat-x scroll center top rgba(128,128,128,0.7); border: 1px solid #0099FF}

--- a/plugins/theme/themes/Excel/stable.css
+++ b/plugins/theme/themes/Excel/stable.css
@@ -4,6 +4,10 @@
   --header-border-color: #f2993c;
   --header-asc-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAFCAYAAACXU8ZrAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAM0lEQVQImWP4//8/AzJOnHD2P7oYEwMSSJp47j8yDQNM6Aqw8ZmwKUBXyPjj+mysCpABAMnILpbMeCuyAAAAAElFTkSuQmCC);
   --col-resize-sep-bg-color: #a0a0a0;
+  /* --row-odd-bg-color: undefined - inherit from standard theme; */
+  /* --row-even-bg-color: undefined - inherit from standard theme; */
+  /* --row-active-bg-color: undefined - inherit from standard theme; */
+  --row-highlight-brightness: 1;
 }
 #list-table { border-color: #9eb6ce }
 .stable-head {
@@ -11,5 +15,4 @@
 }
 
 .stable-body table tr td { border-right: 1px solid #d0d7e5; border-bottom: 1px solid #d0d7e5 }
-.stable-body table tr.selected td {background: #cfdeef}
 .stable-body {background: #ffffff; color: #000000}

--- a/plugins/theme/themes/MaterialDesign/stable.css
+++ b/plugins/theme/themes/MaterialDesign/stable.css
@@ -58,6 +58,10 @@
   --header-border-color: transparent;
   --header-asc-icon: url(data:image/gif;base64,R0lGODlhEAAQAPcAAP//////zP//mf//Zv//M///AP/M///MzP/Mmf/MZv/MM//MAP+Z//+ZzP+Zmf+ZZv+ZM/+ZAP9m//9mzP9mmf9mZv9mM/9mAP8z//8zzP8zmf8zZv8zM/8zAP8A//8AzP8Amf8AZv8AM/8AAMz//8z/zMz/mcz/Zsz/M8z/AMzM/8zMzMzMmczMZszMM8zMAMyZ/8yZzMyZmcyZZsyZM8yZAMxm/8xmzMxmmcxmZsxmM8xmAMwz/8wzzMwzmcwzZswzM8wzAMwA/8wAzMwAmcwAZswAM8wAAJn//5n/zJn/mZn/Zpn/M5n/AJnM/5nMzJnMmZnMZpnMM5nMAJmZ/5mZzJmZmZmZZpmZM5mZAJlm/5lmzJlmmZlmZplmM5lmAJkz/5kzzJkzmZkzZpkzM5kzAJkA/5kAzJkAmZkAZpkAM5kAAGb//2b/zGb/mWb/Zmb/M2b/AGbM/2bMzGbMmWbMZmbMM2bMAGaZ/2aZzGaZmWaZZmaZM2aZAGZm/2ZmzGZmmWZmZmZmM2ZmAGYz/2YzzGYzmWYzZmYzM2YzAGYA/2YAzGYAmWYAZmYAM2YAADP//zP/zDP/mTP/ZjP/MzP/ADPM/zPMzDPMmTPMZjPMMzPMADOZ/zOZzDOZmTOZZjOZMzOZADNm/zNmzDNmmTNmZjNmMzNmADMz/zMzzDMzmTMzZjMzMzMzADMA/zMAzDMAmTMAZjMAMzMAAAD//wD/zAD/mQD/ZgD/MwD/AADM/wDMzADMmQDMZgDMMwDMAACZ/wCZzACZmQCZZgCZMwCZAABm/wBmzABmmQBmZgBmMwBmAAAz/wAzzAAzmQAzZgAzMwAzAAAA/wAAzAAAmQAAZgAAMwAAAICAgHZ2dnV1dVZWVioqKgsLC////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAAN4ALAAAAAAQABAAAAg5AL0JHEiwoMGDCBMqXMjQ4DZsECNuQ9hNW0Rs2bol5HaRm8JrD7Ftu7awojaNDLl5bMiypcuXCwMCADs=);
   --col-resize-sep-bg-color: #a0a0a0;
+  --row-odd-bg-color: #2A2A2A;
+  --row-even-bg-color: #252525;
+  --row-active-bg-color: #191919;
+  --row-highlight-brightness: 0.75;
 }
 .stable-head {
   text-shadow: 0px 1px 0px #000;
@@ -65,18 +69,14 @@
 .stable-head table tr td {
 	font-weight:700;
 	color:#fff;
+  font-family: Ubuntu;
 }
 .stable-head div.resz { border: 1px solid #FF0000; background: transparent url(./images/s.gif) no-repeat scroll left center; }
 .stable-body { background: #181818; text-shadow: 0px 1px 0px #000; color: #CACCCC; }
 .stable-body td { border-bottom: 1px solid #252525; }
-.stable-body td div { height: 16px !important; }
-.stable-body tr.odd td { background-color: #2A2A2A; }
-.stable-body tr.even td { background-color: #252525; }
-.stable-body tr.odd:hover td { background-color: #222222; }
-.stable-body tr.even:hover td { background-color: #1D1D1D; }
+.stable-body td div { font-family: Ubuntu, Verdana, Arial, Helvetica, sans-serif; height: 16px !important; }
 .stable-body tr { height: 22px; }
-.stable-body tr.selected td{ background-color: #191919; color: #009DDD; text-shadow: 0px -1px 0px #000; }
-.stable-body tr.selected:hover td{ background-color: #111111; }
+.stable-body tr.selected td{ color: #009DDD; text-shadow: 0px -1px 0px #000; }
 div.stable-body table tbody tr.even td:nth-child(2n+1) { color: #ffffff; }
 .stable-move-header { background: transparent url(./images/header_move.gif) repeat-x scroll center top; border: 1px solid #0099FF; }
 

--- a/plugins/theme/themes/Oblivion/stable.css
+++ b/plugins/theme/themes/Oblivion/stable.css
@@ -4,6 +4,10 @@
   --header-border-color: transparent;
   --header-asc-icon: url(data:image/gif;base64,R0lGODlhEAAQAPQeAGZmZoeHh4WFhYCAgH9/f3p6enh4eHV1dXR0dHNzc2hoaGdnZ2RkZF1dXVZWVlVVVVNTU01NTUNDQzs7OzU1NSoqKigoKCUlJSIiIhYWFg4ODgwMDAYGBgMDAwAAAAAAACH5BAUAAB4ALAAAAAAQABAAAAU4oCeOZGmeaKqubDkBRiEby3RuUEIMxPFsKAyDIBgoLKmOBBEwRDoqTcPAyLAuDkqrU+G0vuBwKwQAOw==);
   --col-resize-sep-bg-color: #a0a0a0;
+  --row-odd-bg-color: linear-gradient(0deg, #2c2c2c 0%, #272727 100%);
+  --row-even-bg-color: linear-gradient(0deg, #222222 0%, #272727 100%);
+  --row-active-bg-color: linear-gradient(0deg, #121212 0%, #464646 100%);
+  --row-highlight-brightness: 1;
 }
 .stable-head {
   color: #626262;
@@ -13,14 +17,9 @@
 .stable-body {background: window; text-shadow:0px 1px 0px #000;color:#CACCCC; }
 .stable-body td {border-bottom: 1px solid #333333; }
 .stable-body td div {font-family: "Lucida Sans Unicode", "Lucida Grande", Verdana, Arial, Helvetica, sans-serif;height: 16px !important;}
-.stable-body tr.odd td {background: #333333}
-.stable-body tr.even td {background: #191919}
 .stable-body tr {height:22px;}
 .stable-body {background: #181818}
 .stable-body tr.selected td{background: #000 url(./images/headers.png) repeat-x 0px 0px; color:#009DDD;text-shadow:0px -1px 0px #000;}
-div.stable-body table tbody tr.even td {background: #181818 url(./images/headers.png) repeat-x 0px -37px;}
-div.stable-body table tbody tr.even td:nth-child(2n+1) {color:#ffffff;}
-div.stable-body table tbody tr.even:nth-child(2n+1) td{background: #181818 url(./images/headers.png) repeat-x 0px -64px;}
 .stable-move-header { background: transparent url(./images/header_move.gif) repeat-x scroll center top; border: 1px solid #0099FF;}
 
 .stable-move-header { background: transparent url(./images/header_move.gif) repeat-x scroll center top rgba(128,128,128,0.7); border: 1px solid #0099FF; }


### PR DESCRIPTION
- Control s-table alternate row color using CSS.
- Define odd row, even row, and active row background using variables.
- Define highlight row background using color filter with a brightness of 0.75 for MaterialDesign theme only.

This is an amended version of https://github.com/Novik/ruTorrent/pull/2839, which I accidentally closed, and didn't find a way to reopen. Background highlight on hovering is now only enabled in MaterialDesign theme. A variable is created for every theme though, for the consistency among all themes.