### PR TITLE
Allows both count and size part to be right aligned

### DIFF
--- a/css/panel-label.css
+++ b/css/panel-label.css
@@ -46,11 +46,15 @@ div {
 
 [part="count"],
 [part="size"] {
-  color: var(--badge-color);
   background-color: var(--badge-background-color);
   padding: var(--badge-padding, 0.1em 0.3em 0.1em 0.3em);
   border-radius: var(--badge-border-radius, 0.8em);
   white-space: pre;
+}
+
+:not(:host([selected])) [part="count"],
+:not(:host([selected])) [part="size"] {
+  color: var(--badge-color);
 }
 
 [part="icon"] {

--- a/css/style.css
+++ b/css/style.css
@@ -165,7 +165,7 @@ button:not(:disabled):active, input[type=button]:not(:disabled):active, a.Button
 a.dropdown-item {
   width: auto;
 }
-category-list.rightalign-labelsize panel-label::part(size) {
+category-list.rightalign-labelsize panel-label::part(count) {
   margin-left: auto;
 }
 category-list.hide-textoverflow panel-label::part(text) {

--- a/index.html
+++ b/index.html
@@ -144,6 +144,7 @@
 						<div part="icon"></div>
 						<div part="text"></div>
 						<div part="count">0</div>
+						<div part="separator">/</div>
 						<div part="size" style="display: none;"></div>
 					</template>
 					<template id="category-panel-template">

--- a/js/category-list-elements.js
+++ b/js/category-list-elements.js
@@ -30,7 +30,7 @@ customElements.define(
   "panel-label",
   class extends CustomHTMLElement {
     static template = document.getElementById("panel-label-template");
-    static stringAttributeNames = ["prefix", "icon", "text", "count", "size"];
+    static stringAttributeNames = ["prefix", "icon", "text", "count", "separator", "size"];
     static booleanAttributeNames = ["selected"];
     static attributeChangeCallbacks = {
       prefix: function (_, newValue) {
@@ -78,6 +78,7 @@ customElements.define(
       },
       size: function (_, newValue) {
         this._hideOrSetText(this.parts.size, newValue);
+        this._hideOrSetText(this.parts.separator, newValue, true);
       },
       count: function (_, newValue) {
         this._hideOrSetText(this.parts.count, newValue);
@@ -91,10 +92,12 @@ customElements.define(
       this.customDefineAttributes();
     }
 
-    _hideOrSetText(el, newValue) {
+    _hideOrSetText(el, newValue, skipText = null) {
       if (newValue != null) {
         el.style.display = "block";
-        el.textContent = newValue;
+        if (!skipText) {
+          el.textContent = newValue;
+        }
       } else {
         el.style.display = "none";
       }

--- a/plugins/theme/themes/Acid/style.css
+++ b/plugins/theme/themes/Acid/style.css
@@ -85,6 +85,11 @@ panel-label[selected] {
   color: #272E36;
 }
 
+panel-label[selected]::part(count),
+panel-label[selected]::part(size) {
+  color: #FFF;
+}
+
 div#preload {background-image: url(./images/toolbar.png); background-image: url(./images/tstatus.png); background-image: url(./images/t_bg.png); background-image: url(./images/r_bg.gif); background-image: url(./images/i_bg.gif); background-image: url(./images/file.gif); background-image: url(./images/dir.gif);}
 div#cover {background: #272E36}
 div#msg {background: #272E36; border-top: 1px solid #D0D0D0; border-bottom: 1px solid #D0D0D0; color: #00ff00;}


### PR DESCRIPTION
This patch adds a separator between count and size with `/`, allows both to be right aligned, honor the selected state and fix Acid theme selected color to be contrast with background.