### PR TITLE
Fix erasedata: remove hardcoded httprpc dependency, add getCommon fal…

### DIFF
--- a/plugins/erasedata/init.js
+++ b/plugins/erasedata/init.js
@@ -53,12 +53,26 @@ if(plugin.canChangeMenu())
 
 	rTorrentStub.prototype.removewithdata = function()
 	{
-		this.content = "mode=removewithdata&v=" + (plugin.force_delete && plugin.enableForceDeletion ? "2" : "1");
-		for( var i = 0; i < this.hashes.length; i++ )
-			this.content += "&hash=" + this.hashes[i];
-		this.contentType = "application/x-www-form-urlencoded";
-		this.mountPoint = "plugins/httprpc/action.php";
-		this.dataType = "json";
-		this.commands = [];
+		if (plugin.debug) console.log("erasedata: removewithdata called, hashes:", this.hashes, "getCommon available:", typeof this.getCommon === "function");
+		if (typeof this.getCommon === "function") {
+			if (plugin.debug) console.log("erasedata: routing through getCommon (trusted handler)");
+			this.vs[0] = (plugin.force_delete && plugin.enableForceDeletion ? "2" : "1");
+			this.getCommon("removewithdata");
+		} else {
+			if (plugin.debug) console.log("erasedata: using direct XMLRPC fallback");
+			for( var i = 0; i < this.hashes.length; i++ )
+			{
+				var cmd = new rXMLRPCCommand( "d.set_custom5" );
+				cmd.addParameter( "string", this.hashes[i] );
+				cmd.addParameter( "string", (plugin.force_delete && plugin.enableForceDeletion ? "2" : "1") );
+				this.commands.push( cmd );
+				cmd = new rXMLRPCCommand( "d.delete_tied" );
+				cmd.addParameter( "string", this.hashes[i] );
+				this.commands.push( cmd );
+				cmd = new rXMLRPCCommand( "d.erase" );
+				cmd.addParameter( "string", this.hashes[i] );
+				this.commands.push( cmd );
+			}
+		}
 	}
 }

--- a/plugins/httprpc/init.js
+++ b/plugins/httprpc/init.js
@@ -100,6 +100,12 @@ rTorrentStub.prototype.unpause = function()
 	this.getCommon("unpause");
 }
 
+plugin.origremovewithdata = rTorrentStub.prototype.removewithdata;
+rTorrentStub.prototype.removewithdata = function()
+{
+	this.getCommon("removewithdata");
+}
+
 plugin.origupdateTracker = rTorrentStub.prototype.updateTracker;
 rTorrentStub.prototype.updateTracker = function()
 {


### PR DESCRIPTION
The erasedata plugin's `removewithdata` JS function had a hardcoded `mountPoint = "plugins/httprpc/action.php"`, creating an implicit dependency on httprpc. This broke setups using alternative RPC configurations (e.g., nginx SCGI direct without httprpc).