### PR TITLE
feat(check_port): Implement dual IPv4/IPv6 port status checking and display

### DIFF
--- a/plugins/check_port/action.php
+++ b/plugins/check_port/action.php
@@ -189,5 +189,4 @@ if ($currentUseWebsiteIPv6 !== false) {
 }
 
 // Send the final JSON response to the client.
-header('Content-Type: application/json');
-echo json_encode($response);
+CachedEcho::send(JSON::safeEncode($response), "application/json");

--- a/plugins/check_port/action.php
+++ b/plugins/check_port/action.php
@@ -5,71 +5,71 @@ require_once(dirname(__FILE__) . "/../../php/Snoopy.class.inc");
 // Load the plugin's configuration settings from conf.php
 eval(FileUtil::getPluginConf('check_port'));
 
-// Default values for configuration, used if not set in conf.php.
+// Default values for configuration, used if not set in conf.php
 $currentCheckPortTimeout = isset($checkPortTimeout) ? (int)$checkPortTimeout : 15;
 $currentUseWebsiteIPv4 = isset($useWebsiteIPv4) ? $useWebsiteIPv4 : "yougetsignal";
 $currentUseWebsiteIPv6 = isset($useWebsiteIPv6) ? $useWebsiteIPv6 : "portchecker";
 
 /**
- * Gets the public IP address (IPv4 or IPv6) from ipify.org.
- * It uses Snoopy (a curl wrapper) to make the request.
+ * Gets the public IP address (IPv4 or IPv6) from ipify.org
+ * It uses Snoopy (a curl wrapper) to make the request
  *
- * @param string $version '4' for IPv4, '6' for IPv6.
- * @param int $timeout Request timeout.
- * @return string|null The public IP address or null on failure.
+ * @param string $version '4' for IPv4, '6' for IPv6
+ * @param int $timeout Request timeout
+ * @return string|null The public IP address or null on failure
  */
 function get_public_ip($version, $timeout) {
 	if (!Utility::getExternal('curl')) {
-		error_log("check_port plugin: 'curl' executable not found.");
+		error_log("check_port plugin: 'curl' executable not found");
 		return null;
 	}
-	// Initialize the Snoopy client.
+	// Initialize the Snoopy client
 	$snoopy = new Snoopy();
 	$snoopy->agent = "ruTorrent CheckPort Plugin/IP Check";
-	// Set a timeout for the request, with a minimum of 5 seconds.
+	// Set a timeout for the request, with a minimum of 5 seconds
 	$snoopy->read_timeout = max(5, (int)($timeout / 2));
-	$snoopy->proxy_host = ""; // Do not use a proxy for this external IP check.
+	$snoopy->proxy_host = ""; // Do not use a proxy for this external IP check
 
-	// Select the correct ipify API URL based on the requested IP version.
+	// Select the correct ipify API URL based on the requested IP version
 	$url = ($version == '6') ? "https://api64.ipify.org/" : "https://api4.ipify.org/";
-	@$snoopy->fetch($url); // Fetch the URL.
+	@$snoopy->fetch($url); // Fetch the URL
 
-	// Check if the request was successful and returned content.
+	// Check if the request was successful and returned content
 	if ($snoopy->status == 200 && !empty($snoopy->results)) {
 		$ip = trim($snoopy->results);
-		// Validate the returned IP address to ensure it's a valid IPv4 or IPv6.
+		// Validate the returned IP address to ensure it's a valid IPv4 or IPv6
 		$flag = ($version == '6') ? FILTER_FLAG_IPV6 : FILTER_FLAG_IPV4;
 		if (filter_var($ip, FILTER_VALIDATE_IP, $flag)) {
-			return $ip; // Return the valid IP.
+			return $ip; // Return the valid IP
 		}
 		error_log("check_port plugin: {$url} returned invalid IP: " . $ip);
 	} else {
 		error_log("check_port plugin: Failed to fetch from {$url}. Status: {$snoopy->status}, Error: {$snoopy->error}");
 	}
-	return null; // Return null on failure.
+	return null; // Return null on failure
 }
 
 /**
- * Checks port status using yougetsignal.com.
+ * Checks port status using yougetsignal.com
  *
- * @param string $ip The IP address to check.
- * @param int $port The port number to check.
- * @param int $timeout Request timeout in seconds.
- * @return int Status code (0: unknown, 1: closed, 2: open).
+ * @param string $ip The IP address to check
+ * @param int $port The port number to check
+ * @param int $timeout Request timeout in seconds
+ * @return int Status code (0: unknown, 1: closed, 2: open)
  */
 function check_port_yougetsignal($ip, $port, $timeout) {
 	$client = new Snoopy();
 	$client->read_timeout = (int)$timeout;
-	$client->proxy_host = ""; // Do not use a proxy for this check.
+	$client->proxy_host = ""; // Do not use a proxy for this check
 	$post_data = "remoteAddress=" . urlencode($ip) . "&portNumber=" . urlencode($port);
 
-	// Make a POST request to the port checking service.
+	// Make a POST request to the port checking service
 	@$client->fetch("https://ports.yougetsignal.com/check-port.php", "POST", "application/x-www-form-urlencoded", $post_data);
 
-	// Parse the response to determine port status.
+	// Parse the response to determine port status
 	if ($client->status == 200) {
-		if (stripos($client->results, "is closed") !== false) return 1; // Port is closed.
-		if (stripos($client->results, "is open") !== false) return 2; // Port is open.
+		if (stripos($client->results, "is closed") !== false) return 1; // Port is closed
+		if (stripos($client->results, "is open") !== false) return 2; // Port is open
 		error_log("check_port: yougetsignal response indicators not found for IP {$ip}. Response: " . substr($client->results, 0, 500));
 	} else {
 		error_log("check_port: Failed fetch from yougetsignal for IP {$ip}. Status: {$client->status}, Error: {$client->error}");
@@ -78,64 +78,64 @@ function check_port_yougetsignal($ip, $port, $timeout) {
 }
 
 /**
- * Checks port status using portchecker.co.
+ * Checks port status using portchecker.co
  *
- * @param string $ip The IP address to check.
- * @param int $port The port number to check.
- * @param int $timeout Request timeout in seconds.
- * @return int Status code (0: unknown, 1: closed, 2: open).
+ * @param string $ip The IP address to check
+ * @param int $port The port number to check
+ * @param int $timeout Request timeout in seconds
+ * @return int Status code (0: unknown, 1: closed, 2: open)
  */
 function check_port_portchecker($ip, $port, $timeout) {
 	$client = new Snoopy();
 	$client->read_timeout = (int)$timeout;
-	$client->proxy_host = ""; // Do not use a proxy for this check.
+	$client->proxy_host = ""; // Do not use a proxy for this check
 
-	// Fetch the main page to acquire a CSRF token and session cookie.
+	// Fetch the main page to acquire a CSRF token and session cookie
 	@$client->fetch("https://portchecker.co/");
 	if ($client->status != 200) {
 		error_log("check_port: Could not fetch portchecker.co main page. Status: {$client->status}");
 		return 0;
 	}
-	$client->setcookies(); // Store cookies to be sent in the next request.
+	$client->setcookies(); // Store cookies to be sent in the next request
 
-	// Extract the CSRF token from the page content.
+	// Extract the CSRF token from the page content
 	$csrf_token = '';
 	if (preg_match('/name="_csrf" value="(?P<csrf>[^"]+)"/', $client->results, $match)) {
 		$csrf_token = $match["csrf"];
 	}
-	// If no token is found, the check cannot proceed.
+	// If no token is found, the check cannot proceed
 	if (empty($csrf_token)) {
-		error_log("check_port: CSRF token not found from portchecker.co for IP: {$ip}.");
+		error_log("check_port: CSRF token not found from portchecker.co for IP: {$ip}");
 		return 0;
 	}
 
-	// Prepare the POST data for the port check request, including the CSRF token.
+	// Prepare the POST data for the port check request, including the CSRF token
 	$post_data = "target_ip=" . urlencode($ip) . "&port=" . urlencode($port) . "&_csrf=" . urlencode($csrf_token);
-	$client->referer = "https://portchecker.co/"; // Set the referer header.
+	$client->referer = "https://portchecker.co/"; // Set the referer header
 
-	// Make the actual port check request to the API endpoint.
+	// Make the actual port check request to the API endpoint
 	@$client->fetch("https://portchecker.co/check-v0", "POST", "application/x-www-form-urlencoded", $post_data);
 
-	// Parse the JSON response to determine port status.
+	// Parse the JSON response to determine port status
 	if ($client->status == 200) {
-		if (stripos($client->results, 'is <span class="red">closed</span>') !== false) return 1; // Port is closed.
-		if (stripos($client->results, 'is <span class="green">open</span>') !== false) return 2; // Port is open.
+		if (stripos($client->results, 'is <span class="red">closed</span>') !== false) return 1; // Port is closed
+		if (stripos($client->results, 'is <span class="green">open</span>') !== false) return 2; // Port is open
 		error_log("check_port: portchecker response indicators not found for IP {$ip}. Response: " . substr($client->results, 0, 500));
 	} else {
 		error_log("check_port: Failed fetch from portchecker endpoint for IP {$ip}. Status: {$client->status}, Error: {$client->error}");
 	}
-	return 0; // Status is unknown.
+	return 0; // Status is unknown
 }
 
 /**
- * Main logic to get an IP and check its port status for a given IP version.
+ * Main logic to get an IP and check its port status for a given IP version
  *
- * @param string $ip_version '4' or '6', for IPv4 or IPv6.
- * @param string $use_website The checking service to use ('yougetsignal' or 'portchecker').
- * @param string $rtorrent_ip The IP address configured in rTorrent (if any).
- * @param int $rtorrent_port The listening port configured in rTorrent.
- * @param int $timeout The request timeout in seconds.
- * @return array An associative array with 'ip' and 'status' keys.
+ * @param string $ip_version '4' or '6', for IPv4 or IPv6
+ * @param string $use_website The checking service to use ('yougetsignal' or 'portchecker')
+ * @param string $rtorrent_ip The IP address configured in rTorrent (if any)
+ * @param int $rtorrent_port The listening port configured in rTorrent
+ * @param int $timeout The request timeout in seconds
+ * @return array An associative array with 'ip' and 'status' keys
  */
 function get_and_check_ip($ip_version, $use_website, $rtorrent_ip, $rtorrent_port, $timeout) {
 	$ip_to_check = null;
@@ -143,15 +143,15 @@ function get_and_check_ip($ip_version, $use_website, $rtorrent_ip, $rtorrent_por
 
 	if (!empty($rtorrent_ip) && filter_var($rtorrent_ip, FILTER_VALIDATE_IP, $flag)) {
 		$ip_to_check = $rtorrent_ip;
-		// If rTorrent's IP is not set or invalid for the version, fetch the public IP.
+		// If rTorrent's IP is not set or invalid for the version, fetch the public IP
 	} else {
 		$ip_to_check = get_public_ip($ip_version, $timeout);
 	}
 
-	// If an IP was determined, proceed to check the port.
+	// If an IP was determined, proceed to check the port
 	if ($ip_to_check) {
 		$status = 0;
-		// Call the appropriate checking function based on the selected service.
+		// Call the appropriate checking function based on the selected service
 		if ($use_website == "yougetsignal") {
 			$status = check_port_yougetsignal($ip_to_check, $rtorrent_port, $timeout);
 		} elseif ($use_website == "portchecker") {
@@ -159,34 +159,34 @@ function get_and_check_ip($ip_version, $use_website, $rtorrent_ip, $rtorrent_por
 		}
 		return ["ip" => $ip_to_check, "status" => $status];
 	}
-	// Return a default "not available" state if no IP could be determined.
+	// Return a default "not available" state if no IP could be determined
 	return ["ip" => "-", "status" => 0];
 }
 
 // --- Main Execution ---
-// Get rTorrent's listening port and configured IP from settings.
+// Get rTorrent's listening port and configured IP from settings
 $port = rTorrentSettings::get()->port;
 $ip_glob = rTorrentSettings::get()->ip;
 
-// Initialize the response structure that will be sent to the client.
+// Initialize the response structure that will be sent to the client
 $response = [
 	"ipv4" => "-", "ipv4_port" => (int)$port, "ipv4_status" => 0,
 	"ipv6" => "-", "ipv6_port" => (int)$port, "ipv6_status" => 0,
 ];
 
-// Perform the IPv4 check if it's enabled in conf.php.
+// Perform the IPv4 check if it's enabled in conf.php
 if ($currentUseWebsiteIPv4 !== false) {
 	$ipv4_result = get_and_check_ip('4', $currentUseWebsiteIPv4, $ip_glob, $port, $currentCheckPortTimeout);
 	$response["ipv4"] = $ipv4_result["ip"];
 	$response["ipv4_status"] = $ipv4_result["status"];
 }
 
-// Perform the IPv6 check if it's enabled in conf.php.
+// Perform the IPv6 check if it's enabled in conf.php
 if ($currentUseWebsiteIPv6 !== false) {
 	$ipv6_result = get_and_check_ip('6', $currentUseWebsiteIPv6, $ip_glob, $port, $currentCheckPortTimeout);
 	$response["ipv6"] = $ipv6_result["ip"];
 	$response["ipv6_status"] = $ipv6_result["status"];
 }
 
-// Send the final JSON response to the client.
+// Send the final JSON response to the client
 CachedEcho::send(JSON::safeEncode($response), "application/json");

--- a/plugins/check_port/action.php
+++ b/plugins/check_port/action.php
@@ -1,9 +1,9 @@
 <?php
-require_once( dirname(__FILE__)."/../../php/settings.php" );
-require_once( dirname(__FILE__)."/../../php/Snoopy.class.inc" );
+require_once(dirname(__FILE__) . "/../../php/settings.php");
+require_once(dirname(__FILE__) . "/../../php/Snoopy.class.inc");
 
-// Load the plugin's configuration from conf.php.
-eval( FileUtil::getPluginConf( 'check_port' ) );
+// Load the plugin's configuration settings from conf.php
+eval(FileUtil::getPluginConf('check_port'));
 
 // Default values for configuration, used if not set in conf.php.
 $currentCheckPortTimeout = isset($checkPortTimeout) ? (int)$checkPortTimeout : 15;
@@ -19,34 +19,34 @@ $currentUseWebsiteIPv6 = isset($useWebsiteIPv6) ? $useWebsiteIPv6 : "portchecker
  * @return string|null The public IP address or null on failure.
  */
 function get_public_ip($version, $timeout) {
-    if (!Utility::getExternal('curl')) {
-        error_log("check_port plugin: 'curl' executable not found.");
-        return null;
-    }
- 	// Initialize the Snoopy client.
-    $snoopy = new Snoopy();
-    $snoopy->agent = "ruTorrent CheckPort Plugin/IP Check";
- 	// Set a timeout for the request, with a minimum of 5 seconds.
-    $snoopy->read_timeout = max(5, (int)($timeout / 2));
- 	$snoopy->proxy_host = ""; // Do not use a proxy for this external IP check.
+	if (!Utility::getExternal('curl')) {
+		error_log("check_port plugin: 'curl' executable not found.");
+		return null;
+	}
+	// Initialize the Snoopy client.
+	$snoopy = new Snoopy();
+	$snoopy->agent = "ruTorrent CheckPort Plugin/IP Check";
+	// Set a timeout for the request, with a minimum of 5 seconds.
+	$snoopy->read_timeout = max(5, (int)($timeout / 2));
+	$snoopy->proxy_host = ""; // Do not use a proxy for this external IP check.
 
- 	// Select the correct ipify API URL based on the requested IP version.
-    $url = ($version == '6') ? "https://api64.ipify.org/" : "https://api4.ipify.org/";
- 	@$snoopy->fetch($url); // Fetch the URL.
+	// Select the correct ipify API URL based on the requested IP version.
+	$url = ($version == '6') ? "https://api64.ipify.org/" : "https://api4.ipify.org/";
+	@$snoopy->fetch($url); // Fetch the URL.
 
- 	// Check if the request was successful and returned content.
-    if ($snoopy->status == 200 && !empty($snoopy->results)) {
-        $ip = trim($snoopy->results);
- 		// Validate the returned IP address to ensure it's a valid IPv4 or IPv6.
-        $flag = ($version == '6') ? FILTER_FLAG_IPV6 : FILTER_FLAG_IPV4;
-        if (filter_var($ip, FILTER_VALIDATE_IP, $flag)) {
- 			return $ip; // Return the valid IP.
-        }
-        error_log("check_port plugin: {$url} returned invalid IP: " . $ip);
-    } else {
-        error_log("check_port plugin: Failed to fetch from {$url}. Status: {$snoopy->status}, Error: {$snoopy->error}");
-    }
- 	return null; // Return null on failure.
+	// Check if the request was successful and returned content.
+	if ($snoopy->status == 200 && !empty($snoopy->results)) {
+		$ip = trim($snoopy->results);
+		// Validate the returned IP address to ensure it's a valid IPv4 or IPv6.
+		$flag = ($version == '6') ? FILTER_FLAG_IPV6 : FILTER_FLAG_IPV4;
+		if (filter_var($ip, FILTER_VALIDATE_IP, $flag)) {
+			return $ip; // Return the valid IP.
+		}
+		error_log("check_port plugin: {$url} returned invalid IP: " . $ip);
+	} else {
+		error_log("check_port plugin: Failed to fetch from {$url}. Status: {$snoopy->status}, Error: {$snoopy->error}");
+	}
+	return null; // Return null on failure.
 }
 
 /**
@@ -58,23 +58,23 @@ function get_public_ip($version, $timeout) {
  * @return int Status code (0: unknown, 1: closed, 2: open).
  */
 function check_port_yougetsignal($ip, $port, $timeout) {
-    $client = new Snoopy();
-    $client->read_timeout = (int)$timeout;
- 	$client->proxy_host = ""; // Do not use a proxy for this check.
-    $post_data = "remoteAddress=" . urlencode($ip) . "&portNumber=" . urlencode($port);
-    
- 	// Make a POST request to the port checking service.
-    @$client->fetch("https://ports.yougetsignal.com/check-port.php", "POST", "application/x-www-form-urlencoded", $post_data);
+	$client = new Snoopy();
+	$client->read_timeout = (int)$timeout;
+	$client->proxy_host = ""; // Do not use a proxy for this check.
+	$post_data = "remoteAddress=" . urlencode($ip) . "&portNumber=" . urlencode($port);
 
- 	// Parse the response to determine port status.
-    if ($client->status == 200) {
- 		if (stripos($client->results, "is closed") !== false) return 1; // Port is closed.
- 		if (stripos($client->results, "is open") !== false) return 2; // Port is open.
-        error_log("check_port: yougetsignal response indicators not found for IP {$ip}. Response: " . substr($client->results, 0, 500));
-    } else {
-        error_log("check_port: Failed fetch from yougetsignal for IP {$ip}. Status: {$client->status}, Error: {$client->error}");
-    }
-    return 0;
+	// Make a POST request to the port checking service.
+	@$client->fetch("https://ports.yougetsignal.com/check-port.php", "POST", "application/x-www-form-urlencoded", $post_data);
+
+	// Parse the response to determine port status.
+	if ($client->status == 200) {
+		if (stripos($client->results, "is closed") !== false) return 1; // Port is closed.
+		if (stripos($client->results, "is open") !== false) return 2; // Port is open.
+		error_log("check_port: yougetsignal response indicators not found for IP {$ip}. Response: " . substr($client->results, 0, 500));
+	} else {
+		error_log("check_port: Failed fetch from yougetsignal for IP {$ip}. Status: {$client->status}, Error: {$client->error}");
+	}
+	return 0;
 }
 
 /**
@@ -86,45 +86,45 @@ function check_port_yougetsignal($ip, $port, $timeout) {
  * @return int Status code (0: unknown, 1: closed, 2: open).
  */
 function check_port_portchecker($ip, $port, $timeout) {
-    $client = new Snoopy();
-    $client->read_timeout = (int)$timeout;
- 	$client->proxy_host = ""; // Do not use a proxy for this check.
+	$client = new Snoopy();
+	$client->read_timeout = (int)$timeout;
+	$client->proxy_host = ""; // Do not use a proxy for this check.
 
- 	// Fetch the main page to acquire a CSRF token and session cookie.
-    @$client->fetch("https://portchecker.co/");
-    if ($client->status != 200) {
-        error_log("check_port: Could not fetch portchecker.co main page. Status: {$client->status}");
-        return 0;
-    }
- 	$client->setcookies(); // Store cookies to be sent in the next request.
-    
- 	// Extract the CSRF token from the page content.
-    $csrf_token = '';
-    if (preg_match('/name="_csrf" value="(?P<csrf>[^"]+)"/', $client->results, $match)) {
-        $csrf_token = $match["csrf"];
-    }
- 	// If no token is found, the check cannot proceed.
-    if (empty($csrf_token)) {
-        error_log("check_port: CSRF token not found from portchecker.co for IP: {$ip}.");
-        return 0;
-    }
+	// Fetch the main page to acquire a CSRF token and session cookie.
+	@$client->fetch("https://portchecker.co/");
+	if ($client->status != 200) {
+		error_log("check_port: Could not fetch portchecker.co main page. Status: {$client->status}");
+		return 0;
+	}
+	$client->setcookies(); // Store cookies to be sent in the next request.
 
- 	// Prepare the POST data for the port check request, including the CSRF token.
-    $post_data = "target_ip=" . urlencode($ip) . "&port=" . urlencode($port) . "&_csrf=" . urlencode($csrf_token);
- 	$client->referer = "https://portchecker.co/"; // Set the referer header.
+	// Extract the CSRF token from the page content.
+	$csrf_token = '';
+	if (preg_match('/name="_csrf" value="(?P<csrf>[^"]+)"/', $client->results, $match)) {
+		$csrf_token = $match["csrf"];
+	}
+	// If no token is found, the check cannot proceed.
+	if (empty($csrf_token)) {
+		error_log("check_port: CSRF token not found from portchecker.co for IP: {$ip}.");
+		return 0;
+	}
 
- 	// Make the actual port check request to the API endpoint.
-    @$client->fetch("https://portchecker.co/check-v0", "POST", "application/x-www-form-urlencoded", $post_data);
+	// Prepare the POST data for the port check request, including the CSRF token.
+	$post_data = "target_ip=" . urlencode($ip) . "&port=" . urlencode($port) . "&_csrf=" . urlencode($csrf_token);
+	$client->referer = "https://portchecker.co/"; // Set the referer header.
 
- 	// Parse the JSON response to determine port status.
-    if ($client->status == 200) {
- 		if (stripos($client->results, 'is <span class="red">closed</span>') !== false) return 1; // Port is closed.
- 		if (stripos($client->results, 'is <span class="green">open</span>') !== false) return 2; // Port is open.
-        error_log("check_port: portchecker response indicators not found for IP {$ip}. Response: " . substr($client->results, 0, 500));
-    } else {
-        error_log("check_port: Failed fetch from portchecker endpoint for IP {$ip}. Status: {$client->status}, Error: {$client->error}");
-    }
- 	return 0; // Status is unknown.
+	// Make the actual port check request to the API endpoint.
+	@$client->fetch("https://portchecker.co/check-v0", "POST", "application/x-www-form-urlencoded", $post_data);
+
+	// Parse the JSON response to determine port status.
+	if ($client->status == 200) {
+		if (stripos($client->results, 'is <span class="red">closed</span>') !== false) return 1; // Port is closed.
+		if (stripos($client->results, 'is <span class="green">open</span>') !== false) return 2; // Port is open.
+		error_log("check_port: portchecker response indicators not found for IP {$ip}. Response: " . substr($client->results, 0, 500));
+	} else {
+		error_log("check_port: Failed fetch from portchecker endpoint for IP {$ip}. Status: {$client->status}, Error: {$client->error}");
+	}
+	return 0; // Status is unknown.
 }
 
 /**
@@ -138,31 +138,30 @@ function check_port_portchecker($ip, $port, $timeout) {
  * @return array An associative array with 'ip' and 'status' keys.
  */
 function get_and_check_ip($ip_version, $use_website, $rtorrent_ip, $rtorrent_port, $timeout) {
-    $ip_to_check = null;
-    $flag = ($ip_version == '6') ? FILTER_FLAG_IPV6 : FILTER_FLAG_IPV4;
+	$ip_to_check = null;
+	$flag = ($ip_version == '6') ? FILTER_FLAG_IPV6 : FILTER_FLAG_IPV4;
 
-    if (!empty($rtorrent_ip) && filter_var($rtorrent_ip, FILTER_VALIDATE_IP, $flag)) {
-        $ip_to_check = $rtorrent_ip;
- 	// If rTorrent's IP is not set or invalid for the version, fetch the public IP.
-    } else {
-        $ip_to_check = get_public_ip($ip_version, $timeout);
-    }
-    
- 	// If an IP was determined, proceed to check the port.
-    if ($ip_to_check) {
-        $status = 0;
- 		// Call the appropriate checking function based on the selected service.
-        if ($use_website == "yougetsignal") {
-            $status = check_port_yougetsignal($ip_to_check, $rtorrent_port, $timeout);
-        } elseif ($use_website == "portchecker") {
-            $status = check_port_portchecker($ip_to_check, $rtorrent_port, $timeout);
-        }
-        return ["ip" => $ip_to_check, "status" => $status];
-    }
- 	// Return a default "not available" state if no IP could be determined.
-    return ["ip" => "-", "status" => 0];
+	if (!empty($rtorrent_ip) && filter_var($rtorrent_ip, FILTER_VALIDATE_IP, $flag)) {
+		$ip_to_check = $rtorrent_ip;
+		// If rTorrent's IP is not set or invalid for the version, fetch the public IP.
+	} else {
+		$ip_to_check = get_public_ip($ip_version, $timeout);
+	}
+
+	// If an IP was determined, proceed to check the port.
+	if ($ip_to_check) {
+		$status = 0;
+		// Call the appropriate checking function based on the selected service.
+		if ($use_website == "yougetsignal") {
+			$status = check_port_yougetsignal($ip_to_check, $rtorrent_port, $timeout);
+		} elseif ($use_website == "portchecker") {
+			$status = check_port_portchecker($ip_to_check, $rtorrent_port, $timeout);
+		}
+		return ["ip" => $ip_to_check, "status" => $status];
+	}
+	// Return a default "not available" state if no IP could be determined.
+	return ["ip" => "-", "status" => 0];
 }
-
 
 // --- Main Execution ---
 // Get rTorrent's listening port and configured IP from settings.
@@ -171,22 +170,22 @@ $ip_glob = rTorrentSettings::get()->ip;
 
 // Initialize the response structure that will be sent to the client.
 $response = [
-    "ipv4" => "-", "ipv4_port" => (int)$port, "ipv4_status" => 0,
-    "ipv6" => "-", "ipv6_port" => (int)$port, "ipv6_status" => 0,
+	"ipv4" => "-", "ipv4_port" => (int)$port, "ipv4_status" => 0,
+	"ipv6" => "-", "ipv6_port" => (int)$port, "ipv6_status" => 0,
 ];
 
 // Perform the IPv4 check if it's enabled in conf.php.
 if ($currentUseWebsiteIPv4 !== false) {
-    $ipv4_result = get_and_check_ip('4', $currentUseWebsiteIPv4, $ip_glob, $port, $currentCheckPortTimeout);
-    $response["ipv4"] = $ipv4_result["ip"];
-    $response["ipv4_status"] = $ipv4_result["status"];
+	$ipv4_result = get_and_check_ip('4', $currentUseWebsiteIPv4, $ip_glob, $port, $currentCheckPortTimeout);
+	$response["ipv4"] = $ipv4_result["ip"];
+	$response["ipv4_status"] = $ipv4_result["status"];
 }
 
 // Perform the IPv6 check if it's enabled in conf.php.
 if ($currentUseWebsiteIPv6 !== false) {
-    $ipv6_result = get_and_check_ip('6', $currentUseWebsiteIPv6, $ip_glob, $port, $currentCheckPortTimeout);
-    $response["ipv6"] = $ipv6_result["ip"];
-    $response["ipv6_status"] = $ipv6_result["status"];
+	$ipv6_result = get_and_check_ip('6', $currentUseWebsiteIPv6, $ip_glob, $port, $currentCheckPortTimeout);
+	$response["ipv6"] = $ipv6_result["ip"];
+	$response["ipv6_status"] = $ipv6_result["status"];
 }
 
 // Send the final JSON response to the client.

--- a/plugins/check_port/check_port.css
+++ b/plugins/check_port/check_port.css
@@ -7,29 +7,29 @@
 /* Define CSS variables for the different status icons. */
 /* Using data URIs for the icons avoids extra HTTP requests. */
 #StatusBar {
- 	/* Icon for when the port status is unknown or is being checked. */
-  --pane-port-unknown-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAA7ElEQVR4AYyRtUEAQRBFzw2HiDbogYzLKIROKIFKSJEYpwDc3Yd9wUfOgz9r88bWM7MmxetLniEzKypvs6xsEvTnIQP4+ri3j4cDwV5FGSZymnRiHzilAr/eTtrAAjP152IcR/t6sZfjZUNf75eNMKYgE5kpGSect1fmUFu5gTY+mZXt8XBRIPu/WQv5Y3KnGS54pC+B6G5nwd5vVwUyUTahMgqirxrIuVoyZpxIXBIZJ+lsswS0h/2SgBWwkg2nWsbdeaSsJrBQNiAJQNkEuoACc0+fzeSGCF+Y74E1koNxJXIuEEawEeKwdA0A1zpJYUqqdYUAAAAASUVORK5CYII=);
- 	/* Icon for when the port is confirmed to be closed (error state). */
-  --pane-port-error-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAAVFBMVEX////////////////////////////////////////////////ORirORirdcWDlTzzpgW/qXEHtY0XtjnvxbEjyppbznIf0dk71f1j5tqH72dP///8Q8E8oAAAADXRSTlMAAgUGBwgKDRMUFRnTtFxmSQAAAHpJREFUCB0FgAEOwiAMRV8pq5LI/Q+6xDlG+43FAiZw7zIZMBlOXpzg8HkNGXrTH5z5irLetCOP1SAKIHkG+BwyspOl8t5xbYASOA0EJUQJOplC2wtUtPMKiaMBxzq7c40vPyBucNQyqsriVjYDJuHkop5mJmACe2f1P5ZxRkN1OzPZAAAAAElFTkSuQmCC);
- 	/* Icon for when the port is confirmed to be open (success state). */
-  --pane-port-success-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAA/ElEQVR4AWL4//8/DLMDMRuIrdMt9h8ZAwEXSBxKMwExC4ijDMSsIBqmcPGVKSgYJg7VzAGiGWAmgSR6T1f/X393GZguOZwIwjAxEBumWRSmkQ1ZU8rhEGwYXTMLTCOKpqTdPoC6ycIGgRgAgFgUl31YhCHZBB0Bd3e9Tw6nydWvXgElUsVcyD0x4z+J0Fu36QOBHIiO6JKao+qbdDofHZhJniIFRJjtp87wJpXKRQZ7F10CDcjLw/xKOF/OSvC+VI7W5SIqs1wl8XBwvEM6K791FpZImy8JMX2n8CK7bCD/JTkjb480SQPYGch/PLkYkBFIUPnjkfsJwn6EG7GmEErgVbTJAAAAAElFTkSuQmCC);
+	/* Icon for when the port status is unknown or is being checked. */
+	--pane-port-unknown-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAA7ElEQVR4AYyRtUEAQRBFzw2HiDbogYzLKIROKIFKSJEYpwDc3Yd9wUfOgz9r88bWM7MmxetLniEzKypvs6xsEvTnIQP4+ri3j4cDwV5FGSZymnRiHzilAr/eTtrAAjP152IcR/t6sZfjZUNf75eNMKYgE5kpGSect1fmUFu5gTY+mZXt8XBRIPu/WQv5Y3KnGS54pC+B6G5nwd5vVwUyUTahMgqirxrIuVoyZpxIXBIZJ+lsswS0h/2SgBWwkg2nWsbdeaSsJrBQNiAJQNkEuoACc0+fzeSGCF+Y74E1koNxJXIuEEawEeKwdA0A1zpJYUqqdYUAAAAASUVORK5CYII=);
+	/* Icon for when the port is confirmed to be closed (error state). */
+	--pane-port-error-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAAVFBMVEX////////////////////////////////////////////////ORirORirdcWDlTzzpgW/qXEHtY0XtjnvxbEjyppbznIf0dk71f1j5tqH72dP///8Q8E8oAAAADXRSTlMAAgUGBwgKDRMUFRnTtFxmSQAAAHpJREFUCB0FgAEOwiAMRV8pq5LI/Q+6xDlG+43FAiZw7zIZMBlOXpzg8HkNGXrTH5z5irLetCOP1SAKIHkG+BwyspOl8t5xbYASOA0EJUQJOplC2wtUtPMKiaMBxzq7c40vPyBucNQyqsriVjYDJuHkop5mJmACe2f1P5ZxRkN1OzPZAAAAAElFTkSuQmCC);
+	/* Icon for when the port is confirmed to be open (success state). */
+	--pane-port-success-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAA/ElEQVR4AWL4//8/DLMDMRuIrdMt9h8ZAwEXSBxKMwExC4ijDMSsIBqmcPGVKSgYJg7VzAGiGWAmgSR6T1f/X393GZguOZwIwjAxEBumWRSmkQ1ZU8rhEGwYXTMLTCOKpqTdPoC6ycIGgRgAgFgUl31YhCHZBB0Bd3e9Tw6nydWvXgElUsVcyD0x4z+J0Fu36QOBHIiO6JKao+qbdDofHZhJniIFRJjtp87wJpXKRQZ7F10CDcjLw/xKOF/OSvC+VI7W5SIqs1wl8XBwvEM6K791FpZImy8JMX2n8CK7bCD/JTkjb480SQPYGch/PLkYkBFIUPnjkfsJwn6EG7GmEErgVbTJAAAAAElFTkSuQmCC);
 }
 /* General styling for the icon element within the port status pane. */
 #port-pane .icon {
-  background-position: center; /* Center the icon within its container. */
-  background-repeat: no-repeat; /* Prevent the icon from tiling. */
-  width: 14px; /* Explicitly set width to match the icon image. */
-  height: 14px; /* Explicitly set height to match the icon image. */
+	background-position: center; /* Center the icon within its container. */
+	background-repeat: no-repeat; /* Prevent the icon from tiling. */
+	width: 14px; /* Explicitly set width to match the icon image. */
+	height: 14px; /* Explicitly set height to match the icon image. */
 }
 /* Assigns the 'unknown' status icon. */
 #port-pane .pstatus0 {
