### PR TITLE
Adding Stopped state

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,6 +162,7 @@
 							<panel-label id="pstate_all" icon="all" uilangtext="All" selected></panel-label>
 							<panel-label id="-_-_-dls-_-_-" icon="down" uilangtext="Downloading"></panel-label>
 							<panel-label id="-_-_-com-_-_-" icon="completed" uilangtext="Finished"></panel-label>
+							<panel-label id="-_-_-wfa-_-_-" icon="paused" uilangtext="Stopped"></panel-label>
 							<panel-label id="-_-_-act-_-_-" icon="up-down" uilangtext="Active"></panel-label>
 							<panel-label id="-_-_-iac-_-_-" icon="inactive" uilangtext="Inactive"></panel-label>
 							<panel-label id="-_-_-err-_-_-" icon="error" uilangtext="Error"></panel-label>

--- a/js/category-list.js
+++ b/js/category-list.js
@@ -23,7 +23,17 @@ export class CategoryList {
     this.statistic = CategoryListStatistic.from("pview", this.viewSelections, {
       pstate: [
         (_, torrent) => [
-          torrent.done < 1000 ? "-_-_-dls-_-_-" : "-_-_-com-_-_-",
+          torrent.done >= 1000
+            ? "-_-_-com-_-_-"
+            : (torrent.state === 1 && torrent.done === 0 && torrent.dl === 0 && torrent.ul === 0)
+            ? "-_-_-wfa-_-_-"
+            : (torrent.done > 0 && torrent.dl === 0 && torrent.ul === 0)
+            ? "-_-_-wfa-_-_-"
+            : (torrent.done === 0 && torrent.dl === 0 && torrent.ul === 0)
+            ? "-_-_-dls-_-_-"
+            : (torrent.dl > 0 || torrent.ul > 0)
+            ? "-_-_-dls-_-_-"
+            : "-_-_-dls-_-_-",
           torrent.dl >= 1024 || torrent.ul >= 1024
             ? "-_-_-act-_-_-"
             : "-_-_-iac-_-_-",


### PR DESCRIPTION
The new Stopped state will have torrents that
1) Are in downloading status, but nothing have arrived yet and no data moving up or down. Basically dead torrent without seeds.
2) Torrents that are half way, but no data is moving.
3) Paused torrents. Its same thing as half way done, but no traffic.

Completed state have all torrents that are 100% done. Does not matter if they are Finished or Seeding Status.

Downloading State have all torrents that have not started yet. And torrents that are started and have traffic.
The question is. Do this state have only the second type torrents? And all not started torrents will be in Inactive state? Or should there be another state for Waiting torrents? Right now this Downloading State have 1000 not started torrents and nothing else. For me it would be fine like this, but what you guys think?