### PR TITLE
Fix log_history plugin: timestamps, replay safety, UX improvements

### DIFF
--- a/plugins/log_history/init.js
+++ b/plugins/log_history/init.js
@@ -1,92 +1,98 @@
 function stripTimestamp(line) {
-        return line.replace(/^\[[^\]]*\]\s*/, '');
+    return line.replace(/^\[[^\]]*\]\s*/, '');
 }
 
-function fetchLogLines(initialLoad = false) {
+function fetchLogLines() {
     fetch('plugins/log_history/action.php')
         .then(response => {
             if (response.status === 204) {
-                console.log("Log is disabled by server (204 No Content).");
                 return Promise.reject({ disabled: true });
             }
             if (!response.ok) throw new Error('Network response was not ok');
             return response.json();
         })
         .then(data => {
-            const logs = data.logs || data; // backward compatible
-            const style = data.load_style || 'noty'; // default
+            const logs = data.logs || data;
 
             if (!logs.length) {
-                console.log("Log is empty or not configured.");
                 return;
             }
 
-            logs.forEach(entry => {
-                const rawMsg = entry.message || '';
-                const cleanMsg = stripTimestamp(rawMsg);
-                const status = entry.status || 'info';
+            plugin._replaying = true;
+            var lcont = document.getElementById('lcont');
+            if (lcont) {
+                // Save current content (e.g. "WebUI started")
+                var currentContent = lcont.innerHTML;
+                // Clear and rebuild in order
+                lcont.innerHTML = '';
 
-                if (style === 'log') {
-                    log(cleanMsg, false, 'std');
-                } else {
-                    noty(cleanMsg, status);
-                }
-            });
+                // Header
+                var header = document.createElement('span');
+                header.className = 'std';
+                header.textContent = '========== restored log ==========';
+                lcont.appendChild(header);
+
+                // Restored entries
+                logs.forEach(entry => {
+                    var cleanMsg = stripTimestamp(entry.message || '');
+                    var ts = entry.timestamp
+                        ? '[' + theConverter.date(entry.timestamp) + ']'
+                        : '';
+                    var span = document.createElement('span');
+                    span.className = 'std';
+                    span.textContent = ts + ' ' + cleanMsg;
+                    lcont.appendChild(span);
+                });
+
+                // Footer
+                var footer = document.createElement('span');
+                footer.className = 'std';
+                footer.textContent = '========== restored log ==========';
+                lcont.appendChild(footer);
+
+                // Re-append current session content
+                lcont.innerHTML += currentContent;
+
+                lcont.scrollTop = lcont.scrollHeight;
+            }
+            plugin._replaying = false;
         })
         .catch(err => {
             if (err.disabled) return;
-            if (typeof noty === 'function') {
-                noty("Log fetch error: " + err.message, "error");
-            } else {
-                console.error("Log fetch error:", err.message);
-            }
+            console.error("Log fetch error:", err.message);
         });
 }
 
 function sendLogToServer(msg, status) {
+    var timestamp = Math.floor(Date.now() / 1000);
     fetch('plugins/log_history/log_history.php', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
         },
-        body: `message=${encodeURIComponent(msg)}&status=${encodeURIComponent(status)}`
+        body: 'message=' + encodeURIComponent(msg)
+            + '&status=' + encodeURIComponent(status)
+            + '&timestamp=' + timestamp
     })
-        .then(response => {
-            if (response.status === 204) return;
-            return response.json();
-        })
-        .then(data => {
-            if (data) console.log("Log saved to server:", data);
-        })
-        .catch(error => {
-            console.log("Saving Log failed:", error);
-        });
+    .catch(error => {
+        console.log("Saving Log failed:", error);
+    });
 }
 
