### PR TITLE
Added checking torrents by guid before loading it again

### DIFF
--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -275,7 +275,7 @@ class rRSS
 			rTorrentSettings::get()->pushEvent( "RSSFetched", array( "rss"=>&$this ) );
 			if(!$this->hasIncorrectTimes())
 				foreach( $this->items as $url=>$item )
-					$history->correct($url, $item['timestamp']);
+					$history->correct($url, $item['timestamp'], $item['guid']);
 		}
 		return(true);
 	}
@@ -318,20 +318,20 @@ class rRSSHistory
 		$this->version = 2;
 	}
 
-	public function add( $url, $hash, $timestamp )
+	public function add( $url, $hash, $timestamp, $guid = null, $title = null )
 	{
 		$cnt = 0;
 		if(array_key_exists($url,$this->lst))
 			$cnt = ($this->lst[$url]["time"]==$timestamp) ? $this->lst[$url]["cnt"] : 0;
-		$this->lst[$url] = array( "hash"=>$hash, "time"=>$timestamp, "cnt"=>$cnt );
+		$this->lst[$url] = array( "hash" => $hash, "time" => $timestamp, "cnt" => $cnt,	"guid" => $guid, "title" => $title );
 		if($hash=='Failed')
 			$this->lst[$url]["cnt"] = $cnt+1;
 		$this->changed = true;
 	}
-        public function correct( $url, $timestamp )
+	public function correct( $url, $timestamp, $guid = null )
 	{
 		if( array_key_exists($url,$this->lst) && 
-			($this->lst[$url]["time"]!=$timestamp) )
+			($guid && !empty($this->lst[$url]["guid"]) && $this->lst[$url]["guid"] !== $guid) )
 		{
 			unset($this->lst[$url]);
 			$this->changed = true;			
@@ -355,11 +355,24 @@ class rRSSHistory
 			return(intval($this->lst[$url]["cnt"]));
 		return(0);
 	}
-	public function wasLoaded( $url )
+	public function wasLoaded( $url, $guid = null, $title = null )
 	{
 		$ret = false;
 		if(array_key_exists($url,$this->lst))
-			$ret = ($this->lst[$url]["hash"]!=='Failed') || ($this->getCounter( $url )>HISTORY_MAX_TRY);
+		{
+			if($guid && !empty($this->lst[$url]["guid"]))
+			{
+				$ret = ($this->lst[$url]["guid"] === $guid);
+			}
+			if(!$ret && $title && !empty($this->lst[$url]["title"]))
+			{
+				$ret = ($this->lst[$url]["title"] === $title);
+			}
+			if(!$ret)
+			{
+				$ret = ($this->lst[$url]["hash"]!=='Failed') || ($this->getCounter( $url )>HISTORY_MAX_TRY);
+			}
+		}
 		return($ret);
 	}
 	public function getHash( $url )
@@ -857,7 +870,7 @@ class rRSSManager
 		foreach( $urls as $ndx=>$url )
 		{
 			if($state)
-				$this->history->add($url,'Loaded',$times[$ndx]);
+				$this->history->add($url, 'Loaded', $times[$ndx], null, null);
 			else
 				$this->history->del($url);
 		}
@@ -873,15 +886,12 @@ class rRSSManager
 			{
 				if(!$filter->isApplicable( $rss, $this->history, $this->groups ))
 					break;
-				if(     !$this->history->wasLoaded($href) &&
+				if( !$this->history->wasLoaded($href, $item['guid'] ?? null, $item['title'] ?? null) &&
 					$filter->checkItem($href, $item) )
 				{
 					self::log("Filter [".$filter->name."] of channel [".$rss->url."] was applied for [$href]");
-
-				        $this->history->applyFilter( $filter->no );
-
+					$this->history->applyFilter( $filter->no );
 					rTorrentSettings::get()->pushEvent( "RSSAutoLoad", array( "rss"=>&$rss, "href"=>&$href, "item"=>&$item, "filter"=>&$filter ) );
-
 					$this->getTorrents( $rss, $href, 
 						$filter->start, $filter->addPath, $filter->getDirectory(), $filter->getLabel(), $filter->throttle, $filter->ratio, false );
 					if(WAIT_AFTER_LOADING)
@@ -1211,7 +1221,7 @@ class rRSSManager
 			}
 			if($ret===false)
 				$this->rssList->addError( "theUILang.rssCantLoadTorrent", $url );
-			$this->history->add($url,$thash,$rss->getItemTimestamp( $url ));
+			$this->history->add($url, $thash, $rss->getItemTimestamp($url), $rss->items[$url]['guid'] ?? null, $rss->items[$url]['title'] ?? null);
 			if($needFlush)
 				$this->saveHistory();
 		}
@@ -1238,7 +1248,7 @@ class rRSSManager
 			if(count($urls))
 				foreach($this->history->lst as $href=>$hash)
 				{
-					if(!array_key_exists($href,$urls))
+					if(!array_key_exists($href,$urls) && $this->history->lst[$href]["hash"] === 'Failed')
 						$this->history->del($href);
 				}
 		}

--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -364,10 +364,6 @@ class rRSSHistory
 			{
 				$ret = ($this->lst[$url]["guid"] === $guid);
 			}
-			if(!$ret && $title && !empty($this->lst[$url]["title"]))
-			{
-				$ret = ($this->lst[$url]["title"] === $title);
-			}
 			if(!$ret)
 			{
 				$ret = ($this->lst[$url]["hash"]!=='Failed') || ($this->getCounter( $url )>HISTORY_MAX_TRY);


### PR DESCRIPTION
I added check torrents by guid if the torrent was loaded before. Because some torrents have links and dates changing sometimes but file itself stay the same so no it checks first by guid and there is no guid then it check the hash like before. At least this stopped my torrents loading over and over again that i have already deleted 100 times. I also tested addins check by title, but sometimes files have same names but coming from different sources so then these same name torrents from different feed get ignored. Maybe it is the exactly same thing but maybe its not so its better to use guid and not the title. I hope it fixes also this problem https://github.com/Novik/ruTorrent/issues/2637