### PR TITLE
fix(check_port): Adapt to new portchecker.co API requirements

### DIFF
--- a/plugins/check_port/action.php
+++ b/plugins/check_port/action.php
@@ -20,8 +20,9 @@ if($useWebsite=="portchecker")
 	$url = "https://portchecker.co/";
 	$ipMatch = '/data-ip="(?P<ip>[^"]+)/';
 	$checker = "https://portchecker.co/check-v0";
-	$closed = ">closed<";
-	$open = ">open<";
+	// Indicators will be constructed with $port, so define them before calling check_port
+	$closed = 'Port ' . $port . ' is <span class="red">closed</span>.';
+	$open = 'Port ' . $port . ' is <span class="green">open</span>.';
 }
 else
 {
@@ -52,20 +53,59 @@ function check_port($ip,$port,$checker,$closed,$open)
 {
 	global $useWebsite;
 	global $useIpv4;
+	global $url; // Needed for portchecker's initial GET request
 
 	$client = new Snoopy();
 	$client->proxy_host = "";
 	$client->useIpv4 = $useIpv4;
 
 	if($useWebsite=="yougetsignal")
-		$parse = "remoteAddress=".$ip."&portNumber=".$port;
-	if($useWebsite=="portchecker")
 	{
-		@$client->fetch($checker);
-		$client->setcookies();
-		$parse = "target_ip=".$ip."&port=".$port;
-		if(preg_match('/name="_csrf" value="(?P<csrf>[^"]+)/', $client->results, $match))
-			$parse .= "&_csrf=".$match["csrf"];
+		$parse = "remoteAddress=".$ip."&portNumber=".$port;
+	}
+	else if($useWebsite=="portchecker")
+	{
+		// Step 1: Fetch initial page (defined by global $url) to get cookies and CSRF token
+		@$client->fetch($url); // $url is https://portchecker.co/
+		$csrf_token = '';
+		if ($client->status == 200) {
+			$client->setcookies();
+			if (preg_match('/name="_csrf" value="(?P<csrf>[^"]+)"/', $client->results, $match_csrf)) {
+				$csrf_token = $match_csrf["csrf"];
+			} elseif (preg_match('/<meta\s+name="csrf-token"\s+content="(?P<csrf_meta>[^"]+)"/i', $client->results, $match_meta_csrf)) {
+				$csrf_token = $match_meta_csrf['csrf_meta'];
+			}
+		}
+
+		if (empty($csrf_token)) {
+			// CSRF token not found, port check will likely fail or be inaccurate.
+			CachedEcho::send('{ "ip": "'.$ip.'", "port": '.$port.', "status": 0 }',"application/json");
+			return; // Exit function
+		}
+
+		// Prepare POST data
+		$parse = "target_ip=".urlencode($ip)."&port=".urlencode($port)."&selectPort=".urlencode($port)."&_csrf=".urlencode($csrf_token);
+
+		// Set Referer and other headers for the POST request
+		$client->referer = $url; // $url is https://portchecker.co/
+		$client->rawheaders = []; // Clear any previous rawheaders
+		$client->rawheaders["Accept"] = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8";
+		$client->rawheaders["Accept-Language"] = "en-US,en;q=0.5";
+		$url_parts_pc = parse_url($url);
+		if (isset($url_parts_pc['scheme']) && isset($url_parts_pc['host'])) {
+			$client->rawheaders["Origin"] = $url_parts_pc['scheme'] . '://' . $url_parts_pc['host'];
+		}
+		$client->rawheaders["Connection"] = "keep-alive";
+		$client->rawheaders["Upgrade-Insecure-Requests"] = "1";
+		$client->rawheaders["Sec-Fetch-Dest"] = "document";
+		$client->rawheaders["Sec-Fetch-Mode"] = "navigate";
+		$client->rawheaders["Sec-Fetch-Site"] = "same-origin";
+		$client->rawheaders["Sec-Fetch-User"] = "?1";
+	}
+	else // Should not be reached if initial $useWebsite check is done properly
+	{
+		CachedEcho::send('{ "ip": "'.$ip.'", "port": '.$port.', "status": 0 }',"application/json");
+		return;
 	}
 
 	$ret = 0;

--- a/plugins/check_port/conf.php
+++ b/plugins/check_port/conf.php
@@ -1,7 +1,7 @@
 <?php
 // configuration parameter
 
-$useWebsite = "yougetsignal";	// Valid choices:
+$useWebsite = "portchecker";	// Valid choices:
 				// false - disable check_port plugin
 				// "yougetsignal" - use https://www.yougetsignal.com/tools/open-ports/
 				// "portchecker" - use https://portchecker.co/


### PR DESCRIPTION
Following the endpoint update, this commit implements the necessary changes to correctly interact with the new portchecker.co `/check-v0` API:

- Performs an initial GET request to the main page (portchecker.co) to obtain a CSRF token and session cookies.
- Sets appropriate HTTP headers for the POST request, including User-Agent, Referer, Origin, and others to mimic a browser.
- Constructs the POST data with the target IP, port, and the retrieved CSRF token.
- Updates the "open" and "closed" port indicator strings to match the new response format from `/check-v0`.