### PR TITLE
Normalize torrent name for better readability.

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -462,6 +462,68 @@ var theConverter =
 	}
 };
 
+var theNormalizer = {
+	encloses: ['[]', '{}', '()'],
+	getLabel(s) {
+		let res;
+		if (s !== null) {
+			for (const enclose of this.encloses) {
+				const o = enclose.substr(0, 1);
+				const c = enclose.substr(1, 1);
+				const re = new RegExp(`^\\${o}(.*?)\\${c}`, 'i');
+				const matches = re.exec(s);
+				if (matches) {
+					res = [matches[1], s.substr(matches[0].length)];
+					break;
+				}
+			}
+		}
+		return res;
+	},
+	clean(s, sortable = true) {
+		if (s !== null && s.length) {
+			if (sortable) {
+				// replace dot and underscore with whitespace
+				// replace multiple whitespace with single whitespace
+				s = s.replace(/(\.|_|\s{2,})/g, ' ');
+			} else {
+				s = s
+					.replace(/^(\.|_)/g, ' ')
+					.replace(/(\.|_)$/g, ' ');
+			}
+			s = s.trim();
+		}
+		return s;
+	},
+	normalize(s, sortable = true) {
+		if (s !== null) {
+			// get label
+			const label = this.getLabel(s);
+			if (label) {
+				s = label[1];
+			}
+			s = this.clean(s, sortable);
+			if (sortable) {
+				// ignore 'the' in the beginning text
+				if (s.length && s.toLowerCase().substr(0, 3) === 'the') {
+					s = s
+						.substr(3)
+						.trim();
+				}
+			}
+			// append label if necessary
+			if (s.length && label) {
+				s += ` \`${label[0]}\``;
+			}
+			// treat label as string
+			if (s.length === 0 && label) {
+				s = label[0];
+			}
+		}
+		return s;
+	}
+}
+
 var theFormatter =
 {
 	torrents: function(table,arr)
@@ -473,6 +535,9 @@ var theFormatter =
 			else
    			switch(iv(i))
 			{
+				case 0:
+					arr[i] = theNormalizer.normalize(arr[i], false);
+					break;
 				case 3:
 					arr[i] = (arr[i] / 10) + "%";
 					break;

--- a/js/common.js
+++ b/js/common.js
@@ -536,7 +536,9 @@ var theFormatter =
    			switch(iv(i))
 			{
 				case 0:
-					arr[i] = theNormalizer.normalize(arr[i], false);
+					if (theWebUI.settings["webui.normalize_torrent_name"]) {
+						arr[i] = theNormalizer.normalize(arr[i], false);
+					}
 					break;
 				case 3:
 					arr[i] = (arr[i] / 10) + "%";

--- a/js/options.js
+++ b/js/options.js
@@ -33,10 +33,12 @@ const theOptionsWindow = {
 						['webui.selected_labels.keep', theUILang.KeepSelectedLabels],
 						['webui.effects', theUILang.UIEffects],
 						['webui.speedintitle', theUILang.showSpeedInTitle],
+						['webui.normalize_torrent_name', theUILang.normalizeTorrentName],
 					].map(([id, label]) => $("<div>").addClass("col-md-6").append(
 						$("<input>").attr({type: "checkbox", id: id}),
 						$("<label>").attr({for: id}).text(label),
 					)),
+					$("<div>").addClass("col-md-6"),
 					...[
 						["webui.update_interval", theUILang.Update_GUI_every + ": ", theUILang.ms, 3000],
 						["webui.reqtimeout", theUILang.ReqTimeout + ": ", theUILang.ms, 5000],

--- a/js/stable.js
+++ b/js/stable.js
@@ -23,12 +23,13 @@
 */
 
 var TYPE_STRING = 0;
-var TYPE_NUMBER = 1;
-var TYPE_DATE = 2;
-var TYPE_STRING_NO_CASE = 3;
-var TYPE_PROGRESS = 4;
-var TYPE_PEERS = 5;
-var TYPE_SEEDS = 6;
+var TYPE_STRING_LABEL = 1;
+var TYPE_STRING_NO_CASE = 2;
+var TYPE_NUMBER = 3;
+var TYPE_DATE = 4;
+var TYPE_PROGRESS = 5;
+var TYPE_PEERS = 6;
+var TYPE_SEEDS = 7;
 var ALIGN_AUTO = 0;
 var ALIGN_LEFT = 1;
 var ALIGN_CENTER = 2;
@@ -490,6 +491,7 @@ dxSTable.prototype.getSorter = function(colType, valMapping)
 	const peerSort = (x,y) => theSort.PeersConnected(x,y) || theSort.PeersTotal(x,y);
 	const sorter = {
 		[TYPE_STRING]: theSort.AlphaNumeric,
+		[TYPE_STRING_LABEL]: (x, y) => theSort.NormalizedAlphaNumeric(x, y),
 		[TYPE_PROGRESS]: theSort.Numeric,
 		[TYPE_NUMBER]: theSort.Numeric,
 		[TYPE_PEERS]: peerSort,
@@ -528,6 +530,10 @@ var theSort =
 		var a = (x + "").toLowerCase();
 		var b = (y + "").toLowerCase();
 		return(a.localeCompare(b));
+	},
+	NormalizedAlphaNumeric: function(x, y)
+	{
+		return this.AlphaNumeric(theNormalizer.normalize(x), theNormalizer.normalize(y));
 	},
 	PeersTotal: function(x, y)
 	{
@@ -956,12 +962,17 @@ dxSTable.prototype.createRow = function(cols, sId, icon, attr) {
 		const celldata = data[index] || '';
 		const rawvalue = cols[index] || '';
 		const isProgress = cdat.type === TYPE_PROGRESS;
+		const isLabel = cdat.type === TYPE_STRING_LABEL;
 		if (isProgress) {
 			td.attr({rawvalue:rawvalue}).append(
 				$("<span>").addClass("meter-text").css({overflow:"visible"}).text(celldata),
 				$("<div>")
 					.addClass("meter-value")
 					.css(this.progressStyle(celldata)),
+			);
+		} else if (isLabel) {
+			td.append(
+				$("<div>").html((celldata || " ").replace(/`(.*?)`$/, '<code>$1</code>')),
 			);
 		} else {
 			td.append(

--- a/js/webui.js
+++ b/js/webui.js
@@ -9,7 +9,7 @@ var theWebUI = {
 		trt: {
 			obj: new dxSTable(),
 			columns: [
-				{ text: theUILang.Name, 		width: "200px", id: "name",		type: TYPE_STRING },
+				{ text: theUILang.Name, 		width: "200px", id: "name",		type: TYPE_STRING_LABEL },
 				{ text: theUILang.Status, 		width: "100px",	id: "status",		type: TYPE_STRING },
 				{ text: theUILang.Size, 		width: "70px",	id: "size", 		type: TYPE_NUMBER },
 				{ text: theUILang.Done, 		width: "100px",	id: "done",		type: TYPE_PROGRESS },

--- a/js/webui.js
+++ b/js/webui.js
@@ -9,7 +9,7 @@ var theWebUI = {
 		trt: {
 			obj: new dxSTable(),
 			columns: [
-				{ text: theUILang.Name, 		width: "200px", id: "name",		type: TYPE_STRING_LABEL },
+				{ text: theUILang.Name, 		width: "200px", id: "name",		type: TYPE_STRING },
 				{ text: theUILang.Status, 		width: "100px",	id: "status",		type: TYPE_STRING },
 				{ text: theUILang.Size, 		width: "70px",	id: "size", 		type: TYPE_NUMBER },
 				{ text: theUILang.Done, 		width: "100px",	id: "done",		type: TYPE_PROGRESS },
@@ -148,6 +148,7 @@ var theWebUI = {
 		"webui.timeformat":		0,
 		"webui.dateformat":		0,
 		"webui.speedintitle":		0,
+		"webui.normalize_torrent_name":	0,
 		"webui.speedgraph.max_seconds": 600,
 		"webui.log_autoswitch":		1,
 		"webui.labelsize_rightalign":		0,
@@ -456,6 +457,10 @@ var theWebUI = {
 //		this.setStatusUpdate();
 		$.each(this.tables, function(ndx,table)
 		{
+			// is torrent name normalizing enabled?
+			if (ndx === 'trt' && theWebUI.settings["webui.normalize_torrent_name"]) {
+				table.columns.find(c => c.id === 'name').type = TYPE_STRING_LABEL;
+			}
 			table.obj.create($$(table.container), table.columns, ndx);
 			// legacy support of numeric sortId, sortId2
 			for(const name of ['sortId', 'sortId2']) {
@@ -744,6 +749,7 @@ var theWebUI = {
 								break;
 							}
 							case "webui.register_magnet":
+							case "webui.normalize_torrent_name":
 							{
 								reply = theWebUI.reload;
 								break;
@@ -868,7 +874,7 @@ var theWebUI = {
 				cookie[i] = v;
 		}
 		// We must encode the URL here to avoid injection with the "&" symbol from search results
-		theWebUI.request("?action=setuisettings&v=" + encodeURIComponent(JSON.stringify(cookie),reply));
+		theWebUI.request("?action=setuisettings&v=" + encodeURIComponent(JSON.stringify(cookie)), reply);
 	},
 
 //

--- a/lang/bn.js
+++ b/lang/bn.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "সমস্ত ট্যাগ সরান",
  Torrents			: "টরেন্ট (গুলি)",
  copyToClipboardFailed		: "কপি ফাংশন আপনার ব্রাউজারে কাজ করছে না।\nদয়া করে এই কন্টেন্টটি ম্যানুয়ালি কপি করুন:\n\n",
- copyToClipboardSuccess		: "সফলভাবে ক্লিপবোর্ডে কপি করা হয়েছে!"
+ copyToClipboardSuccess		: "সফলভাবে ক্লিপবোর্ডে কপি করা হয়েছে!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/da.js
+++ b/lang/da.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/el.js
+++ b/lang/el.js
@@ -318,5 +318,6 @@ var theUILang =
  removeAllTegs			: "Διαγραφή όλων των ετικετών",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "Η λειτουργία αντιγραφής δεν λειτουργεί στον περιηγητή σας.\nΠαρακαλώ αντιγράψτε αυτό το περιεχόμενο χειροκίνητα:\n\n",
- copyToClipboardSuccess		: "Αντιγράφηκε με επιτυχία στο πρόχειρο!"
+ copyToClipboardSuccess		: "Αντιγράφηκε με επιτυχία στο πρόχειρο!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Retirer tous les tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "La fonction copier ne fonctionne pas dans votre navigateur.\nVeuillez copier ce contenu manuellement :\n\n",
- copyToClipboardSuccess		: "Copié dans le presse-papier avec succès !"
+ copyToClipboardSuccess		: "Copié dans le presse-papier avec succès !",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Minden címke eltávolítása",
  Torrents			: "Torrent(ek)",
  copyToClipboardFailed		: "A másolás funkció nem működik a böngésződben.\nKérlek, másold le ezt a tartalmat kézzel:\n\n",
- copyToClipboardSuccess		: "Sikeresen átmásoltam a vágólapra!"
+ copyToClipboardSuccess		: "Sikeresen átmásoltam a vágólapra!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/it.js
+++ b/lang/it.js
@@ -321,5 +321,6 @@ var theUILang =
  removeAllTegs			: "Rimuovi tutti i tag",
  Torrents			: "Torrent",
  copyToClipboardFailed		: "La funzione copia non funziona nel tuo browser.\nCopia il contenuto manualmente:\n\n",
- copyToClipboardSuccess		: "Copiato con successo negli appunti!"
+ copyToClipboardSuccess		: "Copiato con successo negli appunti!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -318,5 +318,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/no.js
+++ b/lang/no.js
@@ -319,5 +319,6 @@ var theUILang =
  removeAllTegs			: "Fjern alle etiketter",
  Torrents			: "Torrent(er)",
  copyToClipboardFailed		: "Kopier-funksjonen virker ikke i nettleseren din.\nVennligst kopier dette innholdet manuelt:\n\n",
- copyToClipboardSuccess		: "Kopiert til utklippstavlen!"
+ copyToClipboardSuccess		: "Kopiert til utklippstavlen!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -321,5 +321,6 @@ var theUILang =
  removeAllTegs			: "Usuń wszystkie znaczniki",
  Torrents			: "Torrent(y)",
  copyToClipboardFailed		: "Funkcja kopiowania nie działa w Twojej przeglądarce.\nSkopiuj tę zawartość ręcznie:\n\n",
- copyToClipboardSuccess		: "Pomyślnie skopiowano do schowka!"
+ copyToClipboardSuccess		: "Pomyślnie skopiowano do schowka!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/pt-br.js
+++ b/lang/pt-br.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/pt-pt.js
+++ b/lang/pt-pt.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Remover todos os marcadores",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "A função de cópia não está a funcionar no navegador.\nCopia este conteúdo manualmente:\n\n",
- copyToClipboardSuccess		: "Copiado para a área de transferência com sucesso!"
+ copyToClipboardSuccess		: "Copiado para a área de transferência com sucesso!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Удалить все теги",
  Torrents			: "Торренты",
  copyToClipboardFailed		: "Функция копирования не работает в вашем браузере.\nСкопируйте требуемое вручную.\n\n",
- copyToClipboardSuccess		: "Успешно скопировано!"
+ copyToClipboardSuccess		: "Успешно скопировано!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -318,5 +318,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -318,5 +318,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs : "Tüm etiketleri kaldır",
  Torrents: "Torrent",
  copyToClipboardFailed : "Tarayıcınızda kopyalama işlevi çalışmıyor.\nLütfen bunu kendiniz kopyalayın:\n\n",
- copyToClipboardSuccess : "Panoya başarıyla kopyalandı."
+ copyToClipboardSuccess : "Panoya başarıyla kopyalandı.",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -320,5 +320,6 @@ var theUILang =
  removeAllTegs			: "Видалити всі теги",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -318,5 +318,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -318,5 +318,8 @@ var theUILang =
  registerMagnet			: "尝试在启动时注册磁力链协议",
  linkTorTorrentRestored		: "与 rTorrent 的连接已建立.",
  removeAllTegs			: "删除所有标签",
- Torrents			: "Torrent(s)"
+ Torrents			: "Torrent(s)",
+ copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -318,5 +318,6 @@ var theUILang =
  removeAllTegs			: "Remove all tags",
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
- copyToClipboardSuccess		: "Copied to clipboard successfully!"
+ copyToClipboardSuccess		: "Copied to clipboard successfully!",
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
 };


### PR DESCRIPTION
There is no standard way how to name the torrent. Consider the following examples.

```
[TheReleaseGroup] Movie Tittle (2025)
Movie Tittle (2025)
The.Movie.Tittle.(2025)
The_Movie_Tittle_(2025)
```
All those names considered as equal if a normalization is performed.

This patch allows to perform simple normalization such as normalize dots and underscores to whitespace, replaces multiple whitespaces to single one, also recognize label in name (`[Label] Name`) and transform it to *Name `Label`*.