### PR TITLE
Diskspace option to display free bytes (new pull request against develop branch)

### DIFF
--- a/plugins/diskspace/conf.php
+++ b/plugins/diskspace/conf.php
@@ -4,3 +4,4 @@ $diskUpdateInterval = 10;	// in seconds
 $notifySpaceLimit = 512;	// in Mb
 $partitionDirectory = null;	// if null, then we will check rtorrent download directory (or $topDirectory if rtorrent is unavailable)
 				// otherwise, set this to the absolute path for checked partition. 
+$freeBytesInMeter = false;	// show free space instead of %

--- a/plugins/diskspace/init.js
+++ b/plugins/diskspace/init.js
@@ -8,7 +8,8 @@ plugin.setValue = function( full, free )
 	        percent = 100;
 	$("#meter-disk-value").width( percent+"%" ).css( { "background-color": (new RGBackground()).setGradient(this.prgStartColor,this.prgEndColor,percent).getColor(),
 		visibility: !percent ? "hidden" : "visible" } );
-	$("#meter-disk-text").text(percent+'%');
+	if(plugin.freeBytesInMeter) $("#meter-disk-text").text(theConverter.bytes(free));
+	else $("#meter-disk-text").text(percent+'%');
 	$("#meter-disk-pane").prop("title", theConverter.bytes(free)+"/"+theConverter.bytes(full));
 
 	if($.noty && plugin.allStuffLoaded)

--- a/plugins/diskspace/init.php
+++ b/plugins/diskspace/init.php
@@ -21,5 +21,6 @@ if(!function_exists('disk_total_space') || !function_exists('disk_free_space') |
 else
 {
 	$jResult.="plugin.interval = ".$diskUpdateInterval."; plugin.notifySpaceLimit = ".($notifySpaceLimit*1024*1024).";";
+	$jResult.="plugin.freeBytesInMeter = ".($freeBytesInMeter ? 1 : 0).";";
 	$theSettings->registerPlugin($plugin["name"],$pInfo["perms"]);
 }


### PR DESCRIPTION
Currently diskspace plugin shows colored meter with free % on it. Meter tooltip includes free/total bytes, but it is not convenient for me. I want to know whether I can start downloading those 200 GiB of remuxes without tooltip opening.
Here's a solution. Now you can change plugin config to display free bytes instead of %.