-  background-image: var(--pane-port-unknown-icon);
+	background-image: var(--pane-port-unknown-icon);
 }
 /* Assigns the 'error' (closed) status icon. */
 #port-pane .pstatus1 {
-  background-image: var(--pane-port-error-icon);
+	background-image: var(--pane-port-error-icon);
 }
 /* Assigns the 'success' (open) status icon. */
 #port-pane .pstatus2 {
-  background-image: var(--pane-port-success-icon);
+	background-image: var(--pane-port-success-icon);
 }

--- a/plugins/check_port/check_port.css
+++ b/plugins/check_port/check_port.css
@@ -1,18 +1,35 @@
+/*
+ * check_port Plugin Stylesheet
+ *
+ * Defines the icons and layout for the port status indicator in the status bar.
+ */
+
+/* Define CSS variables for the different status icons. */
+/* Using data URIs for the icons avoids extra HTTP requests. */
 #StatusBar {
+ 	/* Icon for when the port status is unknown or is being checked. */
   --pane-port-unknown-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAA7ElEQVR4AYyRtUEAQRBFzw2HiDbogYzLKIROKIFKSJEYpwDc3Yd9wUfOgz9r88bWM7MmxetLniEzKypvs6xsEvTnIQP4+ri3j4cDwV5FGSZymnRiHzilAr/eTtrAAjP152IcR/t6sZfjZUNf75eNMKYgE5kpGSect1fmUFu5gTY+mZXt8XBRIPu/WQv5Y3KnGS54pC+B6G5nwd5vVwUyUTahMgqirxrIuVoyZpxIXBIZJ+lsswS0h/2SgBWwkg2nWsbdeaSsJrBQNiAJQNkEuoACc0+fzeSGCF+Y74E1koNxJXIuEEawEeKwdA0A1zpJYUqqdYUAAAAASUVORK5CYII=);
