### PR TITLE
feat(check_port): Implement dual IPv4/IPv6 port status checking

### DIFF
--- a/plugins/check_port/check_port.css
+++ b/plugins/check_port/check_port.css
@@ -1,18 +1,35 @@
+/*
+ * check_port Plugin Stylesheet
+ *
+ * Defines the icons and layout for the port status indicator in the status bar.
+ */
+
+/* Define CSS variables for the different status icons. */
+/* Using data URIs for the icons avoids extra HTTP requests. */
 #StatusBar {
+ 	/* Icon for when the port status is unknown or is being checked. */
   --pane-port-unknown-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAA7ElEQVR4AYyRtUEAQRBFzw2HiDbogYzLKIROKIFKSJEYpwDc3Yd9wUfOgz9r88bWM7MmxetLniEzKypvs6xsEvTnIQP4+ri3j4cDwV5FGSZymnRiHzilAr/eTtrAAjP152IcR/t6sZfjZUNf75eNMKYgE5kpGSect1fmUFu5gTY+mZXt8XBRIPu/WQv5Y3KnGS54pC+B6G5nwd5vVwUyUTahMgqirxrIuVoyZpxIXBIZJ+lsswS0h/2SgBWwkg2nWsbdeaSsJrBQNiAJQNkEuoACc0+fzeSGCF+Y74E1koNxJXIuEEawEeKwdA0A1zpJYUqqdYUAAAAASUVORK5CYII=);
+ 	/* Icon for when the port is confirmed to be closed (error state). */
   --pane-port-error-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAAVFBMVEX////////////////////////////////////////////////ORirORirdcWDlTzzpgW/qXEHtY0XtjnvxbEjyppbznIf0dk71f1j5tqH72dP///8Q8E8oAAAADXRSTlMAAgUGBwgKDRMUFRnTtFxmSQAAAHpJREFUCB0FgAEOwiAMRV8pq5LI/Q+6xDlG+43FAiZw7zIZMBlOXpzg8HkNGXrTH5z5irLetCOP1SAKIHkG+BwyspOl8t5xbYASOA0EJUQJOplC2wtUtPMKiaMBxzq7c40vPyBucNQyqsriVjYDJuHkop5mJmACe2f1P5ZxRkN1OzPZAAAAAElFTkSuQmCC);
+ 	/* Icon for when the port is confirmed to be open (success state). */
   --pane-port-success-icon: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAA/ElEQVR4AWL4//8/DLMDMRuIrdMt9h8ZAwEXSBxKMwExC4ijDMSsIBqmcPGVKSgYJg7VzAGiGWAmgSR6T1f/X393GZguOZwIwjAxEBumWRSmkQ1ZU8rhEGwYXTMLTCOKpqTdPoC6ycIGgRgAgFgUl31YhCHZBB0Bd3e9Tw6nydWvXgElUsVcyD0x4z+J0Fu36QOBHIiO6JKao+qbdDofHZhJniIFRJjtp87wJpXKRQZ7F10CDcjLw/xKOF/OSvC+VI7W5SIqs1wl8XBwvEM6K791FpZImy8JMX2n8CK7bCD/JTkjb480SQPYGch/PLkYkBFIUPnjkfsJwn6EG7GmEErgVbTJAAAAAElFTkSuQmCC);
 }
+/* General styling for the icon element within the port status pane. */
 #port-pane .icon {
-  background-position: center;
-  background-repeat: no-repeat;
+  background-position: center; /* Center the icon within its container. */
+  background-repeat: no-repeat; /* Prevent the icon from tiling. */
+  width: 14px; /* Explicitly set width to match the icon image. */
+  height: 14px; /* Explicitly set height to match the icon image. */
 }
+/* Assigns the 'unknown' status icon. */
 #port-pane .pstatus0 {
   background-image: var(--pane-port-unknown-icon);
 }
