### PR TITLE
Route d.tracker_announce through trusted httprpc handler

### DIFF
--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -267,6 +267,11 @@ switch($mode)
 		$result = makeSimpleCall(array("d.stop","d.close"), $hash);
 		break;
 	}
+	case "updatetracker":	/**/
+	{
+		$result = makeSimpleCall(array("d.tracker_announce"), $hash);
+		break;
+	}
 	case "pause":	/**/
 	{
 		$result = makeSimpleCall(array("d.stop"), $hash);

--- a/plugins/httprpc/init.js
+++ b/plugins/httprpc/init.js
@@ -100,6 +100,12 @@ rTorrentStub.prototype.unpause = function()
 	this.getCommon("unpause");
 }
 
+plugin.origupdateTracker = rTorrentStub.prototype.updateTracker;
+rTorrentStub.prototype.updateTracker = function()
+{
+	this.getCommon("updatetracker");
+}
+
 plugin.origremove = rTorrentStub.prototype.remove;
 rTorrentStub.prototype.remove = function()
 {


### PR DESCRIPTION
The Update Trackers context menu action sends d.tracker_announce directly via XMLRPC, which is rejected by rtorrent 0.16.8 untrusted connection model. Route it through httprpc like start/stop/pause/remove, using a trusted server-side SCGI connection.