### PR TITLE
Remove "charset=UTF-8" from content type for HTTP post request to RPC2 due to rtorrent bug.

### DIFF
--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -200,7 +200,11 @@ function rTorrentStub( URI )
 	this.content = null;
 	this.mountPoint = theURLs.XMLRPCMountPoint;
 	this.faultString = [];
-	this.contentType = "text/xml; charset=UTF-8";
+	/* Remove 'charset=UTF-8' due to bug in rtorrent.
+	 * https://github.com/Novik/ruTorrent/issues/2879
+	 * https://github.com/rakshasa/rtorrent/issues/1444#issuecomment-2847868158
+	 */
+	this.contentType = "text/xml";
 	this.dataType = "xml";
 	this.method = "POST";
 	this.ifModified = false;


### PR DESCRIPTION

Fixes: #2879