### PR TITLE
tracklabels plugin: only access icon if download was successful

### DIFF
--- a/plugins/tracklabels/action.php
+++ b/plugins/tracklabels/action.php
@@ -87,11 +87,13 @@ if ($png_name !== null) {
 			$client->read_timeout = 5;
 			$client->_fp_timeout = 5;
 			@$client->fetchComplex($url);
-			if ($client->status == 200)
+			if ($client->status == 200) {
 				file_put_contents($ico_name, $client->results);
-			if (strpos(mime_content_type($ico_name), "image/")===false)
-				@unlink($ico_name);
-			try_send_image($ico_name, 'image/x-icon');
+				if (strpos(mime_content_type($ico_name), "image/")===false)
+					@unlink($ico_name);
+				else
+					try_send_image($ico_name, 'image/x-icon');
+			}
 		}
 	}
 }


### PR DESCRIPTION
This message started appearing after I updated from v4.3.10:

```
PHP message: PHP Warning:  mime_content_type(/usr/local/www/ruTorrent-5.1.6/share/settings/trackers/x.ico): Failed to open stream: No such file or directory in /usr/local/www/ruTorrent-5.1.6/plugins/tracklabels/action.php on line 92
```

Apparently `mime_content_type()` tried to access the file even when the icon download failed. This PR fixes the issue. Also now it won't try to send the file if it doesn't exist.