### PR TITLE
Fix: check_port with portchecker.co

### DIFF
--- a/plugins/check_port/action.php
+++ b/plugins/check_port/action.php
@@ -19,7 +19,7 @@ if($useWebsite=="portchecker")
 {
 	$url = "https://portchecker.co/";
 	$ipMatch = '/data-ip="(?P<ip>[^"]+)/';
-	$checker = "https://portchecker.co/check-it";
+	$checker = "https://portchecker.co/check-v0";
 	$closed = ">closed<";
 	$open = ">open<";
 }


### PR DESCRIPTION
Problem: check_port plugin fails checks when using the portchecker alternative site. Whatever their internal API was, changed paths for https://portchecker.co/

Easily checked by opening dev console and seeing the new path, with same body of `target_ip`, `port`, `selectPort`, `_csrf`. POSTing to the legacy path `/check-it` will get a 303 to the main page. Which just has default input form.