### PR TITLE
Don't count size of torrents in a tracker label multiple times

### DIFF
--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -12,7 +12,7 @@ plugin.loadLang();
 const catlist = theWebUI.categoryList;
 const ptrackersPanelArgs = [
 	[['ptrackers_all', {text: theUILang.All, icon: 'all'}]],
-	[(hash) => theWebUI.torrentTrackerIds.get(hash) ?? []]
+	[(hash) => [...new Set(theWebUI.torrentTrackerIds.get(hash) ?? [])]]
 ];
 
 const plabelEntries = catlist.refreshPanel.plabel.bind(catlist);


### PR DESCRIPTION
The tracklabel plugin uses the second and top level domains of the tracker URL to create its labels. If there are multiple trackers in a single torrent which is condensed down to the same label, that torrent's size is counted multiple times.

The setting "Show label size in Labels panel" will have to be enabled for the sizes to show up at all.

Example:
One torrent of 1 GB with 3 trackers, `tracker.example.com`, `example.com` and `tracker.example.org`.
There will be two labels, `example.com` and `example.org`.
The `example.org` label will be listed as 1 GB, while the `example.com` tracker will be 2 GB.