### PR TITLE
Improve $tempDirectory handling:

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -79,7 +79,7 @@
 						// Both Webserver and rtorrent users must have read-write access to it.
 						// For example, if Webserver and rtorrent users are in the same group then the value may be 0770.
 
-	$tempDirectory = $_ENV['RU_TEMP_DIRECTORY'] ?? null;			// Temp directory. Absolute path with trail slash. If null, then autodetect will be used.
+	$tempDirectory = $_ENV['RU_TEMP_DIRECTORY'] ?? null; // Temp directory. Absolute path. If null, then autodetect will be used.
 
 	$canUseXSendFile = false;		// If true then use X-Sendfile feature if it exist
 

--- a/php/getplugins.php
+++ b/php/getplugins.php
@@ -227,11 +227,10 @@ if($handle = opendir('../plugins'))
 {
 	ignore_user_abort(true);
 	set_time_limit(0);
-	$tmp = FileUtil::getTempDirectory();
-	if($tmp!='/tmp/')
-		FileUtil::makeDirectory($tmp);
 
-	if(!@file_exists($tempDirectory.'/.') || !is_readable($tempDirectory) || !is_writable($tempDirectory))
+	// Check/init: $tempDirectory.
+	$tmp = FileUtil::getTempDirectory();
+	if(!is_dir($tmp) || !@file_exists($tmp.'.') || !is_readable($tmp) || !is_writable($tmp))
 		$jResult.="noty(theUILang.badTempPath+' (".$tempDirectory.")','error');";	
 
 	if(!function_exists('preg_match_all'))

--- a/php/initplugins.php
+++ b/php/initplugins.php
@@ -124,9 +124,10 @@ if( count( $argv ) > 1 )
 require_once( "which.php" );
 require_once( "settings.php" );
 
+// Check/init: $tempDirectory.
 $tmp = FileUtil::getTempDirectory();
-if($tmp!='/tmp/')
-	FileUtil::makeDirectory($tmp);
+if(!is_dir($tmp) || !@file_exists($tmp.'.') || !is_readable($tmp) || !is_writable($tmp))
+	exit();
 
 $theSettings = rTorrentSettings::get(true);
 if( $theSettings->linkExist && ($handle = opendir('../plugins')))


### PR DESCRIPTION
- make sure that contain trail slash
- add extra checks to system provided temp dirs detection
- add '/var/tmp' to system provided temp dirs
- add dir exist check and create for user provided and user profile temp dir
- add comments to code

This change is for be sure that setting ```$tempDirectory = '/tmp';``` will not silently break installation.