### PR TITLE
Fix for broken RSS feeds break the rutorrent.

### DIFF
--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -143,12 +143,18 @@ class rRSS
 			$headers['If-Last-Modified'] = $this->lastModified;
 		$cli = call_user_func($this->fetchURL, $this->url, $this->cookies, $headers);
 		if($cli->status<200 || $cli->status>=300) {
-			if ($cli->status!==304) {
-				$this->lastErrorMsgs[] = $cli->status == -100 ? '[RSS-Timeout]' :
-					($cli->status < 100 ? '[RSS-Connection-Error] '.$cli->error : '[RSS-HTTP-Error] Status: '.$cli->status);
-			}
+			if ($cli->status !== 304) {
+                                $msg = $cli->status == -100
+                                        ? '[RSS-Timeout]'
+                                        : ($cli->status < 100
+                                                ? '[RSS-Connection-Error] ' . $cli->error
+                                                : '[RSS-HTTP-Error] Status: ' . $cli->status);
+
+                                $this->lastErrorMsgs[] = $msg;
+                                return false;
+                        }
 			// true if feed not modified
-			return($cli->status===304);
+			return true;
 		}
 
 		// remember etag and lastModified


### PR DESCRIPTION
As much as I tested it will still load Feeds now from cache even if the feed is broken or unavailable. Before it just did not load Feeds at all and start looping some error message. rtorrent down or something like that. Dont remember anymore. But that problem happened when there was many broken feeds. Only one then it was no problem but i had like 5 broken feeds and no feeds get loaded. Not even the good ones.