### PR TITLE
Fix getMinFilePerms(): broken octal permission comparison

### DIFF
--- a/php/utility/fileutil.php
+++ b/php/utility/fileutil.php
@@ -256,12 +256,12 @@ class FileUtil
 		}
 	}
 	
-	public static function getMinFilePerms( $file, $chmod = 755 )
+	public static function getMinFilePerms( $file, $chmod = 0755 )
 	{
 		$code = fileperms($file);
 		
 		if($code!==false)
-			return((decoct($code) & 0777) >= $chmod);
+			return(($code & 0777) >= $chmod);
 		
 		return false;
 	}


### PR DESCRIPTION
decoct() returns a string which PHP casts to decimal for bitwise AND, giving wrong results. The default $chmod was decimal 755 instead of octal 0755. Both caused the function to always return false, breaking all plugins that check external program permissions.

Fixes #3005, fixes #2987