+ 	/* Icon for when the port is confirmed to be closed (error state). */
   --pane-port-error-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAAVFBMVEX////////////////////////////////////////////////ORirORirdcWDlTzzpgW/qXEHtY0XtjnvxbEjyppbznIf0dk71f1j5tqH72dP///8Q8E8oAAAADXRSTlMAAgUGBwgKDRMUFRnTtFxmSQAAAHpJREFUCB0FgAEOwiAMRV8pq5LI/Q+6xDlG+43FAiZw7zIZMBlOXpzg8HkNGXrTH5z5irLetCOP1SAKIHkG+BwyspOl8t5xbYASOA0EJUQJOplC2wtUtPMKiaMBxzq7c40vPyBucNQyqsriVjYDJuHkop5mJmACe2f1P5ZxRkN1OzPZAAAAAElFTkSuQmCC);
+ 	/* Icon for when the port is confirmed to be open (success state). */
   --pane-port-success-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAA/ElEQVR4AWL4//8/DLMDMRuIrdMt9h8ZAwEXSBxKMwExC4ijDMSsIBqmcPGVKSgYJg7VzAGiGWAmgSR6T1f/X393GZguOZwIwjAxEBumWRSmkQ1ZU8rhEGwYXTMLTCOKpqTdPoC6ycIGgRgAgFgUl31YhCHZBB0Bd3e9Tw6nydWvXgElUsVcyD0x4z+J0Fu36QOBHIiO6JKao+qbdDofHZhJniIFRJjtp87wJpXKRQZ7F10CDcjLw/xKOF/OSvC+VI7W5SIqs1wl8XBwvEM6K791FpZImy8JMX2n8CK7bCD/JTkjb480SQPYGch/PLkYkBFIUPnjkfsJwn6EG7GmEErgVbTJAAAAAElFTkSuQmCC);
 }