-window._log_history_status = null;
+plugin._replaying = false;
 
 plugin.init = function () {
-    const originalLog = window.log;
-    window.log = function(text, noTime, divClass, force) {
-        originalLog(text, noTime, divClass, force);
-        const status = window._log_history_status || divClass || 'info';
-        sendLogToServer(text, status);
-        window._log_history_status = null;
-    };
+    plugin._originalNoty = window.noty;
     const originalNoty = window.noty;
-    window.noty = function(msg, status, noTime) {
-        window._log_history_status = status;
 
-        if (typeof originalNoty === 'function') {
-            originalNoty(msg, status, noTime);
-        } else {
-            log(msg, noTime, status);
+    window.noty = function(msg, status, noTime) {
+        originalNoty(msg, status, noTime);
+        if (!plugin._replaying) {
+            sendLogToServer(msg, status || 'info');
         }
     };
-    setTimeout(() => {
-        fetchLogLines(true);
-    }, 3000);
 
+    fetchLogLines();
     plugin.markLoaded();
 };
 

--- a/plugins/log_history/log_history.php
+++ b/plugins/log_history/log_history.php
@@ -2,11 +2,12 @@
 require_once(dirname(__FILE__) . "/../../php/cache.php");
 require_once(dirname(__FILE__) . "/../../php/utility/json.php");
 require_once(dirname(__FILE__) . "/../../php/utility/fileutil.php");
-require_once(dirname(__FILE__) . "/conf.php");
+
+eval(FileUtil::getPluginConf('log_history'));
+
 header('Content-Type: application/json');
 
 if (!isset($LogTab_array) || !is_array($LogTab_array)) {
-	error_log("log_history plugin error: \$LogTab_array missing or invalid in conf.php");
     http_response_code(204);
     exit;
 }
@@ -35,9 +36,6 @@ class LogHandler
 
         $handler->max_entries = max(1, intval($LogTab_array['max_entries']));
         $handler->log_count   = max(1, intval($LogTab_array['log_count']));
-		
-		error_log("Loaded max_entries: " . $handler->max_entries);
-		error_log("Loaded log_count: " . $handler->log_count);
 
         return $handler;
     }
@@ -47,25 +45,26 @@ class LogHandler
         $this->cache = $cache;
     }
 
-    public function saveLog($message, $status)
+    public function saveLog($message, $status, $timestamp = null)
     {
         if (empty($message)) {
             return ['status' => 'error', 'message' => 'No message provided'];
         }
 
-        error_log("Current logs count before save: " . count($this->logs));
         foreach ($this->logs as $log) {
             if ($log['message'] === $message) {
                 return ['status' => 'success', 'message' => 'Log already exists'];
             }
         }
 
-        $this->logs[] = ['message' => $message, 'status' => $status];
+        $this->logs[] = [
+            'message' => $message,
+            'status' => $status,
+            'timestamp' => $timestamp ? intval($timestamp) : time()
+        ];
 
         if (count($this->logs) > $this->max_entries) {
-            $before = count($this->logs);
             $this->logs = array_slice($this->logs, -$this->max_entries);
-            error_log("Sliced logs from {$before} to " . count($this->logs));
         }
 
         $this->cache->set($this);
@@ -89,14 +88,14 @@ class LogHandler
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $msg  = trim($_POST['message'] ?? '');
             $st   = trim($_POST['status'] ?? '');
-            $resp = $handler->saveLog($msg, $st);
+            $ts   = $_POST['timestamp'] ?? null;
+            $resp = $handler->saveLog($msg, $st, $ts);
         } else {
-        	$resp = $handler->getLatestLogs();
-		global $LogTab_array;
-		$resp = [
-			'logs' => $resp,
-			'load_style' => $LogTab_array['load_style'] ?? 'noty'
-		];
+            global $LogTab_array;
+            $resp = [
+                'logs' => $handler->getLatestLogs(),
+                'load_style' => $LogTab_array['load_style'] ?? 'noty'
+            ];
         }
 
         echo JSON::safeEncode($resp);


### PR DESCRIPTION
The log_history plugin had several issues: no timestamps on saved entries, replaying old error messages triggered error popups on every reload, and debug logging was left in the PHP code. The replay now uses direct DOM manipulation with original timestamps, separated from the current session by visual  markers.