### PR TITLE
If Log tab to file is disabled, the console.log give errors fix

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -896,9 +896,16 @@ function sendLogToServer(msg, status) {
                 },
                 body: `message=${encodeURIComponent(msg)}&status=${encodeURIComponent(status)}`
         })
-        .then(response => response.json())
+        .then(response => {
+                if (response.status === 204) {
+                        return;
+                }
+                return response.json();
+        })
         .then(data => {
-                console.log("Log saved to server:", data);
+                if (data) {
+                        console.log("Log saved to server:", data);
+                }
         })
         .catch(error => {
                 console.log("Saving Log failed:", error);


### PR DESCRIPTION
If Log tab to file function is disabled, the console.log show json errors. Will see nothing normally. That will fix this problem. If Logging is turned on you will never know about this problem.