+/* General styling for the icon element within the port status pane. */
 #port-pane .icon {
-  background-position: center;
-  background-repeat: no-repeat;
+  background-position: center; /* Center the icon within its container. */
+  background-repeat: no-repeat; /* Prevent the icon from tiling. */
+  width: 14px; /* Explicitly set width to match the icon image. */
+  height: 14px; /* Explicitly set height to match the icon image. */
 }
+/* Assigns the 'unknown' status icon. */
 #port-pane .pstatus0 {
   background-image: var(--pane-port-unknown-icon);
 }
+/* Assigns the 'error' (closed) status icon. */
 #port-pane .pstatus1 {
   background-image: var(--pane-port-error-icon);
 }
+/* Assigns the 'success' (open) status icon. */
 #port-pane .pstatus2 {
   background-image: var(--pane-port-success-icon);
 }

--- a/plugins/check_port/conf.php
+++ b/plugins/check_port/conf.php
@@ -9,7 +9,7 @@ $useWebsiteIPv4 = "yougetsignal";	// Valid choices:
 $useWebsiteIPv6 = "portchecker";	// Valid choices:
 									// false - disable IPv6 port check
 									// "portchecker" - use https://portchecker.co/ (Known to work for IPv6)
-									// Note: yougetsignal does not appear to support IPv6 checks.
+									// Note: yougetsignal does not appear to support IPv6 checks
 
 $checkPortTimeout = 15; // Timeout in seconds for external port checking services
-						// (e.g., yougetsignal, portchecker) and for IP detection services (e.g., ipify).
+						// (e.g., yougetsignal, portchecker) and for IP detection services (e.g., ipify)

--- a/plugins/check_port/conf.php
+++ b/plugins/check_port/conf.php
@@ -1,15 +1,15 @@
 <?php
-// configuration parameter
+// Configuration for the check_port plugin
 
 $useWebsiteIPv4 = "yougetsignal";	// Valid choices:
- 				// false - disable IPv4 port check
- 				// "yougetsignal" - use https://www.yougetsignal.com/tools/open-ports/
- 				// "portchecker" - use https://portchecker.co/
+									// false - disable IPv4 port check
+									// "yougetsignal" - use https://www.yougetsignal.com/tools/open-ports/
+									// "portchecker" - use https://portchecker.co/
 
 $useWebsiteIPv6 = "portchecker";	// Valid choices:
- 				// false - disable IPv6 port check
- 				// "portchecker" - use https://portchecker.co/ (Known to work for IPv6)
- 				// Note: yougetsignal does not appear to support IPv6 checks.
+									// false - disable IPv6 port check
+									// "portchecker" - use https://portchecker.co/ (Known to work for IPv6)
+									// Note: yougetsignal does not appear to support IPv6 checks.
 
-$checkPortTimeout = 15;  // Timeout in seconds for external port checking services
-                            // (e.g., yougetsignal, portchecker) and for IP detection services (e.g., ipify).
+$checkPortTimeout = 15; // Timeout in seconds for external port checking services
+						// (e.g., yougetsignal, portchecker) and for IP detection services (e.g., ipify).

--- a/plugins/check_port/conf.php
+++ b/plugins/check_port/conf.php
@@ -1,9 +1,15 @@
 <?php
 // configuration parameter
 
-$useWebsite = "portchecker";	// Valid choices:
-				// false - disable check_port plugin
-				// "yougetsignal" - use https://www.yougetsignal.com/tools/open-ports/
-				// "portchecker" - use https://portchecker.co/
+$useWebsiteIPv4 = "yougetsignal";	// Valid choices:
+ 				// false - disable IPv4 port check
+ 				// "yougetsignal" - use https://www.yougetsignal.com/tools/open-ports/
+ 				// "portchecker" - use https://portchecker.co/
 
