### PR TITLE
Fix log_history: clear button support and null-safe stripTimestamp

### DIFF
--- a/plugins/log_history/init.js
+++ b/plugins/log_history/init.js
@@ -1,5 +1,5 @@
 function stripTimestamp(line) {
-    return line.replace(/^\[[^\]]*\]\s*/, '');
+    return (line || '').replace(/^\[[^\]]*\]\s*/, '');
 }
 
 function fetchLogLines() {
@@ -95,6 +95,12 @@ plugin.init = function () {
     };
 
     fetchLogLines();
+
+    // Hook the log tab "Clear" button to also clear saved history
+    $("#clear_log").on("click", function() {
+        fetch('plugins/log_history/log_history.php?clear=1').catch(function() {});
+    });
+
     plugin.markLoaded();
 };
 

--- a/plugins/log_history/log_history.php
+++ b/plugins/log_history/log_history.php
@@ -79,6 +79,13 @@ class LogHandler
     {
         $handler = self::load();
 
+        if (isset($_GET['clear'])) {
+            $handler->logs = [];
+            $handler->cache->set($handler);
+            echo JSON::safeEncode(['status' => 'cleared']);
+            return;
+        }
+
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $msg  = trim($_POST['message'] ?? '');
             $st   = trim($_POST['status'] ?? '');


### PR DESCRIPTION
- Hook the Log tab Clear button to also clear saved log history via new ?clear=1 endpoint, so old entries do not reappear on reload
- Make stripTimestamp() null-safe to prevent JS error when replaying entries with missing message field

Fixes #3029