### PR TITLE
Add danger color to #randomize_hash

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -651,6 +651,7 @@ span#loadimg {padding: 20px; background: transparent url(../images/ajax-loader.g
 .Icon_Share {background: transparent url(../images/share.gif) no-repeat left center}
 
 #tadd-header {background-image: url(../images/world.gif)}
+#randomize_hash {accent-color: red;}
 
 .konqueror div#tadd label { width: 80px; }
 .konqueror div#tadd { height: 290px; }


### PR DESCRIPTION
The torrent add dialog #tadd remembers previous settings now to help users avoid needing to set the same setting repeatedly.

Users also assume that default settings are always safe settings for general usage, and click through without reviewing them.

A user who checks #randomize_hash for one torrent (deliberately or otherwise), then is surprised that none of their torrents download anymore, because #randomize_hash is still checked on all future torrent additions.

Because users may legitimately want this setting to persist through several subequent torrent adds, we don't want to remove persistence for this field. But I think we should draw more attention to its use, because accidental usage can cause the entire client to stop functioning as expected (from a user perspective).