-$useIpv4 = true;		// use ipv4 addresses when checking ports, unless website supports ipv6
+$useWebsiteIPv6 = "portchecker";	// Valid choices:
+ 				// false - disable IPv6 port check
+ 				// "portchecker" - use https://portchecker.co/ (Known to work for IPv6)
+ 				// Note: yougetsignal does not appear to support IPv6 checks.
+
+$checkPortTimeout = 15;  // Timeout in seconds for external port checking services
+                            // (e.g., yougetsignal, portchecker) and for IP detection services (e.g., ipify).

--- a/plugins/check_port/init.js
+++ b/plugins/check_port/init.js
@@ -1,59 +1,59 @@
-// Load language file and CSS for the plugin.
+// Load language file and CSS for the plugin
 plugin.loadLang();
 plugin.loadMainCSS();
 
-// Cache jQuery elements for performance and readability.
+// Cache jQuery elements for performance and readability
 const a = {};
 
 /**
- * Resets the UI elements to a neutral/unknown state, typically while checking.
- * @param {boolean} isUpdate - If true, indicates a manual refresh, adding "..." to the title.
+ * Resets the UI elements to a neutral/unknown state, typically while checking
+ * @param {boolean} isUpdate - If true, indicates a manual refresh, adding "..." to the title
  */
 plugin.resetStatus = function(isUpdate) {
-	// Reset icons to the "unknown" state (pstatus0).
+	// Reset icons to the "unknown" state (pstatus0)
 	a.iconIPv4.removeClass().addClass("icon port-icon-ipv4 pstatus0");
 	a.iconIPv6.removeClass().addClass("icon port-icon-ipv6 pstatus0");
-	// Hide IP address text and the separator.
+	// Hide IP address text and the separator
 	a.textIPv4.text("").hide();
 	a.separator.text("").hide();
 	a.textIPv6.text("").hide();
 
-	// Set a tooltip to indicate that a check is in progress.
+	// Set a tooltip to indicate that a check is in progress
 	let title = theUILang.checkingPort || "Checking port status...";
 	if (isUpdate) {
-		title += "..."; // Append ellipsis for manual updates.
+		title += "..."; // Append ellipsis for manual updates
 	}
 	a.pane.prop("title", title);
 };
 
-// Initial check when the plugin is first loaded.
+// Initial check when the plugin is first loaded
 plugin.init = function() {
 	plugin.resetStatus(false);
-	// Request the initial port status from the backend.
+	// Request the initial port status from the backend
 	theWebUI.request("?action=initportcheck", [plugin.getPortStatus, plugin]);
 };
 
