### PR TITLE
Fix PHP 8.5 deprecations: (integer) cast and backtick operator

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -358,7 +358,7 @@ class rTorrentSettings
 			$schedule_rand = 10;
 		$tm = getdate();
 		$startAt = mktime($tm["hours"],
-			((integer)($tm["minutes"]/$interval))*$interval+$interval,
+			((int)($tm["minutes"]/$interval))*$interval+$interval,
 			0,$tm["mon"],$tm["mday"],$tm["year"])-$tm[0]+rand(0,$schedule_rand);
 		if($startAt<0)
 			$startAt = 0;

--- a/plugins/_cloudflare/cloudflare.php
+++ b/plugins/_cloudflare/cloudflare.php
@@ -54,7 +54,7 @@ class rCloudflare
 			}
 			$code = escapeshellarg(Utility::getExternal('python'))." -c ".
 				escapeshellarg("import cloudscraper\nimport json\ntokens, user_agent = cloudscraper.get_tokens({$url}{$proxies}{$recaptcha})\nprint(json.dumps([tokens,user_agent]))");
-			$data = `{$code}`;
+			$data = shell_exec($code);
 			if($data &&
 				($data = json_decode($data,true)) &&
 				is_array($data) &&


### PR DESCRIPTION
- settings.php: (integer) → (int) (deprecated since PHP 8.5)
- _cloudflare/cloudflare.php: backtick operator → shell_exec() (deprecated since PHP 8.5)

Fixes #2992