### PR TITLE
Fix inconsistent add torrent dialog window width 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -733,7 +733,7 @@ div#tadd {max-width: 95vw;}
   div#HDivider {cursor: e-resize;}
   div#VDivider {cursor: n-resize;}
   div#HDivider:hover, div#VDivider:hover {background: #A0A0A0;}
-  div#tadd {min-width: 600px;}
+  div#tadd {width: 600px;}
   .dlg-window .buttons-list {
     margin: 1rem 0.5rem;
     justify-content: end;

--- a/css/style.css
+++ b/css/style.css
@@ -695,7 +695,7 @@ span#loadimg {padding: 20px; background: transparent url(../images/ajax-loader.g
 /* X-Small devices (portrait phones, less than 576px) */
 /* No media query for `xs` since this is the default in Bootstrap */
 /* Custom rules for medium devices */
-div#tadd {max-width: 95vw;}
+div#tadd {width: 95vw;}
 .dlg-window .buttons-list {
   margin: 0.5rem;
   gap: 0.25rem;


### PR DESCRIPTION
## Overview

This PR fixes a minor issue in the add torrent dialog, where its size changes depending on the selected input torrent file (especially in Firefox). Some long torrent file names with many space breaks can significantly stretch the modal window.

<img width="400" alt="" src="https://github.com/user-attachments/assets/8dfa57ce-179f-4f6f-b686-b3017a65037d" />
<img width="400" alt="" src="https://github.com/user-attachments/assets/7f260742-7c4f-4873-aa82-da80f1dcbb3b" />

I've also updated styles so this window always take 95% of the viewport on a smaller screens.