-// Function to manually trigger an update of the port status.
+// Function to manually trigger an update of the port status
 plugin.update = function() {
 	plugin.resetStatus(true);
-	// Request a port status update from the backend.
+	// Request a port status update from the backend
 	theWebUI.request("?action=updateportcheck", [plugin.getPortStatus, plugin]);
 };
 
 /**
- * Updates the UI for a specific IP protocol (IPv4 or IPv6) based on data from the backend.
- * @param {object} data - The response data containing status for both protocols.
- * @param {string} proto - The protocol to update, either "ipv4" or "ipv6".
- * @param {function} getStatusText - A function to retrieve the localized status string.
- * @returns {string} The formatted title line for this protocol's status.
+ * Updates the UI for a specific IP protocol (IPv4 or IPv6) based on data from the backend
+ * @param {object} data - The response data containing status for both protocols
+ * @param {string} proto - The protocol to update, either "ipv4" or "ipv6"
+ * @param {function} getStatusText - A function to retrieve the localized status string
+ * @returns {string} The formatted title line for this protocol's status
  */
 function updateProtocolStatus(data, proto, getStatusText) {
 	const status = parseInt(data[proto + '_status']);
 	const address = data[proto];
 	const port = data[proto + '_port'];
-	const isAvailable = address && address !== "-"; // Check if an IP address was returned.
+	const isAvailable = address && address !== "-"; // Check if an IP address was returned
 
-	// Select the correct UI elements for the given protocol.
+	// Select the correct UI elements for the given protocol
 	const icon = (proto === 'ipv4') ? a.iconIPv4 : a.iconIPv6;
 	const textEl = (proto === 'ipv4') ? a.textIPv4 : a.textIPv6;
 
@@ -63,71 +63,71 @@ function updateProtocolStatus(data, proto, getStatusText) {
 	let titleText = "";
 
 	if (isAvailable) {
-		// Format display text as IP:PORT, with brackets for IPv6.
+		// Format display text as IP:PORT, with brackets for IPv6
 		displayText = (proto === 'ipv6') ? `[${address}]:${port}` : `${address}:${port}`;
 		textEl.text(displayText).show();
-		// Create a detailed title for the tooltip.
+		// Create a detailed title for the tooltip
 		titleText = `${proto.toUpperCase()}: ${displayText} (${getStatusText(status)})`;
 	} else {
-		// If IP is not available, hide the text element.
+		// If IP is not available, hide the text element
 		textEl.text("").hide();
 		titleText = `${proto.toUpperCase()}: ${(theUILang.notAvailable || "N/A")} (${getStatusText(status)})`;
 	}
-	return titleText; // Return the generated title string.
+	return titleText; // Return the generated title string
 }
 
 /**
- * Main callback to process the port status response from the backend and update the UI.
- * @param {object} d - The JSON object received from the backend response.
+ * Main callback to process the port status response from the backend and update the UI
+ * @param {object} d - The JSON object received from the backend response
  */
 plugin.getPortStatus = function(d) {
-	// Helper function to get the localized text for a status code.
+	// Helper function to get the localized text for a status code
 	const getStatusText = (statusCode) => theUILang.portStatus[statusCode] || theUILang.portStatus[0] || "Unknown";
 
-	// Update the status for both IPv4 and IPv6 and collect their title lines.
+	// Update the status for both IPv4 and IPv6 and collect their title lines
 	const titleLines = [
 		updateProtocolStatus(d, 'ipv4', getStatusText),
 		updateProtocolStatus(d, 'ipv6', getStatusText)
 	];
 
-	// Check if both IPv4 and IPv6 addresses are available.
+	// Check if both IPv4 and IPv6 addresses are available
 	const ipv4Available = d.ipv4 && d.ipv4 !== "-";
 	const ipv6Available = d.ipv6 && d.ipv6 !== "-";
 
-	// Show a separator only if both protocols have an IP address to display.
+	// Show a separator only if both protocols have an IP address to display
 	if (ipv4Available && ipv6Available) {
 		a.separator.text("|").show();
 	} else {
 		a.separator.text("").hide();
 	}
 
-	// Set the combined tooltip for the entire status pane.
+	// Set the combined tooltip for the entire status pane
 	a.pane.prop("title", titleLines.join(" | "));
 };
 
-// Defines the AJAX request for the initial port check.
+// Defines the AJAX request for the initial port check
 rTorrentStub.prototype.initportcheck = function() {
 	this.contentType = "application/x-www-form-urlencoded";
 	this.mountPoint = "plugins/check_port/action.php?init";
 	this.dataType = "json";
 };
 
-// Defines the AJAX request for subsequent port status updates.
+// Defines the AJAX request for subsequent port status updates
 rTorrentStub.prototype.updateportcheck = function() {
 	this.contentType = "application/x-www-form-urlencoded";
 	this.mountPoint = "plugins/check_port/action.php";
 	this.dataType = "json";
 };
 
-// Creates and shows the context menu (right-click menu) for the status pane.
+// Creates and shows the context menu (right-click menu) for the status pane
 plugin.createPortMenu = function(e) {
-	if (e.which === 3) { // Right mouse button.
+	if (e.which === 3) { // Right mouse button
 		theContextMenu.clear();
-		// Add a "Refresh" option to the context menu.
+		// Add a "Refresh" option to the context menu
 		theContextMenu.add([(theUILang.checkPort || "Refresh Port Status"), plugin.update]);
 		theContextMenu.show();
 	}
-	return false; // Prevent the default browser context menu from appearing.
+	return false; // Prevent the default browser context menu from appearing
 };
 
 plugin.onLangLoaded = function() {
@@ -140,13 +140,13 @@ plugin.onLangLoaded = function() {
 	const ipv6Icon = $("<div>").attr("id", "port-icon-ipv6").addClass("icon");
 	const ipv6Text = $("<span>").attr("id", "port-ip-text-ipv6").addClass("d-none d-lg-block port-ip-text-segment");
 
-	// Assemble the elements into the container.
+	// Assemble the elements into the container
 	container.append(ipv4Icon, ipv4Text, separator, ipv6Icon, ipv6Text);
 
-	// Add the newly created pane to the ruTorrent status bar.
+	// Add the newly created pane to the ruTorrent status bar
 	plugin.addPaneToStatusbar("port-pane", container, -1, true);
 
-	// Now that the pane is in the DOM, cache all the jQuery elements for future use.
+	// Now that the pane is in the DOM, cache all the jQuery elements for future use
 	a.pane = $("#port-pane");
 	a.iconIPv4 = $("#port-icon-ipv4");
 	a.textIPv4 = $("#port-ip-text-ipv4");
@@ -154,17 +154,17 @@ plugin.onLangLoaded = function() {
 	a.iconIPv6 = $("#port-icon-ipv6");
 	a.textIPv6 = $("#port-ip-text-ipv6");
 
-	// If the user has permissions, attach the right-click context menu.
+	// If the user has permissions, attach the right-click context menu
 	if (plugin.canChangeMenu()) {
 		a.pane.on("mousedown", plugin.createPortMenu);
 	}
 
-	// Trigger the initial port check.
+	// Trigger the initial port check
 	plugin.init();
 };
 
-// This function is called when the plugin is removed/unloaded.
+// This function is called when the plugin is removed/unloaded
 plugin.onRemove = function() {
-	// Remove the pane from the status bar to clean up the UI.
+	// Remove the pane from the status bar to clean up the UI
 	plugin.removePaneFromStatusbar("port-pane");
 };

--- a/plugins/check_port/init.js
+++ b/plugins/check_port/init.js
@@ -10,34 +10,34 @@ const a = {};
  * @param {boolean} isUpdate - If true, indicates a manual refresh, adding "..." to the title.
  */
 plugin.resetStatus = function(isUpdate) {
- 	// Reset icons to the "unknown" state (pstatus0).
-    a.iconIPv4.removeClass().addClass("icon port-icon-ipv4 pstatus0");
-    a.iconIPv6.removeClass().addClass("icon port-icon-ipv6 pstatus0");
- 	// Hide IP address text and the separator.
-    a.textIPv4.text("").hide();
-    a.separator.text("").hide();
-    a.textIPv6.text("").hide();
-    
- 	// Set a tooltip to indicate that a check is in progress.
-    let title = theUILang.checkingPort || "Checking port status...";
-    if (isUpdate) {
- 		title += "..."; // Append ellipsis for manual updates.
-    }
-    a.pane.prop("title", title);
+	// Reset icons to the "unknown" state (pstatus0).
+	a.iconIPv4.removeClass().addClass("icon port-icon-ipv4 pstatus0");
+	a.iconIPv6.removeClass().addClass("icon port-icon-ipv6 pstatus0");
+	// Hide IP address text and the separator.
+	a.textIPv4.text("").hide();
+	a.separator.text("").hide();
+	a.textIPv6.text("").hide();
+
+	// Set a tooltip to indicate that a check is in progress.
+	let title = theUILang.checkingPort || "Checking port status...";
+	if (isUpdate) {
+		title += "..."; // Append ellipsis for manual updates.
+	}
+	a.pane.prop("title", title);
 };
 
 // Initial check when the plugin is first loaded.
 plugin.init = function() {
-    plugin.resetStatus(false);
- 	// Request the initial port status from the backend.
-    theWebUI.request("?action=initportcheck", [plugin.getPortStatus, plugin]);
+	plugin.resetStatus(false);
+	// Request the initial port status from the backend.
+	theWebUI.request("?action=initportcheck", [plugin.getPortStatus, plugin]);
 };
 
 // Function to manually trigger an update of the port status.
 plugin.update = function() {
-    plugin.resetStatus(true);
- 	// Request a port status update from the backend.
-    theWebUI.request("?action=updateportcheck", [plugin.getPortStatus, plugin]);
+	plugin.resetStatus(true);
+	// Request a port status update from the backend.
+	theWebUI.request("?action=updateportcheck", [plugin.getPortStatus, plugin]);
 };
 
 /**
@@ -48,32 +48,32 @@ plugin.update = function() {
  * @returns {string} The formatted title line for this protocol's status.
  */
 function updateProtocolStatus(data, proto, getStatusText) {
-    const status = parseInt(data[proto + '_status']);
-    const address = data[proto];
-    const port = data[proto + '_port'];
- 	const isAvailable = address && address !== "-"; // Check if an IP address was returned.
-    
- 	// Select the correct UI elements for the given protocol.
-    const icon = (proto === 'ipv4') ? a.iconIPv4 : a.iconIPv6;
-    const textEl = (proto === 'ipv4') ? a.textIPv4 : a.textIPv6;
+	const status = parseInt(data[proto + '_status']);
+	const address = data[proto];
+	const port = data[proto + '_port'];
+	const isAvailable = address && address !== "-"; // Check if an IP address was returned.
 
-    icon.removeClass("pstatus0 pstatus1 pstatus2").addClass("pstatus" + status);
-    
-    let displayText = "";
-    let titleText = "";
+	// Select the correct UI elements for the given protocol.
+	const icon = (proto === 'ipv4') ? a.iconIPv4 : a.iconIPv6;
+	const textEl = (proto === 'ipv4') ? a.textIPv4 : a.textIPv6;
 
-    if (isAvailable) {
- 		// Format display text as IP:PORT, with brackets for IPv6.
-        displayText = (proto === 'ipv6') ? `[${address}]:${port}` : `${address}:${port}`;
-        textEl.text(displayText).show();
- 		// Create a detailed title for the tooltip.
-        titleText = `${proto.toUpperCase()}: ${displayText} (${getStatusText(status)})`;
-    } else {
- 		// If IP is not available, hide the text element.
-        textEl.text("").hide();
-        titleText = `${proto.toUpperCase()}: ${(theUILang.notAvailable || "N/A")} (${getStatusText(status)})`;
-    }
- 	return titleText; // Return the generated title string.
+	icon.removeClass("pstatus0 pstatus1 pstatus2").addClass("pstatus" + status);
+
+	let displayText = "";
+	let titleText = "";
+
+	if (isAvailable) {
+		// Format display text as IP:PORT, with brackets for IPv6.
+		displayText = (proto === 'ipv6') ? `[${address}]:${port}` : `${address}:${port}`;
+		textEl.text(displayText).show();
+		// Create a detailed title for the tooltip.
+		titleText = `${proto.toUpperCase()}: ${displayText} (${getStatusText(status)})`;
+	} else {
+		// If IP is not available, hide the text element.
+		textEl.text("").hide();
+		titleText = `${proto.toUpperCase()}: ${(theUILang.notAvailable || "N/A")} (${getStatusText(status)})`;
+	}
+	return titleText; // Return the generated title string.
 }
 
 /**
@@ -81,90 +81,90 @@ function updateProtocolStatus(data, proto, getStatusText) {
  * @param {object} d - The JSON object received from the backend response.
  */
 plugin.getPortStatus = function(d) {
- 	// Helper function to get the localized text for a status code.
-    const getStatusText = (statusCode) => theUILang.portStatus[statusCode] || theUILang.portStatus[0] || "Unknown";
-    
- 	// Update the status for both IPv4 and IPv6 and collect their title lines.
-    const titleLines = [
-        updateProtocolStatus(d, 'ipv4', getStatusText),
-        updateProtocolStatus(d, 'ipv6', getStatusText)
-    ];
+	// Helper function to get the localized text for a status code.
+	const getStatusText = (statusCode) => theUILang.portStatus[statusCode] || theUILang.portStatus[0] || "Unknown";
 
- 	// Check if both IPv4 and IPv6 addresses are available.
-    const ipv4Available = d.ipv4 && d.ipv4 !== "-";
-    const ipv6Available = d.ipv6 && d.ipv6 !== "-";
+	// Update the status for both IPv4 and IPv6 and collect their title lines.
+	const titleLines = [
+		updateProtocolStatus(d, 'ipv4', getStatusText),
+		updateProtocolStatus(d, 'ipv6', getStatusText)
+	];
 
- 	// Show a separator only if both protocols have an IP address to display.
-    if (ipv4Available && ipv6Available) {
-        a.separator.text("|").show();
-    } else {
-        a.separator.text("").hide();
-    }
+	// Check if both IPv4 and IPv6 addresses are available.
+	const ipv4Available = d.ipv4 && d.ipv4 !== "-";
+	const ipv6Available = d.ipv6 && d.ipv6 !== "-";
 
- 	// Set the combined tooltip for the entire status pane.
-    a.pane.prop("title", titleLines.join(" | "));
+	// Show a separator only if both protocols have an IP address to display.
+	if (ipv4Available && ipv6Available) {
+		a.separator.text("|").show();
+	} else {
+		a.separator.text("").hide();
+	}
+
+	// Set the combined tooltip for the entire status pane.
+	a.pane.prop("title", titleLines.join(" | "));
 };
 
 // Defines the AJAX request for the initial port check.
 rTorrentStub.prototype.initportcheck = function() {
-    this.contentType = "application/x-www-form-urlencoded";
-    this.mountPoint = "plugins/check_port/action.php?init";
-    this.dataType = "json";
+	this.contentType = "application/x-www-form-urlencoded";
+	this.mountPoint = "plugins/check_port/action.php?init";
+	this.dataType = "json";
 };
 
 // Defines the AJAX request for subsequent port status updates.
 rTorrentStub.prototype.updateportcheck = function() {
-    this.contentType = "application/x-www-form-urlencoded";
-    this.mountPoint = "plugins/check_port/action.php";
-    this.dataType = "json";
+	this.contentType = "application/x-www-form-urlencoded";
+	this.mountPoint = "plugins/check_port/action.php";
+	this.dataType = "json";
 };
 
 // Creates and shows the context menu (right-click menu) for the status pane.
 plugin.createPortMenu = function(e) {
- 	if (e.which === 3) { // Right mouse button.
-        theContextMenu.clear();
- 		// Add a "Refresh" option to the context menu.
-        theContextMenu.add([(theUILang.checkPort || "Refresh Port Status"), plugin.update]);
-        theContextMenu.show();
-    }
- 	return false; // Prevent the default browser context menu from appearing.
+	if (e.which === 3) { // Right mouse button.
+		theContextMenu.clear();
+		// Add a "Refresh" option to the context menu.
+		theContextMenu.add([(theUILang.checkPort || "Refresh Port Status"), plugin.update]);
+		theContextMenu.show();
+	}
+	return false; // Prevent the default browser context menu from appearing.
 };
 
 plugin.onLangLoaded = function() {
-    // Create status bar elements in a more readable way
-    const container = $("<div>").addClass("port-status-container");
-    
-    const ipv4Icon = $("<div>").attr("id", "port-icon-ipv4").addClass("icon");
-    const ipv4Text = $("<span>").attr("id", "port-ip-text-ipv4").addClass("d-none d-lg-block port-ip-text-segment");
-    const separator = $("<span>").attr("id", "port-ip-separator").addClass("d-none d-lg-block").css({"margin-left": "3px", "margin-right": "3px"});
-    const ipv6Icon = $("<div>").attr("id", "port-icon-ipv6").addClass("icon");
-    const ipv6Text = $("<span>").attr("id", "port-ip-text-ipv6").addClass("d-none d-lg-block port-ip-text-segment");
+	// Create status bar elements in a more readable way
+	const container = $("<div>").addClass("port-status-container");
 
- 	// Assemble the elements into the container.
-    container.append(ipv4Icon, ipv4Text, separator, ipv6Icon, ipv6Text);
-    
- 	// Add the newly created pane to the ruTorrent status bar.
-    plugin.addPaneToStatusbar("port-pane", container, -1, true);
-    
- 	// Now that the pane is in the DOM, cache all the jQuery elements for future use.
-    a.pane = $("#port-pane");
-    a.iconIPv4 = $("#port-icon-ipv4");
-    a.textIPv4 = $("#port-ip-text-ipv4");
-    a.separator = $("#port-ip-separator");
-    a.iconIPv6 = $("#port-icon-ipv6");
-    a.textIPv6 = $("#port-ip-text-ipv6");
+	const ipv4Icon = $("<div>").attr("id", "port-icon-ipv4").addClass("icon");
+	const ipv4Text = $("<span>").attr("id", "port-ip-text-ipv4").addClass("d-none d-lg-block port-ip-text-segment");
+	const separator = $("<span>").attr("id", "port-ip-separator").addClass("d-none d-lg-block").css({"margin-left": "3px", "margin-right": "3px"});
+	const ipv6Icon = $("<div>").attr("id", "port-icon-ipv6").addClass("icon");
+	const ipv6Text = $("<span>").attr("id", "port-ip-text-ipv6").addClass("d-none d-lg-block port-ip-text-segment");
 
- 	// If the user has permissions, attach the right-click context menu.
-    if (plugin.canChangeMenu()) {
-        a.pane.on("mousedown", plugin.createPortMenu);
-    }
-    
- 	// Trigger the initial port check.
-    plugin.init();
+	// Assemble the elements into the container.
+	container.append(ipv4Icon, ipv4Text, separator, ipv6Icon, ipv6Text);
+
+	// Add the newly created pane to the ruTorrent status bar.
+	plugin.addPaneToStatusbar("port-pane", container, -1, true);
+
+	// Now that the pane is in the DOM, cache all the jQuery elements for future use.
+	a.pane = $("#port-pane");
+	a.iconIPv4 = $("#port-icon-ipv4");
+	a.textIPv4 = $("#port-ip-text-ipv4");
+	a.separator = $("#port-ip-separator");
+	a.iconIPv6 = $("#port-icon-ipv6");
+	a.textIPv6 = $("#port-ip-text-ipv6");
+
+	// If the user has permissions, attach the right-click context menu.
+	if (plugin.canChangeMenu()) {
+		a.pane.on("mousedown", plugin.createPortMenu);
+	}
+
+	// Trigger the initial port check.
+	plugin.init();
 };
 
 // This function is called when the plugin is removed/unloaded.
 plugin.onRemove = function() {
- 	// Remove the pane from the status bar to clean up the UI.
-    plugin.removePaneFromStatusbar("port-pane");
+	// Remove the pane from the status bar to clean up the UI.
+	plugin.removePaneFromStatusbar("port-pane");
 };

--- a/plugins/check_port/init.js
+++ b/plugins/check_port/init.js
@@ -1,68 +1,170 @@
+// Load language file and CSS for the plugin.
 plugin.loadLang();
 plugin.loadMainCSS();
 
-plugin.init = function()
-{
-	$("#port-pane .icon").removeClass().addClass("icon pstatus0");
-	theWebUI.request("?action=initportcheck", [plugin.getPortStatus, plugin]);
+// Cache jQuery elements for performance and readability.
+const a = {};
+
+/**
+ * Resets the UI elements to a neutral/unknown state, typically while checking.
+ * @param {boolean} isUpdate - If true, indicates a manual refresh, adding "..." to the title.
+ */
+plugin.resetStatus = function(isUpdate) {
+ 	// Reset icons to the "unknown" state (pstatus0).
+    a.iconIPv4.removeClass().addClass("icon port-icon-ipv4 pstatus0");
+    a.iconIPv6.removeClass().addClass("icon port-icon-ipv6 pstatus0");
+ 	// Hide IP address text and the separator.
+    a.textIPv4.text("").hide();
+    a.separator.text("").hide();
+    a.textIPv6.text("").hide();
+    
+ 	// Set a tooltip to indicate that a check is in progress.
+    let title = theUILang.checkingPort || "Checking port status...";
+    if (isUpdate) {
+ 		title += "..."; // Append ellipsis for manual updates.
+    }
+    a.pane.prop("title", title);
+};
+
+// Initial check when the plugin is first loaded.
+plugin.init = function() {
+    plugin.resetStatus(false);
+ 	// Request the initial port status from the backend.
+    theWebUI.request("?action=initportcheck", [plugin.getPortStatus, plugin]);
+};
+
+// Function to manually trigger an update of the port status.
+plugin.update = function() {
+    plugin.resetStatus(true);
+ 	// Request a port status update from the backend.
+    theWebUI.request("?action=updateportcheck", [plugin.getPortStatus, plugin]);
+};
+
+/**
+ * Updates the UI for a specific IP protocol (IPv4 or IPv6) based on data from the backend.
+ * @param {object} data - The response data containing status for both protocols.
+ * @param {string} proto - The protocol to update, either "ipv4" or "ipv6".
+ * @param {function} getStatusText - A function to retrieve the localized status string.
+ * @returns {string} The formatted title line for this protocol's status.
+ */
+function updateProtocolStatus(data, proto, getStatusText) {
+    const status = parseInt(data[proto + '_status']);
+    const address = data[proto];
+    const port = data[proto + '_port'];
+ 	const isAvailable = address && address !== "-"; // Check if an IP address was returned.
+    
+ 	// Select the correct UI elements for the given protocol.
+    const icon = (proto === 'ipv4') ? a.iconIPv4 : a.iconIPv6;
+    const textEl = (proto === 'ipv4') ? a.textIPv4 : a.textIPv6;
+
+    icon.removeClass("pstatus0 pstatus1 pstatus2").addClass("pstatus" + status);
+    
+    let displayText = "";
+    let titleText = "";
+
+    if (isAvailable) {
+ 		// Format display text as IP:PORT, with brackets for IPv6.
+        displayText = (proto === 'ipv6') ? `[${address}]:${port}` : `${address}:${port}`;
+        textEl.text(displayText).show();
+ 		// Create a detailed title for the tooltip.
+        titleText = `${proto.toUpperCase()}: ${displayText} (${getStatusText(status)})`;
+    } else {
+ 		// If IP is not available, hide the text element.
+        textEl.text("").hide();
+        titleText = `${proto.toUpperCase()}: ${(theUILang.notAvailable || "N/A")} (${getStatusText(status)})`;
+    }
+ 	return titleText; // Return the generated title string.
 }
 
-plugin.update = function()
-{
-	$("#port-pane .icon").removeClass().addClass("icon pstatus0");
-	theWebUI.request("?action=updateportcheck", [plugin.getPortStatus, plugin]);
-}
+/**
+ * Main callback to process the port status response from the backend and update the UI.
+ * @param {object} d - The JSON object received from the backend response.
+ */
+plugin.getPortStatus = function(d) {
+ 	// Helper function to get the localized text for a status code.
+    const getStatusText = (statusCode) => theUILang.portStatus[statusCode] || theUILang.portStatus[0] || "Unknown";
+    
+ 	// Update the status for both IPv4 and IPv6 and collect their title lines.
+    const titleLines = [
+        updateProtocolStatus(d, 'ipv4', getStatusText),
+        updateProtocolStatus(d, 'ipv6', getStatusText)
+    ];
 
-plugin.getPortStatus = function(d)
-{
-	$("#port-pane").prop("title", d.ip+":"+d.port+": "+theUILang.portStatus[d.status]);
-	$("#port-pane .icon").removeClass().addClass("icon pstatus" + d.status)
-	$("#port-ip-text").text(d.ip+':'+d.port);
-}
+ 	// Check if both IPv4 and IPv6 addresses are available.
+    const ipv4Available = d.ipv4 && d.ipv4 !== "-";
+    const ipv6Available = d.ipv6 && d.ipv6 !== "-";
 
-rTorrentStub.prototype.initportcheck = function()
-{
-	this.contentType = "application/x-www-form-urlencoded";
-	this.mountPoint = "plugins/check_port/action.php?init";
-	this.dataType = "json";
-}
+ 	// Show a separator only if both protocols have an IP address to display.
+    if (ipv4Available && ipv6Available) {
+        a.separator.text("|").show();
+    } else {
+        a.separator.text("").hide();
+    }
 
-rTorrentStub.prototype.updateportcheck = function()
-{
-	this.contentType = "application/x-www-form-urlencoded";
-	this.mountPoint = "plugins/check_port/action.php";
-	this.dataType = "json";
-}
+ 	// Set the combined tooltip for the entire status pane.
+    a.pane.prop("title", titleLines.join(" | "));
+};
 
-plugin.createPortMenu = function(e)
-{
-	if(e.which==3)
-	{
-		theContextMenu.clear();
-		theContextMenu.add([ theUILang.checkPort, plugin.update ]);
-		theContextMenu.show();
-	}
-	return(false);
-}
+// Defines the AJAX request for the initial port check.
+rTorrentStub.prototype.initportcheck = function() {
+    this.contentType = "application/x-www-form-urlencoded";
+    this.mountPoint = "plugins/check_port/action.php?init";
+    this.dataType = "json";
+};
 
-plugin.onLangLoaded = function()
-{
-	plugin.addPaneToStatusbar(
-		"port-pane",
-		$("<div>").append(
-			$("<div>").addClass("icon"),
-			$("<span>").attr("id","port-ip-text").addClass("d-none d-lg-block"),
-		),
-		-1, true,
-	);
-	if(plugin.canChangeMenu()) {
-		$("#port-pane .icon").addClass("pstatus0");
-		$("#port-pane").mouseclick( plugin.createPortMenu );
-	}
-	plugin.init();
-}
+// Defines the AJAX request for subsequent port status updates.
+rTorrentStub.prototype.updateportcheck = function() {
+    this.contentType = "application/x-www-form-urlencoded";
+    this.mountPoint = "plugins/check_port/action.php";
+    this.dataType = "json";
+};
 
-plugin.onRemove = function()
-{
-	plugin.removePaneFromStatusbar("port-pane");
-}
+// Creates and shows the context menu (right-click menu) for the status pane.
+plugin.createPortMenu = function(e) {
+ 	if (e.which === 3) { // Right mouse button.
+        theContextMenu.clear();
+ 		// Add a "Refresh" option to the context menu.
+        theContextMenu.add([(theUILang.checkPort || "Refresh Port Status"), plugin.update]);
+        theContextMenu.show();
+    }
+ 	return false; // Prevent the default browser context menu from appearing.
+};
+
+plugin.onLangLoaded = function() {
+    // Create status bar elements in a more readable way
+    const container = $("<div>").addClass("port-status-container");
+    
+    const ipv4Icon = $("<div>").attr("id", "port-icon-ipv4").addClass("icon");
+    const ipv4Text = $("<span>").attr("id", "port-ip-text-ipv4").addClass("d-none d-lg-block port-ip-text-segment");
+    const separator = $("<span>").attr("id", "port-ip-separator").addClass("d-none d-lg-block").css({"margin-left": "3px", "margin-right": "3px"});
+    const ipv6Icon = $("<div>").attr("id", "port-icon-ipv6").addClass("icon");
+    const ipv6Text = $("<span>").attr("id", "port-ip-text-ipv6").addClass("d-none d-lg-block port-ip-text-segment");
+
+ 	// Assemble the elements into the container.
+    container.append(ipv4Icon, ipv4Text, separator, ipv6Icon, ipv6Text);
+    
+ 	// Add the newly created pane to the ruTorrent status bar.
+    plugin.addPaneToStatusbar("port-pane", container, -1, true);
+    
+ 	// Now that the pane is in the DOM, cache all the jQuery elements for future use.
+    a.pane = $("#port-pane");
+    a.iconIPv4 = $("#port-icon-ipv4");
+    a.textIPv4 = $("#port-ip-text-ipv4");
+    a.separator = $("#port-ip-separator");
+    a.iconIPv6 = $("#port-icon-ipv6");
+    a.textIPv6 = $("#port-ip-text-ipv6");
+
+ 	// If the user has permissions, attach the right-click context menu.
+    if (plugin.canChangeMenu()) {
+        a.pane.on("mousedown", plugin.createPortMenu);
+    }
+    
+ 	// Trigger the initial port check.
+    plugin.init();
+};
+
+// This function is called when the plugin is removed/unloaded.
+plugin.onRemove = function() {
+ 	// Remove the pane from the status bar to clean up the UI.
+    plugin.removePaneFromStatusbar("port-pane");
+};

--- a/plugins/check_port/init.php
+++ b/plugins/check_port/init.php
@@ -3,17 +3,17 @@
 // Load the plugin's configuration settings from conf.php
 eval(FileUtil::getPluginConf($plugin["name"]));
 
-// A service is considered validly configured if set to a known provider.
+// A service is considered validly configured if set to a known provider
 $isIPv4Valid = in_array($useWebsiteIPv4, ["yougetsignal", "portchecker"]);
 $isIPv6Valid = in_array($useWebsiteIPv6, ["portchecker"]);
 
-// The plugin should be active if at least one service is validly configured.
+// The plugin should be active if at least one service is validly configured
 if ($isIPv4Valid || $isIPv6Valid) {
 	$theSettings->registerPlugin($plugin["name"], $pInfo["perms"]);
 } else {
-	// If neither is validly configured, disable the plugin.
-	// Show an error message only if the configuration is not explicitly set to 'false' for both.
-	// This distinguishes between "disabled" and "misconfigured".
+	// If neither is validly configured, disable the plugin
+	// Show an error message only if the configuration is not explicitly set to 'false' for both
+	// This distinguishes between "disabled" and "misconfigured"
 	if ($useWebsiteIPv4 !== false || $useWebsiteIPv6 !== false) {
 		$jResult .= "plugin.disable(); plugin.showError(theUILang.checkWebsiteNotFound);";
 	} else {

--- a/plugins/check_port/init.php
+++ b/plugins/check_port/init.php
@@ -1,5 +1,6 @@
 <?php
 
+// Load the plugin's configuration settings from conf.php
 eval(FileUtil::getPluginConf($plugin["name"]));
 
 // A service is considered validly configured if set to a known provider.
@@ -8,14 +9,14 @@ $isIPv6Valid = in_array($useWebsiteIPv6, ["portchecker"]);
 
 // The plugin should be active if at least one service is validly configured.
 if ($isIPv4Valid || $isIPv6Valid) {
-    $theSettings->registerPlugin($plugin["name"], $pInfo["perms"]);
+	$theSettings->registerPlugin($plugin["name"], $pInfo["perms"]);
 } else {
-    // If neither is validly configured, disable the plugin.
-    // Show an error message only if the configuration is not explicitly set to 'false' for both.
-    // This distinguishes between "disabled" and "misconfigured".
-    if ($useWebsiteIPv4 !== false || $useWebsiteIPv6 !== false) {
-        $jResult .= "plugin.disable(); plugin.showError(theUILang.checkWebsiteNotFound);";
-    } else {
-        $jResult .= "plugin.disable();";
-    }
+	// If neither is validly configured, disable the plugin.
+	// Show an error message only if the configuration is not explicitly set to 'false' for both.
+	// This distinguishes between "disabled" and "misconfigured".
+	if ($useWebsiteIPv4 !== false || $useWebsiteIPv6 !== false) {
+		$jResult .= "plugin.disable(); plugin.showError(theUILang.checkWebsiteNotFound);";
+	} else {
+		$jResult .= "plugin.disable();";
+	}
 }

--- a/plugins/check_port/init.php
+++ b/plugins/check_port/init.php
@@ -2,12 +2,20 @@
 
 eval(FileUtil::getPluginConf($plugin["name"]));
 
-if($useWebsite!==false)
-{
-	if(($useWebsite === "yougetsignal") || ($useWebsite === "portchecker"))
-		$theSettings->registerPlugin($plugin["name"],$pInfo["perms"]);
-	else
-		$jResult.="plugin.disable(); plugin.showError('theUILang.checkWebsiteNotFound+\' (".$useWebsite.").\'');";
+// A service is considered validly configured if set to a known provider.
+$isIPv4Valid = in_array($useWebsiteIPv4, ["yougetsignal", "portchecker"]);
+$isIPv6Valid = in_array($useWebsiteIPv6, ["portchecker"]);
+
+// The plugin should be active if at least one service is validly configured.
+if ($isIPv4Valid || $isIPv6Valid) {
+    $theSettings->registerPlugin($plugin["name"], $pInfo["perms"]);
+} else {
+    // If neither is validly configured, disable the plugin.
+    // Show an error message only if the configuration is not explicitly set to 'false' for both.
+    // This distinguishes between "disabled" and "misconfigured".
+    if ($useWebsiteIPv4 !== false || $useWebsiteIPv6 !== false) {
+        $jResult .= "plugin.disable(); plugin.showError(theUILang.checkWebsiteNotFound);";
+    } else {
+        $jResult .= "plugin.disable();";
+    }
 }
-else
-	$jResult.="plugin.disable();";

--- a/plugins/check_port/lang/cs.js
+++ b/plugins/check_port/lang/cs.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/da.js
+++ b/plugins/check_port/lang/da.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/de.js
+++ b/plugins/check_port/lang/de.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Portstatus überprüfen";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Portstatus ist unbekannt",
  				  "Port ist geschlossen",
  				  "Port ist offen"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/el.js
+++ b/plugins/check_port/lang/el.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Πρόσθετο Check_port: Το πρόσθετο δεν θα λειτουργήσει. Μη έγκυρη παραμετροποίηση";
  theUILang.checkPort		= "Έλεγχος κατάστασης θύρας";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Η κατάσταση της θύρας είναι άγνωστη",
  				  "Η θύρα είναι κλειστή",
  				  "Η θύρα είναι ανοικτή"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/en.js
+++ b/plugins/check_port/lang/en.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/es.js
+++ b/plugins/check_port/lang/es.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Verificar estado del puerto";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Es estado del puerto es desconocido",
  				  "Puerto cerrado",
  				  "Puerto abierto"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/fi.js
+++ b/plugins/check_port/lang/fi.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/fr.js
+++ b/plugins/check_port/lang/fr.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Plugin 'Check_port' : Configuration invalide. Le plugin ne fonctionnera pas.";
  theUILang.checkPort		= "Vérification du port";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Statut du port inconnu",
  				  "Le port est fermé",
  				  "Le port est ouvert"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/hu.js
+++ b/plugins/check_port/lang/hu.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port bővítmény: Bővítmény nem fog működni. Érvénytelen konfiguráció";
  theUILang.checkPort		= "Port állapotának ellenőrzése";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port állapota ismeretlen",
  				  "Port zárva van",
  				  "Port nyitva van"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/it.js
+++ b/plugins/check_port/lang/it.js
@@ -9,10 +9,12 @@
 
  theUILang.checkWebsiteNotFound = "Plugin 'Check_port': Il plugin non funziona. Configurazione non valida.";
  theUILang.checkPort		= "Controlla stato porta";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Stato della porta sconosciuto",
  				  "La porta è chiusa",
  				  "La porta è aperta"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/ko.js
+++ b/plugins/check_port/lang/ko.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "포트 상태 검사";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "포트 상태 알 수 없음",
  				  "포트 닫힘",
  				  "포트 열림"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/lv.js
+++ b/plugins/check_port/lang/lv.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/nl.js
+++ b/plugins/check_port/lang/nl.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/no.js
+++ b/plugins/check_port/lang/no.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port-plugin: Plugin vil ikke virke. Ugyldig oppsett";
  theUILang.checkPort		= "Sjekk portstatus";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Portstatus er ukjent",
  				  "Port er lukket",
  				  "Port er åpen"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pl.js
+++ b/plugins/check_port/lang/pl.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Wtyczka check_port: Wtyczka nie działa. Nieprawidłowa konfiguracja.";
  theUILang.checkPort		= "Sprawdź stan portu";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Stan portu nieznany",
  				  "Port zamknięty",
  				  "Port otwarty"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pt-br.js
+++ b/plugins/check_port/lang/pt-br.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "plugin check_port: O plugin não funcionará. Configuração inválida";
  theUILang.checkPort		= "Verificar Status da Porta";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Status da porta é desconhecido",
  				  "Porta está fechada",
  				  "Porta está aberta"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pt-pt.js
+++ b/plugins/check_port/lang/pt-pt.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: O plug-in não funcionará. Configuração inválida";
  theUILang.checkPort		= "Verificar estado da porta";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "O estado da porta é desconhecido",
  				  "A porta está fechada",
  				  "A porta está aberta"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/ru.js
+++ b/plugins/check_port/lang/ru.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Плагин check_port не будет работать: неверные настройки";
  theUILang.checkPort		= "Проверить статус порта";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Статус порта неизвестен",
  				  "Порт закрыт",
  				  "Порт открыт"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/sk.js
+++ b/plugins/check_port/lang/sk.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/sr.js
+++ b/plugins/check_port/lang/sr.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/sv.js
+++ b/plugins/check_port/lang/sv.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Kontrollera portstatus";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Portstatus okänd",
  				  "Port är stängd",
  				  "Port är öppen"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/tr.js
+++ b/plugins/check_port/lang/tr.js
@@ -9,11 +9,13 @@
 
  theUILang.checkWebsiteNotFound = "Check_port eklentisi: Eklenti çalışmayacak. Yapılandırma geçersiz.";
  theUILang.checkPort		= "Port durumunu denetle";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port durumu bilinmiyor",
  				  "Port kapalı",
  				  "Port açık"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();
 

--- a/plugins/check_port/lang/uk.js
+++ b/plugins/check_port/lang/uk.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Перевірити стан порту";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Стан порту невідомий",
  				  "Порт закрито",
  				  "Порт відкрито"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/vi.js
+++ b/plugins/check_port/lang/vi.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Kiểm tra trạng thái cổng";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Không rõ tình trạng cổng",
  				  "Cổng bị đóng",
  				  "Cổng đang mở"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/zh-cn.js
+++ b/plugins/check_port/lang/zh-cn.js
@@ -8,11 +8,13 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "检查端口状态";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "端口状态未知",
  				  "端口是关闭的",
  				  "端口是开放的"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();
 

--- a/plugins/check_port/lang/zh-tw.js
+++ b/plugins/check_port/lang/zh-tw.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();


### PR DESCRIPTION
- Detect public IPv4 and IPv6 addresses using dedicated APIs (ipify.org).
- Perform port status checks for both IPv4 and IPv6 protocols independently.
- Update the backend (action.php) to return a JSON response containing status for both protocols.
- Revise the frontend to display separate status icons in the ruTorrent status bar, with each IP address shown next to its respective icon.
- Update the tooltip on the status bar pane to show detailed port status for both IPv4 and IPv6.
- Improve visual layout with proper spacing and alignment for status indicators.
