### PR TITLE
Update "State" categories to match "Status" column

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,9 +162,9 @@
 							<panel-label id="pstate_all" icon="all" uilangtext="All" selected></panel-label>
 							<panel-label id="-_-_-dls-_-_-" icon="down" uilangtext="Downloading"></panel-label>
 							<panel-label id="-_-_-com-_-_-" icon="completed" uilangtext="Finished"></panel-label>
-							<panel-label id="-_-_-wfa-_-_-" icon="paused" uilangtext="Stopped"></panel-label>
+							<panel-label id="-_-_-wfa-_-_-" icon="inactive" uilangtext="Stopped"></panel-label>
 							<panel-label id="-_-_-act-_-_-" icon="up-down" uilangtext="Active"></panel-label>
-							<panel-label id="-_-_-iac-_-_-" icon="inactive" uilangtext="Inactive"></panel-label>
+							<panel-label id="-_-_-iac-_-_-" icon="paused" uilangtext="Inactive"></panel-label>
 							<panel-label id="-_-_-err-_-_-" icon="error" uilangtext="Error"></panel-label>
 						</category-panel>
 						<category-panel id="plabel" uilangtext="Labels">


### PR DESCRIPTION
Fix for issue #2638 

Updates logic that determines "State" groups to match the states in the "Status" column of the torrent list:

- Downloading: Include all "started" torrents. Matches the "Downloading" state in the "Status" column.
- Completed: Include all "finished" torrents. Matched the "Finished" state in the "Status" column.
- Stopped: Match all torrents paused or stopped by the user, except ones that are "Completed". i.e. will includes torrents that are either not started at all, or have been partially downloaded and then stopped or paused by the user.
- Active: Only match "Downloading" torrents that have upload/download activity.
- Inactive: Only match "Downloading" torrents that do not have upload/download activity.
- Error: Match all torrents that have an error, except "Completed" ones. Completed torrents only ever have tracker errors which don't matter when the torrent has already completed downloading.

Also swap icons for "Inactive" and "Stopped" states. Now the "Stopped" state has the same icon as stopped torrents in the torrent list. The "Inactive" state now uses the "Paused" icon which is not correct, but there is no dedicated icon for "Inactive" state as of right now. Maybe the current "Active" icon with green background would work better for the "Active" state, and the same icon with red background would work for "Inactive" state.

Ideally we would want to have a dedicated "Paused" state, as well, since there is such state defined in the torrent list already. It also probably makes sense to rename the "Completed" state to "Finished", to match the state in the status column in the torrent list.