### PR TITLE
Fix white border below the nav bar

### DIFF
--- a/plugins/theme/themes/Dark/style.css
+++ b/plugins/theme/themes/Dark/style.css
@@ -146,6 +146,10 @@ td.disabled, label.disabled, span.disabled, div.disabled {color: #333333}
 select.cols {border: 1px solid #333333}
 div#tdetails {background-color: #181818}
 
+.tabbar {
+  border-bottom: none;
+}
+
 .tabbar li.nav-item a.nav-link {
   border: 1px solid #333333;
   background-color: #181818;

--- a/plugins/theme/themes/DarkBetter/style.css
+++ b/plugins/theme/themes/DarkBetter/style.css
@@ -279,6 +279,10 @@ legend {color: #888888}
 select.cols {border: 1px solid #333333}
 div#tdetails {background-color: #181818}
 
+.tabbar {
+  border-bottom: none;
+}
+
 .tabbar li.nav-item a.nav-link {
   border: 1px solid #333333;
   background-color: #181818;


### PR DESCRIPTION
## What's changed

Fixes the *bottom* [white border](https://github.com/Novik/ruTorrent/issues/2883) below the navigation section in the Dark and Dark Better themes.