### PR TITLE
Fix erasedata and version detection for rtorrent 0.16.x

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -230,7 +230,7 @@ class rTorrentSettings
 					$this->apiVersion = $req->val[0];
 			}
 
-                        $req = new rXMLRPCRequest( new rXMLRPCCommand("to_kb", floatval(1024)) );
+                        $req = new rXMLRPCRequest(new rXMLRPCCommand("convert.kb", array('',floatval(1024))));
 			if($req->run())
 			{
 				if(!$req->fault)

--- a/plugins/erasedata/init.js
+++ b/plugins/erasedata/init.js
@@ -53,18 +53,12 @@ if(plugin.canChangeMenu())
 
 	rTorrentStub.prototype.removewithdata = function()
 	{
+		this.content = "mode=removewithdata&v=" + (plugin.force_delete && plugin.enableForceDeletion ? "2" : "1");
 		for( var i = 0; i < this.hashes.length; i++ )
-		{
-			var cmd = new rXMLRPCCommand( "d.set_custom5" );
-			cmd.addParameter( "string", this.hashes[i] );
-			cmd.addParameter( "string", (plugin.force_delete && plugin.enableForceDeletion ? "2" : "1") );
-			this.commands.push( cmd );
-			cmd = new rXMLRPCCommand( "d.delete_tied" );
-			cmd.addParameter( "string", this.hashes[i] );
-			this.commands.push( cmd );
-			cmd = new rXMLRPCCommand( "d.erase" );
-			cmd.addParameter( "string", this.hashes[i] );
-			this.commands.push( cmd );
-		}
+			this.content += "&hash=" + this.hashes[i];
+		this.contentType = "application/x-www-form-urlencoded";
+		this.mountPoint = "plugins/httprpc/action.php";
+		this.dataType = "json";
+		this.commands = [];
 	}
 }

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -277,6 +277,20 @@ switch($mode)
 		$result = makeSimpleCall(array("d.resume"), $hash);
 		break;
 	}
+	case "removewithdata":	/**/
+	{
+		$forceDelete = isset($vs[0]) ? $vs[0] : "1";
+		$req = new rXMLRPCRequest();
+		foreach($hash as $h)
+		{
+			$req->addCommand( new rXMLRPCCommand( getCmd("d.set_custom5"), array($h, $forceDelete) ) );
+			$req->addCommand( new rXMLRPCCommand( getCmd("d.delete_tied"), $h ) );
+			$req->addCommand( new rXMLRPCCommand( getCmd("d.erase"), $h ) );
+		}
+		if($req->success())
+			$result = $req->val;
+		break;
+	}
 	case "remove":	/**/
 	{
 		$result = makeSimpleCall(array("d.erase"), $hash);


### PR DESCRIPTION
rtorrent 0.16.8 introduced a trust model where certain commands (like `d.custom5.set`) are only allowed from trusted SCGI connections. The erasedata plugin was sending these directly from the browser via XMLRPC, which now fails silently. The fix mirrors the approach already taken for `d.start` and `d.resume` in PR #3009.

Tested in live seedboxes.