### PR TITLE
Refactor logging functionality in init.js

### DIFF
--- a/plugins/log_history/init.js
+++ b/plugins/log_history/init.js
@@ -84,13 +84,13 @@ function sendLogToServer(msg, status) {
 plugin._replaying = false;
 
 plugin.init = function () {
-    plugin._originalNoty = window.noty;
-    const originalNoty = window.noty;
+    plugin._originalLog = window.log;
+    const originalLog = window.log;
 
-    window.noty = function(msg, status, noTime) {
-        originalNoty(msg, status, noTime);
+    window.log = function(text, noTime, divClass, force) {
+        originalLog(text, noTime, divClass, force);
         if (!plugin._replaying) {
-            sendLogToServer(msg, status || 'info');
+            sendLogToServer(text, status || 'info');
         }
     };
 


### PR DESCRIPTION
Changing noty() to log(). All messages go trough log function, but only some use noty function, so better to use log function then. That means status info is missing. Also using noty break the popup noty messages