### PR TITLE
Fix PHP 8.2+ deprecation warnings

### DIFF
--- a/php/Torrent.php
+++ b/php/Torrent.php
@@ -11,6 +11,7 @@
 
 require_once( 'util.php' );
 
+#[\AllowDynamicProperties]
 class Torrent
 {
 	protected $errors = array();

--- a/php/cache.php
+++ b/php/cache.php
@@ -115,7 +115,7 @@ class rCache
 	}
 	public function getModified( $obj = null )
 	{
-		return(filemtime( is_null($obj) ? $this->dir : 
+		return(@filemtime( is_null($obj) ? $this->dir : 
 			(is_object($obj) ? $this->getName($obj) : $this->dir."/".$obj) ));
 			
 	}

--- a/php/cache.php
+++ b/php/cache.php
@@ -4,6 +4,7 @@ require_once( 'util.php' );
 class rCache
 {
 	protected $dir;
+	protected static $modifiedTimes = [];
 
 	public function __construct( $name = '' )
 	{
@@ -22,14 +23,20 @@ class rCache
 		}
 		return(true);
 	}
+	protected static function getCacheKey( $rss )
+	{
+		return(get_class($rss).':'.$rss->hash);
+	}
 	public function set( $rss, $arg = null )
 	{
 		global $profileMask;
 		$name = $this->getName($rss);
+		$cacheKey = is_object($rss) ? self::getCacheKey($rss) : null;
+		$modTime = $cacheKey ? (self::$modifiedTimes[$cacheKey] ?? (isset($rss->modified) ? $rss->modified : 0)) : 0;
 		if(     is_object($rss) &&
-			isset($rss->modified) &&
+			$modTime &&
 			method_exists($rss,"merge") &&
-			($rss->modified < filemtime($name)))
+			($modTime < filemtime($name)))
 		{
 		        $className = get_class($rss);
 			$newInstance = new $className();
@@ -88,7 +95,8 @@ class rCache
 					(isset($tmp->version) && ($tmp->version==$rss->version))))
 				{
 					$rss = $tmp;
-					$rss->modified = filemtime($fname);
+					$cacheKey = self::getCacheKey($rss);
+					self::$modifiedTimes[$cacheKey] = filemtime($fname);
 					$ret = true;
 				}
 				else

--- a/plugins/rss/rss.php
+++ b/plugins/rss/rss.php
@@ -21,6 +21,7 @@ class rRSS
 {
 	public $items = array();
 	public $channel = array();
+	public $isValid = false;
 	public $url = null;
 	public $srcURL = null;
 	public $hash = null;

--- a/plugins/trafic/stat.php
+++ b/plugins/trafic/stat.php
@@ -21,15 +21,15 @@ class rStat
 		$this->fname = FileUtil::getSettingsPath().'/trafic/'.$prefix;
 		if($file=@fopen($this->fname,"r"))
 		{
-			$hourUp = fgetcsv($file);
-			$hourDown = fgetcsv($file);
-			$hourHitTimes = fgetcsv($file);
-			$monthUp = fgetcsv($file);
-			$monthDown = fgetcsv($file);
-			$monthHitTimes = fgetcsv($file);
-			$yearUp = fgetcsv($file);
-			$yearDown = fgetcsv($file);
-			$yearHitTimes = fgetcsv($file);
+			$hourUp = fgetcsv($file, 0, ",", "\"", "");
+			$hourDown = fgetcsv($file, 0, ",", "\"", "");
+			$hourHitTimes = fgetcsv($file, 0, ",", "\"", "");
+			$monthUp = fgetcsv($file, 0, ",", "\"", "");
+			$monthDown = fgetcsv($file, 0, ",", "\"", "");
+			$monthHitTimes = fgetcsv($file, 0, ",", "\"", "");
+			$yearUp = fgetcsv($file, 0, ",", "\"", "");
+			$yearDown = fgetcsv($file, 0, ",", "\"", "");
+			$yearHitTimes = fgetcsv($file, 0, ",", "\"", "");
 			fclose($file);
 
 			if ($hourUp) $this->hourUp = $hourUp;
@@ -49,15 +49,15 @@ class rStat
 		$randName = FileUtil::getTempFilename('trafic');
 		if($file=@fopen($randName,"w"))
 		{
-			if( (fputcsv($file,$this->hourUp)!==false) &&
-				(fputcsv($file,$this->hourDown)!==false) &&
-				(fputcsv($file,$this->hourHitTimes)!==false) &&
-				(fputcsv($file,$this->monthUp)!==false) &&
-				(fputcsv($file,$this->monthDown)!==false) &&
-				(fputcsv($file,$this->monthHitTimes)!==false) &&
-				(fputcsv($file,$this->yearUp)!==false) &&
-				(fputcsv($file,$this->yearDown)!==false) &&
-				(fputcsv($file,$this->yearHitTimes)!==false))
+			if( (fputcsv($file,$this->hourUp, ",", "\"", "")!==false) &&
+				(fputcsv($file,$this->hourDown, ",", "\"", "")!==false) &&
+				(fputcsv($file,$this->hourHitTimes, ",", "\"", "")!==false) &&
+				(fputcsv($file,$this->monthUp, ",", "\"", "")!==false) &&
+				(fputcsv($file,$this->monthDown, ",", "\"", "")!==false) &&
+				(fputcsv($file,$this->monthHitTimes, ",", "\"", "")!==false) &&
+				(fputcsv($file,$this->yearUp, ",", "\"", "")!==false) &&
+				(fputcsv($file,$this->yearDown, ",", "\"", "")!==false) &&
+				(fputcsv($file,$this->yearHitTimes, ",", "\"", "")!==false))
 			{
 				if( fclose($file)!==false )
 				{

--- a/plugins/trafic/update.php
+++ b/plugins/trafic/update.php
@@ -20,8 +20,8 @@
 			$wasTorrents = array();
 			if($file=@fopen($dir.'last.csv',"r"))
 			{
-				$was = fgetcsv($file,100);
-				while(($data = fgetcsv($file, 1000)) !== false)
+				$was = fgetcsv($file, 100, ",", "\"", "");
+				while(($data = fgetcsv($file, 1000, ",", "\"", "")) !== false)
 					$wasTorrents[$data[0]] = array_slice($data,1);
 				fclose($file);
 			}
@@ -37,13 +37,13 @@
 			$randName = FileUtil::getTempFilename('trafic');
 			if($file=@fopen($randName,"w"))
 			{
-				if( ($ok = fputcsv($file,$now))!==false )
+				if( ($ok = fputcsv($file, $now, ",", "\"", ""))!==false )
 				{
 					foreach($nowTorrents as $key=>$data)
 					{
 						$tmp = $data;
 						array_unshift($tmp, $key);
-						if( ($ok = fputcsv($file,$tmp))===false )
+						if( ($ok = fputcsv($file, $tmp, ",", "\"", ""))===false )
 							break;
 					}
 				}					


### PR DESCRIPTION
 ## Summary

  - **cache.php**: Replace dynamic `$modified` property injection with a static `$modifiedTimes` array and suppress `filemtime()` warnings on non-existent cache files
  - **Torrent.php**: Add `#[AllowDynamicProperties]` attribute (required by PHP 8.2+)
  - **rss/rss.php**: Declare `$isValid` property to avoid dynamic property deprecation
  - **trafic/stat.php + update.php**: Pass explicit `$escape` parameter to `fgetcsv()`/`fputcsv()` (the default backslash escape was deprecated in PHP 8.4)

 ## Context

 These warnings are noisy on PHP 8.2+ and will become errors in PHP 9. The cache.php change is the most significant — it replaces per-object `$modified` property injection with a class-level static array keyed by class+hash, which is cleaner and avoids the dynamic property entirely while maintaining backward compatibility with plugins that declare their own `$modified`.

 ## Test plan

Tested in a live seedbox, no errors.
