### PR TITLE
Fix log_history: DOM node preservation and duplicate message handling

### DIFF
--- a/plugins/log_history/init.js
+++ b/plugins/log_history/init.js
@@ -21,10 +21,12 @@ function fetchLogLines() {
             plugin._replaying = true;
             var lcont = document.getElementById('lcont');
             if (lcont) {
-                // Save current content (e.g. "WebUI started")
-                var currentContent = lcont.innerHTML;
-                // Clear and rebuild in order
-                lcont.innerHTML = '';
+                // Save current content nodes (e.g. "WebUI started")
+                var currentNodes = [];
+                while (lcont.firstChild) {
+                    currentNodes.push(lcont.firstChild);
+                    lcont.removeChild(lcont.firstChild);
+                }
 
                 // Header
                 var header = document.createElement('span');
@@ -51,7 +53,7 @@ function fetchLogLines() {
                 lcont.appendChild(footer);
 
                 // Re-append current session content
-                lcont.innerHTML += currentContent;
+                currentNodes.forEach(node => lcont.appendChild(node));
 
                 lcont.scrollTop = lcont.scrollHeight;
             }

--- a/plugins/log_history/log_history.php
+++ b/plugins/log_history/log_history.php
@@ -51,12 +51,6 @@ class LogHandler
             return ['status' => 'error', 'message' => 'No message provided'];
         }
 
-        foreach ($this->logs as $log) {
-            if ($log['message'] === $message) {
-                return ['status' => 'success', 'message' => 'Log already exists'];
-            }
-        }
-
         $this->logs[] = [
             'message' => $message,
             'status' => $status,


### PR DESCRIPTION
 1. **Use DOM node manipulation instead of innerHTML** — the previous `innerHTML` save/restore approach destroyed event handlers on existing log nodes. Now uses `removeChild`/`appendChild` to preserve node references.

2. **Remove duplicate message check** — the `saveLog()` function skipped messages that already existed in the log. This prevented legitimate repeated messages (e.g. periodic status updates, repeated warnings) from being saved.

Inspired by #3030 (which also addresses these issues but includes unrelated feature additions).