### PR TITLE
Support conf.local.php for deployment-specific config overrides

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -89,3 +89,8 @@
 	$enableCSRFCheck = false;		// If true then Origin and Referer will be checked
 	$enabledOrigins = array();		// List of enabled domains for CSRF check (only hostnames, without protocols, port etc.).
 						// If empty, then will retrieve domain from HTTP_HOST / HTTP_X_FORWARDED_HOST
+
+	// Load local deployment overrides if present
+	$configLocalPath = dirname(__FILE__)."/config.local.php";
+	if(is_file($configLocalPath) && is_readable($configLocalPath))
+		require($configLocalPath);

--- a/php/utility/fileutil.php
+++ b/php/utility/fileutil.php
@@ -94,6 +94,9 @@ class FileUtil
 		$conf = dirname(__FILE__).'/../../plugins/'.$plugin.'/conf.php';
 		if(is_file($conf) && is_readable($conf))
 			$ret.='require("'.$conf.'");';
+		$local = dirname(__FILE__).'/../../plugins/'.$plugin.'/conf.local.php';
+		if(is_file($local) && is_readable($local))
+			$ret.='require("'.$local.'");';
 		$user = User::getUser();
 		if($user!='')
 		{


### PR DESCRIPTION
Add a mechanism for deployment-specific configuration without modifying upstream files:

This lets deployers set paths, IPs, ports, and other environment-specific values in local files that are not tracked in git, while keeping upstream config.php and plugin conf.php files untouched and easy to update.

- fileutil.php: getPluginConf() now loads conf.local.php after conf.php for each plugin, allowing local overrides without touching upstream files
- config.php: loads conf/config.local.php at the end if it exists