+/* Assigns the 'error' (closed) status icon. */
 #port-pane .pstatus1 {
   background-image: var(--pane-port-error-icon);
 }
+/* Assigns the 'success' (open) status icon. */
 #port-pane .pstatus2 {
   background-image: var(--pane-port-success-icon);
 }

--- a/plugins/check_port/conf.php
+++ b/plugins/check_port/conf.php
@@ -1,9 +1,15 @@
 <?php
 // configuration parameter
 
-$useWebsite = "portchecker";	// Valid choices:
-				// false - disable check_port plugin
-				// "yougetsignal" - use https://www.yougetsignal.com/tools/open-ports/
-				// "portchecker" - use https://portchecker.co/
+$useWebsiteIPv4 = "yougetsignal";	// Valid choices:
+ 				// false - disable IPv4 port check
+ 				// "yougetsignal" - use https://www.yougetsignal.com/tools/open-ports/
+ 				// "portchecker" - use https://portchecker.co/
 
-$useIpv4 = true;		// use ipv4 addresses when checking ports, unless website supports ipv6
+$useWebsiteIPv6 = "portchecker";	// Valid choices:
+ 				// false - disable IPv6 port check
+ 				// "portchecker" - use https://portchecker.co/ (Known to work for IPv6)
+ 				// Note: yougetsignal does not appear to support IPv6 checks.
+
+$checkPortTimeout = 15;  // Timeout in seconds for external port checking services
+                            // (e.g., yougetsignal, portchecker) and for IP detection services (e.g., ipify).

--- a/plugins/check_port/init.js
+++ b/plugins/check_port/init.js
@@ -1,68 +1,170 @@
+// Load language file and CSS for the plugin.
 plugin.loadLang();
 plugin.loadMainCSS();
 
