### PR TITLE
Fix Chrome click-to-sort: ignore phantom zero-movement mousemove events

### DIFF
--- a/js/stable.js
+++ b/js/stable.js
@@ -166,6 +166,7 @@ dxSTable.prototype.create = function(ele, styles, aName)
 				if (this.isResizing) {
 					this.colDragResize(ev);
 				} else {
+					if (ev.originalEvent.movementX === 0 && ev.originalEvent.movementY === 0) return;
 					this.isMoving = true;
 					this.isSorting = false;
 					this.colDragMove(ev);


### PR DESCRIPTION
Chrome fires `mousemove` events on `mousedown`/`mouseup` even when the mouse hasn't physically moved (`movementX === 0`, `movementY === 0`). This caused the DnD handler's `onRun` callback to set `isMoving = true` on every click, triggering the column drag path instead of the sort path.

Add a guard to ignore zero-movement events before setting `isMoving`.

Previously fixed in PR #1637 but lost during the DnD class refactor.

Fixes #3001

Note: Couldn't repro, so maybe Chrome already fixed the issue on their end, but the change is harmless so why not.
