### PR TITLE
Supports relative path in symlink.

### DIFF
--- a/php/utility/permission.php
+++ b/php/utility/permission.php
@@ -37,7 +37,11 @@ class Permission
 				return(true);
 		}
 		if(is_link($file))
-			$file = readlink($file);
+		{
+			$newfile = readlink($file);
+			// check for relative link, e.g. ../path/to/other/dir
+			$file = substr($newfile, 0, 1) === '.' ? realpath(dirname($file) . DIRECTORY_SEPARATOR . $newfile) : $newfile;
+		}
 		if(self::isUserHavePrim($uid,$gids,$file,$flags))
 		{
 			if(($flags & 0x0002) && !is_dir($file))

--- a/tests/php-test.ini
+++ b/tests/php-test.ini
@@ -1,2 +1,3 @@
-assert.active = true
-assert.bail = true
+zend.assertions = 1
+;assert.exception = 0
+;assert.bail = 0

--- a/tests/php-test.sh
+++ b/tests/php-test.sh
@@ -2,12 +2,18 @@
 set -e
 
 TEST_RUN='
-echo "Running tests...\n";
 foreach(get_declared_classes() as $cls) {
 	if (get_parent_class($cls) == "TestCase") {
-		echo "Test: ".$cls."\n";
-		$obj = new $cls;
-		$obj->run();
+		echo "Test: {$cls}\n";
+		$obj = new $cls();
+		try {
+			$obj->setUp();
+			$obj->run();
+		} catch (Exception $e) {
+			echo $e->getMessage()."\n";
+			echo $e->getTraceAsString()."\n";
+		}
+		$obj->tearDown();
 	}
 }'
 

--- a/tests/php/PermissionTest.php
+++ b/tests/php/PermissionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/utility/permission.php');
+
+class PermissionTest extends TestCase
+{
+	protected $fixtureDir = null;
+	protected $dirs = [];
+
+	public function setUp()
+	{
+		$this->fixtureDir = __DIR__ . '/fixtures';
+		$this
+			->addDir('dir1', '/dir1')
+			->addDir('dir2', '/dir2')
+			->addDir('dir3', '/dir1/dir3', $this->fixtureDir . '/dir2')
+			->addDir('dir4', '/dir1/dir4', '../dir2')
+			->createDirs();
+	}
+
+	public function tearDown()
+	{
+		$this->cleanDirs();
+	}
+
+	protected function addDir($name, $dir, $symlink = null)
+	{
+		$this->dirs[$name] = [$this->fixtureDir . $dir, $symlink];
+
+		return $this;
+	}
+
+	protected function getDir($name)
+	{
+		return isset($this->dirs[$name]) ? $this->dirs[$name][0] : null;
+	}
+
+	protected function createDirs()
+	{
+		foreach ($this->dirs as [$dir, $symlink]) {
+			if ($symlink) {
+				if (is_link($dir)) {
+					unlink($dir);
+				}
+				symlink($symlink, $dir);
+			} else {
+				if (!is_dir($dir)) {
+					mkdir($dir, 0777, true);
+				}
+			}
+		}
+
+		return $this;
+	}
+
+	protected function cleanDirs()
+	{
+		foreach (array_reverse($this->dirs) as [$dir, $symlink]) {
+			if ($symlink) {
+				if (is_link($dir)) {
+					unlink($dir);
+				}
+			} else {
+				if (is_dir($dir)) {
+					rmdir($dir);
+				}
+			}
+		}
+
+		return $this;
+	}
+
+	public function testPermission()
+	{
+		$this->assertTrue(Permission::doesUserHave(1000, [1000], $this->getDir('dir1'), 0x0007), 'User has permission for directory');
+		$this->assertTrue(Permission::doesUserHave(1000, [1000], $this->getDir('dir3'), 0x0007), 'User has permission for symlinked directory');
+		$this->assertTrue(Permission::doesUserHave(1000, [1000], $this->getDir('dir4'), 0x0007), 'User has permission for relative symlinked directory');
+	}
+}

--- a/tests/php/TestCase.php
+++ b/tests/php/TestCase.php
@@ -1,25 +1,52 @@
 <?php
 
+foreach (['assert.exception' => 0, 'assert.bail'=> 0] as $configuration => $value) {
+	if ($value !== ($current = ini_get($configuration))) {
+		@ini_set($configuration, $value);
+	}
+}
+
 class TestCase
 {
 	function run() {
 		foreach (get_class_methods($this) as $method) {
 			if (substr($method, 0, 4) == 'test') {
-				echo ">>".$method.">>\n";
-				call_user_func([$this, $method]);
-				echo "\n<<".$method."<<\n";
+				echo ">>{$method}>>\n";
+				try {
+					call_user_func([$this, $method]);
+				} catch (Exception $e) {
+					echo "Test {$method} failed with error: {$e->getMessage()}\n";
+				}
+				echo "<<{$method}<<\n\n";
 			}
 		}
 	}
 
-	public function assertEquals($a, $b): void
+	public function setUp()
 	{
-		assert($a == $b, 'expected '.json_encode($a).' == '.json_encode($b));
 	}
 
-	public function assertTrue($bool, $message=''): void
+	public function tearDown()
 	{
-		assert($bool, $message);
+	}
+
+	public function assertEquals($a, $b, $message = null): void
+	{
+		$message = $message ? $message : 'Expected '.json_encode($a).' == '.json_encode($b);
+		if (@assert($a == $b, $message)) {
+			echo "Passed: {$message}\n";
+		} else {
+			echo "Failed: {$message}\n";
+		}
+	}
+
+	public function assertTrue($bool, $message = null): void
+	{
+		$message = $message ? $message : 'Expected value to be ' . ($bool ? 'true' : 'false');
+		if (@assert($bool, $message)) {
+			echo "Passed: {$message}\n";
+		} else {
+			echo "Failed: {$message}\n";
+		}
 	}
 }
-

--- a/tests/plugins/rss/RSSTest.php
+++ b/tests/plugins/rss/RSSTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
 @define('HISTORY_MAX_TRY', 3, true);
 @define('WAIT_AFTER_LOADING', 0, true);
 
-require(__DIR__ . '/../../php/TestCase.php');
+require_once(__DIR__ . '/../../php/TestCase.php');
 
 $minInterval = 2;	// in minutes
 
@@ -16,7 +16,7 @@ $feedsWithIncorrectTimes = array(
 );
 
 $rss_debug_enabled = true;
-require(__DIR__ . '/../../../plugins/rss/rss.php');
+require_once(__DIR__ . '/../../../plugins/rss/rss.php');
 
 class SnoopyMock
 {
@@ -44,8 +44,6 @@ final class RSSTest extends TestCase
 		$rRSS->lastModified = $exp_lastModified;
 		$history = new rRSSHistory();
 		$succ = $rRSS->fetch($history);
-		var_dump($rRSS->items);
-		var_dump($rRSS->lastErrorMsgs);
 		$this->assertEquals(0, count($rRSS->lastErrorMsgs));
 		$this->assertTrue($succ, 'fetch success');
 
@@ -105,8 +103,6 @@ final class RSSTest extends TestCase
 		$rRSS = new rRSS($exp_url, $rssFetchURL);
 		$history = new rRSSHistory();
 		$succ = $rRSS->fetch($history);
-		var_dump($rRSS->items);
-		var_dump($rRSS->lastErrorMsgs);
 		$this->assertEquals(1, count($rRSS->lastErrorMsgs));
 		$this->assertTrue($succ);
 
@@ -154,8 +150,6 @@ final class RSSTest extends TestCase
 		$rRSS = new rRSS($exp_url, $rssFetchURL);
 		$history = new rRSSHistory();
 		$succ = $rRSS->fetch($history);
-		var_dump($rRSS->items);
-		var_dump($rRSS->lastErrorMsgs);
 		$this->assertEquals(0, count($rRSS->lastErrorMsgs));
 		$this->assertTrue($succ);
 


### PR DESCRIPTION
As symbolic link can be relative, this patch resolve the path before handing it for permission check. 