### PR TITLE
Fixes and dialog window to view and clear full log in log_history plugin.

### DIFF
--- a/plugins/log_history/init.js
+++ b/plugins/log_history/init.js
@@ -143,7 +143,6 @@ theWebUI.showLogHistory = function () {
             return;
         }
 
-        // Lisa nupule sündmus (kui pole veel lisatud)
         const clearBtn = container.find("#clearLogBtn");
         if (clearBtn.length > 0 && !clearBtn.data("bound")) {
             clearBtn.on("click", () => clearLog(container));
@@ -157,7 +156,6 @@ theWebUI.showLogHistory = function () {
 };
 
 function loadLogHistory(container) {
-    // Leia või loo logi ala AINULT KORRA
     let logArea = container.find("#logContent");
     if (logArea.length === 0) {
         logArea = $("<div>").attr("id", "logContent").css({
@@ -165,10 +163,9 @@ function loadLogHistory(container) {
             "flex": "1",
             "overflow-y": "auto"
         });
-        container.append(logArea); // Lisa nupu alla
+        container.append(logArea);
     }
 
-    // KUSTUTA AINULT LOGI SISU, MITTE KOGU CONTAINERIT
     logArea.empty().text("Loading...");
 
     fetch('plugins/log_history/log_history.php?all=1')
@@ -179,7 +176,7 @@ function loadLogHistory(container) {
         })
         .then(data => {
             const logs = data.logs || data;
-            logArea.empty(); // Ainult siin kustutame
+            logArea.empty();
 
             if (!logs || logs.length === 0) {
                 logArea.text("Log is empty.");

--- a/plugins/log_history/init.js
+++ b/plugins/log_history/init.js
@@ -244,7 +244,7 @@ function getStatusColor(status) {
 function clearLog(container) {
     if (!confirm(theUILang.ruLogHistoryConfirmClear || "Clear entire log?")) return;
 
-    fetch('plugins/log_history/log_history.php', { method: 'DELETE' })
+    fetch('plugins/log_history/log_history.php?clear=1')
         .then(r => r.ok ? r.json() : Promise.reject("HTTP " + r.status))
         .then(() => {
             loadLogHistory(container);

--- a/plugins/log_history/init.js
+++ b/plugins/log_history/init.js
@@ -84,13 +84,13 @@ function sendLogToServer(msg, status) {
 plugin._replaying = false;
 
 plugin.init = function () {
-    plugin._originalNoty = window.noty;
-    const originalNoty = window.noty;
+    plugin._originalLog = window.log;
+    const originalLog = window.log;
 
-    window.noty = function(msg, status, noTime) {
-        originalNoty(msg, status, noTime);
+    window.log = function(text, noTime, divClass, force) {
+        originalLog(text, noTime, divClass, force);
         if (!plugin._replaying) {
-            sendLogToServer(msg, status || 'info');
+            sendLogToServer(text, status || 'info');
         }
     };
 

--- a/plugins/log_history/init.js
+++ b/plugins/log_history/init.js
@@ -22,9 +22,11 @@ function fetchLogLines() {
             var lcont = document.getElementById('lcont');
             if (lcont) {
                 // Save current content (e.g. "WebUI started")
-                var currentContent = lcont.innerHTML;
-                // Clear and rebuild in order
-                lcont.innerHTML = '';
+                var currentNodes = [];
+				while (lcont.firstChild) {
+					currentNodes.push(lcont.firstChild);
+					lcont.removeChild(lcont.firstChild);
+				}
 
                 // Header
                 var header = document.createElement('span');
@@ -51,7 +53,7 @@ function fetchLogLines() {
                 lcont.appendChild(footer);
 
                 // Re-append current session content
-                lcont.innerHTML += currentContent;
+                currentNodes.forEach(node => lcont.appendChild(node));
 
                 lcont.scrollTop = lcont.scrollHeight;
             }
@@ -94,6 +96,164 @@ plugin.init = function () {
 
     fetchLogLines();
     plugin.markLoaded();
+};
+
+plugin.onLangLoaded = function () {
+    this.registerTopMenu(20, theUILang.ruLogHistoryMenuName, theWebUI.showLogHistory);
+
+    const container = $("<div>").css({
+        width: "100%",
+        "max-width": "900px",
+        height: "600px",
+        "overflow-y": "hidden",
+        "display": "flex",
+        "flex-direction": "column"
+    }).attr("id", "logHistoryContainer");
+
+    const buttonBar = $("<div>").attr("id", "action-buttons").addClass("action-buttons").css({
+        "padding": "8px",
+        "flex-shrink": "0"
+    });
+
+    const clearBtn = $("<button>")
+        .attr("id", "clearLogBtn")
+        .text(theUILang.ruLogHistoryClear || "Clear Log")
+        .css({
+        });
+
+    buttonBar.append(clearBtn);
+    container.append(buttonBar);
+
+    theDialogManager.make("dlgLogHistory", theUILang.ruLogHistoryMenuName, [container], false);
+};
+
+theWebUI.showLogHistory = function () {
+    theDialogManager.show("dlgLogHistory");
+
+    setTimeout(() => {
+        const dlg = document.getElementById("dlgLogHistory");
+        if (!dlg) {
+            console.error("Log History dialog not found.");
+            return;
+        }
+
+        const container = $("#logHistoryContainer", dlg);
+        if (container.length === 0) {
+            console.error("logHistoryContainer not found in dialog.");
+            return;
+        }
+
+        // Lisa nupule sündmus (kui pole veel lisatud)
+        const clearBtn = container.find("#clearLogBtn");
+        if (clearBtn.length > 0 && !clearBtn.data("bound")) {
+            clearBtn.on("click", () => clearLog(container));
+            clearBtn.data("bound", true);
+        }
+
+        // Lae logid
+        loadLogHistory(container);
+
+    }, 100);
+};
+
+function loadLogHistory(container) {
+    // Leia või loo logi ala AINULT KORRA
+    let logArea = container.find("#logContent");
+    if (logArea.length === 0) {
+        logArea = $("<div>").attr("id", "logContent").css({
+            "margin-top": "10px",
+            "flex": "1",
+            "overflow-y": "auto"
+        });
+        container.append(logArea); // Lisa nupu alla
+    }
+
+    // KUSTUTA AINULT LOGI SISU, MITTE KOGU CONTAINERIT
+    logArea.empty().text("Loading...");
+
+    fetch('plugins/log_history/log_history.php?all=1')
+        .then(r => {
+            if (r.status === 204) throw new Error("Log is disabled");
+            if (!r.ok) throw new Error('Network error');
+            return r.json();
+        })
+        .then(data => {
+            const logs = data.logs || data;
+            logArea.empty(); // Ainult siin kustutame
+
+            if (!logs || logs.length === 0) {
+                logArea.text("Log is empty.");
+                return;
+            }
+
+            logs.forEach((entry, index) => {
+                const msg = entry.message || '';
+                const status = (entry.status || 'info').toUpperCase();
+                const num = String(index + 1).padStart(3, '0');
+
+                const line = $("<div>").css({
+                    "margin-bottom": "4px",
+                    "border-radius": "2px",
+                    "display": "flex",
+                    "align-items": "flex-start"
+                });
+
+                const dotSpan = $("<span>").text("●").css({
+                    "color": getStatusColor(status),
+					"display": "flex",
+                    "font-size": "2.0em",
+					"line-height": "1",
+					"align-items": "center",
+					"justify-content": "center",
+					"padding": "0 0 0 5px"
+                });
+				
+				const numSpan = $("<span>").text("["+ num + "] ").css({
+                    "flex": "0 0 30px",
+                    "padding": "3px 0 3px 5px"
+                });
+
+                const msgSpan = $("<span>").text(msg).css({
+                    "flex": "1",
+                    "padding": "3px 8px 3px 0",
+                    "white-space": "pre-wrap",
+                    "word-break": "break-word"
+                });
+
+                line.append(dotSpan, numSpan, msgSpan);
+                logArea.append(line);
+            });
+
+            setTimeout(() => container.scrollTop(container[0].scrollHeight), 50);
+        })
+        .catch(err => {
+            logArea.text("Error: " + err.message).css("color", "red");
+        });
+}
+
+function getStatusColor(status) {
+    const colors = {
+        ERROR:   'red',
+        WARNING: 'blue',
+        SUCCESS: 'green',
+        INFO:    'black'
+    };
+    return colors[status] || 'black';
+}
+
+function clearLog(container) {
+    if (!confirm(theUILang.ruLogHistoryConfirmClear || "Clear entire log?")) return;
+
+    fetch('plugins/log_history/log_history.php', { method: 'DELETE' })
+        .then(r => r.ok ? r.json() : Promise.reject("HTTP " + r.status))
+        .then(() => {
+            loadLogHistory(container);
+        })
+        .catch(err => alert("Failed to clear: " + err.message));
+}
+
+plugin.onRemove = function () {
+	theDialogManager.hide("dlgLogHistory");
 };
 
 plugin.onRemove = function () {

--- a/plugins/log_history/log_history.php
+++ b/plugins/log_history/log_history.php
@@ -51,12 +51,6 @@ class LogHandler
             return ['status' => 'error', 'message' => 'No message provided'];
         }
 
-        foreach ($this->logs as $log) {
-            if ($log['message'] === $message) {
-                return ['status' => 'success', 'message' => 'Log already exists'];
-            }
-        }
-
         $this->logs[] = [
             'message' => $message,
             'status' => $status,

--- a/plugins/log_history/log_history.php
+++ b/plugins/log_history/log_history.php
@@ -85,6 +85,21 @@ class LogHandler
     {
         $handler = self::load();
 
+        if (isset($_GET['all'])) {
+			echo JSON::safeEncode([
+				'logs' => array_slice($handler->logs, 0, $handler->max_entries),
+				'load_style' => $LogTab_array['load_style'] ?? 'noty'
+			]);
+			exit;
+		}
+		
+		if ($_SERVER['REQUEST_METHOD'] === 'DELETE') {
+			$handler->logs = [];
+			$handler->cache->set($handler);
+			echo JSON::safeEncode(['status' => 'cleared']);
+			exit;
+		}
+
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $msg  = trim($_POST['message'] ?? '');
             $st   = trim($_POST['status'] ?? '');

--- a/plugins/log_history/log_history.php
+++ b/plugins/log_history/log_history.php
@@ -93,7 +93,7 @@ class LogHandler
 			exit;
 		}
 		
-		if ($_SERVER['REQUEST_METHOD'] === 'DELETE') {
+		if (isset($_GET['clear'])) {
 			$handler->logs = [];
 			$handler->cache->set($handler);
 			echo JSON::safeEncode(['status' => 'cleared']);

--- a/plugins/log_history/plugin.info
+++ b/plugins/log_history/plugin.info
@@ -1,5 +1,5 @@
 plugin.name: log_history
-plugin.version: 1.0
+plugin.version: 1.1
 plugin.author: ranirahn
 plugin.description: This plugin saves Log TAB into file and shows last messages from it on startup. Settings in plugins/log_history/conf.php.
 plugin.runlevel: 10.0


### PR DESCRIPTION
Fixing the clear button in log tab. Also made new dialog window to see all saved logs in the .dat file. Can open it from Plugins->Log History. I am not coder, so maybe someone can fix my mess before merging it.