### PR TITLE
Remove noisy error_log in check_port get_public_ip()

### DIFF
--- a/plugins/check_port/action.php
+++ b/plugins/check_port/action.php
@@ -42,9 +42,7 @@ function get_public_ip($version, $timeout) {
 		if (filter_var($ip, FILTER_VALIDATE_IP, $flag)) {
 			return $ip; // Return the valid IP
 		}
-		error_log("check_port plugin: {$url} returned invalid IP: " . $ip);
 	} else {
-		error_log("check_port plugin: Failed to fetch from {$url}. Status: {$snoopy->status}, Error: {$snoopy->error}");
 	}
 	return null; // Return null on failure
 }


### PR DESCRIPTION
On servers without IPv6, api64.ipify.org returns the IPv4 address which fails IPv6 validation. This logged an error on every page load, spamming both PHP and nginx error logs. The failure is expected and already handled by returning null (status -1 to the UI).

Ref: #3018 (comment)