### PR TITLE
tracklabels - option to hide trackers from the panel

### DIFF
--- a/plugins/tracklabels/conf.php
+++ b/plugins/tracklabels/conf.php
@@ -1,5 +1,13 @@
 <?php
 
+// Trackers you want to hide from the panel
+// Example:
+// $hideTrackers = array (
+// "tracker.net", "tracker.org"
+// );
+$hideTrackers = array (
+);
+
 // Label aliases is used:
 // 1. Map a label to already known label
 // 2. Get the favourite icon (favicon.ico or favicon.png) using provided alias

--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -95,6 +95,7 @@ if(!$type(theWebUI.getTrackerName))
 				}
 			}
 		}
+		if ($.inArray( domain, plugin.hideTrackers, domain ) != -1) domain = '';
 		return(domain);
 	}
 }

--- a/plugins/tracklabels/init.php
+++ b/plugins/tracklabels/init.php
@@ -1,0 +1,7 @@
+<?php
+
+eval( FileUtil::getPluginConf( $plugin["name"] ) );
+
+$jResult.=("plugin.hideTrackers = ".JSON::safeEncode($hideTrackers).";");
+
+$theSettings->registerPlugin($plugin["name"],$pInfo["perms"]);


### PR DESCRIPTION
Some sites add several trackers (primary, backup, etc) to their torrents. All of them are visible in the tracklabels panel. I do not like it. So here's an option to define trackers which won't be displayed.