### PR TITLE
fix(rss.php): http status 304 unmodified

### DIFF
--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -143,7 +143,7 @@ class rRSS
 			$headers['If-Last-Modified'] = $this->lastModified;
 		$cli = call_user_func($this->fetchURL, $this->url, $this->cookies, $headers);
 		if($cli->status<200 || $cli->status>=300) {
-			if ($cli->status !== 304) {
+			if ($cli->status != 304) {
                                 $msg = $cli->status == -100
                                         ? '[RSS-Timeout]'
                                         : ($cli->status < 100


### PR DESCRIPTION
I notice there is a small issue due to type coertion in status checking.

We cannot use `$cli->status !== 304` cause we are comparing `string` to `integer`.