### PR TITLE
Update JSON::safeEncode to sanitize, rather than attempting convert/repair

### DIFF
--- a/php/utility/json.php
+++ b/php/utility/json.php
@@ -3,10 +3,9 @@
 require_once('utf.php');
 
 class JSON
-{	
+{
 	public static function safeEncode($value)
 	{
-		$encoded = json_encode($value);
-		return(!function_exists('json_last_error') || json_last_error()==JSON_ERROR_NONE ? $encoded : json_encode(UTF::utf8ize($value)));
+		return json_encode($value, JSON_INVALID_UTF8_SUBSTITUTE);
 	}
 }

--- a/php/utility/utf.php
+++ b/php/utility/utf.php
@@ -107,61 +107,6 @@ class UTF
 		return($outstr);
 	}
 
-	private static function mix2utf($str, $inv = '_') 
-	{
-		$len = strlen($str);
-		for($i = 0; $i < $len; $i++)
-		{
-			$c = ord($str[$i]);
-			if($c > 128) 
-			{
-				$bytes = 0;
-				if(($c > 247)) $str[$i] = $inv;
-				elseif($c > 239) $bytes = 4;
-				elseif($c > 223) $bytes = 3;
-				elseif($c > 191) $bytes = 2;
-				else $str[$i] = $inv;
-				if($bytes)
-				{
-					if(($i + $bytes) > $len) $str[$i] = $inv;
-					else
-					{
-						$start = $i;
-						$cnt = $bytes;
-						while($bytes > 1) 
-						{
-							$i++;
-							$b = ord($str[$i]);
-							if($b < 128 || $b > 191) 
-							{
-								$str[$start] = $inv;
-								$i = $start;
-								break;
-							}
-							$bytes--;
-						}
-					}
-				}
-			}
-		}
-		return($str);
-	}
-
-	public static function utf8ize($mixed) 
-	{
-		if(is_array($mixed) || is_object($mixed)) 
-		{
-				foreach($mixed as $key => $value) 
-				{
-					$mixed[$key] = self::utf8ize($value);
-				}
-			} 
-			else 
-				if(is_string($mixed)) 
-					$mixed = self::mix2utf($mixed);
-		return($mixed);
-	}
-
 	private static function maybe_mb_convert_to_utf8($string) {
 		return function_exists('mb_convert_encoding') ? mb_convert_encoding($string, "UTF-8", "auto") : $string;
 	}

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -496,4 +496,4 @@ if(is_null($result))
 	CachedEcho::send( (isset($req) && $req->fault) ? "Warning: XMLRPC call is failed." : "Link to XMLRPC failed. Maybe, rTorrent is down?","text/html");
 }
 else
-	CachedEcho::send(JSON::safeEncode($result),"application/json");
+	CachedEcho::send(json_encode($result, JSON_THROW_ON_ERROR|JSON_INVALID_UTF8_SUBSTITUTE), "application/json");


### PR DESCRIPTION
Right now, we've got a lot of code attempting to correct every malformed UTF8 string into something usable. This pull request is more of an alternate approach where we don't try and coax every string into something valid, but instead replace invalid sequences with a broken character encoding character.

Also ensures that on JSON encode failures we don't fail silently and return a HTTP 200.

One of two possible fixes for #2977

The other approcah is collecting every broken UTF8 name and adding unit tests for the UTF8 repair class. I have saved some strings that I've observed causing these problems in the wild, and can share them with someone motivated to write tests and fix the UTF8 fixer instead.