### PR TITLE
Fix Chrome performance regression

### DIFF
--- a/js/stable.js
+++ b/js/stable.js
@@ -558,8 +558,9 @@ dxSTable.prototype.setBodyState = function(v) {
 	{
 		if((this.colsdata[i].type==TYPE_PROGRESS) && this.colsdata[i].enabled)
 		{
-                        for(var j = 0; j < this.rows; j++)
-                        {
+			let rowcount = this.rows;
+			for(var j = 0; j < rowcount; j++)
+			{
 				var id = this.rowIDs[j];
 				if($$(id))
 				{
@@ -726,7 +727,9 @@ dxSTable.prototype.scrollPos = function()
 		mid = this.viewRows - 1;
 	var vr =- 1;
 	var str = "";
-	for(var i = 0; i < this.rows; i++)
+
+	let rowcount = this.rows;
+	for(var i = 0; i < rowcount; i++)
 	{
 		var id = this.rowIDs[i];
 		var r = this.rowdata[id];

--- a/js/stable.js
+++ b/js/stable.js
@@ -554,11 +554,12 @@ dxSTable.prototype.init = function() {
 
 dxSTable.prototype.setBodyState = function(v) {
 	this.tBody.css("visibility", v);
-	for(var i = 0; i < this.cols; i++) 
+	const colcount = this.cols;
+	for(var i = 0; i < colcount; i++) 
 	{
 		if((this.colsdata[i].type==TYPE_PROGRESS) && this.colsdata[i].enabled)
 		{
-			let rowcount = this.rows;
+			const rowcount = this.rows;
 			for(var j = 0; j < rowcount; j++)
 			{
 				var id = this.rowIDs[j];
@@ -728,7 +729,7 @@ dxSTable.prototype.scrollPos = function()
 	var vr =- 1;
 	var str = "";
 
-	let rowcount = this.rows;
+	const rowcount = this.rows;
 	for(var i = 0; i < rowcount; i++)
 	{
 		var id = this.rowIDs[i];
@@ -944,7 +945,7 @@ dxSTable.prototype.createIcon = function(icon) {
 }
 
 dxSTable.prototype.createRow = function(cols, sId, icon, attr) {
-	const attrs = { id: sId, index: this.rows, title: cols[0] };
+	const attrs = { id: sId, title: cols[0] };
 	if (sId == null) {
 		delete attrs['id'];
 	}
@@ -975,9 +976,10 @@ dxSTable.prototype.createRow = function(cols, sId, icon, attr) {
 	}
 	row.find("td:first-child div").prepend(this.createIcon(icon));
 	const ret = row[0];
-	const _e = this.tBodyCols;
-	for (let i = 0; i < _e.length; i++) {
-		ret.cells[i].style.textAlign = this.tHeadCols[i].style.textAlign;
+	const _tBodyCols = this.tBodyCols;
+	const _tHeadCols = this.tHeadCols;
+	for (let i = 0; i < _tBodyCols.length; i++) {
+		ret.cells[i].style.textAlign = _tHeadCols[i].style.textAlign;
 	}
 	return ret;
 }


### PR DESCRIPTION
Now that dxSTable.rows is a getter, and not a variable, we need to be mindful about using it in for loops. On an ruTorrent with 20K torrents, putting it into the for loop, instead of copying it into a variable will result in 20K executions of the getter function and tank performance.

By checking the rowcount once, before we start the loop, we can keep the getter (reducing the risk of OOS bugs), without suffering the performance penalty.

Related to #2830