### PR TITLE
Fix hideTrackers: use wrapper instead of inline check, fix $.inArray …

### DIFF
--- a/plugins/tracklabels/init.js
+++ b/plugins/tracklabels/init.js
@@ -95,10 +95,11 @@ if(!$type(theWebUI.getTrackerName))
 				}
 			}
 		}
-		if ($.inArray( domain, plugin.hideTrackers, domain ) != -1) domain = '';
 		return(domain);
 	}
 }
+
+if (plugin.hideTrackers && plugin.hideTrackers.length) {	var _origGetTrackerName = theWebUI.getTrackerName;	theWebUI.getTrackerName = function(announce) {		var domain = _origGetTrackerName(announce);		if ($.inArray(domain, plugin.hideTrackers) != -1) domain = "";		return domain;	};}
 
 plugin.contextMenuEntries = catlist.contextMenuEntries.bind(catlist);
 catlist.contextMenuEntries = function(panelId, labelId) {


### PR DESCRIPTION
The `hideTrackers` check was placed inside the `if(!$type(theWebUI.getTrackerName))` guard, which only runs if no other plugin has already defined `getTrackerName`. Since the `history` plugin (runlevel 11) can define it first, the hide check never executed on many setups.

The fix wraps whatever `getTrackerName` is defined (by any plugin) with a filter that checks the result against the hide list. This works regardless of plugin load order.

Also fixes `$.inArray(domain, plugin.hideTrackers, domain)` — the third parameter to `$.inArray` is `fromIndex`, not a default value. Passing a string caused incorrect matching.