### PR TITLE
Drag and drop s-table header using DnD class

### DIFF
--- a/js/objects.js
+++ b/js/objects.js
@@ -5,8 +5,18 @@
 
 // Drag & Drop object 
 class DnD {
-	constructor(id, options) {
-		this.obj = $('#' + id);
+	/**
+	 * Construct a drag-and-drop instance.
+	 * @param {string | HTMLElement} dndObj Reference to the drag-and-drop element.
+	 * Can be the HTML `id` of the element, or a reference to the HTML element.
+	 * @param {Object} options Drag and drop options to be passed.
+	 */
+	constructor(dndObj, options) {
+		if ($type(dndObj) === "string") {
+			this.obj = $('#' + dndObj);
+		} else {
+			this.obj = $(dndObj);
+		}
 		const headers = this.obj.find(".dlg-header");
 		const header = headers.length > 0 ? $(headers[0]) : this.obj;
 		this.options = options || {};

--- a/js/objects.js
+++ b/js/objects.js
@@ -12,11 +12,9 @@ class DnD {
 	 * @param {Object} options Drag and drop options to be passed.
 	 */
 	constructor(dndObj, options) {
-		if ($type(dndObj) === "string") {
-			this.obj = $('#' + dndObj);
-		} else {
-			this.obj = $(dndObj);
-		}
+		this.obj = ($type(dndObj) === "string")
+			? $('#' + dndObj)
+			: $(dndObj);
 		const headers = this.obj.find(".dlg-header");
 		const header = headers.length > 0 ? $(headers[0]) : this.obj;
 		this.options = options || {};

--- a/plugins/theme/themes/MaterialDesign/stable.css
+++ b/plugins/theme/themes/MaterialDesign/stable.css
@@ -80,7 +80,6 @@
 div.stable-body table tbody tr.even td:nth-child(2n+1) { color: #ffffff; }
 .stable-move-header { background: transparent url(./images/header_move.gif) repeat-x scroll center top; border: 1px solid #0099FF; }
 
-.stable-move-header { background: transparent url(./images/header_move.gif) repeat-x scroll center top rgba(128,128,128,0.7); border: 1px solid #0099FF; }
 .webkit .stable-move-header { background: rgba(128,128,128,0.7); }
 
 .stable-active-header { border-color: threedface !important }


### PR DESCRIPTION
This is a big change that removes the `dxSTable.ColumnMove` object that basically did the same things as the `DnD` utility class, and handles resizing, moving, and sorting actions in one `DnD` object. After this commit, I think we are ready to make the final movement that merge the s-table header and the body into one single HTML table.

- Modify `DnD` class initialization method a bit, so that the object can be attached to an HTML element or an `id` identifier. This is a preparation for the following change.
- Merge header cell resizing and moving methods into one object, reusing ruTorrent's `DnD` utility class, and thus removes the `dxSTable.ColumnMove` object defined in the s-table module that did the same thing as the `DnD` class.
- Rearrange header row drag-and-drop event handling process. Resizing, moving, and sorting actions are distributed according to the position of mouse clicks and displacement of the mouse cursor.
- Remove obsolete properties from S-Table class (`dxSTable.cancelMove` and `dxSTable.cancelSort`).