### PR TITLE
Restore ./ entry in directory picker dropdown

### DIFF
--- a/plugins/_getdir/init.js
+++ b/plugins/_getdir/init.js
@@ -141,6 +141,7 @@ theWebUI.rDirBrowser = class {
 					this.frame.find(".rmenuobj").remove();
 					this.frame.append(
 						$("<div>").addClass("rmenuobj").append(
+							$("<div>").addClass("rmenuitem").text("./"),
 							...res.directories.map(ele => $("<div>").addClass("rmenuitem").text(ele + "/")),
 							...(this.withFiles ? res.files : []).map(ele => $("<div>").addClass("rmenuitem").text(ele)),
 						),
@@ -148,7 +149,7 @@ theWebUI.rDirBrowser = class {
 					this.frame.find(".rmenuitem").on(
 						"click", (ev) => this.selectItem(ev)
 					).on(
-						"dblclick", (ev) => (ev.currentTarget.innerText.endsWith("/")) ? this.requestDir() : this.hide()
+						"dblclick", (ev) => (ev.currentTarget.innerText === "./") ? this.hide() : (ev.currentTarget.innerText.endsWith("/")) ? this.requestDir() : this.hide()
 					);
 				},
 				error: (res) => console.log(res),
@@ -159,7 +160,10 @@ theWebUI.rDirBrowser = class {
 	selectItem(ev) {
 		this.frame.find(".rmenuitem.active").removeClass("active");
 		$(ev.currentTarget).addClass("active");
-		this.edit.val(this.edit.data("cwd") + ev.target.innerText);
+		if (ev.target.innerText === "./")
+			this.edit.val(this.edit.data("cwd"));
+		else
+			this.edit.val(this.edit.data("cwd") + ev.target.innerText);
 	}
 
 	show() {


### PR DESCRIPTION
Add `./` as the first entry in the directory browser dropdown. Single-click selects the current directory path, double-click confirms and closes the dropdown.

This was present in 5.1.x but lost during the 5.2.x UI refactor. Without it, users have to click the text field and then click elsewhere to confirm the path.

Fixes #3002