### PR TITLE
Fix nnmclub regex pattern for incognito mode

### DIFF
--- a/plugins/rutracker_check/trackers/nnmclub.php
+++ b/plugins/rutracker_check/trackers/nnmclub.php
@@ -7,7 +7,7 @@ class NNMClubCheckImpl
         if (preg_match('`^https?://(nnm-club|nnmclub)\.(ru|me|to|name|tv)/forum/viewtopic\.php\?p=(?P<id>\d+)$`', $url, $matches)) {
             $client = ruTrackerChecker::makeClient("https://nnmclub.to/forum/viewtopic.php?p=".$matches["id"]);
             if ($client->status != 200) return ruTrackerChecker::STE_CANT_REACH_TRACKER;
-            if (preg_match('`btih:(?P<hash>[0-9A-Fa-f]{40})&tr`', $client->results, $matches)) {
+            if (preg_match('`btih:(?P<hash>[0-9A-Fa-f]{40})`', $client->results, $matches)) {
                 if (strtoupper($matches["hash"])==$hash) {
                     return  ruTrackerChecker::STE_UPTODATE;
                 }


### PR DESCRIPTION
## Description

Fixes nnm-club tracker `btih:` pattern matching when user credentials are not provided. In anonymous mode, the `&tr` suffix is not present in the magnet link, causing the pattern match to fail.

<img width="687" alt="image" src="https://github.com/user-attachments/assets/2e0965b2-60a9-463b-ae37-ed940696c4c8" />

------------
Old pattern:
<img width="584" alt="image" src="https://github.com/user-attachments/assets/91b44ce7-935d-4877-814d-63e155a8dbb9" />
`&tr` suffix is removed:
<img width="602" alt="image" src="https://github.com/user-attachments/assets/6f9959b3-4373-4694-b1c9-bb1d2d7f8f02" />

This change should also remain backward compatible with links that include the `&tr` suffix.


