### PR TITLE
Improve rXMLRPCRequest send()

### DIFF
--- a/php/xmlrpc.php
+++ b/php/xmlrpc.php
@@ -106,11 +106,11 @@ class rXMLRPCRequest
 			$socket = @fsockopen($scgi_host, $scgi_port, $errno, $errstr, $rpcTimeOut);
 			if($socket) 
 			{
-				$reqheader = "CONTENT_LENGTH\x0".$contentlength."\x0"."SCGI\x0"."1\x0UNTRUSTED_CONNECTION\x0".($trusted ? "0" : "1")."\x0";
+				$reqheader = "CONTENT_LENGTH\x0".$contentlength."\x0"."CONTENT_TYPE\x0"."text/xml\x0"."SCGI\x0"."1\x0UNTRUSTED_CONNECTION\x0".($trusted ? "0" : "1")."\x0";
 				$tosend = strlen($reqheader).":{$reqheader},{$data}";
 				@fwrite($socket,$tosend,strlen($tosend));
 				$result = '';
-				while($data = fread($socket, 4096))
+				while($data = fread($socket, 65536))
 					$result .= $data;
 				fclose($socket);
 			}


### PR DESCRIPTION
Improve rXMLRPCRequest send():
- Add "CONTENT_TYPE" "text/xml" - suggested by @yandrey0
- Increase read buf size from 4096 to 65536

It is partial fix for #2879