### PR TITLE
Fix filedrop: prefer file item over URL when both present

### DIFF
--- a/plugins/filedrop/init.js
+++ b/plugins/filedrop/init.js
@@ -15,6 +15,10 @@ plugin.onLangLoaded = function()
 			// gets called before filedrop's handler.
 
 			const items = [...event.originalEvent.dataTransfer.items];
+			// If a file is present, let the filedrop plugin handle it
+			const hasFile = items.some(item => item.kind === "file");
+			if (hasFile)
+				return true;
 			// find text/uri-list; if not found, find text/plain
 			const uriList = items.find(item =>
 				item.kind === "string" &&


### PR DESCRIPTION
When dragging a `.torrent` from Firefox's download panel, the browser sends both a `file` item (`application/x-bittorrent`) and a `text/uri-list` item. The drop handler was matching the URI list first and trying to process it as a URL download, which silently failed.

Now checks for `file` items first and lets the filedrop jQuery plugin handle them directly. URL-only drops (magnet links, torrent URLs from web pages) still work as before.

 Fixes #2966