-plugin.init = function()
-{
-	$("#port-pane .icon").removeClass().addClass("icon pstatus0");
-	theWebUI.request("?action=initportcheck", [plugin.getPortStatus, plugin]);
+// Cache jQuery elements for performance and readability.
+const a = {};
+
+/**
+ * Resets the UI elements to a neutral/unknown state, typically while checking.
+ * @param {boolean} isUpdate - If true, indicates a manual refresh, adding "..." to the title.
+ */
+plugin.resetStatus = function(isUpdate) {
+ 	// Reset icons to the "unknown" state (pstatus0).
+    a.iconIPv4.removeClass().addClass("icon port-icon-ipv4 pstatus0");
+    a.iconIPv6.removeClass().addClass("icon port-icon-ipv6 pstatus0");
+ 	// Hide IP address text and the separator.
+    a.textIPv4.text("").hide();
+    a.separator.text("").hide();
+    a.textIPv6.text("").hide();
+    
+ 	// Set a tooltip to indicate that a check is in progress.
+    let title = theUILang.checkingPort || "Checking port status...";
+    if (isUpdate) {
+ 		title += "..."; // Append ellipsis for manual updates.
+    }
+    a.pane.prop("title", title);
+};
+
+// Initial check when the plugin is first loaded.
+plugin.init = function() {
+    plugin.resetStatus(false);
+ 	// Request the initial port status from the backend.
+    theWebUI.request("?action=initportcheck", [plugin.getPortStatus, plugin]);
+};
+
+// Function to manually trigger an update of the port status.
+plugin.update = function() {
+    plugin.resetStatus(true);
+ 	// Request a port status update from the backend.
+    theWebUI.request("?action=updateportcheck", [plugin.getPortStatus, plugin]);
+};
+
+/**
+ * Updates the UI for a specific IP protocol (IPv4 or IPv6) based on data from the backend.
+ * @param {object} data - The response data containing status for both protocols.
+ * @param {string} proto - The protocol to update, either "ipv4" or "ipv6".
+ * @param {function} getStatusText - A function to retrieve the localized status string.
+ * @returns {string} The formatted title line for this protocol's status.
+ */
+function updateProtocolStatus(data, proto, getStatusText) {
+    const status = parseInt(data[proto + '_status']);
+    const address = data[proto];
+    const port = data[proto + '_port'];
+ 	const isAvailable = address && address !== "-"; // Check if an IP address was returned.
+    
+ 	// Select the correct UI elements for the given protocol.
+    const icon = (proto === 'ipv4') ? a.iconIPv4 : a.iconIPv6;
+    const textEl = (proto === 'ipv4') ? a.textIPv4 : a.textIPv6;
+
+    icon.removeClass("pstatus0 pstatus1 pstatus2").addClass("pstatus" + status);
+    
+    let displayText = "";
+    let titleText = "";
+
+    if (isAvailable) {
+ 		// Format display text as IP:PORT, with brackets for IPv6.
+        displayText = (proto === 'ipv6') ? `[${address}]:${port}` : `${address}:${port}`;
+        textEl.text(displayText).show();
+ 		// Create a detailed title for the tooltip.
+        titleText = `${proto.toUpperCase()}: ${displayText} (${getStatusText(status)})`;
+    } else {
+ 		// If IP is not available, hide the text element.
+        textEl.text("").hide();
+        titleText = `${proto.toUpperCase()}: ${(theUILang.notAvailable || "N/A")} (${getStatusText(status)})`;
+    }
+ 	return titleText; // Return the generated title string.
 }
 
-plugin.update = function()
-{
-	$("#port-pane .icon").removeClass().addClass("icon pstatus0");
-	theWebUI.request("?action=updateportcheck", [plugin.getPortStatus, plugin]);
-}
+/**
+ * Main callback to process the port status response from the backend and update the UI.
+ * @param {object} d - The JSON object received from the backend response.
+ */
+plugin.getPortStatus = function(d) {
+ 	// Helper function to get the localized text for a status code.
+    const getStatusText = (statusCode) => theUILang.portStatus[statusCode] || theUILang.portStatus[0] || "Unknown";
+    
+ 	// Update the status for both IPv4 and IPv6 and collect their title lines.
+    const titleLines = [
+        updateProtocolStatus(d, 'ipv4', getStatusText),
+        updateProtocolStatus(d, 'ipv6', getStatusText)
+    ];
 
-plugin.getPortStatus = function(d)
-{
-	$("#port-pane").prop("title", d.ip+":"+d.port+": "+theUILang.portStatus[d.status]);
-	$("#port-pane .icon").removeClass().addClass("icon pstatus" + d.status)
-	$("#port-ip-text").text(d.ip+':'+d.port);
-}
+ 	// Check if both IPv4 and IPv6 addresses are available.
+    const ipv4Available = d.ipv4 && d.ipv4 !== "-";
+    const ipv6Available = d.ipv6 && d.ipv6 !== "-";
 
-rTorrentStub.prototype.initportcheck = function()
-{
-	this.contentType = "application/x-www-form-urlencoded";
-	this.mountPoint = "plugins/check_port/action.php?init";
-	this.dataType = "json";
-}
+ 	// Show a separator only if both protocols have an IP address to display.
+    if (ipv4Available && ipv6Available) {
+        a.separator.text("|").show();
+    } else {
+        a.separator.text("").hide();
+    }
 
-rTorrentStub.prototype.updateportcheck = function()
-{
-	this.contentType = "application/x-www-form-urlencoded";
-	this.mountPoint = "plugins/check_port/action.php";
-	this.dataType = "json";
-}
+ 	// Set the combined tooltip for the entire status pane.
+    a.pane.prop("title", titleLines.join(" | "));
+};
 
-plugin.createPortMenu = function(e)
-{
-	if(e.which==3)
-	{
-		theContextMenu.clear();
-		theContextMenu.add([ theUILang.checkPort, plugin.update ]);
-		theContextMenu.show();
-	}
-	return(false);
-}
+// Defines the AJAX request for the initial port check.
+rTorrentStub.prototype.initportcheck = function() {
+    this.contentType = "application/x-www-form-urlencoded";
+    this.mountPoint = "plugins/check_port/action.php?init";
+    this.dataType = "json";
+};
 
-plugin.onLangLoaded = function()
-{
-	plugin.addPaneToStatusbar(
-		"port-pane",
-		$("<div>").append(
-			$("<div>").addClass("icon"),
-			$("<span>").attr("id","port-ip-text").addClass("d-none d-lg-block"),
-		),
-		-1, true,
-	);
-	if(plugin.canChangeMenu()) {
-		$("#port-pane .icon").addClass("pstatus0");
-		$("#port-pane").mouseclick( plugin.createPortMenu );
-	}
-	plugin.init();
-}
+// Defines the AJAX request for subsequent port status updates.
+rTorrentStub.prototype.updateportcheck = function() {
+    this.contentType = "application/x-www-form-urlencoded";
+    this.mountPoint = "plugins/check_port/action.php";
+    this.dataType = "json";
+};
 
-plugin.onRemove = function()
-{
-	plugin.removePaneFromStatusbar("port-pane");
-}
+// Creates and shows the context menu (right-click menu) for the status pane.
+plugin.createPortMenu = function(e) {
+ 	if (e.which === 3) { // Right mouse button.
+        theContextMenu.clear();
+ 		// Add a "Refresh" option to the context menu.
+        theContextMenu.add([(theUILang.checkPort || "Refresh Port Status"), plugin.update]);
+        theContextMenu.show();
+    }
+ 	return false; // Prevent the default browser context menu from appearing.
+};
+
+plugin.onLangLoaded = function() {
+    // Create status bar elements in a more readable way
+    const container = $("<div>").addClass("port-status-container");
+    
+    const ipv4Icon = $("<div>").attr("id", "port-icon-ipv4").addClass("icon");
+    const ipv4Text = $("<span>").attr("id", "port-ip-text-ipv4").addClass("d-none d-lg-block port-ip-text-segment");
+    const separator = $("<span>").attr("id", "port-ip-separator").addClass("d-none d-lg-block").css({"margin-left": "3px", "margin-right": "3px"});
+    const ipv6Icon = $("<div>").attr("id", "port-icon-ipv6").addClass("icon");
+    const ipv6Text = $("<span>").attr("id", "port-ip-text-ipv6").addClass("d-none d-lg-block port-ip-text-segment");
+
+ 	// Assemble the elements into the container.
+    container.append(ipv4Icon, ipv4Text, separator, ipv6Icon, ipv6Text);
+    
+ 	// Add the newly created pane to the ruTorrent status bar.
+    plugin.addPaneToStatusbar("port-pane", container, -1, true);
+    
+ 	// Now that the pane is in the DOM, cache all the jQuery elements for future use.
+    a.pane = $("#port-pane");
+    a.iconIPv4 = $("#port-icon-ipv4");
+    a.textIPv4 = $("#port-ip-text-ipv4");
+    a.separator = $("#port-ip-separator");
+    a.iconIPv6 = $("#port-icon-ipv6");
+    a.textIPv6 = $("#port-ip-text-ipv6");
+
+ 	// If the user has permissions, attach the right-click context menu.
+    if (plugin.canChangeMenu()) {
+        a.pane.on("mousedown", plugin.createPortMenu);
+    }
+    
+ 	// Trigger the initial port check.
+    plugin.init();
+};
+
+// This function is called when the plugin is removed/unloaded.
+plugin.onRemove = function() {
+ 	// Remove the pane from the status bar to clean up the UI.
+    plugin.removePaneFromStatusbar("port-pane");
+};

--- a/plugins/check_port/init.php
+++ b/plugins/check_port/init.php
@@ -2,12 +2,20 @@
 
 eval(FileUtil::getPluginConf($plugin["name"]));
 
-if($useWebsite!==false)
-{
-	if(($useWebsite === "yougetsignal") || ($useWebsite === "portchecker"))
-		$theSettings->registerPlugin($plugin["name"],$pInfo["perms"]);
-	else
-		$jResult.="plugin.disable(); plugin.showError('theUILang.checkWebsiteNotFound+\' (".$useWebsite.").\'');";
+// A service is considered validly configured if set to a known provider.
+$isIPv4Valid = in_array($useWebsiteIPv4, ["yougetsignal", "portchecker"]);
+$isIPv6Valid = in_array($useWebsiteIPv6, ["portchecker"]);
+
+// The plugin should be active if at least one service is validly configured.
+if ($isIPv4Valid || $isIPv6Valid) {
+    $theSettings->registerPlugin($plugin["name"], $pInfo["perms"]);
+} else {
+    // If neither is validly configured, disable the plugin.
+    // Show an error message only if the configuration is not explicitly set to 'false' for both.
+    // This distinguishes between "disabled" and "misconfigured".
+    if ($useWebsiteIPv4 !== false || $useWebsiteIPv6 !== false) {
+        $jResult .= "plugin.disable(); plugin.showError(theUILang.checkWebsiteNotFound);";
+    } else {
+        $jResult .= "plugin.disable();";
+    }
 }
-else
-	$jResult.="plugin.disable();";

--- a/plugins/check_port/lang/cs.js
+++ b/plugins/check_port/lang/cs.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/da.js
+++ b/plugins/check_port/lang/da.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/de.js
+++ b/plugins/check_port/lang/de.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Portstatus überprüfen";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Portstatus ist unbekannt",
  				  "Port ist geschlossen",
  				  "Port ist offen"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/el.js
+++ b/plugins/check_port/lang/el.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Πρόσθετο Check_port: Το πρόσθετο δεν θα λειτουργήσει. Μη έγκυρη παραμετροποίηση";
  theUILang.checkPort		= "Έλεγχος κατάστασης θύρας";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Η κατάσταση της θύρας είναι άγνωστη",
  				  "Η θύρα είναι κλειστή",
  				  "Η θύρα είναι ανοικτή"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/en.js
+++ b/plugins/check_port/lang/en.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/es.js
+++ b/plugins/check_port/lang/es.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Verificar estado del puerto";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Es estado del puerto es desconocido",
  				  "Puerto cerrado",
  				  "Puerto abierto"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/fi.js
+++ b/plugins/check_port/lang/fi.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/fr.js
+++ b/plugins/check_port/lang/fr.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Plugin 'Check_port' : Configuration invalide. Le plugin ne fonctionnera pas.";
  theUILang.checkPort		= "Vérification du port";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Statut du port inconnu",
  				  "Le port est fermé",
  				  "Le port est ouvert"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/hu.js
+++ b/plugins/check_port/lang/hu.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port bővítmény: Bővítmény nem fog működni. Érvénytelen konfiguráció";
  theUILang.checkPort		= "Port állapotának ellenőrzése";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port állapota ismeretlen",
  				  "Port zárva van",
  				  "Port nyitva van"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/it.js
+++ b/plugins/check_port/lang/it.js
@@ -9,10 +9,12 @@
 
  theUILang.checkWebsiteNotFound = "Plugin 'Check_port': Il plugin non funziona. Configurazione non valida.";
  theUILang.checkPort		= "Controlla stato porta";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Stato della porta sconosciuto",
  				  "La porta è chiusa",
  				  "La porta è aperta"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/ko.js
+++ b/plugins/check_port/lang/ko.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "포트 상태 검사";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "포트 상태 알 수 없음",
  				  "포트 닫힘",
  				  "포트 열림"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/lv.js
+++ b/plugins/check_port/lang/lv.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/nl.js
+++ b/plugins/check_port/lang/nl.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/no.js
+++ b/plugins/check_port/lang/no.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port-plugin: Plugin vil ikke virke. Ugyldig oppsett";
  theUILang.checkPort		= "Sjekk portstatus";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Portstatus er ukjent",
  				  "Port er lukket",
  				  "Port er åpen"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pl.js
+++ b/plugins/check_port/lang/pl.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Wtyczka check_port: Wtyczka nie działa. Nieprawidłowa konfiguracja.";
  theUILang.checkPort		= "Sprawdź stan portu";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Stan portu nieznany",
  				  "Port zamknięty",
  				  "Port otwarty"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pt-br.js
+++ b/plugins/check_port/lang/pt-br.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "plugin check_port: O plugin não funcionará. Configuração inválida";
  theUILang.checkPort		= "Verificar Status da Porta";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Status da porta é desconhecido",
  				  "Porta está fechada",
  				  "Porta está aberta"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pt-pt.js
+++ b/plugins/check_port/lang/pt-pt.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: O plug-in não funcionará. Configuração inválida";
  theUILang.checkPort		= "Verificar estado da porta";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "O estado da porta é desconhecido",
  				  "A porta está fechada",
  				  "A porta está aberta"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/ru.js
+++ b/plugins/check_port/lang/ru.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Плагин check_port не будет работать: неверные настройки";
  theUILang.checkPort		= "Проверить статус порта";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Статус порта неизвестен",
  				  "Порт закрыт",
  				  "Порт открыт"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/sk.js
+++ b/plugins/check_port/lang/sk.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/sr.js
+++ b/plugins/check_port/lang/sr.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/sv.js
+++ b/plugins/check_port/lang/sv.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Kontrollera portstatus";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Portstatus okänd",
  				  "Port är stängd",
  				  "Port är öppen"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/tr.js
+++ b/plugins/check_port/lang/tr.js
@@ -9,11 +9,13 @@
 
  theUILang.checkWebsiteNotFound = "Check_port eklentisi: Eklenti çalışmayacak. Yapılandırma geçersiz.";
  theUILang.checkPort		= "Port durumunu denetle";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port durumu bilinmiyor",
  				  "Port kapalı",
  				  "Port açık"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();
 

--- a/plugins/check_port/lang/uk.js
+++ b/plugins/check_port/lang/uk.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Перевірити стан порту";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Стан порту невідомий",
  				  "Порт закрито",
  				  "Порт відкрито"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/vi.js
+++ b/plugins/check_port/lang/vi.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Kiểm tra trạng thái cổng";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Không rõ tình trạng cổng",
  				  "Cổng bị đóng",
  				  "Cổng đang mở"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/zh-cn.js
+++ b/plugins/check_port/lang/zh-cn.js
@@ -8,11 +8,13 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "检查端口状态";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "端口状态未知",
  				  "端口是关闭的",
  				  "端口是开放的"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();
 

--- a/plugins/check_port/lang/zh-tw.js
+++ b/plugins/check_port/lang/zh-tw.js
@@ -8,10 +8,12 @@
 
  theUILang.checkWebsiteNotFound = "Check_port plugin: Plugin will not work. Invalid configuration";
  theUILang.checkPort		= "Check Port Status";
+ theUILang.checkingPort		= "Checking port status";
  theUILang.portStatus		= [
  				  "Port status is unknown",
  				  "Port is closed",
  				  "Port is open"
  				  ];
+ theUILang.notAvailable = "-";
 
 thePlugins.get("check_port").langLoaded();


### PR DESCRIPTION
- Detect public IPv4 and IPv6 addresses using dedicated APIs (ipify.org).
- Perform port status checks for both IPv4 and IPv6 protocols independently.
- Update the backend (action.php) to return a JSON response containing status for both protocols.
- Revise the frontend to display separate status icons in the ruTorrent status bar, with each IP address shown next to its respective icon.
- Update the tooltip on the status bar pane to show detailed port status for both IPv4 and IPv6.
- Improve visual layout with proper spacing and alignment for status indicators.