### PR TITLE
Improve rutracker_check updates for RuTracker and NNMClub

### DIFF
--- a/php/Snoopy.class.inc
+++ b/php/Snoopy.class.inc
@@ -290,7 +290,7 @@ class Snoopy
 			}
 			case "https":
 			{
-				$ret = $this->_httpsrequest($URI,$content_type,$body);
+				$ret = $this->_httpsrequest($URI,$content_type,$body,$method);
 				break;
 			}
 			default:
@@ -484,7 +484,7 @@ class Snoopy
 		return true;
 	}
 
-	function _httpsrequest($url,$content_type="",$body="")
+	function _httpsrequest($url,$content_type="",$body="",$http_method="GET")
 	{
 		if($this->passcookies && $this->_redirectaddr)
 			$this->setcookies();
@@ -519,6 +519,10 @@ class Snoopy
 			$headers[] = "Authorization: Basic ".base64_encode($this->user.":".$this->pass);
 
 		$cmdline_params = '';
+		// Legacy 3-arg callers keep curl's own method choice; explicit callers
+		// (fetch with any method) get the method forwarded verbatim.
+		if(func_num_args() >= 4)
+			$cmdline_params .= " -X ".escapeshellarg(strtoupper($http_method));
 		foreach( $headers as $header )
 			$cmdline_params .= " -H ".escapeshellarg($header);
 

--- a/plugins/rutracker_check/check.php
+++ b/plugins/rutracker_check/check.php
@@ -24,17 +24,24 @@ class ruTrackerChecker
 	const STE_ERROR			= 6;
 	const STE_NOT_NEED		= 7;
 	const STE_IGNORED		= 8;
-	
-	const MAX_LOCK_TIME		= 900;	// 15 min
-	
-	private static $TRACKERS = array();
-	private static $ANNOUNCES = array();	
 
-	static public function registerTracker($commentFiler, $announceFilter, $handler)
+	const MAX_LOCK_TIME		= 900;	// 15 min
+
+	private static $TRACKERS = array();
+	private static $ANNOUNCES = array();
+
+	/**
+	 * Register a tracker handler.
+	 *
+	 * @param string   $commentFilter  Regex pattern for torrent comment
+	 * @param string   $announceFilter Regex pattern for announce URL list
+	 * @param callable $handler        Handler function: handler($url, $hash, $torrent)
+	 */
+	static public function registerTracker($commentFilter, $announceFilter, $handler)
 	{
-		if(!array_key_exists($commentFiler, self::$TRACKERS)) 
+		if(!array_key_exists($commentFilter, self::$TRACKERS))
 		{
-			self::$TRACKERS[$commentFiler] = $handler;
+			self::$TRACKERS[$commentFilter] = $handler;
 			self::$ANNOUNCES[] = $announceFilter;
 		}
 	}
@@ -46,6 +53,18 @@ class ruTrackerChecker
 
 	static protected function setState( $hash, $state )
 	{
+		// First check if the torrent still exists in rTorrent
+		// This prevents "info-hash not found" errors when the torrent was already
+		// deleted (e.g., during replacement in createTorrent)
+		$checkReq = new rXMLRPCRequest( new rXMLRPCCommand( getCmd("d.hash"), $hash ) );
+		$checkReq->important = false;
+		if(!$checkReq->run() || $checkReq->fault)
+		{
+			// Torrent doesn't exist anymore, skip setting state
+			self::logDebug("setState: Torrent " . $hash . " not found, skipping state update");
+			return(true);
+		}
+
 		$req = new rXMLRPCRequest( array(
 			new rXMLRPCCommand( getCmd("d.set_custom"), array($hash, "chk-state", $state."")  ),
 			new rXMLRPCCommand( getCmd("d.set_custom"), array($hash, "chk-time", time()."") )
@@ -76,8 +95,142 @@ class ruTrackerChecker
 			$state = self::STE_INPROGRESS;
 			$time = time();
 			$successful_time = 0;
+			$label = "";
 			return(false);
 		}
+	}
+
+	// Build a list of relative file paths for a torrent (single-file or multi-file).
+	// Used to detect renamed/missing files when swapping torrents.
+	static private function collectTorrentPaths($torrent)
+	{
+		if(!is_object($torrent) || !isset($torrent->info))
+			return array();
+
+		$info = $torrent->info;
+		$paths = array();
+
+		// Multi-file mode
+		if(isset($info['files']) && is_array($info['files']))
+		{
+			// Note: We do NOT prepend $info['name'] (the torrent root folder) here,
+			// because d.get_directory_base already returns the path INCLUDING that folder.
+			// If we added it, we'd get: /base/FolderName/FolderName/file.mkv (duplicate)
+			foreach($info['files'] as $file)
+			{
+				if(!isset($file['path']) || !is_array($file['path']))
+					continue;
+
+				// Build relative path within the torrent folder (without the folder name prefix)
+				$rel = implode('/', $file['path']);
+				// Guard against path traversal
+				if(strpos($rel,'..')!==false)
+					continue;
+				$paths[] = $rel;
+			}
+		}
+		// Single-file mode
+		elseif(isset($info['name']))
+		{
+			if(strpos($info['name'],'..')===false)
+				$paths[] = $info['name'];
+		}
+
+		// Remove possible duplicates
+		return array_values(array_unique($paths));
+	}
+
+	// Helper function to remove empty subdirectories recursively
+	static private function removeEmptySubFolders($path, $baseAbs)
+	{
+		if(empty($path) || $path == $baseAbs)
+			return;
+
+		$dir = dirname($path);
+		// Ensure we're still inside the base directory
+		if(strpos(FileUtil::addslash($dir), $baseAbs) !== 0 || $dir == $baseAbs)
+			return;
+
+		if(is_dir($dir))
+		{
+			// scandir can return false (permissions, etc.), which causes TypeError in array_diff in PHP 8
+			$scanned = @scandir($dir);
+			if(is_array($scanned))
+			{
+				$files = array_diff($scanned, array('.', '..'));
+				if(empty($files))
+				{
+					@rmdir($dir);
+					// Recursively go up
+					self::removeEmptySubFolders($dir, $baseAbs);
+				}
+			}
+		}
+	}
+
+	// Remove files from the old torrent that are absent in the new one (to avoid duplicates after rename).
+	// Runs only after the new torrent is successfully loaded and the old one erased.
+	static private function cleanupObsoleteFiles($oldTorrent, $newTorrent, $baseDir)
+	{
+		self::logDebug("cleanupObsoleteFiles: Starting cleanup. BaseDir: " . $baseDir);
+
+		if(empty($baseDir) || !is_object($oldTorrent) || !is_object($newTorrent)) {
+			self::logDebug("cleanupObsoleteFiles: Invalid arguments or objects.");
+			return;
+		}
+
+		$oldPaths = self::collectTorrentPaths($oldTorrent);
+		if(empty($oldPaths)) {
+			self::logDebug("cleanupObsoleteFiles: No files found in old torrent.");
+			return;
+		}
+
+		$newPaths = self::collectTorrentPaths($newTorrent);
+		$missing = array_diff($oldPaths, $newPaths);
+
+		self::logDebug("cleanupObsoleteFiles: Old files count: " . count($oldPaths));
+		self::logDebug("cleanupObsoleteFiles: New files count: " . count($newPaths));
+		self::logDebug("cleanupObsoleteFiles: Missing files count: " . count($missing));
+
+		if(empty($missing)) {
+			self::logDebug("cleanupObsoleteFiles: No missing files to delete.");
+			return;
+		}
+
+		$baseAbs = FileUtil::addslash(FileUtil::fullpath($baseDir));
+		if(empty($baseAbs)) {
+			self::logDebug("cleanupObsoleteFiles: Could not resolve absolute base path.");
+			return;
+		}
+		self::logDebug("cleanupObsoleteFiles: Absolute base path: " . $baseAbs);
+
+		foreach($missing as $relPath)
+		{
+			// Build an absolute path inside the data directory and ensure it doesn't escape it.
+			$absolute = FileUtil::fullpath($relPath, $baseAbs);
+
+			// Security check
+			if(strpos(FileUtil::addslash($absolute), $baseAbs) !== 0) {
+				self::logDebug("cleanupObsoleteFiles: Security check failed for path: " . $absolute);
+				continue;
+			}
+
+			if(is_file($absolute))
+			{
+				self::logDebug("cleanupObsoleteFiles: Attempting to delete file: " . $absolute);
+				if(@unlink($absolute))
+				{
+					self::logDebug("cleanupObsoleteFiles: Successfully deleted: " . $absolute);
+					// Try to remove parent folder if it became empty
+					self::removeEmptySubFolders($absolute, $baseAbs);
+				} else {
+					self::logDebug("cleanupObsoleteFiles: Failed to delete file (unlink returned false): " . $absolute);
+				}
+			} else {
+				self::logDebug("cleanupObsoleteFiles: File not found or not a file: " . $absolute);
+			}
+		}
+		self::logDebug("cleanupObsoleteFiles: Cleanup finished.");
 	}
 
 	static public function createTorrent($torrent, $hash){
@@ -87,6 +240,11 @@ class ruTrackerChecker
 		if( $torrent->errors() ) return self::STE_DELETED;
 
 		if( $torrent->hash_info()==$hash ) return self::STE_UPTODATE;
+
+		// Keep the current torrent to compare file lists for cleanup after successful replacement.
+		// If loading the new torrent fails, the old files remain untouched.
+		$oldTorrent = rTorrent::getSource($hash);
+
 		$req =  new rXMLRPCRequest( array(
 			new rXMLRPCCommand("d.get_directory_base",$hash),
 			new rXMLRPCCommand("d.get_custom1",$hash),
@@ -100,6 +258,7 @@ class ruTrackerChecker
 		));
 
 		if($req->success()){
+			$baseDir = $req->val[0];
 			$addition = array(
 				getCmd("d.set_connection_seed=").$req->val[3],
 				getCmd("d.set_custom")."=chk-state,".self::STE_UPDATED,
@@ -109,15 +268,20 @@ class ruTrackerChecker
 			$isStart = (($req->val[4]!=0) && ($req->val[5]!=0) && ($req->val[6]!=0));
 			if(!empty($req->val[2]))
 				$addition[] = getCmd("d.set_throttle_name=").$req->val[2];
-			if(preg_match('/rat_(\d+)/',$req->val[3],$ratio))
-				$addition[] = getCmd("view.set_visible=")."rat_".$ratio;
+			// Preserve ratio-group view if it was set (values like "rat_1", "rat_5" etc).
+			// Check if regex matched and index exists
+			if(preg_match('/rat_(\d+)/',$req->val[3],$ratio) && isset($ratio[1]))
+				$addition[] = getCmd("view.set_visible=")."rat_".$ratio[1];
 			$label = rawurldecode($req->val[1]);
-			if(rTorrent::sendTorrent($torrent, $isStart, false, $req->val[0],
+			if(rTorrent::sendTorrent($torrent, $isStart, false, $baseDir,
 				$label, $saveUploadedTorrents, false, true, $addition))
 			{
 				$req = new rXMLRPCRequest( new rXMLRPCCommand("d.erase", $hash ) );
-				if($req->success())
+				if($req->success()){
+					self::cleanupObsoleteFiles($oldTorrent, $torrent, $baseDir);
+					// Successful .torrent replacement: new torrent state is already set via $addition
 					return null;
+				}
 			}
 		}
 		return self::STE_ERROR;
@@ -126,24 +290,74 @@ class ruTrackerChecker
 	static public function run_ex($hash, $fname){
 		$torrent = new Torrent( $fname );
 		if(!$torrent->errors()){
-			foreach (self::$TRACKERS as $key => $value)
+			// Get both announce URL and comment for matching
+			$announce = $torrent->announce();
+			$comment = $torrent->comment();
+
+			foreach (self::$TRACKERS as $pattern => $handler)
 			{
-				if( preg_match($key, $torrent->comment()) ) 
+				$matchedUrl = null;
+
+				// First check comment: usually contains topic URL (e.g., viewtopic.php?t=...)
+				if( preg_match($pattern, $comment) )
 				{
-					return call_user_func($value, $torrent->comment(), $hash, $torrent);
+					$matchedUrl = $comment;
+				}
+				// If not found in comment, try announce
+				elseif( preg_match($pattern, $announce) )
+				{
+					$matchedUrl = $announce;
+				}
+
+				if($matchedUrl !== null)
+				{
+					return call_user_func($handler, $matchedUrl, $hash, $torrent);
 				}
 			}
 		}
 		return self::STE_NOT_NEED;
 	}
 
+	/**
+	 * Simple plugin logger.
+	 * Writes to /tmp/rutracker_check.log
+	 */
+	static public function logDebug($message)
+	{
+		$logFile = '/tmp/rutracker_check.log';
+		$logDir = dirname($logFile);
+
+		// Protection: verify permissions before attempting to write
+		$canWrite = file_exists($logFile) ? is_writable($logFile) : is_writable($logDir);
+
+		if($canWrite)
+		{
+			$line = '[' . gmdate('Y-m-d H:i:s') . '] ' . $message . PHP_EOL;
+			@file_put_contents($logFile, $line, FILE_APPEND);
+		}
+	}
+
 	static public function makeClient( $url, $method="GET", $content_type="", $body="" )
 	{
 		$client = new Snoopy();
 		$client->read_timeout = 5;
-		$client->_fp_timeout = 5;
-		@$client->fetchComplex($url,$method,$content_type,$body);
-		return($client);
+		$client->_fp_timeout  = 5;
+
+		// Pretend to be a modern browser to reduce 403/anti-bot errors
+		$client->agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+		               . "AppleWebKit/537.36 (KHTML, like Gecko) "
+		               . "Chrome/120.0.0.0 Safari/537.36";
+
+		// Suppress Snoopy errors with @, but log status on failure
+		@$client->fetchComplex($url, $method, $content_type, $body);
+
+		// Convention: plugins consider status < 0 as "tracker unreachable"
+		if($client->status < 0)
+		{
+			self::logDebug("Snoopy fetch failed: url=".$url." status=".$client->status);
+		}
+
+		return $client;
 	}
 
 	static public function run( $hash, $state = null, $time = null, $successful_time = null, $label = null )
@@ -151,8 +365,10 @@ class ruTrackerChecker
 		global $ignoreLabels;
 
 		if(is_null($state)) self::getState( $hash, $state, $time, $successful_time, $label );
-		
-		if (!is_null($label) && in_array($label, $ignoreLabels)) {
+
+		// Skip torrent if its label is in the ignore list
+		if(!is_null($label) && isset($ignoreLabels) && is_array($ignoreLabels) && in_array($label, $ignoreLabels))
+		{
 			$state = self::STE_IGNORED;
 			self::setState($hash, $state);
 			return(true);
@@ -164,7 +380,16 @@ class ruTrackerChecker
 			$state = self::STE_INPROGRESS;
 			if(!self::setState( $hash, $state )) return(false);
 
-			$fname = rTorrentSettings::get()->session.$hash.".torrent";
+			// Main path: via rTorrentSettings
+			if(class_exists('rTorrentSettings') && method_exists('rTorrentSettings', 'get'))
+			{
+				$fname = rTorrentSettings::get()->session.$hash.".torrent";
+			}
+			else
+			{
+				// Fallback for non-standard configurations
+				$fname = getSettingsPath().'/session/'.$hash.".torrent";
+			}
 
 			if(is_readable($fname))	$state = self::run_ex($hash, $fname);
 			if($state==self::STE_INPROGRESS) $state=self::STE_ERROR;

--- a/plugins/rutracker_check/check.php
+++ b/plugins/rutracker_check/check.php
@@ -27,6 +27,17 @@ class ruTrackerChecker
 
 	const MAX_LOCK_TIME		= 900;	// 15 min
 
+	// load_raw inserts the torrent from a deferred rTorrent event-loop task,
+	// so waiting for the staged copy to appear is the only wait in the
+	// replacement transaction; every other command is synchronous.
+	const LOAD_WAIT_ATTEMPTS	= 40;
+	const LOAD_WAIT_DELAY_US	= 50000;
+	const REPLACEMENT_MARKER_KEY	= 'chk-replacement';
+
+	const USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+		. "AppleWebKit/537.36 (KHTML, like Gecko) "
+		. "Chrome/120.0.0.0 Safari/537.36";
+
 	private static $TRACKERS = array();
 	private static $ANNOUNCES = array();
 
@@ -41,7 +52,10 @@ class ruTrackerChecker
 	{
 		if(!array_key_exists($commentFilter, self::$TRACKERS))
 		{
-			self::$TRACKERS[$commentFilter] = $handler;
+			self::$TRACKERS[$commentFilter] = array(
+				'announceFilter' => $announceFilter,
+				'handler' => $handler,
+			);
 			self::$ANNOUNCES[] = $announceFilter;
 		}
 	}
@@ -51,120 +65,140 @@ class ruTrackerChecker
 		return(self::$ANNOUNCES);
 	}
 
+	/**
+	 * Check whether rTorrent still knows a hash.
+	 *
+	 * @return bool|null true when present, false when the target is missing,
+	 *                   null when the XMLRPC request itself failed
+	 */
+	static protected function torrentExists( $hash )
+	{
+		$req = new rXMLRPCRequest( new rXMLRPCCommand( getCmd("d.hash"), $hash ) );
+		$req->important = false;
+		if(!$req->run())
+			return(null);
+		return(!$req->fault);
+	}
+
 	static protected function setState( $hash, $state )
 	{
-		// First check if the torrent still exists in rTorrent
-		// This prevents "info-hash not found" errors when the torrent was already
-		// deleted (e.g., during replacement in createTorrent)
-		$checkReq = new rXMLRPCRequest( new rXMLRPCCommand( getCmd("d.hash"), $hash ) );
-		$checkReq->important = false;
-		if(!$checkReq->run() || $checkReq->fault)
-		{
-			// Torrent doesn't exist anymore, skip setting state
-			self::logDebug("setState: Torrent " . $hash . " not found, skipping state update");
-			return(true);
-		}
-
 		$req = new rXMLRPCRequest( array(
 			new rXMLRPCCommand( getCmd("d.set_custom"), array($hash, "chk-state", $state."")  ),
 			new rXMLRPCCommand( getCmd("d.set_custom"), array($hash, "chk-time", time()."") )
 			));
 		if($state == self::STE_UPTODATE)
 			$req->addCommand(new rXMLRPCCommand( getCmd("d.set_custom"), array($hash, "chk-stime", time()."") ));
-		return($req->success());
+		$req->important = false;
+		if($req->success())
+			return(true);
+
+		// The write faults when the hash is unknown; only then is the miss final.
+		$exists = self::torrentExists($hash);
+		if($exists === false)
+		{
+			self::logDebug("setState: Torrent " . $hash . " not found, skipping state update");
+			return(null);
+		}
+		return(false);
 	}
 
 	static protected function getState( $hash, &$state, &$time, &$successful_time, &$label )
 	{
+		$state = self::STE_INPROGRESS;
+		$time = time();
+		$successful_time = 0;
+		$label = "";
+
+		$exists = self::torrentExists($hash);
+		if($exists === false)
+		{
+			$state = self::STE_NOT_NEED;
+			self::logDebug("getState: Torrent " . $hash . " not found, skipping state read");
+			return(false);
+		}
+		if($exists === null)
+			return(false);
+
 		$req = new rXMLRPCRequest( array(
 			new rXMLRPCCommand( getCmd("d.get_custom"), array($hash, "chk-state")  ),
 			new rXMLRPCCommand( getCmd("d.get_custom"), array($hash, "chk-time") ),
 			new rXMLRPCCommand( getCmd("d.get_custom"), array($hash, "chk-stime") ),
 			new rXMLRPCCommand( getCmd("d.get_custom1"), $hash )
 			));
-		if($req->success())
-		{
-			$state = intval($req->val[0]);
-			$time = intval($req->val[1]);
-			$successful_time = intval($req->val[2]);
-			$label = $req->val[3];
-			return(true);
-		}
-		else
-		{
-			$state = self::STE_INPROGRESS;
-			$time = time();
-			$successful_time = 0;
-			$label = "";
+		$req->important = false;
+		if(!$req->success())
 			return(false);
-		}
+
+		$state = intval($req->val[0]);
+		$time = intval($req->val[1]);
+		$successful_time = intval($req->val[2]);
+		$label = $req->val[3];
+		return(true);
 	}
 
-	// Build a list of relative file paths for a torrent (single-file or multi-file).
-	// Used to detect renamed/missing files when swapping torrents.
+	// Build a list of safe relative file paths for a torrent.
 	static private function collectTorrentPaths($torrent)
 	{
 		if(!is_object($torrent) || !isset($torrent->info))
-			return array();
+			return(null);
 
 		$info = $torrent->info;
+		if(!is_array($info))
+			return(null);
 		$paths = array();
 
-		// Multi-file mode
 		if(isset($info['files']) && is_array($info['files']))
 		{
-			// Note: We do NOT prepend $info['name'] (the torrent root folder) here,
-			// because d.get_directory_base already returns the path INCLUDING that folder.
-			// If we added it, we'd get: /base/FolderName/FolderName/file.mkv (duplicate)
 			foreach($info['files'] as $file)
 			{
 				if(!isset($file['path']) || !is_array($file['path']))
-					continue;
-
-				// Build relative path within the torrent folder (without the folder name prefix)
-				$rel = implode('/', $file['path']);
-				// Guard against path traversal
-				if(strpos($rel,'..')!==false)
-					continue;
-				$paths[] = $rel;
+					return(null);
+				$path = self::makeSafeRelativePath($file['path']);
+				if($path === null)
+					return(null);
+				$paths[] = $path;
 			}
 		}
-		// Single-file mode
 		elseif(isset($info['name']))
 		{
-			if(strpos($info['name'],'..')===false)
-				$paths[] = $info['name'];
+			$path = self::makeSafeRelativePath(array($info['name']));
+			if($path === null)
+				return(null);
+			$paths[] = $path;
 		}
 
-		// Remove possible duplicates
 		return array_values(array_unique($paths));
 	}
 
-	// Helper function to remove empty subdirectories recursively
+	static private function makeSafeRelativePath($components)
+	{
+		$normalized = array();
+		foreach($components as $component)
+		{
+			if(!is_string($component) && !is_numeric($component))
+				return(null);
+			$component = (string) $component;
+			if($component === '' || $component === '.' || $component === '..' ||
+				strpos($component, "\0") !== false || strpos($component, '/') !== false ||
+				strpos($component, '\\') !== false)
+				return(null);
+			$normalized[] = $component;
+		}
+		return(count($normalized) ? implode('/', $normalized) : null);
+	}
+
 	static private function removeEmptySubFolders($path, $baseAbs)
 	{
-		if(empty($path) || $path == $baseAbs)
-			return;
-
 		$dir = dirname($path);
-		// Ensure we're still inside the base directory
-		if(strpos(FileUtil::addslash($dir), $baseAbs) !== 0 || $dir == $baseAbs)
-			return;
-
-		if(is_dir($dir))
+		$basePrefix = FileUtil::addslash($baseAbs);
+		while($dir !== $baseAbs && strpos(FileUtil::addslash($dir), $basePrefix) === 0)
 		{
-			// scandir can return false (permissions, etc.), which causes TypeError in array_diff in PHP 8
+			if(is_link($dir) || realpath($dir) !== $dir)
+				return;
 			$scanned = @scandir($dir);
-			if(is_array($scanned))
-			{
-				$files = array_diff($scanned, array('.', '..'));
-				if(empty($files))
-				{
-					@rmdir($dir);
-					// Recursively go up
-					self::removeEmptySubFolders($dir, $baseAbs);
-				}
-			}
+			if(!is_array($scanned) || count(array_diff($scanned, array('.', '..'))) || !@rmdir($dir))
+				return;
+			$dir = dirname($dir);
 		}
 	}
 
@@ -172,169 +206,338 @@ class ruTrackerChecker
 	// Runs only after the new torrent is successfully loaded and the old one erased.
 	static private function cleanupObsoleteFiles($oldTorrent, $newTorrent, $baseDir)
 	{
-		self::logDebug("cleanupObsoleteFiles: Starting cleanup. BaseDir: " . $baseDir);
-
-		if(empty($baseDir) || !is_object($oldTorrent) || !is_object($newTorrent)) {
-			self::logDebug("cleanupObsoleteFiles: Invalid arguments or objects.");
+		if(empty($baseDir))
 			return;
-		}
 
 		$oldPaths = self::collectTorrentPaths($oldTorrent);
-		if(empty($oldPaths)) {
-			self::logDebug("cleanupObsoleteFiles: No files found in old torrent.");
-			return;
-		}
-
 		$newPaths = self::collectTorrentPaths($newTorrent);
+		if(empty($oldPaths) || empty($newPaths))
+		{
+			self::logDebug("cleanupObsoleteFiles: Missing a safe file manifest, skipping cleanup");
+			return;
+		}
 		$missing = array_diff($oldPaths, $newPaths);
+		self::logDebug("cleanupObsoleteFiles: Old " . count($oldPaths) . ", new " . count($newPaths)
+			. ", missing " . count($missing) . " in " . $baseDir);
+		if(empty($missing))
+			return;
 
-		self::logDebug("cleanupObsoleteFiles: Old files count: " . count($oldPaths));
-		self::logDebug("cleanupObsoleteFiles: New files count: " . count($newPaths));
-		self::logDebug("cleanupObsoleteFiles: Missing files count: " . count($missing));
-
-		if(empty($missing)) {
-			self::logDebug("cleanupObsoleteFiles: No missing files to delete.");
+		$baseAbs = realpath($baseDir);
+		// A torrent rooted at the filesystem root is too broad a cleanup scope.
+		if($baseAbs === false || !is_dir($baseAbs) || $baseAbs === DIRECTORY_SEPARATOR)
+		{
+			self::logDebug("cleanupObsoleteFiles: Unusable base path, skipping cleanup");
 			return;
 		}
+		$baseAbs = rtrim($baseAbs, DIRECTORY_SEPARATOR);
+		$basePrefix = FileUtil::addslash($baseAbs);
 
-		$baseAbs = FileUtil::addslash(FileUtil::fullpath($baseDir));
-		if(empty($baseAbs)) {
-			self::logDebug("cleanupObsoleteFiles: Could not resolve absolute base path.");
-			return;
+		// On a case-insensitive or normalizing filesystem a renamed-away path can
+		// alias the very file the new torrent references; a byte-wise path diff
+		// cannot see that, so compare inodes before deleting anything.
+		$newFileIds = array();
+		foreach($newPaths as $relPath)
+		{
+			$stat = @stat($basePrefix . $relPath);
+			if(is_array($stat) && !empty($stat['ino']))
+				$newFileIds[$stat['dev'] . ':' . $stat['ino']] = true;
 		}
-		self::logDebug("cleanupObsoleteFiles: Absolute base path: " . $baseAbs);
 
 		foreach($missing as $relPath)
 		{
-			// Build an absolute path inside the data directory and ensure it doesn't escape it.
-			$absolute = FileUtil::fullpath($relPath, $baseAbs);
+			$candidate = $basePrefix . $relPath;
+			$absolute = realpath($candidate);
+			// Reject missing paths, symlinks (including a symlinked parent), and escapes.
+			if($absolute === false || $absolute !== $candidate || is_link($candidate) ||
+				strpos(FileUtil::addslash($absolute), $basePrefix) !== 0)
+			{
+				self::logDebug("cleanupObsoleteFiles: Security check failed for path: " . $candidate);
+				continue;
+			}
+			if(!is_file($absolute))
+				continue;
 
-			// Security check
-			if(strpos(FileUtil::addslash($absolute), $baseAbs) !== 0) {
-				self::logDebug("cleanupObsoleteFiles: Security check failed for path: " . $absolute);
+			$stat = @stat($absolute);
+			if(is_array($stat) && !empty($stat['ino']) && isset($newFileIds[$stat['dev'] . ':' . $stat['ino']]))
+			{
+				self::logDebug("cleanupObsoleteFiles: Path aliases a file of the new torrent, keeping: " . $absolute);
 				continue;
 			}
 
-			if(is_file($absolute))
-			{
-				self::logDebug("cleanupObsoleteFiles: Attempting to delete file: " . $absolute);
-				if(@unlink($absolute))
-				{
-					self::logDebug("cleanupObsoleteFiles: Successfully deleted: " . $absolute);
-					// Try to remove parent folder if it became empty
-					self::removeEmptySubFolders($absolute, $baseAbs);
-				} else {
-					self::logDebug("cleanupObsoleteFiles: Failed to delete file (unlink returned false): " . $absolute);
-				}
-			} else {
-				self::logDebug("cleanupObsoleteFiles: File not found or not a file: " . $absolute);
-			}
+			if(@unlink($absolute))
+				self::removeEmptySubFolders($absolute, $baseAbs);
+			else
+				self::logDebug("cleanupObsoleteFiles: Failed to delete file: " . $absolute);
 		}
-		self::logDebug("cleanupObsoleteFiles: Cleanup finished.");
+	}
+
+	static private function buildReplacementAddition($connectionSeed, $throttle, $ratioViews, $state, $marker)
+	{
+		$now = time();
+		$addition = array(
+			getCmd("d.set_custom")."=".self::REPLACEMENT_MARKER_KEY.",".$marker,
+			getCmd("d.set_connection_seed=").$connectionSeed,
+			getCmd("d.set_custom")."=chk-state,".$state,
+			getCmd("d.set_custom")."=chk-time,".$now,
+			getCmd("d.set_custom")."=chk-stime,".$now,
+		);
+		if(!empty($throttle))
+			$addition[] = getCmd("d.set_throttle_name=").$throttle;
+		foreach($ratioViews as $ratioView)
+			$addition[] = getCmd("view.set_visible=").$ratioView;
+		return($addition);
+	}
+
+	/**
+	 * Wait for the staged torrent to be inserted by rTorrent's deferred load.
+	 * The addition commands run in the same event-loop step as the insert, so
+	 * once the hash resolves, the marker is authoritative.
+	 *
+	 * @return string 'ours' | 'foreign' | 'missing'
+	 */
+	static private function waitForLoad($hash, $marker)
+	{
+		for($attempt = 0; $attempt < self::LOAD_WAIT_ATTEMPTS; $attempt++)
+		{
+			if($attempt)
+				usleep(self::LOAD_WAIT_DELAY_US);
+			$req = new rXMLRPCRequest( new rXMLRPCCommand(
+				getCmd("d.get_custom"), array($hash, self::REPLACEMENT_MARKER_KEY) ) );
+			$req->important = false;
+			if(!$req->run() || $req->fault)
+				continue;
+			return((isset($req->val[0]) && (string) $req->val[0] === (string) $marker) ? 'ours' : 'foreign');
+		}
+		return('missing');
+	}
+
+	// Erase a hash that was verified to carry our replacement marker.
+	static private function eraseStaged($hash)
+	{
+		$req = new rXMLRPCRequest( new rXMLRPCCommand("d.erase", $hash) );
+		$req->important = false;
+		if($req->success())
+			return(true);
+		return(self::torrentExists($hash) === false);
+	}
+
+	static private function restoreExistingTorrent($hash, $wasOpen, $wasStarted)
+	{
+		if(!$wasOpen && !$wasStarted)
+			return(true);
+		$restore = new rXMLRPCRequest( new rXMLRPCCommand($wasStarted ? "d.start" : "d.open", $hash) );
+		$restore->important = false;
+		return($restore->success());
+	}
+
+	// Runs after the commit point: failures are logged and the replacement is
+	// left stopped rather than reported as a failed check.
+	static private function activateReplacement($hash, $wasOpen, $wasStarted)
+	{
+		if(!$wasOpen && !$wasStarted)
+			return(true);
+		for($attempt = 0; $attempt < 2; $attempt++)
+		{
+			self::restoreExistingTorrent($hash, $wasOpen, $wasStarted);
+			$check = new rXMLRPCRequest( array(
+				new rXMLRPCCommand("d.get_state", $hash),
+				new rXMLRPCCommand("d.is_open", $hash),
+			));
+			$check->important = false;
+			if(!$check->success() || !isset($check->val[1]))
+				continue;
+			// A started torrent may stay closed until the scheduler grants a slot.
+			if($wasStarted ? (intval($check->val[0]) === 1) : (intval($check->val[1]) === 1))
+				return(true);
+		}
+		self::logDebug("activateReplacement: Could not confirm activation of " . $hash);
+		return(false);
+	}
+
+	static private function clearReplacementMarker($hash)
+	{
+		$req = new rXMLRPCRequest( new rXMLRPCCommand(
+			getCmd("d.set_custom"), array($hash, self::REPLACEMENT_MARKER_KEY, "")
+		) );
+		$req->important = false;
+		$req->success();
 	}
 
 	static public function createTorrent($torrent, $hash){
 		global $saveUploadedTorrents;
-		$torrent = new Torrent( $torrent );
+		// PHP 7.4 warns when Torrent probes binary metainfo as a filename.
+		$torrent = @new Torrent( $torrent );
 
+		// Legacy handlers feed HTTP-200 "topic removed" HTML pages straight in
+		// here and rely on a parse failure meaning the topic is gone.
 		if( $torrent->errors() ) return self::STE_DELETED;
 
-		if( $torrent->hash_info()==$hash ) return self::STE_UPTODATE;
+		$newHash = $torrent->hash_info();
+		if( $newHash==$hash ) return self::STE_UPTODATE;
 
-		// Keep the current torrent to compare file lists for cleanup after successful replacement.
-		// If loading the new torrent fails, the old files remain untouched.
+		$exists = self::torrentExists($newHash);
+		if($exists === null) return self::STE_ERROR;
+		if($exists === true)
+		{
+			// A staged copy abandoned by a crashed run still carries a marker
+			// (it is only cleared on success) and is always stopped and closed;
+			// discard it and redo the replacement. Anything unmarked is foreign
+			// and must not be touched.
+			$markerReq = new rXMLRPCRequest( array(
+				new rXMLRPCCommand(getCmd("d.get_custom"), array($newHash, self::REPLACEMENT_MARKER_KEY)),
+				new rXMLRPCCommand("d.get_state", $newHash),
+				new rXMLRPCCommand("d.is_open", $newHash),
+			) );
+			$markerReq->important = false;
+			if(!$markerReq->success() || !isset($markerReq->val[2]) || (string) $markerReq->val[0] === '')
+				return self::STE_ERROR;
+			if(intval($markerReq->val[1]) !== 0 || intval($markerReq->val[2]) !== 0)
+			{
+				// A running torrent with a leftover marker is a committed
+				// replacement whose final marker clear was lost; repair the
+				// marker, but never treat a live torrent as disposable.
+				self::clearReplacementMarker($newHash);
+				return self::STE_ERROR;
+			}
+			if(!self::eraseStaged($newHash))
+				return self::STE_ERROR;
+		}
+
+		// Keep the old metainfo for post-replacement file cleanup.
 		$oldTorrent = rTorrent::getSource($hash);
+		if(!is_object($oldTorrent)) return self::STE_ERROR;
 
-		$req =  new rXMLRPCRequest( array(
+		try
+		{
+			$marker = bin2hex(random_bytes(16));
+		}
+		catch(Exception $error)
+		{
+			return self::STE_ERROR;
+		}
+
+		// Ratio-group membership lives in rat_N views (see plugins/ratio).
+		$viewsReq = new rXMLRPCRequest( new rXMLRPCCommand(getCmd("d.views"), $hash) );
+		$viewsReq->important = false;
+		if(!$viewsReq->success()) return self::STE_ERROR;
+		$ratioViews = array();
+		foreach($viewsReq->val as $view)
+			if(is_string($view) && preg_match('/^rat_\d+$/', $view))
+				$ratioViews[$view] = true;
+		$ratioViews = array_keys($ratioViews);
+
+		// Snapshot the logical state and stop/close it in the same multicall so a
+		// scheduler action cannot slip between the read and the mutation.
+		$req = new rXMLRPCRequest( array(
 			new rXMLRPCCommand("d.get_directory_base",$hash),
 			new rXMLRPCCommand("d.get_custom1",$hash),
 			new rXMLRPCCommand("d.get_throttle_name",$hash),
 			new rXMLRPCCommand("d.get_connection_seed",$hash),
-			new rXMLRPCCommand("d.is_open",$hash),
-			new rXMLRPCCommand("d.is_active",$hash),
 			new rXMLRPCCommand("d.get_state",$hash),
+			new rXMLRPCCommand("d.is_open",$hash),
 			new rXMLRPCCommand("d.stop",$hash),
 			new rXMLRPCCommand("d.close",$hash),
 		));
-
-		if($req->success()){
-			$baseDir = $req->val[0];
-			$addition = array(
-				getCmd("d.set_connection_seed=").$req->val[3],
-				getCmd("d.set_custom")."=chk-state,".self::STE_UPDATED,
-				getCmd("d.set_custom")."=chk-time,".time(),
-				getCmd("d.set_custom")."=chk-stime,".time()
-			);
-			$isStart = (($req->val[4]!=0) && ($req->val[5]!=0) && ($req->val[6]!=0));
-			if(!empty($req->val[2]))
-				$addition[] = getCmd("d.set_throttle_name=").$req->val[2];
-			// Preserve ratio-group view if it was set (values like "rat_1", "rat_5" etc).
-			// Check if regex matched and index exists
-			if(preg_match('/rat_(\d+)/',$req->val[3],$ratio) && isset($ratio[1]))
-				$addition[] = getCmd("view.set_visible=")."rat_".$ratio[1];
-			$label = rawurldecode($req->val[1]);
-			if(rTorrent::sendTorrent($torrent, $isStart, false, $baseDir,
-				$label, $saveUploadedTorrents, false, true, $addition))
-			{
-				$req = new rXMLRPCRequest( new rXMLRPCCommand("d.erase", $hash ) );
-				if($req->success()){
-					self::cleanupObsoleteFiles($oldTorrent, $torrent, $baseDir);
-					// Successful .torrent replacement: new torrent state is already set via $addition
-					return null;
-				}
-			}
+		$req->important = false;
+		if(!$req->success() || !isset($req->val[5]))
+		{
+			if(isset($req->val[5]))
+				self::restoreExistingTorrent($hash, $req->val[5] != 0, $req->val[4] != 0);
+			return self::STE_ERROR;
 		}
-		return self::STE_ERROR;
+
+		$baseDir = $req->val[0];
+		$label = rawurldecode($req->val[1]);
+		$throttle = $req->val[2];
+		$connectionSeed = $req->val[3];
+		$wasStarted = ($req->val[4] != 0);
+		$wasOpen = ($req->val[5] != 0);
+		$addition = self::buildReplacementAddition(
+			$connectionSeed, $throttle, $ratioViews, self::STE_UPDATED, $marker
+		);
+
+		// Stage stopped: a failed pre-commit replacement cannot write shared data.
+		$loadedHash = rTorrent::sendTorrent($torrent, false, false, $baseDir,
+			$label, $saveUploadedTorrents, false, true, $addition);
+		$owner = self::waitForLoad($newHash, $marker);
+		if(!$loadedHash || strcasecmp((string) $loadedHash, (string) $newHash) !== 0 || $owner !== 'ours')
+		{
+			// Restore the old torrent even when the staged status is unknown:
+			// d.start on it is safe to repeat and is the only recovery there is.
+			if($owner === 'ours')
+				self::eraseStaged($newHash);
+			self::restoreExistingTorrent($hash, $wasOpen, $wasStarted);
+			return self::STE_ERROR;
+		}
+
+		// Commit point: erase the old torrent.
+		$eraseReq = new rXMLRPCRequest( new rXMLRPCCommand("d.erase", $hash ) );
+		$eraseReq->important = false;
+		if(!$eraseReq->success())
+		{
+			$oldExists = self::torrentExists($hash);
+			if($oldExists === true)
+			{
+				self::eraseStaged($newHash);
+				self::restoreExistingTorrent($hash, $wasOpen, $wasStarted);
+				return self::STE_ERROR;
+			}
+			if($oldExists === null)
+			{
+				// Both fates are unknowable: keep the marked staged copy so a
+				// later run can adopt it, and touch nothing else.
+				return self::STE_ERROR;
+			}
+			// The old torrent is gone despite the failed erase: proceed.
+		}
+
+		self::activateReplacement($newHash, $wasOpen, $wasStarted);
+		self::cleanupObsoleteFiles($oldTorrent, $torrent, $baseDir);
+		self::clearReplacementMarker($newHash);
+		return null;
+	}
+
+	static private function appendAnnounceUrls($value, &$urls)
+	{
+		if(is_array($value))
+		{
+			foreach($value as $item)
+				self::appendAnnounceUrls($item, $urls);
+		}
+		elseif(is_string($value) && $value !== '' && !in_array($value, $urls, true))
+			$urls[] = $value;
 	}
 
 	static public function run_ex($hash, $fname){
 		$torrent = new Torrent( $fname );
 		if(!$torrent->errors()){
-			// Get both announce URL and comment for matching
-			$announce = $torrent->announce();
-			$comment = $torrent->comment();
+			$comment = (string) $torrent->comment();
 
-			foreach (self::$TRACKERS as $pattern => $handler)
+			foreach (self::$TRACKERS as $commentFilter => $tracker)
+				if(preg_match($commentFilter, $comment))
+					return call_user_func($tracker['handler'], $comment, $hash, $torrent);
+
+			$announces = array();
+			self::appendAnnounceUrls($torrent->announce(), $announces);
+			self::appendAnnounceUrls($torrent->announce_list(), $announces);
+
+			// Announce matching is a fallback only after every comment handler had
+			// a chance to claim the topic URL.
+			foreach (self::$TRACKERS as $tracker)
 			{
-				$matchedUrl = null;
-
-				// First check comment: usually contains topic URL (e.g., viewtopic.php?t=...)
-				if( preg_match($pattern, $comment) )
-				{
-					$matchedUrl = $comment;
-				}
-				// If not found in comment, try announce
-				elseif( preg_match($pattern, $announce) )
-				{
-					$matchedUrl = $announce;
-				}
-
-				if($matchedUrl !== null)
-				{
-					return call_user_func($handler, $matchedUrl, $hash, $torrent);
-				}
+				foreach($announces as $announce)
+					if(preg_match($tracker['announceFilter'], $announce))
+						return call_user_func($tracker['handler'], $announce, $hash, $torrent);
 			}
 		}
 		return self::STE_NOT_NEED;
 	}
 
-	/**
-	 * Simple plugin logger.
-	 * Writes to /tmp/rutracker_check.log
-	 */
 	static public function logDebug($message)
 	{
-		$logFile = '/tmp/rutracker_check.log';
-		$logDir = dirname($logFile);
-
-		// Protection: verify permissions before attempting to write
-		$canWrite = file_exists($logFile) ? is_writable($logFile) : is_writable($logDir);
-
-		if($canWrite)
-		{
-			$line = '[' . gmdate('Y-m-d H:i:s') . '] ' . $message . PHP_EOL;
-			@file_put_contents($logFile, $line, FILE_APPEND);
-		}
+		global $rutrackerCheckDebug;
+		if(!empty($rutrackerCheckDebug))
+			FileUtil::toLog('rutracker_check: ' . preg_replace('/[\r\n]+/', ' ', (string) $message));
 	}
 
 	static public function makeClient( $url, $method="GET", $content_type="", $body="" )
@@ -344,17 +547,16 @@ class ruTrackerChecker
 		$client->_fp_timeout  = 5;
 
 		// Pretend to be a modern browser to reduce 403/anti-bot errors
-		$client->agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-		               . "AppleWebKit/537.36 (KHTML, like Gecko) "
-		               . "Chrome/120.0.0.0 Safari/537.36";
+		$client->agent = self::USER_AGENT;
 
-		// Suppress Snoopy errors with @, but log status on failure
 		@$client->fetchComplex($url, $method, $content_type, $body);
 
-		// Convention: plugins consider status < 0 as "tracker unreachable"
-		if($client->status < 0)
+		// Socket errors are negative; the https path stores curl's exit code,
+		// which is below any real HTTP status.
+		if($client->status < 100)
 		{
-			self::logDebug("Snoopy fetch failed: url=".$url." status=".$client->status);
+			$host = @parse_url($url, PHP_URL_HOST);
+			self::logDebug("Snoopy fetch failed: host=".(is_string($host) ? $host : 'unknown')." status=".$client->status);
 		}
 
 		return $client;
@@ -364,7 +566,19 @@ class ruTrackerChecker
 	{
 		global $ignoreLabels;
 
-		if(is_null($state)) self::getState( $hash, $state, $time, $successful_time, $label );
+		// update.php can pass cached state directly, bypassing getState(). Check
+		// the live target before acting on a possibly stale scheduler row.
+		if(!is_null($state))
+		{
+			$exists = self::torrentExists($hash);
+			if($exists === false)
+				return(true);
+			if($exists === null)
+				return(false);
+		}
+
+		if(is_null($state) && !self::getState( $hash, $state, $time, $successful_time, $label ) && ($state == self::STE_NOT_NEED))
+			return(true);
 
 		// Skip torrent if its label is in the ignore list
 		if(!is_null($label) && isset($ignoreLabels) && is_array($ignoreLabels) && in_array($label, $ignoreLabels))
@@ -378,18 +592,11 @@ class ruTrackerChecker
 
 		if($state!==self::STE_INPROGRESS){
 			$state = self::STE_INPROGRESS;
-			if(!self::setState( $hash, $state )) return(false);
+			$stateWrite = self::setState( $hash, $state );
+			if($stateWrite === null) return(true);
+			if(!$stateWrite) return(false);
 
-			// Main path: via rTorrentSettings
-			if(class_exists('rTorrentSettings') && method_exists('rTorrentSettings', 'get'))
-			{
-				$fname = rTorrentSettings::get()->session.$hash.".torrent";
-			}
-			else
-			{
-				// Fallback for non-standard configurations
-				$fname = getSettingsPath().'/session/'.$hash.".torrent";
-			}
+			$fname = rTorrentSettings::get()->session.$hash.".torrent";
 
 			if(is_readable($fname))	$state = self::run_ex($hash, $fname);
 			if($state==self::STE_INPROGRESS) $state=self::STE_ERROR;

--- a/plugins/rutracker_check/check.php
+++ b/plugins/rutracker_check/check.php
@@ -30,11 +30,18 @@ class ruTrackerChecker
 	private static $TRACKERS = array();
 	private static $ANNOUNCES = array();
 
-	static public function registerTracker($commentFiler, $announceFilter, $handler)
+	/**
+	 * Register a tracker handler.
+	 *
+	 * @param string   $commentFilter  Regex pattern for torrent comment
+	 * @param string   $announceFilter Regex pattern for announce URL list
+	 * @param callable $handler        Handler function: handler($url, $hash, $torrent)
+	 */
+	static public function registerTracker($commentFilter, $announceFilter, $handler)
 	{
-		if(!array_key_exists($commentFiler, self::$TRACKERS))
+		if(!array_key_exists($commentFilter, self::$TRACKERS))
 		{
-			self::$TRACKERS[$commentFiler] = $handler;
+			self::$TRACKERS[$commentFilter] = $handler;
 			self::$ANNOUNCES[] = $announceFilter;
 		}
 	}
@@ -46,6 +53,18 @@ class ruTrackerChecker
 
 	static protected function setState( $hash, $state )
 	{
+		// First check if the torrent still exists in rTorrent
+		// This prevents "info-hash not found" errors when the torrent was already
+		// deleted (e.g., during replacement in createTorrent)
+		$checkReq = new rXMLRPCRequest( new rXMLRPCCommand( getCmd("d.hash"), $hash ) );
+		$checkReq->important = false;
+		if(!$checkReq->run() || $checkReq->fault)
+		{
+			// Torrent doesn't exist anymore, skip setting state
+			self::logDebug("setState: Torrent " . $hash . " not found, skipping state update");
+			return(true);
+		}
+
 		$req = new rXMLRPCRequest( array(
 			new rXMLRPCCommand( getCmd("d.set_custom"), array($hash, "chk-state", $state."")  ),
 			new rXMLRPCCommand( getCmd("d.set_custom"), array($hash, "chk-time", time()."") )
@@ -76,8 +95,142 @@ class ruTrackerChecker
 			$state = self::STE_INPROGRESS;
 			$time = time();
 			$successful_time = 0;
+			$label = "";
 			return(false);
 		}
+	}
+
+	// Build a list of relative file paths for a torrent (single-file or multi-file).
+	// Used to detect renamed/missing files when swapping torrents.
+	static private function collectTorrentPaths($torrent)
+	{
+		if(!is_object($torrent) || !isset($torrent->info))
+			return array();
+
+		$info = $torrent->info;
+		$paths = array();
+
+		// Multi-file mode
+		if(isset($info['files']) && is_array($info['files']))
+		{
+			// Note: We do NOT prepend $info['name'] (the torrent root folder) here,
+			// because d.get_directory_base already returns the path INCLUDING that folder.
+			// If we added it, we'd get: /base/FolderName/FolderName/file.mkv (duplicate)
+			foreach($info['files'] as $file)
+			{
+				if(!isset($file['path']) || !is_array($file['path']))
+					continue;
+
+				// Build relative path within the torrent folder (without the folder name prefix)
+				$rel = implode('/', $file['path']);
+				// Guard against path traversal
+				if(strpos($rel,'..')!==false)
+					continue;
+				$paths[] = $rel;
+			}
+		}
+		// Single-file mode
+		elseif(isset($info['name']))
+		{
+			if(strpos($info['name'],'..')===false)
+				$paths[] = $info['name'];
+		}
+
+		// Remove possible duplicates
+		return array_values(array_unique($paths));
+	}
+
+	// Helper function to remove empty subdirectories recursively
+	static private function removeEmptySubFolders($path, $baseAbs)
+	{
+		if(empty($path) || $path == $baseAbs)
+			return;
+
+		$dir = dirname($path);
+		// Ensure we're still inside the base directory
+		if(strpos(FileUtil::addslash($dir), $baseAbs) !== 0 || $dir == $baseAbs)
+			return;
+
+		if(is_dir($dir))
+		{
+			// scandir can return false (permissions, etc.), which causes TypeError in array_diff in PHP 8
+			$scanned = @scandir($dir);
+			if(is_array($scanned))
+			{
+				$files = array_diff($scanned, array('.', '..'));
+				if(empty($files))
+				{
+					@rmdir($dir);
+					// Recursively go up
+					self::removeEmptySubFolders($dir, $baseAbs);
+				}
+			}
+		}
+	}
+
+	// Remove files from the old torrent that are absent in the new one (to avoid duplicates after rename).
+	// Runs only after the new torrent is successfully loaded and the old one erased.
+	static private function cleanupObsoleteFiles($oldTorrent, $newTorrent, $baseDir)
+	{
+		self::logDebug("cleanupObsoleteFiles: Starting cleanup. BaseDir: " . $baseDir);
+
+		if(empty($baseDir) || !is_object($oldTorrent) || !is_object($newTorrent)) {
+			self::logDebug("cleanupObsoleteFiles: Invalid arguments or objects.");
+			return;
+		}
+
+		$oldPaths = self::collectTorrentPaths($oldTorrent);
+		if(empty($oldPaths)) {
+			self::logDebug("cleanupObsoleteFiles: No files found in old torrent.");
+			return;
+		}
+
+		$newPaths = self::collectTorrentPaths($newTorrent);
+		$missing = array_diff($oldPaths, $newPaths);
+
+		self::logDebug("cleanupObsoleteFiles: Old files count: " . count($oldPaths));
+		self::logDebug("cleanupObsoleteFiles: New files count: " . count($newPaths));
+		self::logDebug("cleanupObsoleteFiles: Missing files count: " . count($missing));
+
+		if(empty($missing)) {
+			self::logDebug("cleanupObsoleteFiles: No missing files to delete.");
+			return;
+		}
+
+		$baseAbs = FileUtil::addslash(FileUtil::fullpath($baseDir));
+		if(empty($baseAbs)) {
+			self::logDebug("cleanupObsoleteFiles: Could not resolve absolute base path.");
+			return;
+		}
+		self::logDebug("cleanupObsoleteFiles: Absolute base path: " . $baseAbs);
+
+		foreach($missing as $relPath)
+		{
+			// Build an absolute path inside the data directory and ensure it doesn't escape it.
+			$absolute = FileUtil::fullpath($relPath, $baseAbs);
+
+			// Security check
+			if(strpos(FileUtil::addslash($absolute), $baseAbs) !== 0) {
+				self::logDebug("cleanupObsoleteFiles: Security check failed for path: " . $absolute);
+				continue;
+			}
+
+			if(is_file($absolute))
+			{
+				self::logDebug("cleanupObsoleteFiles: Attempting to delete file: " . $absolute);
+				if(@unlink($absolute))
+				{
+					self::logDebug("cleanupObsoleteFiles: Successfully deleted: " . $absolute);
+					// Try to remove parent folder if it became empty
+					self::removeEmptySubFolders($absolute, $baseAbs);
+				} else {
+					self::logDebug("cleanupObsoleteFiles: Failed to delete file (unlink returned false): " . $absolute);
+				}
+			} else {
+				self::logDebug("cleanupObsoleteFiles: File not found or not a file: " . $absolute);
+			}
+		}
+		self::logDebug("cleanupObsoleteFiles: Cleanup finished.");
 	}
 
 	static public function createTorrent($torrent, $hash){
@@ -87,6 +240,11 @@ class ruTrackerChecker
 		if( $torrent->errors() ) return self::STE_DELETED;
 
 		if( $torrent->hash_info()==$hash ) return self::STE_UPTODATE;
+
+		// Keep the current torrent to compare file lists for cleanup after successful replacement.
+		// If loading the new torrent fails, the old files remain untouched.
+		$oldTorrent = rTorrent::getSource($hash);
+
 		$req =  new rXMLRPCRequest( array(
 			new rXMLRPCCommand("d.get_directory_base",$hash),
 			new rXMLRPCCommand("d.get_custom1",$hash),
@@ -100,6 +258,7 @@ class ruTrackerChecker
 		));
 
 		if($req->success()){
+			$baseDir = $req->val[0];
 			$addition = array(
 				getCmd("d.set_connection_seed=").$req->val[3],
 				getCmd("d.set_custom")."=chk-state,".self::STE_UPDATED,
@@ -109,15 +268,20 @@ class ruTrackerChecker
 			$isStart = (($req->val[4]!=0) && ($req->val[5]!=0) && ($req->val[6]!=0));
 			if(!empty($req->val[2]))
 				$addition[] = getCmd("d.set_throttle_name=").$req->val[2];
-			if(preg_match('/rat_(\d+)/',$req->val[3],$ratio))
-				$addition[] = getCmd("view.set_visible=")."rat_".$ratio;
+			// Preserve ratio-group view if it was set (values like "rat_1", "rat_5" etc).
+			// Check if regex matched and index exists
+			if(preg_match('/rat_(\d+)/',$req->val[3],$ratio) && isset($ratio[1]))
+				$addition[] = getCmd("view.set_visible=")."rat_".$ratio[1];
 			$label = rawurldecode($req->val[1]);
-			if(rTorrent::sendTorrent($torrent, $isStart, false, $req->val[0],
+			if(rTorrent::sendTorrent($torrent, $isStart, false, $baseDir,
 				$label, $saveUploadedTorrents, false, true, $addition))
 			{
 				$req = new rXMLRPCRequest( new rXMLRPCCommand("d.erase", $hash ) );
-				if($req->success())
+				if($req->success()){
+					self::cleanupObsoleteFiles($oldTorrent, $torrent, $baseDir);
+					// Successful .torrent replacement: new torrent state is already set via $addition
 					return null;
+				}
 			}
 		}
 		return self::STE_ERROR;
@@ -126,24 +290,74 @@ class ruTrackerChecker
 	static public function run_ex($hash, $fname){
 		$torrent = new Torrent( $fname );
 		if(!$torrent->errors()){
-			foreach (self::$TRACKERS as $key => $value)
+			// Get both announce URL and comment for matching
+			$announce = $torrent->announce();
+			$comment = $torrent->comment();
+
+			foreach (self::$TRACKERS as $pattern => $handler)
 			{
-				if( preg_match($key, $torrent->comment()) )
+				$matchedUrl = null;
+
+				// First check comment: usually contains topic URL (e.g., viewtopic.php?t=...)
+				if( preg_match($pattern, $comment) )
 				{
-					return call_user_func($value, $torrent->comment(), $hash, $torrent);
+					$matchedUrl = $comment;
+				}
+				// If not found in comment, try announce
+				elseif( preg_match($pattern, $announce) )
+				{
+					$matchedUrl = $announce;
+				}
+
+				if($matchedUrl !== null)
+				{
+					return call_user_func($handler, $matchedUrl, $hash, $torrent);
 				}
 			}
 		}
 		return self::STE_NOT_NEED;
 	}
 
+	/**
+	 * Simple plugin logger.
+	 * Writes to /tmp/rutracker_check.log
+	 */
+	static public function logDebug($message)
+	{
+		$logFile = '/tmp/rutracker_check.log';
+		$logDir = dirname($logFile);
+
+		// Protection: verify permissions before attempting to write
+		$canWrite = file_exists($logFile) ? is_writable($logFile) : is_writable($logDir);
+
+		if($canWrite)
+		{
+			$line = '[' . gmdate('Y-m-d H:i:s') . '] ' . $message . PHP_EOL;
+			@file_put_contents($logFile, $line, FILE_APPEND);
+		}
+	}
+
 	static public function makeClient( $url, $method="GET", $content_type="", $body="" )
 	{
 		$client = new Snoopy();
 		$client->read_timeout = 5;
-		$client->_fp_timeout = 5;
-		@$client->fetchComplex($url,$method,$content_type,$body);
-		return($client);
+		$client->_fp_timeout  = 5;
+
+		// Pretend to be a modern browser to reduce 403/anti-bot errors
+		$client->agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+		               . "AppleWebKit/537.36 (KHTML, like Gecko) "
+		               . "Chrome/120.0.0.0 Safari/537.36";
+
+		// Suppress Snoopy errors with @, but log status on failure
+		@$client->fetchComplex($url, $method, $content_type, $body);
+
+		// Convention: plugins consider status < 0 as "tracker unreachable"
+		if($client->status < 0)
+		{
+			self::logDebug("Snoopy fetch failed: url=".$url." status=".$client->status);
+		}
+
+		return $client;
 	}
 
 	static public function run( $hash, $state = null, $time = null, $successful_time = null, $label = null )
@@ -152,7 +366,9 @@ class ruTrackerChecker
 
 		if(is_null($state)) self::getState( $hash, $state, $time, $successful_time, $label );
 
-		if (!is_null($label) && in_array($label, $ignoreLabels)) {
+		// Skip torrent if its label is in the ignore list
+		if(!is_null($label) && isset($ignoreLabels) && is_array($ignoreLabels) && in_array($label, $ignoreLabels))
+		{
 			$state = self::STE_IGNORED;
 			self::setState($hash, $state);
 			return(true);
@@ -164,7 +380,16 @@ class ruTrackerChecker
 			$state = self::STE_INPROGRESS;
 			if(!self::setState( $hash, $state )) return(false);
 
-			$fname = rTorrentSettings::get()->session.$hash.".torrent";
+			// Main path: via rTorrentSettings
+			if(class_exists('rTorrentSettings') && method_exists('rTorrentSettings', 'get'))
+			{
+				$fname = rTorrentSettings::get()->session.$hash.".torrent";
+			}
+			else
+			{
+				// Fallback for non-standard configurations
+				$fname = getSettingsPath().'/session/'.$hash.".torrent";
+			}
 
 			if(is_readable($fname))	$state = self::run_ex($hash, $fname);
 			if($state==self::STE_INPROGRESS) $state=self::STE_ERROR;

--- a/plugins/rutracker_check/conf.php
+++ b/plugins/rutracker_check/conf.php
@@ -2,3 +2,4 @@
 
 $updateInterval 	= 60;	// in minutes, zero for disable
 $ignoreLabels 	= ['tv-sonarr', 'radarr'];	// list of labels to ignore
+$rutrackerCheckDebug = false;	// write diagnostic messages to the configured ruTorrent log

--- a/plugins/rutracker_check/trackers/nnmclub.php
+++ b/plugins/rutracker_check/trackers/nnmclub.php
@@ -1,26 +1,854 @@
 <?php
 
+/**
+ * NNMClub Torrent Checker — Cloudflare-Resilient Override
+ *
+ * This file overrides the upstream trackers/nnmclub.php to work around
+ * Cloudflare Turnstile CAPTCHA protection on NNMClub's website.
+ *
+ * ## Background
+ *
+ * NNMClub (nnmclub.to) is a BitTorrent tracker forum based on phpBB.
+ * The upstream checker fetches the topic page (viewtopic.php) and looks for
+ * a magnet `btih:` hash in the HTML to detect torrent updates. However,
+ * NNMClub is now behind Cloudflare Turnstile, which blocks automated logins
+ * via the `loginmgr` plugin. Without authentication, the topic page is
+ * served as a "guest" page (~16 KB) that does NOT contain the btih hash.
+ * This causes the upstream code to always return STE_DELETED (false positive).
+ *
+ * ## Key Discoveries
+ *
+ * 1. The guest page DOES contain a `download.php?id=...` link.
+ * 2. The `download.php` endpoint is NOT behind Cloudflare and returns
+ *    a valid .torrent file (~521 KB) even for unauthenticated requests.
+ * 3. Guest-downloaded torrents contain a dummy passkey (`ffffffff...`)
+ *    in the announce URL instead of the user's real passkey.
+ * 4. The BitTorrent tracker (bt02.nnm-club.cc:2710) is NOT behind
+ *    Cloudflare and responds to scrape requests directly.
+ * 5. NNMClub passkeys are per-user (not per-torrent): any passkey from
+ *    the same user account works for scraping any torrent.
+ *
+ * ## Two-Phase Algorithm
+ *
+ * Phase 1 — Tracker Scrape (fast, ~67 bytes response):
+ *   Scrapes bt02.nnm-club.cc directly with the user's passkey extracted
+ *   from an existing NNMClub torrent. If the current info_hash is found
+ *   in the scrape response, the torrent is up-to-date. This handles
+ *   ~99% of checks with minimal bandwidth.
+ *   Note: Dummy/guest passkeys (all-f's) are filtered out and never used.
+ *
+ * Phase 2 — Guest Torrent Download (only if scrape says "not found"):
+ *   Downloads the guest .torrent from download.php, compares its info_hash
+ *   with the current hash. If they differ, the torrent was updated on NNMClub.
+ *   The dummy passkey in the downloaded torrent is patched with the real one
+ *   before handing it to createTorrent() for replacement.
+ *
+ * ## Session Patching
+ *
+ * If a torrent in the rtorrent session lacks a passkey in its announce URL
+ * (e.g., previously downloaded without authentication), and a donor passkey
+ * is found from another NNMClub torrent, the session .torrent file is patched
+ * using the Torrent class.  libtorrent_resume and rtorrent metadata are
+ * preserved so fast-resume works correctly after restart.
+ *
+ * @see https://nnmclub.to  NNMClub tracker forum
+ */
+
 class NNMClubCheckImpl
 {
-    static public function download_torrent($url, $hash, $old_torrent)
+    private const DEFAULT_USER_AGENT =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+      . "AppleWebKit/537.36 (KHTML, like Gecko) "
+      . "Chrome/120.0.0.0 Safari/537.36";
+
+    /**
+     * Tracker hostnames for scrape requests (NOT behind Cloudflare).
+     * If the first host fails, the next is tried.
+     */
+    private const TRACKER_HOSTS = ['bt02.nnm-club.cc', 'bt02.nnm-club.info'];
+    private const TRACKER_PORT  = 2710;
+
+    /**
+     * Default site domain for viewtopic/download requests.
+     * Used as fallback when the domain from comment URL is not available.
+     */
+    private const SITE_DOMAIN = 'nnmclub.to';
+
+    /**
+     * Explicit allowlist for topic hosts to avoid requesting arbitrary domains.
+     */
+    private const TOPIC_HOSTS = [
+        'nnmclub.ru',
+        'nnmclub.me',
+        'nnmclub.to',
+        'nnmclub.name',
+        'nnmclub.tv',
+        'nnm-club.ru',
+        'nnm-club.me',
+        'nnm-club.to',
+        'nnm-club.name',
+        'nnm-club.tv',
+    ];
+
+    /**
+     * Regex to match dummy/guest passkeys that must be ignored.
+     * Guest downloads produce all-f's; all-zeros is another degenerate case.
+     */
+    private const DUMMY_PASSKEY_RE = '/^(?:f{32}|0{32})$/i';
+
+    /**
+     * Regex fragment for NNMClub hostnames in announce URLs.
+     * Port is optional to support URLs with implicit default ports.
+     */
+    private const ANNOUNCE_HOST_RE = '(?:nnm-club|nnmclub)\.\w+(?::\d+)?';
+
+    /**
+     * Regex to extract a 32-character hex passkey from an NNMClub announce URL.
+     * Supports both domain formats: nnm-club.* and nnmclub.*.
+     */
+    private const TOKEN_RE = '`' . self::ANNOUNCE_HOST_RE . '/([0-9a-f]{32})/announce`i';
+
+    private const SCRAPE_RESULT_UPTODATE = 1;
+    private const SCRAPE_RESULT_NOT_FOUND = 2;
+    private const SCRAPE_RESULT_FAILED = 3;
+
+    /** @var string|null Cached rtorrent session directory path */
+    private static $sessionDirCache = null;
+
+    /** @var bool True once session dir lookup has been attempted */
+    private static $sessionDirCacheLoaded = false;
+
+    /** @var bool True once donor passkey lookup has been attempted */
+    private static $donorPasskeyCacheLoaded = false;
+
+    /** @var string|null Cached donor passkey (null means not found) */
+    private static $donorPasskeyCache = null;
+
+    // ====================================================================
+    // Logging
+    // ====================================================================
+
+    /**
+     * Log a message through ruTrackerChecker::logDebug().
+     * @param string $message  Message (auto-prefixed with [NNMClub])
+     */
+    private static function log($message)
     {
-        if (preg_match('`^https?://(nnm-club|nnmclub)\.(ru|me|to|name|tv)/forum/viewtopic\.php\?p=(?P<id>\d+)$`', $url, $matches)) {
-            $client = ruTrackerChecker::makeClient("https://nnmclub.to/forum/viewtopic.php?p=".$matches["id"]);
-            if ($client->status != 200) return ruTrackerChecker::STE_CANT_REACH_TRACKER;
-            if (preg_match('`btih:(?P<hash>[0-9A-Fa-f]{40})`', $client->results, $matches)) {
-                if (strtoupper($matches["hash"])==$hash) {
-                    return  ruTrackerChecker::STE_UPTODATE;
+        ruTrackerChecker::logDebug('[NNMClub] ' . $message);
+    }
+
+    /**
+     * Build a plain Snoopy client for "guest mode" requests.
+     * Intentionally uses fetch() (not fetchComplex()) to bypass loginmgr logic.
+     *
+     * @return Snoopy
+     */
+    private static function makeGuestClient()
+    {
+        $client = new Snoopy();
+        $client->read_timeout = 5;
+        $client->_fp_timeout = 5;
+        $client->agent = self::DEFAULT_USER_AGENT;
+        return $client;
+    }
+
+    /**
+     * Execute a single guest HTTP request with logging for transport failures.
+     *
+     * @param  Snoopy $client
+     * @param  string $url
+     * @param  string $method
+     * @param  string $contentType
+     * @param  string $body
+     * @return void
+     */
+    private static function guestFetch($client, $url, $method = "GET", $contentType = "", $body = "")
+    {
+        @$client->fetch($url, $method, $contentType, $body);
+        if ($client->status < 0) {
+            self::log("Guest fetch failed: url={$url} status={$client->status}");
+        }
+    }
+
+    /**
+     * Detect common anti-bot/challenge pages where download link is absent.
+     *
+     * @param  string $html
+     * @return bool
+     */
+    private static function looksLikeChallengePage($html)
+    {
+        return is_string($html)
+            && $html !== ''
+            && (bool) preg_match('/cf-chl|turnstile|captcha|cloudflare|just a moment|challenge-platform/i', $html);
+    }
+
+    /**
+     * Parse and normalize an NNMClub viewtopic URL.
+     * Supports both ?p=... and ?t=... topic references.
+     *
+     * @param  string $url
+     * @return array|null ['host' => string, 'query' => string, 'id' => string]
+     */
+    private static function parseTopicRef($url)
+    {
+        if (!is_string($url) || $url === '') return null;
+
+        $parts = @parse_url(trim($url));
+        if (!is_array($parts)) return null;
+
+        if (isset($parts['scheme']) && !preg_match('`^https?$`i', $parts['scheme'])) {
+            return null;
+        }
+
+        $hostOnly = isset($parts['host']) ? strtolower($parts['host']) : self::SITE_DOMAIN;
+        if (!self::isAllowedTopicHost($hostOnly)) {
+            return null;
+        }
+        $host = $hostOnly;
+
+        if (isset($parts['port'])) {
+            $port = (int) $parts['port'];
+            if ($port < 1 || $port > 65535) return null;
+            $host .= ':' . $port;
+        }
+
+        $path = isset($parts['path']) ? $parts['path'] : '';
+        if (!preg_match('`^/forum/viewtopic\.php/?$`i', $path)) {
+            return null;
+        }
+
+        $query = [];
+        parse_str(isset($parts['query']) ? $parts['query'] : '', $query);
+
+        foreach (['p', 't'] as $param) {
+            if (array_key_exists($param, $query) && ctype_digit((string) $query[$param])) {
+                return [
+                    'host' => $host,
+                    'query' => $param . '=' . $query[$param],
+                    'id' => (string) $query[$param],
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Validate topic host against a strict allowlist.
+     *
+     * @param  string $host
+     * @return bool
+     */
+    private static function isAllowedTopicHost($host)
+    {
+        return in_array($host, self::TOPIC_HOSTS, true);
+    }
+
+    // ====================================================================
+    // Passkey Discovery
+    // ====================================================================
+
+    /**
+     * Extract a real 32-hex passkey from an announce URL or announce-list.
+     * Dummy/guest passkeys (all-f's, all-zeros) are filtered out.
+     *
+     * @param  string|array|null $announce  Single URL, announce-list array, or null
+     * @return string|null  Lowercase 32-hex passkey, or null if not found / dummy
+     */
+    private static function extractPasskey($announce)
+    {
+        if ($announce === null) return null;
+
+        if (is_array($announce)) {
+            foreach ($announce as $tier) {
+                $urls = is_array($tier) ? $tier : [$tier];
+                foreach ($urls as $url) {
+                    $pk = self::extractPasskey($url);
+                    if ($pk !== null) return $pk;
                 }
-                if (preg_match('`\"download.php\?id=(?P<id>\d+)\"`', $client->results, $matches)) {
-                    $client->setcookies();
-                    $client->fetchComplex("https://nnmclub.to/forum/download.php?id=".$matches["id"]);
-                    if ($client->status != 200) return (($client->status < 0) ? ruTrackerChecker::STE_CANT_REACH_TRACKER : ruTrackerChecker::STE_DELETED);
-                    return ruTrackerChecker::createTorrent($client->results, $hash);
+            }
+            return null;
+        }
+
+        // Accept any string (URL or raw bencode data from findDonorPasskey)
+        if (!is_string($announce)) return null;
+
+        if (preg_match(self::TOKEN_RE, $announce, $m)) {
+            $pk = strtolower($m[1]);
+            if (preg_match(self::DUMMY_PASSKEY_RE, $pk)) {
+                return null;  // Reject dummy passkey
+            }
+            return $pk;
+        }
+        return null;
+    }
+
+    /**
+     * Scan rtorrent session directory for any NNMClub torrent with a real passkey.
+     *
+     * Since NNMClub passkeys are per-user (all interchangeable), we can
+     * borrow a passkey from ANY NNMClub torrent belonging to the same user.
+     *
+     * Optimization: reads only the first 4 KB for quick rejection and
+     * passkey extraction before falling back to full file read.
+     *
+     * @return string|null  32-hex passkey from a donor torrent, or null
+     */
+    private static function findDonorPasskey()
+    {
+        if (self::$donorPasskeyCacheLoaded) {
+            self::log("Using cached donor passkey lookup result");
+            return self::$donorPasskeyCache;
+        }
+
+        $sessionDir = self::getSessionDir();
+        if ($sessionDir === null) return self::cacheDonorPasskey(null);
+
+        $sessionDir = rtrim($sessionDir, '/');
+        if ($sessionDir === '') {
+            self::log("Invalid session dir from get_session, skipping donor passkey lookup");
+            return self::cacheDonorPasskey(null);
+        }
+
+        $files = @glob($sessionDir . '/*.torrent');
+        if (!$files) {
+            self::log("No session torrents found for donor passkey lookup");
+            return self::cacheDonorPasskey(null);
+        }
+
+        foreach ($files as $path) {
+            // Quick rejection: check first 4 KB for NNMClub signature
+            $head = @file_get_contents($path, false, null, 0, 4096);
+            if ($head === false
+                || (stripos($head, 'nnm-club') === false
+                    && stripos($head, 'nnmclub') === false)) {
+                continue;
+            }
+
+            // Passkey is usually near the beginning of the bencoded data.
+            // Try head first, then full file only when needed.
+            $pk = self::extractPasskey($head);
+            if ($pk !== null) {
+                return self::cacheDonorPasskey($pk);
+            }
+
+            if (strlen($head) >= 4096) {
+                $full = @file_get_contents($path);
+                if ($full !== false) {
+                    $pk = self::extractPasskey($full);
+                    if ($pk !== null) {
+                        return self::cacheDonorPasskey($pk);
+                    }
                 }
             }
         }
-        return ruTrackerChecker::STE_NOT_NEED;
+        self::log("Donor passkey not found in session torrents");
+        return self::cacheDonorPasskey(null);
+    }
+
+    /**
+     * Save donor passkey lookup result in cache.
+     *
+     * @param  string|null $passkey  Found passkey or null if absent
+     * @return string|null
+     */
+    private static function cacheDonorPasskey($passkey)
+    {
+        self::$donorPasskeyCacheLoaded = true;
+        self::$donorPasskeyCache = $passkey;
+        return $passkey;
+    }
+
+    /**
+     * Get rtorrent session directory via XMLRPC (result is cached).
+     * @return string|null  Session directory path, or null on failure
+     */
+    private static function getSessionDir()
+    {
+        if (self::$sessionDirCacheLoaded) {
+            return self::$sessionDirCache;
+        }
+
+        self::$sessionDirCacheLoaded = true;
+
+        $req = new rXMLRPCRequest(new rXMLRPCCommand("get_session"));
+        if ($req->run() && !$req->fault && !empty($req->val[0])) {
+            self::$sessionDirCache = $req->val[0];
+            return self::$sessionDirCache;
+        }
+
+        self::$sessionDirCache = null;
+        self::log("Failed to resolve rtorrent session directory via get_session");
+        return null;
+    }
+
+    // ====================================================================
+    // Session Torrent Patching
+    // ====================================================================
+
+    /**
+     * Patch announce URLs in the session .torrent file to include passkey.
+     *
+     * Uses the Torrent class for clean bencode parsing and serialization.
+     * Preserves libtorrent_resume and rtorrent metadata so that
+     * fast-resume works correctly after rtorrent restart.
+     *
+     * @param  string $hash     Info hash (hex, uppercase)
+     * @param  string $passkey  32-hex passkey to inject
+     * @return bool   True if the file was patched and saved
+     */
+    private static function patchSessionTorrent($hash, $passkey)
+    {
+        $sessionDir = self::getSessionDir();
+        if ($sessionDir === null) {
+            self::log("patchSessionTorrent skipped: no session dir for {$hash}");
+            return false;
+        }
+
+        $path = rtrim($sessionDir, '/') . '/' . $hash . '.torrent';
+        if (!is_writable($path)) {
+            self::log("patchSessionTorrent skipped: not writable {$path}");
+            return false;
+        }
+
+        $torrent = new Torrent($path);
+        if ($torrent->errors()) {
+            self::log("patchSessionTorrent failed: unreadable torrent {$path}");
+            return false;
+        }
+
+        $changed = self::patchPasskeyInTorrent($torrent, $passkey);
+        if (!$changed) {
+            self::log("patchSessionTorrent no-op for {$hash}: no announce URLs to patch");
+            return false;
+        }
+
+        // NOTE: We intentionally preserve libtorrent_resume and rtorrent
+        // metadata — they are needed for fast-resume after rtorrent restart.
+        // Only the announce URLs are modified (outside the info dict),
+        // so the info_hash and resume data remain valid.
+
+        $saved = (bool) $torrent->save($path);
+        self::log("patchSessionTorrent " . ($saved ? "saved" : "failed to save") . " for {$hash}");
+        return $saved;
+    }
+
+    /**
+     * Patch NNMClub announce URLs inside a Torrent object.
+     *
+     * @param  Torrent $torrent
+     * @param  string  $passkey
+     * @return bool  True when at least one URL was changed
+     */
+    private static function patchPasskeyInTorrent($torrent, $passkey)
+    {
+        $announceChanged = false;
+        $listChanged = false;
+
+        $announce = $torrent->announce();
+        if (is_string($announce) && $announce !== '') {
+            $patched = self::injectPasskeyIntoUrl($announce, $passkey);
+            if ($patched !== $announce) {
+                $torrent->announce($patched);
+                $announceChanged = true;
+            }
+        }
+
+        $list = $torrent->announce_list();
+        if (is_array($list)) {
+            $newList = [];
+            foreach ($list as $tier) {
+                $newTier = [];
+                $urls = is_array($tier) ? $tier : [$tier];
+                foreach ($urls as $url) {
+                    $patchedUrl = is_string($url)
+                        ? self::injectPasskeyIntoUrl($url, $passkey)
+                        : $url;
+                    if ($patchedUrl !== $url) {
+                        $listChanged = true;
+                    }
+                    $newTier[] = $patchedUrl;
+                }
+                $newList[] = $newTier;
+            }
+            if ($listChanged) {
+                $torrent->announce_list($newList);
+            }
+        }
+
+        return $announceChanged || $listChanged;
+    }
+
+    /**
+     * Inject a passkey into an NNMClub announce URL.
+     * Supports both nnm-club.* and nnmclub.* domain formats.
+     * Non-NNMClub URLs are returned unchanged.
+     *
+     * @param  string $url      Announce URL
+     * @param  string $passkey  32-hex passkey to inject
+     * @return string  Modified URL (or original if not NNMClub)
+     */
+    private static function injectPasskeyIntoUrl($url, $passkey)
+    {
+        $hostGroup = '(' . self::ANNOUNCE_HOST_RE . ')';
+        $result = preg_replace(
+            '`' . $hostGroup . '/(?:[0-9a-f]{32}/)?announce`i',
+            '$1/' . $passkey . '/announce',
+            $url,
+            1,
+            $count
+        );
+        if ($count > 0 && $result !== null) {
+            return $result;
+        }
+
+        return $url;
+    }
+
+    // ====================================================================
+    // Tracker Scrape
+    // ====================================================================
+
+    /**
+     * Decode one bencoded value from $data starting at $offset.
+     *
+     * @param  string $data
+     * @param  int    $offset
+     * @return mixed
+     * @throws Exception
+     */
+    private static function decodeBencodeValue($data, &$offset)
+    {
+        if (!isset($data[$offset])) {
+            throw new Exception("Unexpected EOF at offset {$offset}");
+        }
+
+        $token = $data[$offset];
+        if ($token >= '0' && $token <= '9') {
+            return self::decodeBencodeString($data, $offset);
+        }
+
+        if ($token === 'i') {
+            $offset++;
+            $end = strpos($data, 'e', $offset);
+            if ($end === false) {
+                throw new Exception("Invalid integer at offset {$offset}");
+            }
+            $num = substr($data, $offset, $end - $offset);
+            if ($num === '' || !preg_match('/^-?\d+$/', $num)) {
+                throw new Exception("Invalid integer value at offset {$offset}");
+            }
+            $offset = $end + 1;
+            return (int) $num;
+        }
+
+        if ($token === 'l') {
+            $offset++;
+            $list = [];
+            while (isset($data[$offset]) && $data[$offset] !== 'e') {
+                $list[] = self::decodeBencodeValue($data, $offset);
+            }
+            if (!isset($data[$offset])) {
+                throw new Exception("Unterminated list at offset {$offset}");
+            }
+            $offset++;
+            return $list;
+        }
+
+        if ($token === 'd') {
+            $offset++;
+            $dict = [];
+            while (isset($data[$offset]) && $data[$offset] !== 'e') {
+                $key = self::decodeBencodeString($data, $offset);
+                $dict[$key] = self::decodeBencodeValue($data, $offset);
+            }
+            if (!isset($data[$offset])) {
+                throw new Exception("Unterminated dict at offset {$offset}");
+            }
+            $offset++;
+            return $dict;
+        }
+
+        throw new Exception("Unknown token '{$token}' at offset {$offset}");
+    }
+
+    /**
+     * Decode one bencoded byte string from $data starting at $offset.
+     *
+     * @param  string $data
+     * @param  int    $offset
+     * @return string
+     * @throws Exception
+     */
+    private static function decodeBencodeString($data, &$offset)
+    {
+        $colon = strpos($data, ':', $offset);
+        if ($colon === false) {
+            throw new Exception("Invalid string length at offset {$offset}");
+        }
+
+        $lenRaw = substr($data, $offset, $colon - $offset);
+        if ($lenRaw === '' || preg_match('/\D/', $lenRaw)) {
+            throw new Exception("Invalid string size '{$lenRaw}' at offset {$offset}");
+        }
+
+        $len = (int) $lenRaw;
+        $offset = $colon + 1;
+        if (($offset + $len) > strlen($data)) {
+            throw new Exception("String out of bounds at offset {$offset}");
+        }
+
+        $value = substr($data, $offset, $len);
+        $offset += $len;
+        return $value;
+    }
+
+    /**
+     * Parse scrape bencode and check whether "files" contains $binaryHash key.
+     *
+     * @param  string $payload
+     * @param  string $binaryHash  Raw 20-byte hash
+     * @return bool|null  true: found, false: not found, null: parse error
+     */
+    private static function scrapeContainsHash($payload, $binaryHash)
+    {
+        if (!is_string($payload) || !is_string($binaryHash) || strlen($binaryHash) !== 20) {
+            return false;
+        }
+
+        try {
+            $offset = 0;
+            $root = self::decodeBencodeValue($payload, $offset);
+        } catch (Exception $e) {
+            self::log("Scrape parse failed: " . $e->getMessage());
+            return null;
+        }
+
+        return is_array($root)
+            && isset($root['files'])
+            && is_array($root['files'])
+            && array_key_exists($binaryHash, $root['files']);
+    }
+
+    /**
+     * Scrape the NNMClub tracker to check if a hash is registered.
+     *
+     * Uses Snoopy (via makeClient) for consistency with the rest of the
+     * plugin (respects proxy settings, bind IP, timeouts).
+     * Tries all configured TRACKER_HOSTS with fallback on failure.
+     *
+     * @param  string $passkey  32-hex passkey for tracker auth
+     * @param  string $hash     Info hash (hex, uppercase, 40 chars)
+     * @return int  One of SCRAPE_RESULT_* constants
+     */
+    private static function checkViaScrape($passkey, $hash)
+    {
+        $binary = @pack('H*', $hash);
+        if (strlen($binary) !== 20) {
+            self::log("Scrape skipped: invalid info hash format {$hash}");
+            return self::SCRAPE_RESULT_FAILED;
+        }
+
+        $sawNotFound = false;
+
+        foreach (self::TRACKER_HOSTS as $host) {
+            $url = 'http://' . $host . ':' . self::TRACKER_PORT
+                 . '/' . $passkey . '/scrape?info_hash=' . rawurlencode($binary);
+
+            $client = ruTrackerChecker::makeClient($url);
+
+            if ($client->status == 200
+                && is_string($client->results)
+                && $client->results !== '') {
+                $hashState = self::scrapeContainsHash($client->results, $binary);
+                if ($hashState === true) {
+                    return self::SCRAPE_RESULT_UPTODATE;
+                }
+                if ($hashState === null) {
+                    self::log("Scrape response parse error on {$host}");
+                    continue;
+                }
+                self::log("Scrape response OK on {$host}, hash {$hash} not found");
+                $sawNotFound = true;
+                continue;
+            }
+            self::log("Scrape failed on {$host}: status={$client->status}");
+        }
+
+        return $sawNotFound
+            ? self::SCRAPE_RESULT_NOT_FOUND
+            : self::SCRAPE_RESULT_FAILED;
+    }
+
+    // ====================================================================
+    // Formatting
+    // ====================================================================
+
+    /**
+     * Convert result values to readable log-safe strings.
+     *
+     * @param  mixed $value
+     * @return string
+     */
+    private static function stringify($value)
+    {
+        if ($value === null) return 'null';
+        if ($value === true) return 'true';
+        if ($value === false) return 'false';
+        if (is_int($value) || is_float($value) || is_string($value)) {
+            return (string) $value;
+        }
+        return gettype($value);
+    }
+
+    // ====================================================================
+    // Main Entry Point
+    // ====================================================================
+
+    /**
+     * Check whether an NNMClub torrent needs updating.
+     *
+     * @param  string  $url         Topic URL (viewtopic.php?p=... or ?t=...)
+     * @param  string  $hash        Current info hash (hex, uppercase, 40 chars)
+     * @param  Torrent $old_torrent Current torrent object (from session)
+     * @return int     One of ruTrackerChecker::STE_* constants
+     */
+    public static function download_torrent($url, $hash, $old_torrent)
+    {
+        $hash = strtoupper((string) $hash);
+
+        // Prefer matched URL, but fallback to torrent comment if handler was
+        // invoked via announce URL.
+        $topicRef = self::parseTopicRef($url);
+        if ($topicRef === null && is_object($old_torrent)) {
+            $topicRef = self::parseTopicRef($old_torrent->comment());
+        }
+        if ($topicRef === null) {
+            self::log("Skip check: unable to parse NNMClub topic reference from URL/comment");
+            return ruTrackerChecker::STE_NOT_NEED;
+        }
+        $siteDomain = $topicRef['host'];
+        $topicQuery = $topicRef['query'];
+        self::log("Start check for {$hash} using {$siteDomain}/forum/viewtopic.php?{$topicQuery}");
+
+        // =============================================================
+        // PASSKEY DISCOVERY
+        // =============================================================
+
+        $passkey = self::extractPasskey($old_torrent->announce())
+                ?? self::extractPasskey($old_torrent->announce_list());
+        if ($passkey !== null) {
+            self::log("Using passkey from current torrent metadata");
+        }
+
+        if ($passkey === null) {
+            $passkey = self::findDonorPasskey();
+            if ($passkey !== null) {
+                self::log("Found donor passkey, patching session torrent {$hash}");
+                if (!self::patchSessionTorrent($hash, $passkey)) {
+                    self::log("Session patch attempt finished without file changes for {$hash}");
+                }
+            } else {
+                self::log("No passkey found for {$hash}, skipping scrape");
+            }
+        }
+
+        // =============================================================
+        // PHASE 1: TRACKER SCRAPE (fast path)
+        // =============================================================
+
+        if ($passkey !== null) {
+            $scrapeResult = self::checkViaScrape($passkey, $hash);
+            if ($scrapeResult === self::SCRAPE_RESULT_UPTODATE) {
+                return ruTrackerChecker::STE_UPTODATE;
+            }
+            if ($scrapeResult === self::SCRAPE_RESULT_FAILED) {
+                self::log("All scrape hosts failed for {$hash}");
+            }
+            if ($scrapeResult === self::SCRAPE_RESULT_NOT_FOUND) {
+                self::log("Scrape did not find hash {$hash}, falling back to guest download");
+            }
+        }
+
+        // =============================================================
+        // PHASE 2: GUEST TORRENT DOWNLOAD
+        // =============================================================
+
+        // --- Step 1: Fetch guest topic page ---
+        $client = self::makeGuestClient();
+        self::guestFetch($client, "https://{$siteDomain}/forum/viewtopic.php?" . $topicQuery);
+        if ($client->status != 200) {
+            self::log("viewtopic fetch failed: status={$client->status}");
+            return ruTrackerChecker::STE_CANT_REACH_TRACKER;
+        }
+
+        // --- Step 2: btih shortcut (for authenticated sessions) ---
+        if (preg_match('`btih:(?P<hash>[0-9A-Fa-f]{40})`', $client->results, $btihMatch)) {
+            if (strtoupper($btihMatch['hash']) === $hash) {
+                return ruTrackerChecker::STE_UPTODATE;
+            }
+            self::log("Topic btih differs for {$topicQuery}, verifying via downloaded .torrent");
+        }
+
+        // --- Step 3: Find download link ---
+        if (!preg_match('`(?:/forum/)?download\.php\?id=(?P<dlid>\d+)`i', $client->results, $dlMatch)) {
+            if (self::looksLikeChallengePage($client->results)) {
+                self::log("No download link for {$topicQuery}: challenge page detected");
+                return ruTrackerChecker::STE_CANT_REACH_TRACKER;
+            }
+            self::log("No download link for {$topicQuery}: unexpected topic page format");
+            return ruTrackerChecker::STE_ERROR;
+        }
+        $downloadId = $dlMatch['dlid'];
+
+        // --- Step 4: Download guest .torrent ---
+        $client->setcookies();
+        self::guestFetch($client, "https://{$siteDomain}/forum/download.php?id=" . $downloadId);
+        if ($client->status != 200 || empty($client->results)) {
+            self::log("download.php failed: status={$client->status} id={$downloadId}");
+            return ($client->status < 0)
+                ? ruTrackerChecker::STE_CANT_REACH_TRACKER
+                : ruTrackerChecker::STE_ERROR;
+        }
+
+        $guestData = $client->results;
+
+        // --- Step 5: Compare info_hash ---
+        $guestTorrent = new Torrent($guestData);
+        if ($guestTorrent->errors()) {
+            self::log("Failed to parse downloaded torrent for {$topicQuery}");
+            return ruTrackerChecker::STE_ERROR;
+        }
+
+        $guestHash = strtoupper((string) $guestTorrent->hash_info());
+        if ($guestHash === $hash) {
+            self::log("Guest torrent hash matches current hash for {$topicQuery}");
+            return ruTrackerChecker::STE_UPTODATE;
+        }
+
+        // --- Step 6: Hash differs → torrent was updated ---
+        self::log("Hash changed for {$topicQuery}: {$hash} -> {$guestHash}");
+        if ($passkey === null) {
+            self::log("Hash differs but passkey is unavailable; refusing replacement");
+            return ruTrackerChecker::STE_ERROR;
+        }
+        if (!self::patchPasskeyInTorrent($guestTorrent, $passkey)) {
+            self::log("Hash differs but passkey patch found no NNMClub announce URLs");
+            return ruTrackerChecker::STE_ERROR;
+        }
+
+        $replaceResult = ruTrackerChecker::createTorrent((string) $guestTorrent, $hash);
+        self::log("createTorrent result for {$hash}: " . self::stringify($replaceResult));
+        return $replaceResult;
     }
 }
 
-ruTrackerChecker::registerTracker("/(nnm-club|nnmclub)\./", "/nnm-club\./", "NNMClubCheckImpl::download_torrent");
+// Register this tracker handler with ruTrackerChecker.
+// First regex: matches the torrent's comment URL.
+// Second regex: matches announce URLs containing "nnm-club" or "nnmclub".
+ruTrackerChecker::registerTracker(
+    "/(nnm-club|nnmclub)\./",
+    "/(nnm-club|nnmclub)\./",
+    "NNMClubCheckImpl::download_torrent"
+);

--- a/plugins/rutracker_check/trackers/nnmclub.php
+++ b/plugins/rutracker_check/trackers/nnmclub.php
@@ -1,82 +1,25 @@
 <?php
 
 /**
- * NNMClub Torrent Checker — Cloudflare-Resilient Override
+ * NNMClub handler, resilient to the Cloudflare Turnstile that now blocks
+ * loginmgr-based authentication (an unauthenticated topic page has no btih
+ * hash, which made the upstream checker report every torrent as deleted).
  *
- * This file overrides the upstream trackers/nnmclub.php to work around
- * Cloudflare Turnstile CAPTCHA protection on NNMClub's website.
- *
- * ## Background
- *
- * NNMClub (nnmclub.to) is a BitTorrent tracker forum based on phpBB.
- * The upstream checker fetches the topic page (viewtopic.php) and looks for
- * a magnet `btih:` hash in the HTML to detect torrent updates. However,
- * NNMClub is now behind Cloudflare Turnstile, which blocks automated logins
- * via the `loginmgr` plugin. Without authentication, the topic page is
- * served as a "guest" page (~16 KB) that does NOT contain the btih hash.
- * This causes the upstream code to always return STE_DELETED (false positive).
- *
- * ## Key Discoveries
- *
- * 1. The guest page DOES contain a `download.php?id=...` link.
- * 2. The `download.php` endpoint is NOT behind Cloudflare and returns
- *    a valid .torrent file (~521 KB) even for unauthenticated requests.
- * 3. Guest-downloaded torrents contain a dummy passkey (`ffffffff...`)
- *    in the announce URL instead of the user's real passkey.
- * 4. The BitTorrent tracker (bt02.nnm-club.cc:2710) is NOT behind
- *    Cloudflare and responds to scrape requests directly.
- * 5. NNMClub passkeys are per-user (not per-torrent): any passkey from
- *    the same user account works for scraping any torrent.
- *
- * ## Two-Phase Algorithm
- *
- * Phase 1 — Tracker Scrape (fast, ~67 bytes response):
- *   Scrapes bt02.nnm-club.cc directly with the user's passkey extracted
- *   from an existing NNMClub torrent. If the current info_hash is found
- *   in the scrape response, the torrent is up-to-date. This handles
- *   ~99% of checks with minimal bandwidth.
- *   Note: Dummy/guest passkeys (all-f's) are filtered out and never used.
- *
- * Phase 2 — Guest Torrent Download (only if scrape says "not found"):
- *   Downloads the guest .torrent from download.php, compares its info_hash
- *   with the current hash. If they differ, the torrent was updated on NNMClub.
- *   The dummy passkey in the downloaded torrent is patched with the real one
- *   before handing it to createTorrent() for replacement.
- *
- * ## Session Patching
- *
- * If a torrent in the rtorrent session lacks a passkey in its announce URL
- * (e.g., previously downloaded without authentication), and a donor passkey
- * is found from another NNMClub torrent, the session .torrent file is patched
- * using the Torrent class.  libtorrent_resume and rtorrent metadata are
- * preserved so fast-resume works correctly after restart.
- *
- * @see https://nnmclub.to  NNMClub tracker forum
+ * Phase 1: scrape the tracker endpoint derived from the torrent's announce
+ * URL — download.php and the tracker itself are not behind Cloudflare.
+ * Phase 2 (only when scrape says the hash is gone): download the guest
+ * .torrent from download.php and compare info hashes. Guest torrents carry a
+ * dummy credential; it is replaced with the reusable `uk` profile credential
+ * before the replacement is loaded. Path-style credentials belong to one
+ * distribution and are never transplanted to another torrent.
  */
 
 class NNMClubCheckImpl
 {
-    private const DEFAULT_USER_AGENT =
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-      . "AppleWebKit/537.36 (KHTML, like Gecko) "
-      . "Chrome/120.0.0.0 Safari/537.36";
-
-    /**
-     * Tracker hostnames for scrape requests (NOT behind Cloudflare).
-     * If the first host fails, the next is tried.
-     */
-    private const TRACKER_HOSTS = ['bt02.nnm-club.cc', 'bt02.nnm-club.info'];
-    private const TRACKER_PORT  = 2710;
-
-    /**
-     * Default site domain for viewtopic/download requests.
-     * Used as fallback when the domain from comment URL is not available.
-     */
+    /** Default site domain when the topic URL carries no host. */
     private const SITE_DOMAIN = 'nnmclub.to';
 
-    /**
-     * Explicit allowlist for topic hosts to avoid requesting arbitrary domains.
-     */
+    /** Explicit allowlist for topic hosts to avoid requesting arbitrary domains. */
     private const TOPIC_HOSTS = [
         'nnmclub.ru',
         'nnmclub.me',
@@ -91,91 +34,79 @@ class NNMClubCheckImpl
     ];
 
     /**
-     * Regex to match dummy/guest passkeys that must be ignored.
-     * Guest downloads produce all-f's; all-zeros is another degenerate case.
+     * Official tracker hosts that may receive a reusable profile credential.
+     * Keep this exact: matching an arbitrary nnmclub-like domain would leak it.
      */
+    private const TRACKER_HOSTS = [
+        'bt.searchtor.to',
+        'ipv6.bt.searchtor.to',
+        'nnm-club.ru',
+        'bt.nnm-club.ru',
+        'bt01.nnm-club.ru',
+        'bt02.nnm-club.ru',
+        'bt.ipv6.nnm-club.ru',
+        'bt01.ipv6.nnm-club.ru',
+        'bt02.ipv6.nnm-club.ru',
+        'nnm-club.cc',
+        'bt.nnm-club.cc',
+        'bt01.nnm-club.cc',
+        'bt02.nnm-club.cc',
+        'bt.ipv6.nnm-club.cc',
+        'bt01.ipv6.nnm-club.cc',
+        'bt02.ipv6.nnm-club.cc',
+        'nnm-club.info',
+        'bt.nnm-club.info',
+        'bt01.nnm-club.info',
+        'bt02.nnm-club.info',
+        'bt.ipv6.nnm-club.info',
+        'bt01.ipv6.nnm-club.info',
+        'bt02.ipv6.nnm-club.info',
+        'nnmclub.to',
+        'bt.nnmclub.to',
+        'bt.ipv6.nnmclub.to',
+        'ipv6.nnmclub.to',
+    ];
+
+    /** Dummy/guest passkeys that must never be treated as credentials. */
     private const DUMMY_PASSKEY_RE = '/^(?:f{32}|0{32})$/i';
 
-    /**
-     * Regex fragment for NNMClub hostnames in announce URLs.
-     * Port is optional to support URLs with implicit default ports.
-     */
-    private const ANNOUNCE_HOST_RE = '(?:nnm-club|nnmclub)\.\w+(?::\d+)?';
-
-    /**
-     * Regex to extract a 32-character hex passkey from an NNMClub announce URL.
-     * Supports both domain formats: nnm-club.* and nnmclub.*.
-     */
-    private const TOKEN_RE = '`' . self::ANNOUNCE_HOST_RE . '/([0-9a-f]{32})/announce`i';
+    private const TOKEN_RE = '/^[A-Za-z0-9]{32}$/D';
+    private const TRACKER_URL_RE = '`https?://[A-Za-z0-9.-]+(?::\d+)?/'
+        . '(?:[A-Za-z0-9]{32}/)?announce(?:\?uk=[A-Za-z0-9]{32})?`i';
 
     private const SCRAPE_RESULT_UPTODATE = 1;
     private const SCRAPE_RESULT_NOT_FOUND = 2;
     private const SCRAPE_RESULT_FAILED = 3;
 
-    /** @var string|null Cached rtorrent session directory path */
-    private static $sessionDirCache = null;
+    /** @var false|null|array false = not looked up, null = absent, array = found */
+    private static $donor = false;
 
-    /** @var bool True once session dir lookup has been attempted */
-    private static $sessionDirCacheLoaded = false;
-
-    /** @var bool True once donor passkey lookup has been attempted */
-    private static $donorPasskeyCacheLoaded = false;
-
-    /** @var string|null Cached donor passkey (null means not found) */
-    private static $donorPasskeyCache = null;
-
-    // ====================================================================
-    // Logging
-    // ====================================================================
-
-    /**
-     * Log a message through ruTrackerChecker::logDebug().
-     * @param string $message  Message (auto-prefixed with [NNMClub])
-     */
     private static function log($message)
     {
         ruTrackerChecker::logDebug('[NNMClub] ' . $message);
     }
 
-    /**
-     * Build a plain Snoopy client for "guest mode" requests.
-     * Intentionally uses fetch() (not fetchComplex()) to bypass loginmgr logic.
-     *
-     * @return Snoopy
-     */
+    // fetch() (not fetchComplex()) deliberately bypasses loginmgr: this handler
+    // works as a guest, and a Cloudflare-blocked login would poison the check.
     private static function makeGuestClient()
     {
         $client = new Snoopy();
         $client->read_timeout = 5;
         $client->_fp_timeout = 5;
-        $client->agent = self::DEFAULT_USER_AGENT;
+        $client->agent = ruTrackerChecker::USER_AGENT;
         return $client;
     }
 
-    /**
-     * Execute a single guest HTTP request with logging for transport failures.
-     *
-     * @param  Snoopy $client
-     * @param  string $url
-     * @param  string $method
-     * @param  string $contentType
-     * @param  string $body
-     * @return void
-     */
     private static function guestFetch($client, $url, $method = "GET", $contentType = "", $body = "")
     {
         @$client->fetch($url, $method, $contentType, $body);
-        if ($client->status < 0) {
+        // Socket errors are negative; the https path stores curl's exit code,
+        // which is below any real HTTP status.
+        if ($client->status < 100) {
             self::log("Guest fetch failed: url={$url} status={$client->status}");
         }
     }
 
-    /**
-     * Detect common anti-bot/challenge pages where download link is absent.
-     *
-     * @param  string $html
-     * @return bool
-     */
     private static function looksLikeChallengePage($html)
     {
         return is_string($html)
@@ -184,11 +115,9 @@ class NNMClubCheckImpl
     }
 
     /**
-     * Parse and normalize an NNMClub viewtopic URL.
-     * Supports both ?p=... and ?t=... topic references.
+     * Parse and normalize an NNMClub viewtopic URL (?p=... or ?t=...).
      *
-     * @param  string $url
-     * @return array|null ['host' => string, 'query' => string, 'id' => string]
+     * @return array|null ['host' => string, 'query' => string]
      */
     private static function parseTopicRef($url)
     {
@@ -222,11 +151,12 @@ class NNMClubCheckImpl
         parse_str(isset($parts['query']) ? $parts['query'] : '', $query);
 
         foreach (['p', 't'] as $param) {
-            if (array_key_exists($param, $query) && ctype_digit((string) $query[$param])) {
+            if (array_key_exists($param, $query)
+                && is_scalar($query[$param])
+                && ctype_digit((string) $query[$param])) {
                 return [
                     'host' => $host,
                     'query' => $param . '=' . $query[$param],
-                    'id' => (string) $query[$param],
                 ];
             }
         }
@@ -234,221 +164,164 @@ class NNMClubCheckImpl
         return null;
     }
 
-    /**
-     * Validate topic host against a strict allowlist.
-     *
-     * @param  string $host
-     * @return bool
-     */
     private static function isAllowedTopicHost($host)
     {
-        return in_array($host, self::TOPIC_HOSTS, true);
+        $normalized = preg_replace('/^www\./i', '', (string) $host);
+        return in_array($normalized, self::TOPIC_HOSTS, true);
     }
 
-    // ====================================================================
-    // Passkey Discovery
-    // ====================================================================
+    private static function isAllowedTrackerHost($host)
+    {
+        return is_string($host)
+            && in_array(strtolower($host), self::TRACKER_HOSTS, true);
+    }
 
     /**
-     * Extract a real 32-hex passkey from an announce URL or announce-list.
-     * Dummy/guest passkeys (all-f's, all-zeros) are filtered out.
+     * Parse one announce URL into a typed credential descriptor.
+     * Path credentials are distribution-specific; `uk` credentials are reusable.
      *
-     * @param  string|array|null $announce  Single URL, announce-list array, or null
-     * @return string|null  Lowercase 32-hex passkey, or null if not found / dummy
+     * @return array|null ['mode' => 'dynamic'|'static', 'token' => string, 'announceUrl' => string]
      */
-    private static function extractPasskey($announce)
+    private static function parseAuthUrl($url)
+    {
+        if (!is_string($url) || $url === '') return null;
+
+        $url = trim($url);
+        $parts = @parse_url($url);
+        if (!is_array($parts)
+            || !isset($parts['scheme'], $parts['host'])
+            || !preg_match('/^https?$/i', $parts['scheme'])
+            || !self::isAllowedTrackerHost(strtolower($parts['host']))) {
+            return null;
+        }
+        $path = isset($parts['path']) ? $parts['path'] : '';
+        if (!preg_match('`/(?:[A-Za-z0-9]{32}/)?announce/?$`', $path)) return null;
+
+        $query = array();
+        parse_str(isset($parts['query']) ? $parts['query'] : '', $query);
+        if (isset($query['uk'])
+            && is_scalar($query['uk'])
+            && preg_match(self::TOKEN_RE, (string) $query['uk'])
+            && !preg_match(self::DUMMY_PASSKEY_RE, (string) $query['uk'])) {
+            return array(
+                'mode' => 'static',
+                'token' => (string) $query['uk'],
+                'announceUrl' => $url,
+            );
+        }
+
+        if (preg_match('`/([A-Za-z0-9]{32})/announce/?$`', $path, $match)
+            && !preg_match(self::DUMMY_PASSKEY_RE, $match[1])) {
+            return array(
+                'mode' => 'dynamic',
+                'token' => $match[1],
+                'announceUrl' => $url,
+            );
+        }
+        return null;
+    }
+
+    /**
+     * Extract a typed credential from announce metadata or raw session bencode.
+     *
+     * @param  string|array|null $announce
+     * @param  string|null       $requiredMode Optional `dynamic` or `static` filter
+     * @return array|null
+     */
+    private static function extractAuth($announce, $requiredMode = null)
     {
         if ($announce === null) return null;
 
         if (is_array($announce)) {
-            foreach ($announce as $tier) {
-                $urls = is_array($tier) ? $tier : [$tier];
-                foreach ($urls as $url) {
-                    $pk = self::extractPasskey($url);
-                    if ($pk !== null) return $pk;
-                }
+            foreach ($announce as $value) {
+                $auth = self::extractAuth($value, $requiredMode);
+                if ($auth !== null) return $auth;
             }
             return null;
         }
-
-        // Accept any string (URL or raw bencode data from findDonorPasskey)
         if (!is_string($announce)) return null;
 
-        if (preg_match(self::TOKEN_RE, $announce, $m)) {
-            $pk = strtolower($m[1]);
-            if (preg_match(self::DUMMY_PASSKEY_RE, $pk)) {
-                return null;  // Reject dummy passkey
+        $auth = self::parseAuthUrl($announce);
+        if ($auth !== null && ($requiredMode === null || $auth['mode'] === $requiredMode)) {
+            return $auth;
+        }
+
+        if (preg_match_all(self::TRACKER_URL_RE, $announce, $matches)) {
+            foreach ($matches[0] as $url) {
+                $auth = self::parseAuthUrl($url);
+                if ($auth !== null && ($requiredMode === null || $auth['mode'] === $requiredMode)) {
+                    return $auth;
+                }
             }
-            return $pk;
         }
         return null;
     }
 
     /**
-     * Scan rtorrent session directory for any NNMClub torrent with a real passkey.
-     *
-     * Since NNMClub passkeys are per-user (all interchangeable), we can
-     * borrow a passkey from ANY NNMClub torrent belonging to the same user.
-     *
-     * Optimization: reads only the first 4 KB for quick rejection and
-     * passkey extraction before falling back to full file read.
-     *
-     * @return string|null  32-hex passkey from a donor torrent, or null
+     * Scan the rTorrent session directory for a reusable profile `uk`
+     * credential; the result (or its absence) is cached per process.
      */
-    private static function findDonorPasskey()
+    private static function findDonorStaticAuth()
     {
-        if (self::$donorPasskeyCacheLoaded) {
-            self::log("Using cached donor passkey lookup result");
-            return self::$donorPasskeyCache;
+        if (self::$donor !== false) {
+            return self::$donor;
         }
+        self::$donor = null;
 
-        $sessionDir = self::getSessionDir();
-        if ($sessionDir === null) return self::cacheDonorPasskey(null);
-
-        $sessionDir = rtrim($sessionDir, '/');
+        $sessionDir = rtrim((string) rTorrentSettings::get()->session, '/');
         if ($sessionDir === '') {
-            self::log("Invalid session dir from get_session, skipping donor passkey lookup");
-            return self::cacheDonorPasskey(null);
+            self::log("No session directory, skipping reusable credential lookup");
+            return null;
         }
 
         $files = @glob($sessionDir . '/*.torrent');
         if (!$files) {
-            self::log("No session torrents found for donor passkey lookup");
-            return self::cacheDonorPasskey(null);
+            self::log("No session torrents found for reusable credential lookup");
+            return null;
         }
 
         foreach ($files as $path) {
-            // Quick rejection: check first 4 KB for NNMClub signature
-            $head = @file_get_contents($path, false, null, 0, 4096);
-            if ($head === false
-                || (stripos($head, 'nnm-club') === false
-                    && stripos($head, 'nnmclub') === false)) {
+            // announce keys precede the info dict in bencode order, so a
+            // bounded head read finds any credential the file has.
+            $head = @file_get_contents($path, false, null, 0, 65536);
+            if ($head === false || !preg_match('/nnm-?club|searchtor/i', $head)) {
                 continue;
             }
-
-            // Passkey is usually near the beginning of the bencoded data.
-            // Try head first, then full file only when needed.
-            $pk = self::extractPasskey($head);
-            if ($pk !== null) {
-                return self::cacheDonorPasskey($pk);
-            }
-
-            if (strlen($head) >= 4096) {
-                $full = @file_get_contents($path);
-                if ($full !== false) {
-                    $pk = self::extractPasskey($full);
-                    if ($pk !== null) {
-                        return self::cacheDonorPasskey($pk);
-                    }
-                }
+            $auth = self::extractAuth($head, 'static');
+            if ($auth !== null) {
+                return (self::$donor = $auth);
             }
         }
-        self::log("Donor passkey not found in session torrents");
-        return self::cacheDonorPasskey(null);
-    }
-
-    /**
-     * Save donor passkey lookup result in cache.
-     *
-     * @param  string|null $passkey  Found passkey or null if absent
-     * @return string|null
-     */
-    private static function cacheDonorPasskey($passkey)
-    {
-        self::$donorPasskeyCacheLoaded = true;
-        self::$donorPasskeyCache = $passkey;
-        return $passkey;
-    }
-
-    /**
-     * Get rtorrent session directory via XMLRPC (result is cached).
-     * @return string|null  Session directory path, or null on failure
-     */
-    private static function getSessionDir()
-    {
-        if (self::$sessionDirCacheLoaded) {
-            return self::$sessionDirCache;
-        }
-
-        self::$sessionDirCacheLoaded = true;
-
-        $req = new rXMLRPCRequest(new rXMLRPCCommand("get_session"));
-        if ($req->run() && !$req->fault && !empty($req->val[0])) {
-            self::$sessionDirCache = $req->val[0];
-            return self::$sessionDirCache;
-        }
-
-        self::$sessionDirCache = null;
-        self::log("Failed to resolve rtorrent session directory via get_session");
+        self::log("Reusable profile credential not found in session torrents");
         return null;
     }
 
-    // ====================================================================
-    // Session Torrent Patching
-    // ====================================================================
-
-    /**
-     * Patch announce URLs in the session .torrent file to include passkey.
-     *
-     * Uses the Torrent class for clean bencode parsing and serialization.
-     * Preserves libtorrent_resume and rtorrent metadata so that
-     * fast-resume works correctly after rtorrent restart.
-     *
-     * @param  string $hash     Info hash (hex, uppercase)
-     * @param  string $passkey  32-hex passkey to inject
-     * @return bool   True if the file was patched and saved
-     */
-    private static function patchSessionTorrent($hash, $passkey)
+    private static function rebuildTrackerUrl($parts, $path, $query)
     {
-        $sessionDir = self::getSessionDir();
-        if ($sessionDir === null) {
-            self::log("patchSessionTorrent skipped: no session dir for {$hash}");
-            return false;
+        $url = strtolower($parts['scheme']) . '://' . strtolower($parts['host']);
+        if (isset($parts['port'])) $url .= ':' . (int) $parts['port'];
+        $url .= $path;
+        if (count($query)) {
+            $url .= '?' . http_build_query($query, '', '&', PHP_QUERY_RFC3986);
         }
-
-        $path = rtrim($sessionDir, '/') . '/' . $hash . '.torrent';
-        if (!is_writable($path)) {
-            self::log("patchSessionTorrent skipped: not writable {$path}");
-            return false;
-        }
-
-        $torrent = new Torrent($path);
-        if ($torrent->errors()) {
-            self::log("patchSessionTorrent failed: unreadable torrent {$path}");
-            return false;
-        }
-
-        $changed = self::patchPasskeyInTorrent($torrent, $passkey);
-        if (!$changed) {
-            self::log("patchSessionTorrent no-op for {$hash}: no announce URLs to patch");
-            return false;
-        }
-
-        // NOTE: We intentionally preserve libtorrent_resume and rtorrent
-        // metadata — they are needed for fast-resume after rtorrent restart.
-        // Only the announce URLs are modified (outside the info dict),
-        // so the info_hash and resume data remain valid.
-
-        $saved = (bool) $torrent->save($path);
-        self::log("patchSessionTorrent " . ($saved ? "saved" : "failed to save") . " for {$hash}");
-        return $saved;
+        return $url;
     }
 
     /**
-     * Patch NNMClub announce URLs inside a Torrent object.
+     * Patch NNMClub announce URLs with a reusable profile credential.
      *
-     * @param  Torrent $torrent
-     * @param  string  $passkey
-     * @return bool  True when at least one URL was changed
+     * @return bool True when at least one URL was changed
      */
-    private static function patchPasskeyInTorrent($torrent, $passkey)
+    private static function patchStaticAuthInTorrent($torrent, $auth)
     {
+        if (!is_array($auth) || ($auth['mode'] ?? null) !== 'static') return false;
+
         $announceChanged = false;
         $listChanged = false;
 
         $announce = $torrent->announce();
         if (is_string($announce) && $announce !== '') {
-            $patched = self::injectPasskeyIntoUrl($announce, $passkey);
+            $patched = self::injectStaticAuthIntoUrl($announce, $auth['token']);
             if ($patched !== $announce) {
                 $torrent->announce($patched);
                 $announceChanged = true;
@@ -463,7 +336,7 @@ class NNMClubCheckImpl
                 $urls = is_array($tier) ? $tier : [$tier];
                 foreach ($urls as $url) {
                     $patchedUrl = is_string($url)
-                        ? self::injectPasskeyIntoUrl($url, $passkey)
+                        ? self::injectStaticAuthIntoUrl($url, $auth['token'])
                         : $url;
                     if ($patchedUrl !== $url) {
                         $listChanged = true;
@@ -480,194 +353,113 @@ class NNMClubCheckImpl
         return $announceChanged || $listChanged;
     }
 
-    /**
-     * Inject a passkey into an NNMClub announce URL.
-     * Supports both nnm-club.* and nnmclub.* domain formats.
-     * Non-NNMClub URLs are returned unchanged.
-     *
-     * @param  string $url      Announce URL
-     * @param  string $passkey  32-hex passkey to inject
-     * @return string  Modified URL (or original if not NNMClub)
-     */
-    private static function injectPasskeyIntoUrl($url, $passkey)
+    /** Convert an NNMClub announce URL to reusable `announce?uk=TOKEN` form. */
+    private static function injectStaticAuthIntoUrl($url, $token)
     {
-        $hostGroup = '(' . self::ANNOUNCE_HOST_RE . ')';
-        $result = preg_replace(
-            '`' . $hostGroup . '/(?:[0-9a-f]{32}/)?announce`i',
-            '$1/' . $passkey . '/announce',
-            $url,
-            1,
-            $count
-        );
-        if ($count > 0 && $result !== null) {
-            return $result;
+        if (!is_string($url) || !preg_match(self::TOKEN_RE, (string) $token)) return $url;
+        $parts = @parse_url($url);
+        if (!is_array($parts)
+            || !isset($parts['scheme'], $parts['host'], $parts['path'])
+            || !preg_match('/^https?$/i', $parts['scheme'])
+            || !self::isAllowedTrackerHost(strtolower($parts['host']))) {
+            return $url;
         }
 
-        return $url;
-    }
+        $path = preg_replace('`/(?:[A-Za-z0-9]{32}/)?announce/?$`', '/announce', $parts['path'], 1, $count);
+        if ($count !== 1 || $path === null) return $url;
 
-    // ====================================================================
-    // Tracker Scrape
-    // ====================================================================
-
-    /**
-     * Decode one bencoded value from $data starting at $offset.
-     *
-     * @param  string $data
-     * @param  int    $offset
-     * @return mixed
-     * @throws Exception
-     */
-    private static function decodeBencodeValue($data, &$offset)
-    {
-        if (!isset($data[$offset])) {
-            throw new Exception("Unexpected EOF at offset {$offset}");
-        }
-
-        $token = $data[$offset];
-        if ($token >= '0' && $token <= '9') {
-            return self::decodeBencodeString($data, $offset);
-        }
-
-        if ($token === 'i') {
-            $offset++;
-            $end = strpos($data, 'e', $offset);
-            if ($end === false) {
-                throw new Exception("Invalid integer at offset {$offset}");
-            }
-            $num = substr($data, $offset, $end - $offset);
-            if ($num === '' || !preg_match('/^-?\d+$/', $num)) {
-                throw new Exception("Invalid integer value at offset {$offset}");
-            }
-            $offset = $end + 1;
-            return (int) $num;
-        }
-
-        if ($token === 'l') {
-            $offset++;
-            $list = [];
-            while (isset($data[$offset]) && $data[$offset] !== 'e') {
-                $list[] = self::decodeBencodeValue($data, $offset);
-            }
-            if (!isset($data[$offset])) {
-                throw new Exception("Unterminated list at offset {$offset}");
-            }
-            $offset++;
-            return $list;
-        }
-
-        if ($token === 'd') {
-            $offset++;
-            $dict = [];
-            while (isset($data[$offset]) && $data[$offset] !== 'e') {
-                $key = self::decodeBencodeString($data, $offset);
-                $dict[$key] = self::decodeBencodeValue($data, $offset);
-            }
-            if (!isset($data[$offset])) {
-                throw new Exception("Unterminated dict at offset {$offset}");
-            }
-            $offset++;
-            return $dict;
-        }
-
-        throw new Exception("Unknown token '{$token}' at offset {$offset}");
+        $query = array();
+        parse_str(isset($parts['query']) ? $parts['query'] : '', $query);
+        $query['uk'] = $token;
+        return self::rebuildTrackerUrl($parts, $path, $query);
     }
 
     /**
-     * Decode one bencoded byte string from $data starting at $offset.
+     * Check whether a scrape response lists the given hash. Scrape bodies are
+     * tiny bencoded dicts keyed by raw 20-byte hashes, so finding the bencoded
+     * key is enough; phase 2 (guest download + hash comparison) independently
+     * re-verifies before any replacement happens.
      *
-     * @param  string $data
-     * @param  int    $offset
-     * @return string
-     * @throws Exception
-     */
-    private static function decodeBencodeString($data, &$offset)
-    {
-        $colon = strpos($data, ':', $offset);
-        if ($colon === false) {
-            throw new Exception("Invalid string length at offset {$offset}");
-        }
-
-        $lenRaw = substr($data, $offset, $colon - $offset);
-        if ($lenRaw === '' || preg_match('/\D/', $lenRaw)) {
-            throw new Exception("Invalid string size '{$lenRaw}' at offset {$offset}");
-        }
-
-        $len = (int) $lenRaw;
-        $offset = $colon + 1;
-        if (($offset + $len) > strlen($data)) {
-            throw new Exception("String out of bounds at offset {$offset}");
-        }
-
-        $value = substr($data, $offset, $len);
-        $offset += $len;
-        return $value;
-    }
-
-    /**
-     * Parse scrape bencode and check whether "files" contains $binaryHash key.
-     *
-     * @param  string $payload
-     * @param  string $binaryHash  Raw 20-byte hash
-     * @return bool|null  true: found, false: not found, null: parse error
+     * @param  string $binaryHash Raw 20-byte hash
      */
     private static function scrapeContainsHash($payload, $binaryHash)
     {
-        if (!is_string($payload) || !is_string($binaryHash) || strlen($binaryHash) !== 20) {
-            return false;
-        }
+        return is_string($payload)
+            && is_string($binaryHash) && strlen($binaryHash) === 20
+            && isset($payload[0]) && $payload[0] === 'd'
+            && strpos($payload, '20:' . $binaryHash) !== false;
+    }
 
-        try {
-            $offset = 0;
-            $root = self::decodeBencodeValue($payload, $offset);
-        } catch (Exception $e) {
-            self::log("Scrape parse failed: " . $e->getMessage());
+    /** Derive a scrape URL without changing the credential's meaning or case. */
+    private static function buildScrapeUrl($auth, $binaryHash)
+    {
+        if (!is_array($auth) || !isset($auth['mode'], $auth['token'], $auth['announceUrl'])) {
+            return null;
+        }
+        $parts = @parse_url($auth['announceUrl']);
+        if (!is_array($parts)
+            || !isset($parts['scheme'], $parts['host'], $parts['path'])
+            || !self::isAllowedTrackerHost(strtolower($parts['host']))) {
             return null;
         }
 
-        return is_array($root)
-            && isset($root['files'])
-            && is_array($root['files'])
-            && array_key_exists($binaryHash, $root['files']);
+        $path = preg_replace('`/announce/?$`', '/scrape', $parts['path'], 1, $count);
+        if ($count !== 1 || $path === null) return null;
+
+        $query = array();
+        parse_str(isset($parts['query']) ? $parts['query'] : '', $query);
+        unset($query['info_hash']);
+        if ($auth['mode'] === 'static') {
+            $query['uk'] = $auth['token'];
+        } elseif ($auth['mode'] !== 'dynamic') {
+            return null;
+        }
+
+        $url = self::rebuildTrackerUrl($parts, $path, $query);
+        return $url . (count($query) ? '&' : '?') . 'info_hash=' . rawurlencode($binaryHash);
     }
 
     /**
-     * Scrape the NNMClub tracker to check if a hash is registered.
+     * Scrape the tracker endpoint associated with a typed credential.
+     * Static credentials may fall back to the current official IPv4 endpoint;
+     * dynamic credentials must stay on their original distribution URL.
      *
-     * Uses Snoopy (via makeClient) for consistency with the rest of the
-     * plugin (respects proxy settings, bind IP, timeouts).
-     * Tries all configured TRACKER_HOSTS with fallback on failure.
-     *
-     * @param  string $passkey  32-hex passkey for tracker auth
-     * @param  string $hash     Info hash (hex, uppercase, 40 chars)
-     * @return int  One of SCRAPE_RESULT_* constants
+     * @return int One of SCRAPE_RESULT_* constants
      */
-    private static function checkViaScrape($passkey, $hash)
+    private static function checkViaScrape($auth, $hash)
     {
-        $binary = @pack('H*', $hash);
-        if (strlen($binary) !== 20) {
+        if (!is_string($hash) || !preg_match('/^[0-9A-F]{40}$/i', $hash)) {
             self::log("Scrape skipped: invalid info hash format {$hash}");
             return self::SCRAPE_RESULT_FAILED;
         }
+        $binary = pack('H*', $hash);
+
+        $urls = array();
+        $primary = self::buildScrapeUrl($auth, $binary);
+        if ($primary !== null) $urls[] = $primary;
+        if (($auth['mode'] ?? null) === 'static') {
+            $fallback = self::buildScrapeUrl(array(
+                'mode' => 'static',
+                'token' => $auth['token'],
+                'announceUrl' => 'http://bt.searchtor.to/announce?uk=' . rawurlencode($auth['token']),
+            ), $binary);
+            if ($fallback !== null && !in_array($fallback, $urls, true)) $urls[] = $fallback;
+        }
+        if (!count($urls)) return self::SCRAPE_RESULT_FAILED;
 
         $sawNotFound = false;
 
-        foreach (self::TRACKER_HOSTS as $host) {
-            $url = 'http://' . $host . ':' . self::TRACKER_PORT
-                 . '/' . $passkey . '/scrape?info_hash=' . rawurlencode($binary);
+        foreach ($urls as $url) {
+            $host = @parse_url($url, PHP_URL_HOST);
+            $host = is_string($host) ? $host : 'unknown';
 
             $client = ruTrackerChecker::makeClient($url);
 
             if ($client->status == 200
                 && is_string($client->results)
                 && $client->results !== '') {
-                $hashState = self::scrapeContainsHash($client->results, $binary);
-                if ($hashState === true) {
+                if (self::scrapeContainsHash($client->results, $binary)) {
                     return self::SCRAPE_RESULT_UPTODATE;
-                }
-                if ($hashState === null) {
-                    self::log("Scrape response parse error on {$host}");
-                    continue;
                 }
                 self::log("Scrape response OK on {$host}, hash {$hash} not found");
                 $sawNotFound = true;
@@ -680,31 +472,6 @@ class NNMClubCheckImpl
             ? self::SCRAPE_RESULT_NOT_FOUND
             : self::SCRAPE_RESULT_FAILED;
     }
-
-    // ====================================================================
-    // Formatting
-    // ====================================================================
-
-    /**
-     * Convert result values to readable log-safe strings.
-     *
-     * @param  mixed $value
-     * @return string
-     */
-    private static function stringify($value)
-    {
-        if ($value === null) return 'null';
-        if ($value === true) return 'true';
-        if ($value === false) return 'false';
-        if (is_int($value) || is_float($value) || is_string($value)) {
-            return (string) $value;
-        }
-        return gettype($value);
-    }
-
-    // ====================================================================
-    // Main Entry Point
-    // ====================================================================
 
     /**
      * Check whether an NNMClub torrent needs updating.
@@ -721,45 +488,38 @@ class NNMClubCheckImpl
         // Prefer matched URL, but fallback to torrent comment if handler was
         // invoked via announce URL.
         $topicRef = self::parseTopicRef($url);
-        if ($topicRef === null && is_object($old_torrent)) {
+        if ($topicRef === null && is_object($old_torrent) && method_exists($old_torrent, 'comment')) {
             $topicRef = self::parseTopicRef($old_torrent->comment());
         }
-        if ($topicRef === null) {
-            self::log("Skip check: unable to parse NNMClub topic reference from URL/comment");
-            return ruTrackerChecker::STE_NOT_NEED;
-        }
-        $siteDomain = $topicRef['host'];
-        $topicQuery = $topicRef['query'];
-        self::log("Start check for {$hash} using {$siteDomain}/forum/viewtopic.php?{$topicQuery}");
-
-        // =============================================================
-        // PASSKEY DISCOVERY
-        // =============================================================
-
-        $passkey = self::extractPasskey($old_torrent->announce())
-                ?? self::extractPasskey($old_torrent->announce_list());
-        if ($passkey !== null) {
-            self::log("Using passkey from current torrent metadata");
+        if ($topicRef !== null) {
+            self::log("Start check for {$hash} using {$topicRef['host']}/forum/viewtopic.php?{$topicRef['query']}");
+        } else {
+            self::log("Start announce-only check for {$hash}; guest replacement will be unavailable");
         }
 
-        if ($passkey === null) {
-            $passkey = self::findDonorPasskey();
-            if ($passkey !== null) {
-                self::log("Found donor passkey, patching session torrent {$hash}");
-                if (!self::patchSessionTorrent($hash, $passkey)) {
-                    self::log("Session patch attempt finished without file changes for {$hash}");
-                }
+        $announces = array($url);
+        if (is_object($old_torrent)) {
+            if (method_exists($old_torrent, 'announce')) $announces[] = $old_torrent->announce();
+            if (method_exists($old_torrent, 'announce_list')) $announces[] = $old_torrent->announce_list();
+        }
+        $staticAuth = self::extractAuth($announces, 'static');
+        $scrapeAuth = self::extractAuth($announces, 'dynamic') ?: $staticAuth;
+
+        if ($scrapeAuth !== null) {
+            self::log("Using {$scrapeAuth['mode']} credential from current torrent metadata");
+        } else {
+            $staticAuth = self::findDonorStaticAuth();
+            $scrapeAuth = $staticAuth;
+            if ($staticAuth !== null) {
+                self::log("Using reusable profile credential from a session torrent");
             } else {
-                self::log("No passkey found for {$hash}, skipping scrape");
+                self::log("No tracker credential found for {$hash}, skipping scrape");
             }
         }
 
-        // =============================================================
-        // PHASE 1: TRACKER SCRAPE (fast path)
-        // =============================================================
-
-        if ($passkey !== null) {
-            $scrapeResult = self::checkViaScrape($passkey, $hash);
+        // Phase 1: tracker scrape (fast path).
+        if ($scrapeAuth !== null) {
+            $scrapeResult = self::checkViaScrape($scrapeAuth, $hash);
             if ($scrapeResult === self::SCRAPE_RESULT_UPTODATE) {
                 return ruTrackerChecker::STE_UPTODATE;
             }
@@ -771,11 +531,14 @@ class NNMClubCheckImpl
             }
         }
 
-        // =============================================================
-        // PHASE 2: GUEST TORRENT DOWNLOAD
-        // =============================================================
+        if ($topicRef === null) {
+            self::log("No topic reference for {$hash}; guest download and replacement are unavailable");
+            return ruTrackerChecker::STE_NOT_NEED;
+        }
+        $siteDomain = $topicRef['host'];
+        $topicQuery = $topicRef['query'];
 
-        // --- Step 1: Fetch guest topic page ---
+        // Phase 2: guest topic page + torrent download.
         $client = self::makeGuestClient();
         self::guestFetch($client, "https://{$siteDomain}/forum/viewtopic.php?" . $topicQuery);
         if ($client->status != 200) {
@@ -783,7 +546,7 @@ class NNMClubCheckImpl
             return ruTrackerChecker::STE_CANT_REACH_TRACKER;
         }
 
-        // --- Step 2: btih shortcut (for authenticated sessions) ---
+        // btih shortcut (present only for authenticated sessions).
         if (preg_match('`btih:(?P<hash>[0-9A-Fa-f]{40})`', $client->results, $btihMatch)) {
             if (strtoupper($btihMatch['hash']) === $hash) {
                 return ruTrackerChecker::STE_UPTODATE;
@@ -791,7 +554,6 @@ class NNMClubCheckImpl
             self::log("Topic btih differs for {$topicQuery}, verifying via downloaded .torrent");
         }
 
-        // --- Step 3: Find download link ---
         if (!preg_match('`(?:/forum/)?download\.php\?id=(?P<dlid>\d+)`i', $client->results, $dlMatch)) {
             if (self::looksLikeChallengePage($client->results)) {
                 self::log("No download link for {$topicQuery}: challenge page detected");
@@ -802,7 +564,6 @@ class NNMClubCheckImpl
         }
         $downloadId = $dlMatch['dlid'];
 
-        // --- Step 4: Download guest .torrent ---
         $client->setcookies();
         self::guestFetch($client, "https://{$siteDomain}/forum/download.php?id=" . $downloadId);
         if ($client->status != 200 || empty($client->results)) {
@@ -814,8 +575,8 @@ class NNMClubCheckImpl
 
         $guestData = $client->results;
 
-        // --- Step 5: Compare info_hash ---
-        $guestTorrent = new Torrent($guestData);
+        // Suppress PHP 7.4's filename-probe warning for binary metainfo.
+        $guestTorrent = @new Torrent($guestData);
         if ($guestTorrent->errors()) {
             self::log("Failed to parse downloaded torrent for {$topicQuery}");
             return ruTrackerChecker::STE_ERROR;
@@ -827,28 +588,31 @@ class NNMClubCheckImpl
             return ruTrackerChecker::STE_UPTODATE;
         }
 
-        // --- Step 6: Hash differs → torrent was updated ---
+        // Hash differs: the torrent was updated on NNMClub.
         self::log("Hash changed for {$topicQuery}: {$hash} -> {$guestHash}");
-        if ($passkey === null) {
-            self::log("Hash differs but passkey is unavailable; refusing replacement");
+        if ($staticAuth === null) {
+            $staticAuth = self::findDonorStaticAuth();
+        }
+        if ($staticAuth === null) {
+            self::log("Hash differs but a reusable profile credential is unavailable; refusing replacement");
             return ruTrackerChecker::STE_ERROR;
         }
-        if (!self::patchPasskeyInTorrent($guestTorrent, $passkey)) {
-            self::log("Hash differs but passkey patch found no NNMClub announce URLs");
+        if (!self::patchStaticAuthInTorrent($guestTorrent, $staticAuth)) {
+            self::log("Hash differs but credential patch found no NNMClub announce URLs");
             return ruTrackerChecker::STE_ERROR;
         }
 
         $replaceResult = ruTrackerChecker::createTorrent((string) $guestTorrent, $hash);
-        self::log("createTorrent result for {$hash}: " . self::stringify($replaceResult));
+        self::log("createTorrent result for {$hash}: " . var_export($replaceResult, true));
         return $replaceResult;
     }
 }
 
 // Register this tracker handler with ruTrackerChecker.
 // First regex: matches the torrent's comment URL.
-// Second regex: matches announce URLs containing "nnm-club" or "nnmclub".
+// Second regex also covers the current official searchtor announcers.
 ruTrackerChecker::registerTracker(
     "/(nnm-club|nnmclub)\./",
-    "/(nnm-club|nnmclub)\./",
+    "/(?:nnm-club|nnmclub)\.|(?:ipv6\.)?bt\.searchtor\.to/i",
     "NNMClubCheckImpl::download_torrent"
 );

--- a/plugins/rutracker_check/trackers/rutracker.php
+++ b/plugins/rutracker_check/trackers/rutracker.php
@@ -2,22 +2,156 @@
 
 class RuTrackerCheckImpl
 {
+    // Decode CP1251 HTML to UTF-8 for reliable text search.
+    static private function decodePage($content)
+    {
+        if (!$content) return '';
+
+        $decoded = false;
+        if (function_exists('iconv')) {
+            $decoded = @iconv('CP1251', 'UTF-8//IGNORE', $content);
+        }
+        if (($decoded === false) && function_exists('mb_convert_encoding')) {
+            $decoded = @mb_convert_encoding($content, 'UTF-8', 'CP1251');
+        }
+        return ($decoded === false || is_null($decoded)) ? $content : $decoded;
+    }
+
+    // Load the last page of the topic
+    static private function extractLastPageHtml($client, $topic_id)
+    {
+        $topicUrl = "https://rutracker.org/forum/viewtopic.php?t=" . $topic_id;
+        $client->setcookies();
+        $client->fetchComplex($topicUrl);
+
+        if (($client->status != 200) || empty($client->results)) {
+            return null;
+        }
+
+        $html = self::decodePage($client->results);
+        $lastStart = 0;
+
+        // Look for pagination parameters (&start= or &amp;start=)
+        if (preg_match_all('~viewtopic\.php\?t=' . $topic_id . '(?:&amp;|&)start=(\d+)~i', $html, $startMatches) && count($startMatches[1])) {
+            $lastStart = max(array_map('intval', $startMatches[1]));
+        }
+
+        if ($lastStart > 0) {
+            $client->setcookies();
+            $client->fetchComplex($topicUrl . "&start=" . $lastStart);
+            if (($client->status == 200) && !empty($client->results)) {
+                $html = self::decodePage($client->results);
+            }
+        }
+
+        return $html;
+    }
+
+    // Detect new topic (if old one was absorbed) without relying on specific HTML tags
+    static private function detectAbsorbedTopic($client, $topic_id)
+    {
+        $html = self::extractLastPageHtml($client, $topic_id);
+
+        if (empty($html)) return null;
+
+        // Search for keywords "absorbed" (поглощ) or "merged" (объедин) - case-insensitive, UTF-8
+        if (preg_match_all('/(поглощ|объедин)/iu', $html, $matches, PREG_OFFSET_CAPTURE)) {
+
+            // Take the last occurrence of the keyword on the page
+            $lastMatch = end($matches[0]);
+            $keywordPos = $lastMatch[1];
+
+            // Search for a link in a 3000-character radius BEFORE the keyword (links often appear before the word)
+            $searchZoneBefore = substr($html, max(0, $keywordPos - 3000), 3000);
+
+            // Look for the new topic ID (t=Digits) BEFORE the keyword
+            if (preg_match_all('/viewtopic\.php\?t=(\d+)/i', $searchZoneBefore, $linkMatches)) {
+                // Get the last link before the keyword (closest to it)
+                $lastLinkId = end($linkMatches[1]);
+                $newTopicId = intval($lastLinkId);
+                if ($newTopicId && $newTopicId != $topic_id) {
+                    return $newTopicId;
+                }
+            }
+
+            // If not found before, search AFTER the keyword (2000-character radius)
+            $searchZoneAfter = substr($html, $keywordPos, 2000);
+
+            if (preg_match('/viewtopic\.php\?t=(\d+)/i', $searchZoneAfter, $linkMatch)) {
+                $newTopicId = intval($linkMatch[1]);
+                if ($newTopicId && $newTopicId != $topic_id) {
+                    return $newTopicId;
+                }
+            }
+        }
+
+        return null;
+    }
+
     static public function download_torrent($url, $hash, $old_torrent)
     {
         if (preg_match('`^https?://rutracker\.(org|cr|net|nl)/forum/viewtopic\.php\?t=(?P<id>\d+)$`', $url, $matches)) {
             $topic_id = $matches["id"];
+
+            // --- STAGE 1: Check via API ---
             $req_url = "https://api.rutracker.cc/v1/get_tor_hash?by=topic_id&val=" . $topic_id;
             $client = ruTrackerChecker::makeClient($req_url);
-            if ($client->status != 200) return ruTrackerChecker::STE_CANT_REACH_TRACKER;
-            $ret = json_decode($client->results, true);
-            if (array_key_exists("result", $ret)) $ret = $ret["result"];
-            if ($ret && array_key_exists($topic_id, $ret) && (strtoupper($ret[$topic_id]) == $hash)) {
-                return ruTrackerChecker::STE_UPTODATE;
+
+            if ($client->status == 200) {
+                $ret = @json_decode($client->results, true);
+
+                if (is_array($ret)) {
+                     if (array_key_exists("result", $ret)) $ret = $ret["result"];
+
+                     // IMPORTANT: We ignore error_code == 1 (Deleted) here,
+                     // to allow the script to manually check for absorption/relocation on the site.
+
+                     if (array_key_exists($topic_id, $ret)) {
+                         $apiVal = $ret[$topic_id];
+                         // The hash can be a string or an array ['hash' => '...']
+                         $remoteHash = (is_array($apiVal) && isset($apiVal['hash'])) ? $apiVal['hash'] : $apiVal;
+
+                         if (!empty($hash) && strtoupper($remoteHash) == strtoupper($hash)) {
+                             return ruTrackerChecker::STE_UPTODATE;
+                         }
+                     }
                 }
+            }
+
+            // --- STAGE 2: Attempt direct download ---
             $client->setcookies();
             $client->fetchComplex("https://rutracker.org/forum/dl.php?t=" . $topic_id);
-            if ($client->status != 200) return (($client->status < 0) ? ruTrackerChecker::STE_CANT_REACH_TRACKER : ruTrackerChecker::STE_DELETED);
-            return ruTrackerChecker::createTorrent($client->results, $hash);
+
+            // Protection against "Soft 404": server returned 200 OK, but the content is an HTML error
+            // Check for HTML tags (full or fragments) and error messages
+            $is_html_garbage = (stripos($client->results, '<html') !== false)
+                            || (stripos($client->results, '<!DOCTYPE') !== false)
+                            || (stripos($client->results, '<center>') !== false)
+                            || (stripos($client->results, 'Error:') !== false)
+                            || (stripos($client->results, 'attachment data not found') !== false);
+
+            if ($client->status == 200 && !$is_html_garbage) {
+                return ruTrackerChecker::createTorrent($client->results, $hash);
+            }
+
+            // --- STAGE 3: If download failed, check for relocation (absorption) ---
+
+            // We enter here if status != 200 OR if HTML garbage was returned
+            $absorbedTopicId = self::detectAbsorbedTopic($client, $topic_id);
+
+            if (!is_null($absorbedTopicId)) {
+                $client->setcookies();
+                // Download torrent for the NEW topic
+                $client->fetchComplex("https://rutracker.org/forum/dl.php?t=" . $absorbedTopicId);
+
+                $is_new_html_garbage = (stripos($client->results, '<html') !== false);
+
+                if ($client->status == 200 && !$is_new_html_garbage) {
+                    return ruTrackerChecker::createTorrent($client->results, $hash);
+                }
+            }
+
+            return (($client->status < 0) ? ruTrackerChecker::STE_CANT_REACH_TRACKER : ruTrackerChecker::STE_DELETED);
         }
         return ruTrackerChecker::STE_NOT_NEED;
     }

--- a/plugins/rutracker_check/trackers/rutracker.php
+++ b/plugins/rutracker_check/trackers/rutracker.php
@@ -2,10 +2,44 @@
 
 class RuTrackerCheckImpl
 {
+    static private function looksLikeHtmlError($content)
+    {
+        if (!is_string($content) || trim($content) === '') return true;
+
+        // A valid metainfo dictionary starts with "d". Only classify leading
+        // text/markup as an HTTP error; arbitrary binary fields may themselves
+        // contain words such as "Error" or fragments that look like HTML.
+        $leading = ltrim($content, "\xEF\xBB\xBF \t\r\n");
+        return isset($leading[0]) && ($leading[0] === '<'
+            || preg_match('/^(?:Error:|attachment data not found\b)/i', $leading));
+    }
+
+    static private function normalizeHash($value)
+    {
+        if (!is_string($value)) return null;
+        $value = strtoupper(trim($value));
+        return preg_match('/^[0-9A-F]{40}$/', $value) ? $value : null;
+    }
+
+    static private function extractTopicId($url)
+    {
+        if (!is_string($url) || $url === '') return null;
+        $parts = @parse_url(trim($url));
+        if (!is_array($parts) || !isset($parts['scheme'], $parts['host'], $parts['path'])) return null;
+        if (!preg_match('/^https?$/i', $parts['scheme'])) return null;
+        if (!preg_match('/^rutracker\.(?:org|cr|net|nl)$/i', $parts['host'])) return null;
+        if (strcasecmp($parts['path'], '/forum/viewtopic.php') !== 0) return null;
+
+        $query = array();
+        parse_str(isset($parts['query']) ? $parts['query'] : '', $query);
+        if (!isset($query['t']) || !is_scalar($query['t']) || !ctype_digit((string) $query['t'])) return null;
+        return (int) $query['t'];
+    }
+
     // Decode CP1251 HTML to UTF-8 for reliable text search.
     static private function decodePage($content)
     {
-        if (!$content) return '';
+        if (!is_string($content) || $content === '') return '';
 
         $decoded = false;
         if (function_exists('iconv')) {
@@ -17,143 +51,198 @@ class RuTrackerCheckImpl
         return ($decoded === false || is_null($decoded)) ? $content : $decoded;
     }
 
-    // Load the last page of the topic
-    static private function extractLastPageHtml($client, $topic_id)
+    static private function extractLastPageHtml($client, $topicId)
     {
-        $topicUrl = "https://rutracker.org/forum/viewtopic.php?t=" . $topic_id;
+        $topicUrl = 'https://rutracker.org/forum/viewtopic.php?t=' . $topicId;
         $client->setcookies();
         $client->fetchComplex($topicUrl);
 
-        if (($client->status != 200) || empty($client->results)) {
-            return null;
-        }
+        if ($client->status != 200 || empty($client->results)) return null;
 
         $html = self::decodePage($client->results);
         $lastStart = 0;
+        if (preg_match_all('/<a\b[^>]*>/i', $html, $anchors)) {
+            foreach ($anchors[0] as $anchor) {
+                if (!preg_match('/\bclass\s*=\s*(["\'])(.*?)\1/is', $anchor, $classMatch)
+                    || !preg_match('/(?:^|\s)pg(?:\s|$)/i', $classMatch[2])
+                    || !preg_match('/\bhref\s*=\s*(["\'])(.*?)\1/is', $anchor, $hrefMatch)) {
+                    continue;
+                }
 
-        // Look for pagination parameters (&start= or &amp;start=)
-        if (preg_match_all('~viewtopic\.php\?t=' . $topic_id . '(?:&amp;|&)start=(\d+)~i', $html, $startMatches) && count($startMatches[1])) {
-            $lastStart = max(array_map('intval', $startMatches[1]));
+                $href = html_entity_decode($hrefMatch[2], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $parts = @parse_url($href);
+                if (!is_array($parts) || !isset($parts['path'], $parts['query'])
+                    || strcasecmp(basename($parts['path']), 'viewtopic.php') !== 0
+                    || (isset($parts['host']) && !preg_match('/^rutracker\.(?:org|cr|net|nl)$/i', $parts['host']))) {
+                    continue;
+                }
+                $query = array();
+                parse_str($parts['query'], $query);
+                if (!isset($query['t'], $query['start'])
+                    || !is_scalar($query['t']) || !is_scalar($query['start'])
+                    || (int) $query['t'] !== (int) $topicId
+                    || !ctype_digit((string) $query['start'])) {
+                    continue;
+                }
+                $lastStart = max($lastStart, (int) $query['start']);
+            }
         }
 
         if ($lastStart > 0) {
             $client->setcookies();
-            $client->fetchComplex($topicUrl . "&start=" . $lastStart);
-            if (($client->status == 200) && !empty($client->results)) {
-                $html = self::decodePage($client->results);
-            }
+            $client->fetchComplex($topicUrl . '&start=' . $lastStart);
+            if ($client->status != 200 || empty($client->results)) return null;
+            $html = self::decodePage($client->results);
         }
 
         return $html;
     }
 
-    // Detect new topic (if old one was absorbed) without relying on specific HTML tags
-    static private function detectAbsorbedTopic($client, $topic_id)
+    static private function isModeratorPost($postHtml)
     {
-        $html = self::extractLastPageHtml($client, $topic_id);
+        if (!preg_match_all('/<img\b[^>]*>/i', $postHtml, $images)) return false;
 
-        if (empty($html)) return null;
-
-        // Search for keywords "absorbed" (поглощ) or "merged" (объедин) - case-insensitive, UTF-8
-        if (preg_match_all('/(поглощ|объедин)/iu', $html, $matches, PREG_OFFSET_CAPTURE)) {
-
-            // Take the last occurrence of the keyword on the page
-            $lastMatch = end($matches[0]);
-            $keywordPos = $lastMatch[1];
-
-            // Search for a link in a 3000-character radius BEFORE the keyword (links often appear before the word)
-            $searchZoneBefore = substr($html, max(0, $keywordPos - 3000), 3000);
-
-            // Look for the new topic ID (t=Digits) BEFORE the keyword
-            if (preg_match_all('/viewtopic\.php\?t=(\d+)/i', $searchZoneBefore, $linkMatches)) {
-                // Get the last link before the keyword (closest to it)
-                $lastLinkId = end($linkMatches[1]);
-                $newTopicId = intval($lastLinkId);
-                if ($newTopicId && $newTopicId != $topic_id) {
-                    return $newTopicId;
-                }
-            }
-
-            // If not found before, search AFTER the keyword (2000-character radius)
-            $searchZoneAfter = substr($html, $keywordPos, 2000);
-
-            if (preg_match('/viewtopic\.php\?t=(\d+)/i', $searchZoneAfter, $linkMatch)) {
-                $newTopicId = intval($linkMatch[1]);
-                if ($newTopicId && $newTopicId != $topic_id) {
-                    return $newTopicId;
-                }
-            }
+        foreach ($images[0] as $image) {
+            if (!preg_match('/\bclass\s*=\s*(["\'])(.*?)\1/is', $image, $classMatch)) continue;
+            if (!preg_match('/(?:^|\s)user-rank(?:\s|$)/i', $classMatch[2])) continue;
+            if (!preg_match('/\balt\s*=\s*(["\'])(.*?)\1/is', $image, $altMatch)) continue;
+            if (preg_match('/\bmoderator\b|модератор/iu', $altMatch[2])) return true;
         }
+        return false;
+    }
 
+    static private function extractPostBody($postHtml)
+    {
+        if (!preg_match_all('/<div\b[^>]*>/i', $postHtml, $divs, PREG_OFFSET_CAPTURE)) return null;
+
+        foreach ($divs[0] as $div) {
+            $tag = $div[0];
+            if (!preg_match('/\bclass\s*=\s*(["\'])(.*?)\1/is', $tag, $classMatch)) continue;
+            if (!preg_match('/(?:^|\s)post_body(?:\s|$)/i', $classMatch[2])) continue;
+
+            $start = $div[1] + strlen($tag);
+            if (!preg_match('/<\/div>\s*<!--\/post_body-->/i', $postHtml, $end, PREG_OFFSET_CAPTURE, $start)) {
+                return null;
+            }
+            return substr($postHtml, $start, $end[0][1] - $start);
+        }
         return null;
     }
 
-    static public function download_torrent($url, $hash, $old_torrent)
+    // Accept only a final absorption marker written in a moderator post.
+    static private function detectAbsorbedTopic($client, $topicId)
     {
-        if (preg_match('`^https?://rutracker\.(org|cr|net|nl)/forum/viewtopic\.php\?t=(?P<id>\d+)$`', $url, $matches)) {
-            $topic_id = $matches["id"];
+        $html = self::extractLastPageHtml($client, $topicId);
+        if (empty($html)) return null;
 
-            // --- STAGE 1: Check via API ---
-            $req_url = "https://api.rutracker.cc/v1/get_tor_hash?by=topic_id&val=" . $topic_id;
-            $client = ruTrackerChecker::makeClient($req_url);
+        if (!preg_match_all(
+            '~<tbody\b[^>]*\bid=["\']post_\d+["\'][^>]*>.*?</tbody>~is',
+            $html,
+            $posts
+        )) return null;
 
-            if ($client->status == 200) {
-                $ret = @json_decode($client->results, true);
+        foreach (array_reverse($posts[0]) as $post) {
+            if (!self::isModeratorPost($post)) continue;
+            $body = self::extractPostBody($post);
+            if ($body === null) continue;
 
-                if (is_array($ret)) {
-                     if (array_key_exists("result", $ret)) $ret = $ret["result"];
+            $plain = html_entity_decode(
+                preg_replace('/<[^>]+>/', ' ', $body),
+                ENT_QUOTES | ENT_HTML5,
+                'UTF-8'
+            );
+            $plain = preg_replace('/\s+/u', ' ', trim($plain));
+            if (!preg_match('/(?:^|\s)(?:Поглощено|Объединено)\.?$/iu', $plain)) continue;
 
-                     // IMPORTANT: We ignore error_code == 1 (Deleted) here,
-                     // to allow the script to manually check for absorption/relocation on the site.
+            $decodedBody = html_entity_decode($body, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            if (!preg_match_all(
+                '~href=["\'](?:(?:https?://rutracker\.(?:org|cr|net|nl)/forum/)|/forum/|\./)?viewtopic\.php\?[^"\']*\bt=(\d+)[^"\']*["\']~i',
+                $decodedBody,
+                $links
+            )) continue;
 
-                     if (array_key_exists($topic_id, $ret)) {
-                         $apiVal = $ret[$topic_id];
-                         // The hash can be a string or an array ['hash' => '...']
-                         $remoteHash = (is_array($apiVal) && isset($apiVal['hash'])) ? $apiVal['hash'] : $apiVal;
+            $candidates = array();
+            foreach ($links[1] as $candidate) {
+                $candidate = (int) $candidate;
+                if ($candidate && $candidate !== (int) $topicId) $candidates[$candidate] = true;
+            }
+            if (count($candidates) === 1) return (int) key($candidates);
+        }
+        return null;
+    }
 
-                         if (!empty($hash) && strtoupper($remoteHash) == strtoupper($hash)) {
-                             return ruTrackerChecker::STE_UPTODATE;
-                         }
-                     }
+    static public function download_torrent($url, $hash, $oldTorrent)
+    {
+        $topicId = self::extractTopicId($url);
+        if ($topicId === null && is_object($oldTorrent)) {
+            $topicId = self::extractTopicId($oldTorrent->comment());
+        }
+        if ($topicId === null) return ruTrackerChecker::STE_NOT_NEED;
+
+        $localHash = self::normalizeHash($hash);
+        $remoteHash = null;
+        $apiDeleted = false;
+
+        $apiUrl = 'https://api.rutracker.cc/v1/get_tor_hash?by=topic_id&val=' . $topicId;
+        $client = ruTrackerChecker::makeClient($apiUrl);
+        if ($client->status == 200) {
+            $response = @json_decode($client->results, true);
+            if (is_array($response) && isset($response['result']) && is_array($response['result'])
+                && array_key_exists($topicId, $response['result'])) {
+                $apiValue = $response['result'][$topicId];
+                if (is_array($apiValue)) {
+                    $remoteHash = self::normalizeHash(isset($apiValue['hash']) ? $apiValue['hash'] : null);
+                    $apiDeleted = ($remoteHash === null && isset($apiValue['error_code'])
+                        && (int) $apiValue['error_code'] === 1);
+                } else {
+                    $remoteHash = self::normalizeHash($apiValue);
+                }
+
+                if ($remoteHash !== null && $remoteHash === $localHash) {
+                    return ruTrackerChecker::STE_UPTODATE;
                 }
             }
+        }
 
-            // --- STAGE 2: Attempt direct download ---
+        $client->setcookies();
+        $client->fetchComplex('https://rutracker.org/forum/dl.php?t=' . $topicId);
+        $directStatus = $client->status;
+        $directBody = $client->results;
+        $directParseError = false;
+        if ($directStatus == 200 && !self::looksLikeHtmlError($directBody)) {
+            $downloadedTorrent = @new Torrent($directBody);
+            if (!$downloadedTorrent->errors()
+                && self::normalizeHash($downloadedTorrent->hash_info()) !== null) {
+                // A valid payload reached the local replacement transaction.
+                // Its error must not trigger a second, potentially conflicting replacement.
+                return ruTrackerChecker::createTorrent($directBody, $hash);
+            }
+            $directParseError = true;
+        }
+
+        $absorbedTopicId = self::detectAbsorbedTopic($client, $topicId);
+        if ($absorbedTopicId !== null) {
             $client->setcookies();
-            $client->fetchComplex("https://rutracker.org/forum/dl.php?t=" . $topic_id);
-
-            // Protection against "Soft 404": server returned 200 OK, but the content is an HTML error
-            // Check for HTML tags (full or fragments) and error messages
-            $is_html_garbage = (stripos($client->results, '<html') !== false)
-                            || (stripos($client->results, '<!DOCTYPE') !== false)
-                            || (stripos($client->results, '<center>') !== false)
-                            || (stripos($client->results, 'Error:') !== false)
-                            || (stripos($client->results, 'attachment data not found') !== false);
-
-            if ($client->status == 200 && !$is_html_garbage) {
+            $client->fetchComplex('https://rutracker.org/forum/dl.php?t=' . $absorbedTopicId);
+            if ($client->status == 200 && !self::looksLikeHtmlError($client->results)) {
+                // createTorrent treats unparseable payloads as a deleted topic
+                // (legacy handler contract); for a replacement download that
+                // would be wrong, so validate the payload here.
+                $replacement = @new Torrent($client->results);
+                if ($replacement->errors()
+                    || self::normalizeHash($replacement->hash_info()) === null) {
+                    return ruTrackerChecker::STE_ERROR;
+                }
                 return ruTrackerChecker::createTorrent($client->results, $hash);
             }
-
-            // --- STAGE 3: If download failed, check for relocation (absorption) ---
-
-            // We enter here if status != 200 OR if HTML garbage was returned
-            $absorbedTopicId = self::detectAbsorbedTopic($client, $topic_id);
-
-            if (!is_null($absorbedTopicId)) {
-                $client->setcookies();
-                // Download torrent for the NEW topic
-                $client->fetchComplex("https://rutracker.org/forum/dl.php?t=" . $absorbedTopicId);
-
-                $is_new_html_garbage = (stripos($client->results, '<html') !== false);
-
-                if ($client->status == 200 && !$is_new_html_garbage) {
-                    return ruTrackerChecker::createTorrent($client->results, $hash);
-                }
-            }
-
-            return (($client->status < 0) ? ruTrackerChecker::STE_CANT_REACH_TRACKER : ruTrackerChecker::STE_DELETED);
+            return ruTrackerChecker::STE_CANT_REACH_TRACKER;
         }
-        return ruTrackerChecker::STE_NOT_NEED;
+
+        // Only a topic-specific API deletion is authoritative. Transport,
+        // login and unexpected payload failures must remain retryable.
+        if ($apiDeleted) return ruTrackerChecker::STE_DELETED;
+        if ($directParseError) return ruTrackerChecker::STE_ERROR;
+        return ruTrackerChecker::STE_CANT_REACH_TRACKER;
     }
 }
 

--- a/tests/php/SnoopyTest.php
+++ b/tests/php/SnoopyTest.php
@@ -1,0 +1,126 @@
+<?php
+
+// Deliberately not using tests/plugins/rutracker_check/TestLib.php here:
+// Snoopy.class.inc transitively loads php/settings.php -> php/xmlrpc.php,
+// whose real rXMLRPC* classes collide with TestLib's doubles in either
+// require order. A minimal local runner keeps the real classes intact.
+require_once(__DIR__ . '/../../php/Snoopy.class.inc');
+
+function snoopyAssertTrue($condition, $message)
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+function snoopyAssertSame($expected, $actual, $message)
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException(
+            $message . '; expected ' . var_export($expected, true)
+            . ', got ' . var_export($actual, true)
+        );
+    }
+}
+
+function snoopyCurlArgs()
+{
+    return file(getenv('SNOOPY_TEST_ARGS'), FILE_IGNORE_NEW_LINES);
+}
+
+// Fake curl: records every argument, then fabricates a successful response.
+$curlPath = tempnam(sys_get_temp_dir(), 'snoopy-curl-');
+$argsPath = tempnam(sys_get_temp_dir(), 'snoopy-args-');
+$script = <<<'SH'
+#!/bin/sh
+: > "$SNOOPY_TEST_ARGS"
+header_file=
+body_file=
+while [ "$#" -gt 0 ]; do
+	printf '%s\n' "$1" >> "$SNOOPY_TEST_ARGS"
+	case "$1" in
+		-D)
+			shift
+			header_file=$1
+			;;
+		-o)
+			shift
+			body_file=$1
+			;;
+	esac
+	shift
+done
+printf 'HTTP/1.1 200 OK\r\n\r\n' > "$header_file"
+: > "$body_file"
+SH;
+file_put_contents($curlPath, $script);
+chmod($curlPath, 0700);
+putenv('SNOOPY_TEST_ARGS=' . $argsPath);
+$pathToExternals['curl'] = $curlPath;
+
+$tests = array(
+    'explicit HTTPS POST forwards -X POST to curl' => function () {
+        $client = new Snoopy();
+        snoopyAssertTrue(
+            $client->fetch('https://example.test/resource', 'POST', 'application/x-www-form-urlencoded', ''),
+            'HTTPS request did not complete through the curl test double'
+        );
+        $args = snoopyCurlArgs();
+        $flag = array_search('-X', $args, true);
+        snoopyAssertTrue($flag !== false, 'Explicit HTTPS method was not passed to curl');
+        snoopyAssertSame(
+            'POST',
+            isset($args[$flag + 1]) ? $args[$flag + 1] : null,
+            'Empty-body explicit POST request was not preserved'
+        );
+    },
+    'legacy positional HTTPS request never adds -X' => function () {
+        $client = new Snoopy();
+        snoopyAssertTrue(
+            $client->_httpsrequest('https://example.test/legacy', 'application/x-www-form-urlencoded', 'payload'),
+            'Legacy positional HTTPS request did not complete'
+        );
+        $args = snoopyCurlArgs();
+        snoopyAssertSame(
+            false,
+            array_search('-X', $args, true),
+            'Legacy 3-argument call must leave the HTTP method to curl'
+        );
+        snoopyAssertTrue(
+            in_array('Content-type: application/x-www-form-urlencoded', $args, true),
+            'Legacy positional content-type argument remains supported'
+        );
+        snoopyAssertTrue(in_array('payload', $args, true), 'Legacy positional request body remains supported');
+    },
+    'explicit HTTPS GET with body keeps -X GET' => function () {
+        $client = new Snoopy();
+        snoopyAssertTrue(
+            $client->fetch('https://example.test/get-with-body', 'GET', 'text/plain', 'payload'),
+            'Explicit GET-with-body request did not complete'
+        );
+        $args = snoopyCurlArgs();
+        $flag = array_search('-X', $args, true);
+        snoopyAssertTrue(
+            $flag !== false && isset($args[$flag + 1]) && $args[$flag + 1] === 'GET',
+            'Explicit HTTPS GET method must not be changed to POST by curl -d'
+        );
+    },
+);
+
+$failures = 0;
+foreach ($tests as $name => $callback) {
+    try {
+        $callback();
+        echo "ok - {$name}\n";
+    } catch (Throwable $error) {
+        $failures++;
+        echo "not ok - {$name}\n";
+        echo '  ' . get_class($error) . ': ' . $error->getMessage() . "\n";
+    }
+}
+echo count($tests) . ' tests, ' . $failures . " failures\n";
+
+putenv('SNOOPY_TEST_ARGS');
+@unlink($curlPath);
+@unlink($argsPath);
+exit($failures === 0 ? 0 : 1);

--- a/tests/plugins/rutracker_check/CheckerTest.php
+++ b/tests/plugins/rutracker_check/CheckerTest.php
@@ -1,0 +1,936 @@
+<?php
+
+/**
+ * Focused regression tests for plugins/rutracker_check/check.php.
+ *
+ * The runner, the assertions and the XMLRPC test double live in TestLib.php;
+ * this file keeps only the checker-specific fakes: the real ruTrackerChecker
+ * (evaled out of check.php), a fixture-based Torrent and a recording rTorrent.
+ *
+ * Two rollback tests deliberately exhaust the waitForLoad poll budget and each
+ * spend about two seconds in usleep; every other test completes immediately.
+ */
+
+require __DIR__ . '/TestLib.php';
+
+function loadClassDefinition($filename, $className)
+{
+	$source = file_get_contents($filename);
+	$offset = strpos($source, 'class ' . $className);
+	if($offset === false)
+		throw new RuntimeException("Class {$className} was not found in {$filename}");
+	// ruTrackerChecker is the final declaration in check.php.
+	return substr($source, $offset);
+}
+
+function getCmd($command)
+{
+	return $command;
+}
+
+class FileUtil
+{
+	public static $log = array();
+
+	public static function addslash($path)
+	{
+		return rtrim($path, '/') . '/';
+	}
+
+	public static function toLog($message)
+	{
+		self::$log[] = $message;
+	}
+}
+
+class Torrent
+{
+	public static $fixtures = array();
+	public $info = array();
+	private $hash = '';
+	private $hasErrors = false;
+	private $announceUrl = '';
+	private $announceList = array();
+	private $commentUrl = '';
+
+	public function __construct($source)
+	{
+		$fixture = is_array($source) ? $source : (self::$fixtures[$source] ?? array('errors' => true));
+		$this->hash = $fixture['hash'] ?? '';
+		$this->info = $fixture['info'] ?? array();
+		$this->hasErrors = !empty($fixture['errors']);
+		$this->announceUrl = $fixture['announce'] ?? '';
+		$this->announceList = $fixture['announce_list'] ?? array();
+		$this->commentUrl = $fixture['comment'] ?? '';
+	}
+
+	public function errors()
+	{
+		return $this->hasErrors;
+	}
+
+	public function hash_info()
+	{
+		return $this->hash;
+	}
+
+	public function announce()
+	{
+		return $this->announceUrl;
+	}
+
+	public function announce_list()
+	{
+		return $this->announceList;
+	}
+
+	public function comment()
+	{
+		return $this->commentUrl;
+	}
+}
+
+class rTorrent
+{
+	public static $source = false;
+	public static $sendResult = false;
+	public static $lastSend = null;
+	public static $sends = array();
+
+	public static function getSource($hash)
+	{
+		return self::$source;
+	}
+
+	public static function sendTorrent($torrent, $isStart, $isAddPath, $directory, $label, $saveTorrent, $isFast, $isNew = true, $addition = null)
+	{
+		self::$lastSend = compact('torrent', 'isStart', 'isAddPath', 'directory', 'label', 'saveTorrent', 'isFast', 'isNew', 'addition');
+		self::$sends[] = self::$lastSend;
+		return self::$sendResult;
+	}
+}
+
+eval(loadClassDefinition(
+	__DIR__ . '/../../../plugins/rutracker_check/check.php',
+	'ruTrackerChecker'
+));
+
+class CheckerProbe extends ruTrackerChecker
+{
+	public static function setStateForTest($hash, $state)
+	{
+		return parent::setState($hash, $state);
+	}
+
+	public static function getStateForTest($hash, &$state, &$time, &$successful_time, &$label)
+	{
+		return parent::getState($hash, $state, $time, $successful_time, $label);
+	}
+}
+
+// Minimal double for makeClient(): only the status matters to the tests.
+class Snoopy
+{
+	public static $nextStatus = 200;
+
+	public $status = 0;
+	public $results = '';
+	public $read_timeout = 0;
+	public $_fp_timeout = 0;
+	public $agent = '';
+
+	public function fetchComplex($url, $method = 'GET', $contentType = '', $body = '')
+	{
+		$this->status = self::$nextStatus;
+		return true;
+	}
+}
+
+class CheckerTest
+{
+	const SNAPSHOT_KEY = 'd.get_directory_base|d.get_custom1|d.get_throttle_name|d.get_connection_seed|d.get_state|d.is_open|d.stop|d.close';
+	const GETSTATE_KEY = 'd.get_custom|d.get_custom|d.get_custom|d.get_custom1';
+	const PREFLIGHT_KEY = 'd.get_custom|d.get_state|d.is_open';
+	const PREFLIGHT_KEY_COMMANDS = array('d.get_custom', 'd.get_state', 'd.is_open');
+
+	private function resetFakes()
+	{
+		Torrent::$fixtures = array();
+		rTorrent::$source = false;
+		rTorrent::$sendResult = false;
+		rTorrent::$lastSend = null;
+		rTorrent::$sends = array();
+		rXMLRPCRequest::reset();
+		FileUtil::$log = array();
+		strictSetPrivateStatic('ruTrackerChecker', 'TRACKERS', array());
+		strictSetPrivateStatic('ruTrackerChecker', 'ANNOUNCES', array());
+	}
+
+	// Fixtures for a replacement of hash OLD by hash NEW.
+	private function stageTorrents($oldInfo = array(), $newInfo = array())
+	{
+		Torrent::$fixtures['new-torrent'] = array('hash' => 'NEW', 'info' => $newInfo);
+		rTorrent::$source = new Torrent(array('hash' => 'OLD', 'info' => $oldInfo));
+		rTorrent::$sendResult = 'NEW';
+	}
+
+	private function queueViews($views = null)
+	{
+		rXMLRPCRequest::queue('d.views', true, false,
+			$views === null ? array('main', 'rat_2', 'rat_7', 'rat_9', 'rat_bad', 'rat_2_extra') : $views);
+	}
+
+	private function queueSnapshot($baseDir, $state = 1, $open = 1)
+	{
+		rXMLRPCRequest::queue(
+			array('d.get_directory_base', 'd.get_custom1', 'd.get_throttle_name', 'd.get_connection_seed', 'd.get_state', 'd.is_open', 'd.stop', 'd.close'),
+			true,
+			false,
+			array($baseDir, 'label', 'slow', 'seed-value', $state, $open, 0, 0)
+		);
+	}
+
+	// Preflight (NEW hash absent), ratio views, then the snapshot-and-stop multicall.
+	private function queueTransactionStart($baseDir, $state = 1, $open = 1)
+	{
+		rXMLRPCRequest::queue('d.hash', true, true, array());
+		$this->queueViews();
+		$this->queueSnapshot($baseDir, $state, $open);
+	}
+
+	private function currentReplacementMarker()
+	{
+		if(!is_array(rTorrent::$lastSend) || !is_array(rTorrent::$lastSend['addition']))
+			return '';
+		foreach(rTorrent::$lastSend['addition'] as $addition)
+			if(strpos($addition, 'd.set_custom=chk-replacement,') === 0)
+				return substr($addition, strlen('d.set_custom=chk-replacement,'));
+		return '';
+	}
+
+	// One waitForLoad poll answer; the marker is resolved lazily because the
+	// production code generates it randomly right before sendTorrent().
+	private function queueLoadConfirmed($marker = null)
+	{
+		rXMLRPCRequest::queue('d.get_custom', true, false, function() use ($marker) {
+			return array($marker === null ? $this->currentReplacementMarker() : $marker);
+		});
+	}
+
+	// Everything a committed replacement needs except the activation commands.
+	private function stageHappyReplacement($baseDir, $state = 1, $open = 1, $oldInfo = array(), $newInfo = array())
+	{
+		$this->stageTorrents($oldInfo, $newInfo);
+		$this->queueTransactionStart($baseDir, $state, $open);
+		$this->queueLoadConfirmed();
+		rXMLRPCRequest::queue('d.erase', true, false, array(0));
+		rXMLRPCRequest::queue('d.set_custom', true, false, array());
+	}
+
+	private function requestIndexes($key, $params = null)
+	{
+		$indexes = array();
+		foreach(rXMLRPCRequest::$requests as $index => $request)
+			if($request['key'] === $key && ($params === null || $request['commands'][0]->params === $params))
+				$indexes[] = $index;
+		return $indexes;
+	}
+
+	private function assertNoRequestKeyContains($needle, $message)
+	{
+		foreach(rXMLRPCRequest::$requests as $request)
+			strictAssertTrue(strpos($request['key'], $needle) === false, $message . ' (saw ' . $request['key'] . ')');
+	}
+
+	private function invokeCleanup($oldTorrent, $newTorrent, $baseDir)
+	{
+		strictInvoke('ruTrackerChecker', 'cleanupObsoleteFiles', array($oldTorrent, $newTorrent, $baseDir));
+	}
+
+	public function testStartedReplacementSucceeds()
+	{
+		$this->resetFakes();
+		$this->stageHappyReplacement(sys_get_temp_dir());
+		rXMLRPCRequest::queue('d.start', true, false, array(0));
+		rXMLRPCRequest::queue(array('d.get_state', 'd.is_open'), true, false, array(1, 1));
+
+		strictAssertSame(null, ruTrackerChecker::createTorrent('new-torrent', 'OLD'), 'a started replacement should succeed');
+		strictAssertSame(false, rTorrent::$lastSend['isStart'], 'the replacement must be staged stopped');
+		strictAssertSame(sys_get_temp_dir(), rTorrent::$lastSend['directory'], 'the staged copy must reuse the old base directory');
+		strictAssertSame('label', rTorrent::$lastSend['label'], 'the staged copy must reuse the old label');
+		$addition = rTorrent::$lastSend['addition'];
+		strictAssertTrue(strpos($addition[0], 'd.set_custom=chk-replacement,') === 0, 'the ownership marker must be the first load command');
+		strictAssertTrue(in_array('d.set_connection_seed=seed-value', $addition, true), 'the connection seed must be forwarded');
+		strictAssertTrue(in_array('d.set_throttle_name=slow', $addition, true), 'the throttle must be forwarded');
+		$views = array_values(array_filter($addition, function($command) {
+			return strpos($command, 'view.set_visible=') === 0;
+		}));
+		strictAssertSame(
+			array('view.set_visible=rat_2', 'view.set_visible=rat_7', 'view.set_visible=rat_9'),
+			$views,
+			'exactly the rat_N view memberships must be forwarded'
+		);
+
+		$waits = $this->requestIndexes('d.get_custom');
+		$oldErases = $this->requestIndexes('d.erase', 'OLD');
+		strictAssertSame(1, count($oldErases), 'the old hash must be erased exactly once');
+		strictAssertTrue(count($waits) === 1 && $oldErases[0] > $waits[0], 'the old hash may be erased only after the staged copy is confirmed');
+		strictAssertSame(1, count($this->requestIndexes('d.start', 'NEW')), 'the replacement must be started after commit');
+
+		$clears = rXMLRPCRequest::requestsFor('d.set_custom');
+		strictAssertSame(1, count($clears), 'the replacement marker must be cleared exactly once');
+		strictAssertSame(array('NEW', 'chk-replacement', ''), $clears[0]['commands'][0]->params, 'the marker clear must target the new hash');
+	}
+
+	public function testStoppedOpenReplacementUsesOpen()
+	{
+		$this->resetFakes();
+		$this->stageHappyReplacement(sys_get_temp_dir(), 0, 1);
+		rXMLRPCRequest::queue('d.open', true, false, array(0));
+		rXMLRPCRequest::queue(array('d.get_state', 'd.is_open'), true, false, array(0, 1));
+
+		strictAssertSame(null, ruTrackerChecker::createTorrent('new-torrent', 'OLD'), 'a stopped-but-open replacement should succeed');
+		strictAssertSame(1, count($this->requestIndexes('d.open', 'NEW')), 'a stopped-but-open torrent must be reopened, not started');
+		strictAssertSame(0, count($this->requestIndexes('d.start')), 'a stopped torrent must never be started');
+	}
+
+	public function testFullyStoppedReplacementSkipsActivation()
+	{
+		$this->resetFakes();
+		$base = sys_get_temp_dir() . '/rut-check-stopped-' . bin2hex(random_bytes(5));
+		mkdir($base, 0777, true);
+		file_put_contents($base . '/old.mkv', 'old');
+		$this->stageHappyReplacement($base, 0, 0, array('name' => 'old.mkv'), array('name' => 'new.mkv'));
+
+		try
+		{
+			strictAssertSame(null, ruTrackerChecker::createTorrent('new-torrent', 'OLD'), 'a fully stopped replacement should still commit');
+			strictAssertSame(0, count($this->requestIndexes('d.start')), 'a fully stopped torrent must not be started');
+			strictAssertSame(0, count($this->requestIndexes('d.open')), 'a fully stopped torrent must not be opened');
+			strictAssertTrue(!file_exists($base . '/old.mkv'), 'cleanup must still run for a stopped replacement');
+			strictAssertSame(1, count(rXMLRPCRequest::requestsFor('d.set_custom')), 'the marker must still be cleared for a stopped replacement');
+		}
+		finally
+		{
+			strictRemoveTree($base);
+		}
+	}
+
+	public function testStartedReplacementMayRemainClosedWhileWaitingForSchedulerSlot()
+	{
+		$this->resetFakes();
+		$this->stageHappyReplacement(sys_get_temp_dir(), 1, 1);
+		rXMLRPCRequest::queue('d.start', true, false, array(0));
+		// Started but still closed: the scheduler has not granted a slot yet.
+		rXMLRPCRequest::queue(array('d.get_state', 'd.is_open'), true, false, array(1, 0));
+
+		strictAssertSame(null, ruTrackerChecker::createTorrent('new-torrent', 'OLD'), 'a started-but-closed replacement is an activation success');
+		strictAssertSame(1, count($this->requestIndexes('d.start', 'NEW')), 'a scheduler-queued start must not be retried');
+		strictAssertSame(1, count(rXMLRPCRequest::requestsFor('d.get_state|d.is_open')), 'activation must be confirmed on the first attempt');
+	}
+
+	public function testPreExistingForeignHashLeavesOldTorrentUntouched()
+	{
+		$this->resetFakes();
+		Torrent::$fixtures['new-torrent'] = array('hash' => 'NEW', 'info' => array('name' => 'new.mkv'));
+		rXMLRPCRequest::queue('d.hash', true, false, array('NEW'));
+		rXMLRPCRequest::queue(self::PREFLIGHT_KEY_COMMANDS, true, false, array('', 0, 0));
+
+		strictAssertSame(
+			ruTrackerChecker::STE_ERROR,
+			ruTrackerChecker::createTorrent('new-torrent', 'OLD'),
+			'an unmarked pre-existing target hash must abort the replacement'
+		);
+		$probes = rXMLRPCRequest::requestsFor('d.hash');
+		strictAssertSame(1, count($probes), 'the preflight must issue exactly one hash probe');
+		strictAssertSame('NEW', $probes[0]['commands'][0]->params, 'the preflight probe must target the new hash, not the old one');
+		$markerReads = rXMLRPCRequest::requestsFor(self::PREFLIGHT_KEY);
+		strictAssertSame(1, count($markerReads), 'the pre-existing hash must be inspected exactly once');
+		strictAssertSame(array('NEW', 'chk-replacement'), $markerReads[0]['commands'][0]->params, 'the marker read must target the new hash');
+		$this->assertNoRequestKeyContains('d.stop', 'a preflight conflict must not stop anything');
+		$this->assertNoRequestKeyContains('d.erase', 'a foreign target hash must never be erased');
+		strictAssertSame(null, rTorrent::$lastSend, 'a preflight conflict must not enqueue a load');
+	}
+
+	public function testLiveTorrentWithStaleMarkerIsNotAdopted()
+	{
+		$this->resetFakes();
+		Torrent::$fixtures['new-torrent'] = array('hash' => 'NEW', 'info' => array('name' => 'new.mkv'));
+		rXMLRPCRequest::queue('d.hash', true, false, array('NEW'));
+		// A committed replacement whose final marker clear was lost: running.
+		rXMLRPCRequest::queue(self::PREFLIGHT_KEY_COMMANDS, true, false, array('stale-marker-from-dead-run', 1, 1));
+		rXMLRPCRequest::queue('d.set_custom', true, false, array());
+
+		strictAssertSame(
+			ruTrackerChecker::STE_ERROR,
+			ruTrackerChecker::createTorrent('new-torrent', 'OLD'),
+			'a live torrent with a leftover marker must not be adopted'
+		);
+		$this->assertNoRequestKeyContains('d.erase', 'a live marked torrent must never be erased');
+		$clears = rXMLRPCRequest::requestsFor('d.set_custom');
+		strictAssertSame(1, count($clears), 'the stale marker must be repaired');
+		strictAssertSame(array('NEW', 'chk-replacement', ''), $clears[0]['commands'][0]->params, 'the repair must clear the marker of the live torrent');
+		strictAssertSame(null, rTorrent::$lastSend, 'no load may be enqueued');
+	}
+
+	public function testOrphanedStagedCopyIsAdoptedAndReplaced()
+	{
+		$this->resetFakes();
+		$this->stageTorrents();
+		rXMLRPCRequest::queue('d.hash', true, false, array('NEW'));
+		rXMLRPCRequest::queue(self::PREFLIGHT_KEY_COMMANDS, true, false, array('stale-marker-from-dead-run', 0, 0));
+		rXMLRPCRequest::queue('d.erase', true, false, array(0));
+		$this->queueViews();
+		$this->queueSnapshot(sys_get_temp_dir(), 1, 1);
+		$this->queueLoadConfirmed();
+		rXMLRPCRequest::queue('d.erase', true, false, array(0));
+		rXMLRPCRequest::queue('d.start', true, false, array(0));
+		rXMLRPCRequest::queue(array('d.get_state', 'd.is_open'), true, false, array(1, 1));
+
+		strictAssertSame(null, ruTrackerChecker::createTorrent('new-torrent', 'OLD'), 'an orphaned marked staged copy must be discarded and replaced');
+		$erases = rXMLRPCRequest::requestsFor('d.erase');
+		strictAssertSame(2, count($erases), 'the orphan and the old hash must each be erased once');
+		strictAssertSame('NEW', $erases[0]['commands'][0]->params, 'the orphaned staged copy must be erased first');
+		strictAssertSame('OLD', $erases[1]['commands'][0]->params, 'the old hash must be erased at commit');
+	}
+
+	public function testRollbackRestoresOldTorrentEvenWhenStagedStatusUnknown()
+	{
+		$this->resetFakes();
+		$this->stageTorrents();
+		$this->queueTransactionStart(sys_get_temp_dir(), 1, 1);
+		// Nothing queued for d.get_custom: every waitForLoad poll fails.
+		rXMLRPCRequest::queue('d.start', true, false, array(0));
+
+		strictAssertSame(
+			ruTrackerChecker::STE_ERROR,
+			ruTrackerChecker::createTorrent('new-torrent', 'OLD'),
+			'an unconfirmed staged copy must abort the replacement'
+		);
+		strictAssertSame(
+			ruTrackerChecker::LOAD_WAIT_ATTEMPTS,
+			count(rXMLRPCRequest::requestsFor('d.get_custom')),
+			'the staged copy must be polled until the wait budget is exhausted'
+		);
+		strictAssertSame(1, count($this->requestIndexes('d.start', 'OLD')), 'the old torrent must be restored even when the staged status is unknown');
+		strictAssertSame(0, count(rXMLRPCRequest::requestsFor('d.erase')), 'a hash of unknown ownership must not be erased blindly');
+	}
+
+	public function testCommitEraseWithUnknownOldStateLeavesStagedCopy()
+	{
+		$this->resetFakes();
+		$this->stageTorrents();
+		$this->queueTransactionStart(sys_get_temp_dir(), 1, 1);
+		$this->queueLoadConfirmed();
+		rXMLRPCRequest::queue('d.erase', false, true, array());
+		// Nothing queued for the follow-up d.hash probe: the old torrent's fate
+		// is unknowable, so the marked staged copy must be left for adoption.
+
+		strictAssertSame(
+			ruTrackerChecker::STE_ERROR,
+			ruTrackerChecker::createTorrent('new-torrent', 'OLD'),
+			'an unknowable commit outcome must abort the replacement'
+		);
+		$erases = rXMLRPCRequest::requestsFor('d.erase');
+		strictAssertSame(1, count($erases), 'only the old-hash erase may be attempted');
+		strictAssertSame('OLD', $erases[0]['commands'][0]->params, 'the staged copy must never be erased while the old fate is unknown');
+		strictAssertSame(0, count($this->requestIndexes('d.start')), 'nothing may be restarted while both fates are unknown');
+		strictAssertSame(0, count($this->requestIndexes('d.open')), 'nothing may be reopened while both fates are unknown');
+	}
+
+	public function testCurlExitCodeStatusIsLoggedAsTransportFailure()
+	{
+		$this->resetFakes();
+		$savedDebug = isset($GLOBALS['rutrackerCheckDebug']) ? $GLOBALS['rutrackerCheckDebug'] : null;
+		$GLOBALS['rutrackerCheckDebug'] = true;
+		try
+		{
+			// The https path stores curl's exit code (6 = DNS failure) as status.
+			Snoopy::$nextStatus = 6;
+			ruTrackerChecker::makeClient('https://tracker.test/scrape');
+			strictAssertSame(1, count(FileUtil::$log), 'a curl exit-code status must be logged as a failed fetch');
+			strictAssertTrue(
+				strpos(FileUtil::$log[0], 'Snoopy fetch failed: host=tracker.test status=6') !== false,
+				'the transport-failure log line must carry the host and status'
+			);
+
+			FileUtil::$log = array();
+			Snoopy::$nextStatus = 200;
+			ruTrackerChecker::makeClient('https://tracker.test/scrape');
+			strictAssertSame(0, count(FileUtil::$log), 'a successful fetch must not be logged as a failure');
+		}
+		finally
+		{
+			Snoopy::$nextStatus = 200;
+			if($savedDebug === null)
+				unset($GLOBALS['rutrackerCheckDebug']);
+			else
+				$GLOBALS['rutrackerCheckDebug'] = $savedDebug;
+		}
+	}
+
+	public function testForeignMarkerAfterLoadIsNeverErased()
+	{
+		$this->resetFakes();
+		$this->stageTorrents();
+		$this->queueTransactionStart(sys_get_temp_dir(), 1, 1);
+		$this->queueLoadConfirmed('another-workers-marker');
+		rXMLRPCRequest::queue('d.start', true, false, array(0));
+
+		strictAssertSame(
+			ruTrackerChecker::STE_ERROR,
+			ruTrackerChecker::createTorrent('new-torrent', 'OLD'),
+			'a staged hash owned by another worker must abort the replacement'
+		);
+		strictAssertSame(1, count(rXMLRPCRequest::requestsFor('d.get_custom')), 'a foreign marker must be recognised on the first poll');
+		strictAssertSame(0, count(rXMLRPCRequest::requestsFor('d.erase')), 'a foreign staged copy must never be erased');
+		strictAssertSame(1, count($this->requestIndexes('d.start', 'OLD')), 'the old torrent must be restored after a foreign takeover');
+	}
+
+	public function testSynchronousLoadFailureRestoresOldTorrent()
+	{
+		$this->resetFakes();
+		$base = sys_get_temp_dir() . '/rut-check-send-fail-' . bin2hex(random_bytes(5));
+		mkdir($base, 0777, true);
+		file_put_contents($base . '/old.mkv', 'keep');
+		$this->stageTorrents(array('name' => 'old.mkv'), array('name' => 'new.mkv'));
+		rTorrent::$sendResult = false;
+		$this->queueTransactionStart($base, 1, 1);
+		// Nothing queued for d.get_custom: the load never happened.
+		rXMLRPCRequest::queue('d.start', true, false, array(0));
+
+		try
+		{
+			strictAssertSame(
+				ruTrackerChecker::STE_ERROR,
+				ruTrackerChecker::createTorrent('new-torrent', 'OLD'),
+				'a synchronous load failure must abort the replacement'
+			);
+			strictAssertTrue(is_file($base . '/old.mkv'), 'a failed load must not clean up any files');
+			strictAssertSame(0, count(rXMLRPCRequest::requestsFor('d.erase')), 'no hash may be erased when enqueueing the new torrent fails');
+			strictAssertSame(1, count($this->requestIndexes('d.start', 'OLD')), 'the old torrent must be restored after a failed load');
+		}
+		finally
+		{
+			strictRemoveTree($base);
+		}
+	}
+
+	public function testEraseRaceStillCompletesReplacement()
+	{
+		$this->resetFakes();
+		$this->stageTorrents();
+		$this->queueTransactionStart(sys_get_temp_dir(), 1, 1);
+		$this->queueLoadConfirmed();
+		rXMLRPCRequest::queue('d.erase', true, true, array());
+		rXMLRPCRequest::queue('d.hash', true, true, array());
+		rXMLRPCRequest::queue('d.start', true, false, array(0));
+		rXMLRPCRequest::queue(array('d.get_state', 'd.is_open'), true, false, array(1, 1));
+
+		strictAssertSame(null, ruTrackerChecker::createTorrent('new-torrent', 'OLD'), 'an already-gone old hash means the replacement is committed');
+		$erases = rXMLRPCRequest::requestsFor('d.erase');
+		strictAssertSame(1, count($erases), 'only the raced commit erase may run');
+		strictAssertSame('OLD', $erases[0]['commands'][0]->params, 'the commit erase must target the old hash');
+		strictAssertSame(false, $erases[0]['important'], 'the commit erase must be non-important');
+		$probes = rXMLRPCRequest::requestsFor('d.hash');
+		strictAssertSame(2, count($probes), 'a failed commit erase needs exactly one follow-up probe');
+		strictAssertSame('OLD', $probes[1]['commands'][0]->params, 'the post-erase probe must recheck the old hash');
+	}
+
+	public function testEraseFailureRestoresOldTorrentWithoutCleanup()
+	{
+		$this->resetFakes();
+		$base = sys_get_temp_dir() . '/rut-check-erase-fail-' . bin2hex(random_bytes(5));
+		mkdir($base, 0777, true);
+		file_put_contents($base . '/old.mkv', 'keep');
+		$this->stageTorrents(array('name' => 'old.mkv'), array('name' => 'new.mkv'));
+		$this->queueTransactionStart($base, 1, 1);
+		$this->queueLoadConfirmed();
+		rXMLRPCRequest::queue('d.erase', true, true, array());
+		rXMLRPCRequest::queue('d.hash', true, false, array('OLD'));
+		rXMLRPCRequest::queue('d.erase', true, false, array(0));
+		rXMLRPCRequest::queue('d.start', true, false, array(0));
+
+		try
+		{
+			strictAssertSame(
+				ruTrackerChecker::STE_ERROR,
+				ruTrackerChecker::createTorrent('new-torrent', 'OLD'),
+				'a failed commit erase with the old hash still present must roll back'
+			);
+			strictAssertTrue(is_file($base . '/old.mkv'), 'an aborted commit must not clean up any files');
+			$erases = rXMLRPCRequest::requestsFor('d.erase');
+			strictAssertSame(2, count($erases), 'rollback must discard the staged copy after the failed commit erase');
+			strictAssertSame('OLD', $erases[0]['commands'][0]->params, 'the commit erase targets the old hash');
+			strictAssertSame('NEW', $erases[1]['commands'][0]->params, 'rollback erases the staged copy');
+			strictAssertSame(1, count($this->requestIndexes('d.start', 'OLD')), 'the old started torrent must return through the scheduler');
+			strictAssertSame(0, count(rXMLRPCRequest::requestsFor('d.set_custom')), 'the marker of a discarded staged copy needs no clearing');
+		}
+		finally
+		{
+			strictRemoveTree($base);
+		}
+	}
+
+	public function testActivationFailureAfterCommitStillFinishes()
+	{
+		$this->resetFakes();
+		$base = sys_get_temp_dir() . '/rut-check-activation-' . bin2hex(random_bytes(5));
+		mkdir($base, 0777, true);
+		file_put_contents($base . '/old.mkv', 'remove');
+		$this->stageHappyReplacement($base, 1, 1, array('name' => 'old.mkv'), array('name' => 'new.mkv'));
+		// No activation responses queued: both start attempts and checks fail.
+
+		try
+		{
+			strictAssertSame(null, ruTrackerChecker::createTorrent('new-torrent', 'OLD'), 'activation trouble after commit must not fail the check');
+			strictAssertSame(2, count(rXMLRPCRequest::requestsFor('d.get_state|d.is_open')), 'activation must be attempted exactly twice');
+			strictAssertTrue(!file_exists($base . '/old.mkv'), 'cleanup must run even when activation fails');
+			$clears = rXMLRPCRequest::requestsFor('d.set_custom');
+			strictAssertSame(1, count($clears), 'the marker must be cleared even when activation fails');
+			strictAssertSame(array('NEW', 'chk-replacement', ''), $clears[0]['commands'][0]->params, 'the marker clear must target the new hash');
+		}
+		finally
+		{
+			strictRemoveTree($base);
+		}
+	}
+
+	public function testMissingOldMetainfoAbortsBeforeStoppingAnything()
+	{
+		$this->resetFakes();
+		Torrent::$fixtures['new-torrent'] = array('hash' => 'NEW', 'info' => array('name' => 'new.mkv'));
+		rXMLRPCRequest::queue('d.hash', true, true, array());
+
+		strictAssertSame(
+			ruTrackerChecker::STE_ERROR,
+			ruTrackerChecker::createTorrent('new-torrent', 'OLD'),
+			'replacement needs the old metainfo for a safe post-commit recovery'
+		);
+		strictAssertSame(1, count(rXMLRPCRequest::$requests), 'missing old metainfo must abort right after the preflight probe');
+		strictAssertSame('d.hash', rXMLRPCRequest::$requests[0]['key'], 'only the preflight probe may run without the old metainfo');
+		strictAssertSame(null, rTorrent::$lastSend, 'missing old metainfo must not enqueue a replacement');
+	}
+
+	public function testStateSnapshotAndStopShareOneMulticall()
+	{
+		$this->resetFakes();
+		$this->stageHappyReplacement(sys_get_temp_dir());
+		rXMLRPCRequest::queue('d.start', true, false, array(0));
+		rXMLRPCRequest::queue(array('d.get_state', 'd.is_open'), true, false, array(1, 1));
+
+		strictAssertSame(null, ruTrackerChecker::createTorrent('new-torrent', 'OLD'), 'the happy path should succeed');
+		strictAssertSame(1, count(rXMLRPCRequest::requestsFor(self::SNAPSHOT_KEY)), 'state snapshot and stop/close must share one multicall');
+		strictAssertSame(0, count(rXMLRPCRequest::requestsFor('d.stop|d.close')), 'no standalone stop/close request may race the snapshot');
+		strictAssertSame(0, count(rXMLRPCRequest::requestsFor('d.stop')), 'no lone stop command may race the snapshot');
+	}
+
+	public function testInvalidPayloadIsReportedAsDeletedTopic()
+	{
+		$this->resetFakes();
+		Torrent::$fixtures['not-a-torrent'] = array('errors' => true);
+
+		strictAssertSame(
+			ruTrackerChecker::STE_DELETED,
+			ruTrackerChecker::createTorrent('not-a-torrent', 'OLD'),
+			'legacy handlers rely on an unparseable payload meaning a removed topic'
+		);
+		strictAssertSame(0, count(rXMLRPCRequest::$requests), 'a parse failure must not touch rTorrent');
+	}
+
+	public function testMissingHashSkipsStateRead()
+	{
+		$this->resetFakes();
+		rXMLRPCRequest::queue('d.hash', true, true, array());
+		$state = null;
+		$time = null;
+		$successful_time = null;
+		$label = null;
+
+		strictAssertSame(false, CheckerProbe::getStateForTest('MISSING', $state, $time, $successful_time, $label), 'a missing hash must fail the state read');
+		strictAssertSame(ruTrackerChecker::STE_NOT_NEED, $state, 'a missing hash must resolve to STE_NOT_NEED');
+		strictAssertSame(0, count(rXMLRPCRequest::requestsFor(self::GETSTATE_KEY)), 'a missing hash must not read custom state');
+
+		rXMLRPCRequest::reset();
+		rXMLRPCRequest::queue('d.hash', true, true, array());
+		strictAssertSame(true, ruTrackerChecker::run('MISSING'), 'a stale worker must be a successful no-op');
+		strictAssertSame(1, count(rXMLRPCRequest::$requests), 'the stale worker path should only probe the hash');
+	}
+
+	public function testStateWriteRaceReportsMissingHashWithoutAnError()
+	{
+		$this->resetFakes();
+		rXMLRPCRequest::queue('d.set_custom|d.set_custom', true, true, array());
+		rXMLRPCRequest::queue('d.hash', true, true, array());
+
+		strictAssertSame(null, CheckerProbe::setStateForTest('OLD', ruTrackerChecker::STE_UPDATED), 'setState must report that its target disappeared');
+		strictAssertSame(2, count(rXMLRPCRequest::$requests), 'a failed state write needs exactly one follow-up probe');
+		strictAssertSame('d.set_custom|d.set_custom', rXMLRPCRequest::$requests[0]['key'], 'the state write must be issued before any probe');
+		strictAssertSame(false, rXMLRPCRequest::$requests[0]['important'], 'the racy state write must be non-important');
+		strictAssertSame('d.hash', rXMLRPCRequest::$requests[1]['key'], 'the miss is confirmed by a hash probe after the failed write');
+
+		// run() maps the vanished target to a successful no-op.
+		rXMLRPCRequest::reset();
+		rXMLRPCRequest::queue('d.hash', true, false, array('OLD'));
+		rXMLRPCRequest::queue('d.set_custom|d.set_custom', true, true, array());
+		rXMLRPCRequest::queue('d.hash', true, true, array());
+		strictAssertSame(
+			true,
+			ruTrackerChecker::run('OLD', ruTrackerChecker::STE_UPTODATE, time(), 0, ''),
+			'a state-write race must not be reported as a check failure'
+		);
+		strictAssertSame(3, count(rXMLRPCRequest::$requests), 'the raced run must stop right after the confirming probe');
+	}
+
+	public function testSchedulerStateStillSkipsMissingHash()
+	{
+		$this->resetFakes();
+		rXMLRPCRequest::queue('d.hash', true, true, array());
+
+		strictAssertSame(
+			true,
+			ruTrackerChecker::run('MISSING', ruTrackerChecker::STE_UPTODATE, time(), 0, ''),
+			'a stale scheduler row must be a successful no-op'
+		);
+		strictAssertSame(1, count(rXMLRPCRequest::$requests), 'cached scheduler state must not bypass the missing-hash guard');
+		strictAssertSame('d.hash', rXMLRPCRequest::$requests[0]['key'], 'the stale scheduler path should only probe the hash');
+	}
+
+	public function testDispatchPrefersCommentMatchesAndFallsBackToAnnounce()
+	{
+		$rows = array(
+			'comment match' => array(
+				'fixture' => array(
+					'hash' => 'OLD',
+					'info' => array('name' => 'file.mkv'),
+					'announce' => 'http://unrelated.invalid/announce',
+					'comment' => 'https://topic.comment-test.invalid/view?id=42',
+				),
+				'trackers' => array(
+					array('/topic\.comment-test\.invalid/', '/tracker\.comment-test\.invalid/', 'comment-test'),
+				),
+				'expect' => array('comment-test', 'https://topic.comment-test.invalid/view?id=42'),
+			),
+			'announce fallback' => array(
+				'fixture' => array(
+					'hash' => 'OLD',
+					'info' => array('name' => 'file.mkv'),
+					'announce' => 'http://tracker.announce-test.invalid/announce',
+					'comment' => 'no topic URL here',
+				),
+				'trackers' => array(
+					array('/topic\.announce-test\.invalid/', '/tracker\.announce-test\.invalid/', 'announce-test'),
+				),
+				'expect' => array('announce-test', 'http://tracker.announce-test.invalid/announce'),
+			),
+			'comment priority across handlers' => array(
+				'fixture' => array(
+					'hash' => 'OLD',
+					'info' => array('name' => 'file.mkv'),
+					'announce' => 'http://tracker.first-priority.invalid/announce',
+					'comment' => 'https://topic.second-priority.invalid/view?id=42',
+				),
+				'trackers' => array(
+					array('/topic\.first-priority\.invalid/', '/tracker\.first-priority\.invalid/', 'first'),
+					array('/topic\.second-priority\.invalid/', '/tracker\.second-priority\.invalid/', 'second'),
+				),
+				'expect' => array('second', 'https://topic.second-priority.invalid/view?id=42'),
+			),
+			'announce-list flattening' => array(
+				'fixture' => array(
+					'hash' => 'OLD',
+					'info' => array('name' => 'file.mkv'),
+					'announce' => 'http://unrelated.invalid/announce',
+					'announce_list' => array(
+						array('http://unrelated-two.invalid/announce'),
+						array('http://tracker.list-test.invalid/announce'),
+					),
+					'comment' => 'no topic URL here',
+				),
+				'trackers' => array(
+					array('/topic\.list-test\.invalid/', '/tracker\.list-test\.invalid/', 'list-test'),
+				),
+				'expect' => array('list-test', 'http://tracker.list-test.invalid/announce'),
+			),
+		);
+
+		foreach($rows as $label => $row)
+		{
+			$this->resetFakes();
+			Torrent::$fixtures['dispatch'] = $row['fixture'];
+			$calls = array();
+			foreach($row['trackers'] as $tracker)
+			{
+				list($commentFilter, $announceFilter, $id) = $tracker;
+				ruTrackerChecker::registerTracker($commentFilter, $announceFilter, function($url) use (&$calls, $id) {
+					$calls[] = array($id, $url);
+					return ruTrackerChecker::STE_UPTODATE;
+				});
+				strictAssertTrue(
+					in_array($announceFilter, ruTrackerChecker::supportedTrackers(), true),
+					$label . ': supportedTrackers must expose the registered announce filter'
+				);
+			}
+
+			strictAssertSame(
+				ruTrackerChecker::STE_UPTODATE,
+				ruTrackerChecker::run_ex('OLD', 'dispatch'),
+				$label . ': the matching handler result must be returned'
+			);
+			strictAssertSame(
+				array(array($row['expect'][0], $row['expect'][1])),
+				$calls,
+				$label . ': exactly the expected handler must run with the matched URL'
+			);
+		}
+	}
+
+	public function testCleanupDeletesOnlyRenamedOldFileAndKeepsBase()
+	{
+		$this->resetFakes();
+		$base = sys_get_temp_dir() . '/rut-check-clean-' . bin2hex(random_bytes(5));
+		mkdir($base . '/old', 0777, true);
+		file_put_contents($base . '/old/video-old.mkv', 'old');
+		file_put_contents($base . '/shared.nfo', 'shared');
+		file_put_contents($base . '/unrelated.txt', 'keep');
+		$old = new Torrent(array('hash' => 'OLD', 'info' => array('files' => array(
+			array('path' => array('old', 'video-old.mkv'), 'length' => 3),
+			array('path' => array('shared.nfo'), 'length' => 6),
+		))));
+		$new = new Torrent(array('hash' => 'NEW', 'info' => array('files' => array(
+			array('path' => array('video-new.mkv'), 'length' => 3),
+			array('path' => array('shared.nfo'), 'length' => 6),
+		))));
+
+		try
+		{
+			$this->invokeCleanup($old, $new, $base);
+			strictAssertTrue(!file_exists($base . '/old/video-old.mkv'), 'the renamed old-only file should be deleted');
+			strictAssertTrue(!is_dir($base . '/old'), 'an empty child directory should be removed');
+			strictAssertTrue(is_file($base . '/shared.nfo'), 'a file present in both torrents must remain');
+			strictAssertTrue(is_file($base . '/unrelated.txt'), 'unrelated files must remain');
+			strictAssertTrue(is_dir($base), 'the torrent base directory must never be removed');
+		}
+		finally
+		{
+			strictRemoveTree($base);
+		}
+	}
+
+	public function testCleanupDoesNotFollowDirectorySymlinkOutsideBase()
+	{
+		$this->resetFakes();
+		$root = sys_get_temp_dir() . '/rut-check-link-' . bin2hex(random_bytes(5));
+		$base = $root . '/base';
+		$outside = $root . '/outside';
+		mkdir($base, 0777, true);
+		mkdir($outside, 0777, true);
+		file_put_contents($outside . '/victim.mkv', 'keep');
+		symlink($outside, $base . '/link');
+		$old = new Torrent(array('hash' => 'OLD', 'info' => array('files' => array(
+			array('path' => array('link', 'victim.mkv'), 'length' => 4),
+		))));
+		$new = new Torrent(array('hash' => 'NEW', 'info' => array('name' => 'replacement.mkv')));
+
+		try
+		{
+			$this->invokeCleanup($old, $new, $base);
+			strictAssertTrue(is_file($outside . '/victim.mkv'), 'cleanup must not follow a directory symlink outside the base');
+		}
+		finally
+		{
+			strictRemoveTree($root);
+		}
+	}
+
+	public function testCleanupAbortsWhenNewManifestContainsUnsafePath()
+	{
+		$this->resetFakes();
+		$base = sys_get_temp_dir() . '/rut-check-unsafe-' . bin2hex(random_bytes(5));
+		mkdir($base . '/folder', 0777, true);
+		file_put_contents($base . '/folder/file.mkv', 'keep');
+		$old = new Torrent(array('hash' => 'OLD', 'info' => array('files' => array(
+			array('path' => array('folder', 'file.mkv'), 'length' => 4),
+		))));
+		$new = new Torrent(array('hash' => 'NEW', 'info' => array('files' => array(
+			array('path' => array('folder/file.mkv'), 'length' => 4),
+		))));
+
+		try
+		{
+			$this->invokeCleanup($old, $new, $base);
+			strictAssertTrue(is_file($base . '/folder/file.mkv'), 'an unsafe new manifest must abort cleanup instead of hiding a live path');
+		}
+		finally
+		{
+			strictRemoveTree($base);
+		}
+	}
+
+	public function testCleanupNeverRemovesBaseDirectory()
+	{
+		$this->resetFakes();
+		$base = sys_get_temp_dir() . '/rut-check-base-' . bin2hex(random_bytes(5));
+		mkdir($base, 0777, true);
+		file_put_contents($base . '/old.mkv', 'old');
+		$old = new Torrent(array('hash' => 'OLD', 'info' => array('name' => 'old.mkv', 'length' => 3)));
+		$new = new Torrent(array('hash' => 'NEW', 'info' => array('name' => 'new.mkv', 'length' => 3)));
+
+		try
+		{
+			$this->invokeCleanup($old, $new, $base);
+			strictAssertTrue(is_dir($base), 'cleanup may remove an old file but never its base directory');
+		}
+		finally
+		{
+			strictRemoveTree($base);
+		}
+	}
+
+	public function testCleanupRefusesFilesystemRootAsBase()
+	{
+		$this->resetFakes();
+		$path = tempnam(sys_get_temp_dir(), 'rut-check-root-');
+		file_put_contents($path, 'keep');
+		$old = new Torrent(array('hash' => 'OLD', 'info' => array('files' => array(
+			array('path' => explode('/', ltrim($path, '/')), 'length' => 4),
+		))));
+		$new = new Torrent(array('hash' => 'NEW', 'info' => array('name' => 'replacement.mkv')));
+
+		try
+		{
+			$this->invokeCleanup($old, $new, DIRECTORY_SEPARATOR);
+			strictAssertTrue(is_file($path), 'cleanup must refuse the filesystem root as its base directory');
+		}
+		finally
+		{
+			@unlink($path);
+		}
+	}
+
+	public function testCleanupKeepsFileAliasedByNewTorrent()
+	{
+		$this->resetFakes();
+		$base = sys_get_temp_dir() . '/rut-check-alias-' . bin2hex(random_bytes(5));
+		mkdir($base, 0777, true);
+		file_put_contents($base . '/a.mkv', 'payload');
+		link($base . '/a.mkv', $base . '/b.mkv');
+		$old = new Torrent(array('hash' => 'OLD', 'info' => array('name' => 'b.mkv')));
+		$new = new Torrent(array('hash' => 'NEW', 'info' => array('name' => 'a.mkv')));
+
+		try
+		{
+			$this->invokeCleanup($old, $new, $base);
+			strictAssertTrue(is_file($base . '/b.mkv'), 'a path aliasing a file of the new torrent must be kept');
+			strictAssertTrue(is_file($base . '/a.mkv'), 'the new torrent file itself must be kept');
+		}
+		finally
+		{
+			strictRemoveTree($base);
+		}
+	}
+}
+
+$suite = new StrictTestSuite();
+$suite->addFromObject(new CheckerTest());
+exit($suite->run());

--- a/tests/plugins/rutracker_check/NNMClubHandlerTest.php
+++ b/tests/plugins/rutracker_check/NNMClubHandlerTest.php
@@ -1,0 +1,350 @@
+<?php
+
+define('TESTLIB_HANDLER_STUBS', 1);
+require_once(__DIR__ . '/TestLib.php');
+require_once(testFindRepoRoot() . '/plugins/rutracker_check/trackers/nnmclub.php');
+
+function nnmReset()
+{
+    ruTrackerChecker::reset();
+    strictSetPrivateStatic('NNMClubCheckImpl', 'donor', false);
+    rTorrentSettings::get()->session = '/nonexistent/';
+}
+
+function nnmDynamicScrapeUrl($host, $passkey, $hash)
+{
+    return 'http://' . $host . '/' . $passkey
+        . '/scrape?info_hash=' . rawurlencode(hex2bin($hash));
+}
+
+function nnmStaticScrapeUrl($host, $passkey, $hash)
+{
+    return 'http://' . $host . '/scrape?uk=' . rawurlencode($passkey)
+        . '&info_hash=' . rawurlencode(hex2bin($hash));
+}
+
+function nnmTopicUrl($topicId)
+{
+    return 'https://nnmclub.to/forum/viewtopic.php?t=' . $topicId;
+}
+
+function nnmDownloadUrl($downloadId)
+{
+    return 'https://nnmclub.to/forum/download.php?id=' . $downloadId;
+}
+
+$suite = new StrictTestSuite();
+$realPasskey = 'AbCdEf0123456789AbCdEf0123456789';
+$dummyPasskey = str_repeat('f', 32);
+
+$suite->test('scrape hit returns up to date without guest request', function () use ($realPasskey) {
+    $rows = array(
+        array(
+            'label' => 'path-style credential on official tracker host',
+            'name' => 'current.bin',
+            'announce' => 'http://bt02.nnm-club.cc:2710/' . $realPasskey . '/announce',
+            'comment' => nnmTopicUrl(42),
+            'url' => nnmTopicUrl(42),
+            'scrapeHost' => 'bt02.nnm-club.cc:2710',
+            'scrapeMode' => 'dynamic',
+        ),
+        array(
+            'label' => 'announce-only torrent is confirmed by its tracker scrape',
+            'name' => 'announce-only.bin',
+            'announce' => 'http://bt.searchtor.to/announce?uk=' . $realPasskey,
+            'comment' => '',
+            'url' => 'http://bt.searchtor.to/announce?uk=' . $realPasskey,
+            'scrapeHost' => 'bt.searchtor.to',
+            'scrapeMode' => 'static',
+        ),
+        array(
+            'label' => 'documented legacy static tracker host bt.nnm-club.ru',
+            'name' => 'legacy-ru.bin',
+            'announce' => 'http://bt.nnm-club.ru:2710/announce?uk=' . $realPasskey,
+            'comment' => nnmTopicUrl(42),
+            'url' => nnmTopicUrl(42),
+            'scrapeHost' => 'bt.nnm-club.ru:2710',
+            'scrapeMode' => 'static',
+        ),
+        array(
+            'label' => 'documented legacy static tracker host nnm-club.info',
+            'name' => 'legacy-info.bin',
+            'announce' => 'http://nnm-club.info:2710/announce?uk=' . $realPasskey,
+            'comment' => nnmTopicUrl(42),
+            'url' => nnmTopicUrl(42),
+            'scrapeHost' => 'nnm-club.info:2710',
+            'scrapeMode' => 'static',
+        ),
+        array(
+            'label' => 'current searchtor dynamic credential scrapes its own hash',
+            'name' => 'current-searchtor.bin',
+            'announce' => 'http://bt.searchtor.to/' . $realPasskey . '/announce',
+            'comment' => nnmTopicUrl(42),
+            'url' => nnmTopicUrl(42),
+            'scrapeHost' => 'bt.searchtor.to',
+            'scrapeMode' => 'dynamic',
+        ),
+        array(
+            'label' => 'www topic host and static searchtor credential',
+            'name' => 'www-topic.bin',
+            'announce' => 'http://bt.searchtor.to/announce?uk=' . $realPasskey,
+            'comment' => 'https://www.nnmclub.to/forum/viewtopic.php?t=42',
+            'url' => 'https://www.nnmclub.to/forum/viewtopic.php?t=42',
+            'scrapeHost' => 'bt.searchtor.to',
+            'scrapeMode' => 'static',
+        ),
+    );
+
+    foreach ($rows as $row) {
+        nnmReset();
+        $raw = strictTorrentRaw(
+            $row['name'],
+            $row['announce'],
+            $row['comment'],
+            isset($row['announceList']) ? $row['announceList'] : null
+        );
+        $torrent = @new Torrent($raw);
+        strictAssertTrue(!$torrent->errors(), $row['label'] . ': fixture must parse');
+        $hash = $torrent->hash_info();
+        $scrapeUrl = $row['scrapeMode'] === 'dynamic'
+            ? nnmDynamicScrapeUrl($row['scrapeHost'], $realPasskey, $hash)
+            : nnmStaticScrapeUrl($row['scrapeHost'], $realPasskey, $hash);
+        Snoopy::queue($scrapeUrl, 200, strictScrapePayload($hash, true));
+
+        $result = NNMClubCheckImpl::download_torrent($row['url'], $hash, $torrent);
+
+        strictAssertSame(ruTrackerChecker::STE_UPTODATE, $result, $row['label'] . ': scrape hit is up to date');
+        strictAssertSame(
+            array(array('fetchComplex', $scrapeUrl)),
+            Snoopy::$requests,
+            $row['label'] . ': exactly the expected scrape request, no guest request'
+        );
+        strictAssertSame(0, count(ruTrackerChecker::$created), $row['label'] . ': up-to-date torrent is not replaced');
+    }
+});
+
+$suite->test('scrape miss downloads guest torrent and patches real passkey', function () use ($realPasskey, $dummyPasskey) {
+    nnmReset();
+    $oldRaw = strictTorrentRaw(
+        'old.bin',
+        'http://bt.searchtor.to/announce?uk=' . $realPasskey,
+        nnmTopicUrl(42)
+    );
+    $oldTorrent = @new Torrent($oldRaw);
+    strictAssertTrue(!$oldTorrent->errors(), 'Old torrent fixture must parse');
+    $oldHash = $oldTorrent->hash_info();
+
+    $guestRaw = strictTorrentRaw(
+        'new.bin',
+        'http://bt.searchtor.to/' . $dummyPasskey . '/announce',
+        nnmTopicUrl(42),
+        array(
+            array('http://ipv6.bt.searchtor.to/' . $dummyPasskey . '/announce'),
+            array('http://bt.nnmclub.example/' . $dummyPasskey . '/announce'),
+            array('https://example.test/announce'),
+        )
+    );
+    $guestTorrent = @new Torrent($guestRaw);
+    strictAssertTrue(!$guestTorrent->errors(), 'Guest torrent fixture must parse');
+    $guestHash = $guestTorrent->hash_info();
+    strictAssertTrue($guestHash !== $oldHash, 'Guest fixture must represent an update');
+
+    Snoopy::queue(
+        nnmStaticScrapeUrl('bt.searchtor.to', $realPasskey, $oldHash),
+        200,
+        strictScrapePayload($oldHash, false)
+    );
+    Snoopy::queue(nnmTopicUrl(42), 200, '<a href="download.php?id=7">download</a>');
+    Snoopy::queue(nnmDownloadUrl(7), 200, $guestRaw);
+
+    $result = NNMClubCheckImpl::download_torrent(nnmTopicUrl(42), $oldHash, $oldTorrent);
+
+    strictAssertSame(null, $result, 'Successful replacement propagates createTorrent result');
+    strictAssertSame(1, count(ruTrackerChecker::$created), 'Changed guest torrent is replaced once');
+    $patched = @new Torrent(ruTrackerChecker::$created[0]['payload']);
+    strictAssertTrue(!$patched->errors(), 'Patched replacement torrent must remain valid');
+    strictAssertSame($guestHash, $patched->hash_info(), 'Passkey patch must not change info hash');
+    strictAssertTrue(
+        strpos($patched->announce(), '/announce?uk=' . $realPasskey) !== false,
+        'Primary announce gets the reusable profile passkey in query form'
+    );
+    $patchedRaw = (string) $patched;
+    strictAssertTrue(
+        strpos($patchedRaw, 'http://ipv6.bt.searchtor.to/announce?uk=' . $realPasskey) !== false,
+        'Official alternate announce gets the reusable profile passkey'
+    );
+    strictAssertTrue(
+        strpos($patchedRaw, 'http://bt.nnmclub.example/' . $dummyPasskey . '/announce') !== false,
+        'Lookalike tracker URL remains unchanged'
+    );
+    strictAssertTrue(
+        strpos($patchedRaw, 'bt.nnmclub.example/announce?uk=' . $realPasskey) === false,
+        'Reusable profile passkey is never sent to a lookalike tracker host'
+    );
+    strictAssertTrue(strpos($patchedRaw, 'https://example.test/announce') !== false, 'Unrelated announce URL remains unchanged');
+});
+
+$suite->test('dynamic credential is never transplanted into a changed torrent', function () use ($realPasskey, $dummyPasskey) {
+    nnmReset();
+    $oldRaw = strictTorrentRaw(
+        'old-dynamic.bin',
+        'http://bt.searchtor.to/' . $realPasskey . '/announce',
+        nnmTopicUrl(42)
+    );
+    $oldTorrent = @new Torrent($oldRaw);
+    $oldHash = $oldTorrent->hash_info();
+    $guestRaw = strictTorrentRaw(
+        'new-dynamic.bin',
+        'http://bt.searchtor.to/' . $dummyPasskey . '/announce',
+        nnmTopicUrl(42)
+    );
+    Snoopy::queue(
+        nnmDynamicScrapeUrl('bt.searchtor.to', $realPasskey, $oldHash),
+        200,
+        strictScrapePayload($oldHash, false)
+    );
+    Snoopy::queue(nnmTopicUrl(42), 200, '<a href="download.php?id=7">download</a>');
+    Snoopy::queue(nnmDownloadUrl(7), 200, $guestRaw);
+
+    $result = NNMClubCheckImpl::download_torrent(nnmTopicUrl(42), $oldHash, $oldTorrent);
+
+    strictAssertSame(ruTrackerChecker::STE_ERROR, $result, 'A changed torrent needs a reusable profile credential');
+    strictAssertSame(0, count(ruTrackerChecker::$created), 'Per-distribution credential must not be copied to a new hash');
+});
+
+$suite->test('array topic parameters are rejected without warnings', function () use ($dummyPasskey) {
+    nnmReset();
+    $url = 'https://nnmclub.to/forum/viewtopic.php?t[]=42';
+    $raw = strictTorrentRaw(
+        'malformed-topic.bin',
+        'http://bt.searchtor.to/' . $dummyPasskey . '/announce',
+        $url
+    );
+    $torrent = @new Torrent($raw);
+    set_error_handler(function ($severity, $message, $file, $line) {
+        throw new ErrorException($message, 0, $severity, $file, $line);
+    });
+    try {
+        $result = NNMClubCheckImpl::download_torrent($url, $torrent->hash_info(), $torrent);
+    } finally {
+        restore_error_handler();
+    }
+
+    strictAssertSame(ruTrackerChecker::STE_NOT_NEED, $result, 'Non-scalar topic IDs are invalid');
+    strictAssertSame(0, count(Snoopy::$requests), 'Invalid topic references must not trigger network requests');
+});
+
+$suite->test('Cloudflare challenge is a reachability error', function () use ($dummyPasskey) {
+    nnmReset();
+    $raw = strictTorrentRaw(
+        'challenge.bin',
+        'http://bt02.nnm-club.cc:2710/' . $dummyPasskey . '/announce',
+        nnmTopicUrl(42)
+    );
+    $torrent = @new Torrent($raw);
+    strictAssertTrue(!$torrent->errors(), 'Challenge torrent fixture must parse');
+    Snoopy::queue(
+        nnmTopicUrl(42),
+        200,
+        '<html><div id="cf-chl">Cloudflare Turnstile challenge</div></html>'
+    );
+
+    $result = NNMClubCheckImpl::download_torrent(nnmTopicUrl(42), $torrent->hash_info(), $torrent);
+
+    strictAssertSame(
+        ruTrackerChecker::STE_CANT_REACH_TRACKER,
+        $result,
+        'Challenge page is temporary tracker unavailability'
+    );
+    strictAssertSame(0, count(ruTrackerChecker::$created), 'Challenge page never replaces a torrent');
+});
+
+$suite->test('donor passkey is used in memory without rewriting session torrent', function () use ($realPasskey, $dummyPasskey) {
+    nnmReset();
+    $tempDir = sys_get_temp_dir() . '/nnmclub-donor-red-' . getmypid() . '-' . mt_rand();
+    mkdir($tempDir, 0700, true);
+
+    try {
+        $targetRaw = strictTorrentRaw(
+            'target.bin',
+            'http://bt02.nnm-club.cc:2710/' . $dummyPasskey . '/announce',
+            nnmTopicUrl(42),
+            null,
+            array(
+                'libtorrent_resume' => array('bitfield' => 1),
+                'rtorrent' => array('state' => 1),
+            )
+        );
+        $target = @new Torrent($targetRaw);
+        strictAssertTrue(!$target->errors(), 'Target torrent fixture must parse');
+        $targetHash = $target->hash_info();
+        $targetPath = $tempDir . '/' . $targetHash . '.torrent';
+        file_put_contents($targetPath, $targetRaw);
+
+        $donorRaw = strictTorrentRaw(
+            'donor.bin',
+            'http://bt.searchtor.to/announce?uk=' . $realPasskey,
+            nnmTopicUrl(77)
+        );
+        file_put_contents($tempDir . '/' . str_repeat('D', 40) . '.torrent', $donorRaw);
+
+        rTorrentSettings::get()->session = $tempDir . '/';
+        Snoopy::queue(
+            nnmStaticScrapeUrl('bt.searchtor.to', $realPasskey, $targetHash),
+            200,
+            strictScrapePayload($targetHash, true)
+        );
+
+        $before = file_get_contents($targetPath);
+        $result = NNMClubCheckImpl::download_torrent(nnmTopicUrl(42), $targetHash, $target);
+        $after = file_get_contents($targetPath);
+
+        strictAssertSame(ruTrackerChecker::STE_UPTODATE, $result, 'Donor passkey can authenticate scrape');
+        strictAssertSame(
+            $before,
+            $after,
+            'Donor passkey lookup must not mutate the live rTorrent session file'
+        );
+    } finally {
+        strictRemoveTree($tempDir);
+    }
+});
+
+$suite->test('hostile deeply nested scrape payload is dismissed without recursion', function () {
+    nnmReset();
+    $hash = str_repeat('AB', 20);
+    $binary = hex2bin($hash);
+    // With the old recursive bencode decoder this payload exhausted the call
+    // stack / memory limit and killed the whole test process.
+    $hostile = 'd' . str_repeat('l', 300000);
+    strictAssertSame(
+        false,
+        strictInvoke('NNMClubCheckImpl', 'scrapeContainsHash', array($hostile, $binary)),
+        'a hostile payload must simply not match'
+    );
+    strictAssertSame(
+        true,
+        strictInvoke('NNMClubCheckImpl', 'scrapeContainsHash', array(strictScrapePayload($hash, true), $binary)),
+        'a well-formed payload listing the hash must match'
+    );
+    strictAssertSame(
+        false,
+        strictInvoke('NNMClubCheckImpl', 'scrapeContainsHash', array(strictScrapePayload($hash, false), $binary)),
+        'a well-formed payload without the hash must not match'
+    );
+});
+
+$suite->test('guest transport failure with a curl exit code is logged', function () {
+    nnmReset();
+    // The https path stores curl's exit code (6 = DNS failure) as the status.
+    Snoopy::queue('https://nnmclub.to/forum/viewtopic.php?t=1', 6, '');
+    $client = new Snoopy();
+    strictInvoke('NNMClubCheckImpl', 'guestFetch', array($client, 'https://nnmclub.to/forum/viewtopic.php?t=1'));
+    $failureLogs = array_values(array_filter(ruTrackerChecker::$logs, function ($line) {
+        return strpos($line, 'Guest fetch failed') !== false;
+    }));
+    strictAssertSame(1, count($failureLogs), 'a curl exit-code status must be logged as a failed guest fetch');
+    strictAssertTrue(strpos($failureLogs[0], 'status=6') !== false, 'the log line must carry the status');
+});
+
+exit($suite->run());

--- a/tests/plugins/rutracker_check/RuTrackerHandlerTest.php
+++ b/tests/plugins/rutracker_check/RuTrackerHandlerTest.php
@@ -1,0 +1,229 @@
+<?php
+
+define('TESTLIB_HANDLER_STUBS', 1);
+require_once(__DIR__ . '/TestLib.php');
+require_once(testFindRepoRoot() . '/plugins/rutracker_check/trackers/rutracker.php');
+
+function ruApiUrl($topicId)
+{
+    return 'https://api.rutracker.cc/v1/get_tor_hash?by=topic_id&val=' . $topicId;
+}
+
+function ruDownloadUrl($topicId)
+{
+    return 'https://rutracker.org/forum/dl.php?t=' . $topicId;
+}
+
+function ruTopicUrl($topicId, $start = null)
+{
+    $url = 'https://rutracker.org/forum/viewtopic.php?t=' . $topicId;
+    return $start === null ? $url : $url . '&start=' . $start;
+}
+
+function ruUserPost($topicId)
+{
+    return strictCp1251(
+        '<table class="topic"><tbody id="post_100" class="row1"><tr>'
+        . '<td class="poster_info td1"><p class="nick nick-author">ordinary-user</p>'
+        . '<p class="rank_img"><img class="user-rank" alt="User"></p></td>'
+        . '<td><div class="post_body"><a href="viewtopic.php?t=' . $topicId . '">other topic</a>'
+        . ' Этот фильм было Поглощено вниманием зрителей.</div><!--/post_body--></td></tr></tbody></table>'
+    );
+}
+
+function ruModeratorPost($topicId, $prefix = '')
+{
+    return strictCp1251(
+        '<table class="topic">' . $prefix . '<tbody id="post_200" class="row1"><tr>'
+        . '<td class="poster_info td1"><p class="nick nick-author">tracker-moderator</p>'
+        . '<p class="rank_img"><img class="user-rank" alt="Moderator"></p></td>'
+        . '<td><div class="post_body"><a class="postLink" href="viewtopic.php?t=' . $topicId . '">replacement</a>'
+        . '<span class="post-b">Поглощено</span></div><!--/post_body--></td></tr></tbody></table>'
+    );
+}
+
+$suite = new StrictTestSuite();
+$oldHash = str_repeat('A', 40);
+$newHash = str_repeat('B', 40);
+
+$suite->test('error pages and ambiguous topics classify without createTorrent', function () use ($oldHash, $newHash) {
+    $ambiguous = strictCp1251(
+        '<table class="topic"><tbody id="post_200" class="row1"><tr>'
+        . '<td><img class="user-rank" alt="Moderator"></td><td><div class="post_body">'
+        . '<a href="viewtopic.php?t=98">related</a><a href="viewtopic.php?t=99">replacement</a>'
+        . '<span>Поглощено</span></div><!--/post_body--></td></tr></tbody></table>'
+    );
+    $rows = array(
+        array(
+            'label' => 'API object without a hash falls back without TypeError',
+            'responses' => array(
+                array(ruApiUrl(42), 200, json_encode(array('result' => array('42' => array('error_code' => 1))))),
+                array(ruDownloadUrl(42), 200, '<html>attachment data not found</html>'),
+                array(ruTopicUrl(42), 200, strictCp1251('<div class="post_body">Topic unavailable</div>')),
+            ),
+            'expected' => ruTrackerChecker::STE_DELETED,
+        ),
+        array(
+            'label' => 'concrete remote hash plus login page is a reachability error',
+            'responses' => array(
+                array(ruApiUrl(42), 200, json_encode(array('result' => array('42' => $newHash)))),
+                array(ruDownloadUrl(42), 200, '<!DOCTYPE html><html><form><input name="login_password"></form></html>'),
+                array(ruTopicUrl(42), 200, strictCp1251('<div class="post_body">Active topic</div>')),
+            ),
+            'expected' => ruTrackerChecker::STE_CANT_REACH_TRACKER,
+        ),
+        array(
+            'label' => 'ordinary user text containing Pogloshcheno does not trigger replacement',
+            'responses' => array(
+                array(ruApiUrl(42), 500, ''),
+                array(ruDownloadUrl(42), 200, '<html>attachment data not found</html>'),
+                array(ruTopicUrl(42), 200, ruUserPost(99)),
+                // Canary: if the user link were followed, this junk payload
+                // would turn the result into STE_ERROR and fail the row.
+                array(ruDownloadUrl(99), 200, 'wrong-user-triggered-replacement'),
+            ),
+            'expected' => ruTrackerChecker::STE_CANT_REACH_TRACKER,
+        ),
+        array(
+            'label' => 'ambiguous moderator absorption links do not select a replacement',
+            'responses' => array(
+                array(ruApiUrl(42), 500, ''),
+                array(ruDownloadUrl(42), 200, '<html>attachment data not found</html>'),
+                array(ruTopicUrl(42), 200, $ambiguous),
+            ),
+            'expected' => ruTrackerChecker::STE_CANT_REACH_TRACKER,
+        ),
+        array(
+            'label' => 'HTML error from replacement topic is not passed to createTorrent',
+            'responses' => array(
+                array(ruApiUrl(42), 500, ''),
+                array(ruDownloadUrl(42), 200, '<html>attachment data not found</html>'),
+                array(ruTopicUrl(42), 200, ruModeratorPost(99)),
+                array(ruDownloadUrl(99), 200, 'Error: attachment data not found'),
+            ),
+            'expected' => ruTrackerChecker::STE_CANT_REACH_TRACKER,
+        ),
+    );
+
+    foreach ($rows as $row) {
+        ruTrackerChecker::reset();
+        foreach ($row['responses'] as $response) {
+            Snoopy::queue($response[0], $response[1], $response[2]);
+        }
+
+        $result = RuTrackerCheckImpl::download_torrent(
+            'https://rutracker.org/forum/viewtopic.php?t=42',
+            $oldHash,
+            null
+        );
+
+        strictAssertSame($row['expected'], $result, $row['label'] . ': classification result');
+        strictAssertSame(0, count(ruTrackerChecker::$created), $row['label'] . ': junk must never reach createTorrent');
+    }
+});
+
+$suite->test('final exact moderator absorption notice triggers replacement', function () use ($oldHash) {
+    ruTrackerChecker::reset();
+    Snoopy::queue(ruApiUrl(42), 500, '');
+    Snoopy::queue(ruDownloadUrl(42), 200, '<html>attachment data not found</html>');
+    $ordinary = '<tbody id="post_150" class="row1"><tr><td class="poster_info td1"><p class="rank_img">User</p></td>'
+        . '<td><div class="post_body">Earlier unrelated post</div><!--/post_body--></td></tr></tbody>';
+    Snoopy::queue(ruTopicUrl(42), 200, ruModeratorPost(99, $ordinary));
+    $replacementPayload = strictTorrentRaw('replacement.mkv', 'http://tracker.example/announce');
+    Snoopy::queue(ruDownloadUrl(99), 200, $replacementPayload);
+
+    $result = RuTrackerCheckImpl::download_torrent(
+        'https://rutracker.org/forum/viewtopic.php?t=42',
+        $oldHash,
+        null
+    );
+
+    strictAssertSame(null, $result, 'Successful replacement propagates createTorrent result');
+    strictAssertSame(1, count(ruTrackerChecker::$created), 'Exact final moderator notice triggers one replacement');
+    strictAssertSame(
+        $replacementPayload,
+        ruTrackerChecker::$created[0]['payload'],
+        'Replacement topic payload is forwarded unchanged'
+    );
+});
+
+$suite->test('unparseable absorbed replacement payload is an error without createTorrent', function () use ($oldHash) {
+    ruTrackerChecker::reset();
+    Snoopy::queue(ruApiUrl(42), 500, '');
+    Snoopy::queue(ruDownloadUrl(42), 200, '<html>attachment data not found</html>');
+    Snoopy::queue(ruTopicUrl(42), 200, ruModeratorPost(99));
+    // Passes looksLikeHtmlError (no leading '<', no error phrase) but is not
+    // parseable metainfo: pre-validation must stop it before createTorrent.
+    Snoopy::queue(ruDownloadUrl(99), 200, "junk\x00payload that is not bencoded metainfo");
+
+    $result = RuTrackerCheckImpl::download_torrent(
+        'https://rutracker.org/forum/viewtopic.php?t=42',
+        $oldHash,
+        null
+    );
+
+    strictAssertSame(ruTrackerChecker::STE_ERROR, $result, 'Unparseable replacement download is a hard error');
+    strictAssertSame(0, count(ruTrackerChecker::$created), 'Unparseable replacement must never reach createTorrent');
+});
+
+$suite->test('last page ignores same-topic start links inside post bodies', function () use ($oldHash) {
+    ruTrackerChecker::reset();
+    Snoopy::queue(ruApiUrl(42), 500, '');
+    Snoopy::queue(ruDownloadUrl(42), 200, '<html>attachment data not found</html>');
+    $firstPage = strictCp1251(
+        '<a class="pg" href="viewtopic.php?t=42&amp;start=50">2</a>'
+        . '<tbody id="post_100"><tr><td><div class="post_body">'
+        . '<a href="viewtopic.php?t=42&amp;start=999999">stale user link</a>'
+        . '</div><!--/post_body--></td></tr></tbody>'
+    );
+    Snoopy::queue(ruTopicUrl(42), 200, $firstPage);
+    Snoopy::queue(ruTopicUrl(42, 50), 200, ruModeratorPost(99));
+    $replacementPayload = strictTorrentRaw('replacement-last-page.mkv', 'http://tracker.example/announce');
+    Snoopy::queue(ruDownloadUrl(99), 200, $replacementPayload);
+
+    $result = RuTrackerCheckImpl::download_torrent(
+        'https://rutracker.org/forum/viewtopic.php?t=42',
+        $oldHash,
+        null
+    );
+
+    strictAssertSame(null, $result, 'real pagination leads to the final moderator absorption notice');
+    strictAssertSame(1, count(ruTrackerChecker::$created), 'only the replacement from the real last page is used');
+});
+
+$suite->test('valid metainfo containing Error text is not mistaken for an HTTP error', function () use ($oldHash, $newHash) {
+    ruTrackerChecker::reset();
+    ruTrackerChecker::$createResult = ruTrackerChecker::STE_UPDATED;
+    $payload = strictTorrentRaw('Error: valid release.mkv', 'http://tracker.example/announce');
+    Snoopy::queue(ruApiUrl(42), 200, json_encode(array('result' => array('42' => $newHash))));
+    Snoopy::queue(ruDownloadUrl(42), 200, $payload);
+
+    $result = RuTrackerCheckImpl::download_torrent(
+        'https://rutracker.org/forum/viewtopic.php?t=42',
+        $oldHash,
+        null
+    );
+
+    strictAssertSame(ruTrackerChecker::STE_UPDATED, $result, 'valid binary metainfo must reach createTorrent');
+    strictAssertSame(1, count(ruTrackerChecker::$created), 'valid metainfo should be submitted exactly once');
+});
+
+$suite->test('valid direct metainfo transaction error does not trigger a second fallback', function () use ($oldHash, $newHash) {
+    ruTrackerChecker::reset();
+    ruTrackerChecker::$createResult = ruTrackerChecker::STE_ERROR;
+    $payload = strictTorrentRaw('replacement.mkv', 'http://tracker.example/announce');
+    Snoopy::queue(ruApiUrl(42), 200, json_encode(array('result' => array('42' => $newHash))));
+    Snoopy::queue(ruDownloadUrl(42), 200, $payload);
+
+    $result = RuTrackerCheckImpl::download_torrent(
+        'https://rutracker.org/forum/viewtopic.php?t=42',
+        $oldHash,
+        null
+    );
+
+    strictAssertSame(ruTrackerChecker::STE_ERROR, $result, 'local replacement failure is returned unchanged');
+    strictAssertSame(1, count(ruTrackerChecker::$created), 'valid direct metainfo is submitted only once');
+    strictAssertSame(2, count(Snoopy::$requests), 'transaction failure must not fetch the topic for another replacement');
+});
+
+exit($suite->run());

--- a/tests/plugins/rutracker_check/TestLib.php
+++ b/tests/plugins/rutracker_check/TestLib.php
@@ -1,0 +1,389 @@
+<?php
+
+/**
+ * Shared harness for the rutracker_check test suite.
+ *
+ * The always-defined part carries the runner, assertions and the XMLRPC test
+ * doubles. Handler-facing stubs (Snoopy, a fake ruTrackerChecker, bencode
+ * fixture builders backed by the real Torrent class) are defined only when the
+ * including test sets TESTLIB_HANDLER_STUBS, because CheckerTest loads the
+ * real ruTrackerChecker and a fake Torrent instead.
+ */
+
+function testFindRepoRoot()
+{
+    $path = realpath(__DIR__ . '/../../..');
+    if ($path !== false && is_file($path . '/plugins/rutracker_check/trackers/rutracker.php')) return $path;
+    throw new RuntimeException('Unable to locate the ruTorrent repository root');
+}
+
+class StrictTestSuite
+{
+    private $tests = array();
+
+    public function test($name, $callback)
+    {
+        $this->tests[] = array($name, $callback);
+    }
+
+    // Register every public test* method of an object as a test case.
+    public function addFromObject($object)
+    {
+        foreach (get_class_methods($object) as $method) {
+            if (strpos($method, 'test') === 0) {
+                $this->tests[] = array($method, array($object, $method));
+            }
+        }
+    }
+
+    public function run()
+    {
+        $failures = 0;
+        foreach ($this->tests as $test) {
+            list($name, $callback) = $test;
+            try {
+                call_user_func($callback);
+                echo "ok - {$name}\n";
+            } catch (Throwable $error) {
+                $failures++;
+                echo "not ok - {$name}\n";
+                echo '  ' . get_class($error) . ': ' . $error->getMessage() . "\n";
+            }
+        }
+        echo count($this->tests) . ' tests, ' . $failures . " failures\n";
+        return $failures === 0 ? 0 : 1;
+    }
+}
+
+function strictAssertTrue($condition, $message)
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+function strictAssertSame($expected, $actual, $message)
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException(
+            $message . '; expected ' . var_export($expected, true)
+            . ', got ' . var_export($actual, true)
+        );
+    }
+}
+
+function strictRemoveTree($path)
+{
+    if (is_link($path) || is_file($path)) {
+        @unlink($path);
+        return;
+    }
+    if (!is_dir($path)) {
+        return;
+    }
+    foreach (array_diff(scandir($path), array('.', '..')) as $entry) {
+        strictRemoveTree($path . '/' . $entry);
+    }
+    @rmdir($path);
+}
+
+function strictSetPrivateStatic($className, $property, $value)
+{
+    $reflection = new ReflectionProperty($className, $property);
+    if (PHP_VERSION_ID < 80100) {
+        $reflection->setAccessible(true);
+    }
+    $reflection->setValue(null, $value);
+}
+
+function strictInvoke($className, $method, $arguments = array())
+{
+    $reflection = new ReflectionMethod($className, $method);
+    if (PHP_VERSION_ID < 80100) {
+        $reflection->setAccessible(true);
+    }
+    return $reflection->invokeArgs(null, $arguments);
+}
+
+class rXMLRPCCommand
+{
+    public $command;
+    public $params;
+
+    public function __construct($command, $params = null)
+    {
+        $this->command = $command;
+        $this->params = $params;
+    }
+}
+
+/**
+ * XMLRPC test double. Responses are queued per command-name pipeline
+ * ('d.hash' or array('d.get_state', 'd.is_open')); every executed request is
+ * recorded with its full command objects so tests can assert the parameters
+ * (e.g. WHICH hash a d.hash probe targeted), not just the command sequence.
+ */
+class rXMLRPCRequest
+{
+    public static $responses = array();
+    public static $requests = array();
+    private $commands = array();
+    public $important = true;
+    public $fault = false;
+    public $val = array();
+
+    public function __construct($commands = null)
+    {
+        if (is_array($commands))
+            $this->commands = $commands;
+        elseif ($commands !== null)
+            $this->commands[] = $commands;
+    }
+
+    public function addCommand($command)
+    {
+        $this->commands[] = $command;
+    }
+
+    public static function reset()
+    {
+        self::$responses = array();
+        self::$requests = array();
+    }
+
+    public static function queue($commands, $ok, $fault, $values = array())
+    {
+        $key = is_array($commands) ? implode('|', $commands) : $commands;
+        self::$responses[$key][] = array($ok, $fault, $values);
+    }
+
+    public static function requestsFor($key)
+    {
+        $matched = array();
+        foreach (self::$requests as $request)
+            if ($request['key'] === $key)
+                $matched[] = $request;
+        return $matched;
+    }
+
+    private function execute()
+    {
+        $key = implode('|', array_map(function ($command) { return $command->command; }, $this->commands));
+        self::$requests[] = array('key' => $key, 'important' => $this->important, 'commands' => $this->commands);
+        $response = (isset(self::$responses[$key]) && count(self::$responses[$key]))
+            ? array_shift(self::$responses[$key])
+            : array(false, true, array());
+        $this->fault = $response[1];
+        $this->val = is_callable($response[2]) ? call_user_func($response[2], $this->commands) : $response[2];
+        return $response[0];
+    }
+
+    public function run($trusted = true)
+    {
+        return $this->execute();
+    }
+
+    public function success($trusted = true)
+    {
+        return $this->execute() && !$this->fault;
+    }
+}
+
+class rTorrentSettings
+{
+    public $session = '/nonexistent/';
+    private static $instance;
+
+    public static function get()
+    {
+        if (!self::$instance)
+            self::$instance = new self();
+        return self::$instance;
+    }
+}
+
+if (defined('TESTLIB_HANDLER_STUBS')) {
+
+    $testLibRepoRoot = testFindRepoRoot();
+    $testLibPrevCwd = getcwd();
+    chdir($testLibRepoRoot . '/php');
+    require_once($testLibRepoRoot . '/php/Torrent.php');
+    chdir($testLibPrevCwd);
+
+    if (!function_exists('iconv')) {
+        function iconv($from, $to, $content)
+        {
+            $utf8 = 'Поглощено';
+            $cp1251 = "\xCF\xEE\xE3\xEB\xEE\xF9\xE5\xED\xEE";
+            if (stripos($from, 'UTF-8') === 0 && stripos($to, 'CP1251') === 0) {
+                return str_replace($utf8, $cp1251, $content);
+            }
+            if (stripos($from, 'CP1251') === 0 && stripos($to, 'UTF-8') === 0) {
+                return str_replace($cp1251, $utf8, $content);
+            }
+            return false;
+        }
+    }
+
+    // Fixtures use the production encoder, so they are byte-identical to what
+    // the plugin itself produces and re-parses.
+    class TorrentEncoder extends Torrent
+    {
+        public static function raw($value)
+        {
+            return self::encode($value);
+        }
+    }
+
+    function strictTorrentRaw($name, $announce, $comment = '', $announceList = null, $extra = array())
+    {
+        $root = array(
+            'announce' => $announce,
+            'info' => array(
+                'length' => 1,
+                'name' => $name,
+                'piece length' => 16384,
+                'pieces' => str_repeat("\0", 20),
+            ),
+        );
+        if ($comment !== '') {
+            $root['comment'] = $comment;
+        }
+        if ($announceList !== null) {
+            $root['announce-list'] = $announceList;
+        }
+        foreach ($extra as $key => $value) {
+            $root[$key] = $value;
+        }
+        return TorrentEncoder::raw($root);
+    }
+
+    // Built by hand: Torrent::encode drops dictionary keys that start with a
+    // NUL byte, and scrape dictionaries are keyed by raw 20-byte hashes.
+    function strictScrapePayload($hash, $found)
+    {
+        if (!$found) {
+            return 'd5:filesdee';
+        }
+        return 'd5:filesd20:' . hex2bin($hash)
+            . 'd8:completei1e10:downloadedi1e10:incompletei0eee'
+            . 'e';
+    }
+
+    function strictCp1251($html)
+    {
+        $encoded = iconv('UTF-8', 'CP1251//IGNORE', $html);
+        if ($encoded === false) {
+            throw new RuntimeException('Unable to create CP1251 test fixture');
+        }
+        return $encoded;
+    }
+
+    class Snoopy
+    {
+        public static $responses = array();
+        public static $requests = array();
+
+        public $status = -1;
+        public $results = '';
+        public $read_timeout = 0;
+        public $_fp_timeout = 0;
+        public $agent = '';
+
+        public static function reset()
+        {
+            self::$responses = array();
+            self::$requests = array();
+        }
+
+        public static function queue($url, $status, $results)
+        {
+            if (!isset(self::$responses[$url])) {
+                self::$responses[$url] = array();
+            }
+            self::$responses[$url][] = array($status, $results);
+        }
+
+        private function respond($method, $url)
+        {
+            self::$requests[] = array($method, $url);
+            if (!isset(self::$responses[$url]) || count(self::$responses[$url]) === 0) {
+                throw new RuntimeException("Unexpected {$method} request: {$url}");
+            }
+            list($this->status, $this->results) = array_shift(self::$responses[$url]);
+            return true;
+        }
+
+        public function fetch($url, $method = 'GET', $contentType = '', $body = '')
+        {
+            return $this->respond('fetch', $url);
+        }
+
+        public function fetchComplex($url, $method = 'GET', $contentType = '', $body = '')
+        {
+            return $this->respond('fetchComplex', $url);
+        }
+
+        public function setcookies()
+        {
+        }
+    }
+
+    class ruTrackerChecker
+    {
+        const STE_INPROGRESS = 1;
+        const STE_UPDATED = 2;
+        const STE_UPTODATE = 3;
+        const STE_DELETED = 4;
+        const STE_CANT_REACH_TRACKER = 5;
+        const STE_ERROR = 6;
+        const STE_NOT_NEED = 7;
+        const STE_IGNORED = 8;
+
+        const USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            . "AppleWebKit/537.36 (KHTML, like Gecko) "
+            . "Chrome/120.0.0.0 Safari/537.36";
+
+        public static $created = array();
+        public static $logs = array();
+        public static $registrations = array();
+        public static $createResult = null;
+
+        public static function reset()
+        {
+            self::$created = array();
+            self::$logs = array();
+            self::$registrations = array();
+            self::$createResult = null;
+            Snoopy::reset();
+            rXMLRPCRequest::reset();
+        }
+
+        public static function registerTracker($commentFilter, $announceFilter, $handler)
+        {
+            self::$registrations[] = array($commentFilter, $announceFilter, $handler);
+        }
+
+        public static function makeClient($url, $method = 'GET', $contentType = '', $body = '')
+        {
+            $client = new Snoopy();
+            $client->fetchComplex($url, $method, $contentType, $body);
+            return $client;
+        }
+
+        public static function createTorrent($payload, $oldHash)
+        {
+            $parsed = @new Torrent($payload);
+            if ($parsed->errors() || strlen((string) $parsed->hash_info()) !== 40) {
+                return self::STE_ERROR;
+            }
+            self::$created[] = array('payload' => $payload, 'old_hash' => $oldHash);
+            return self::$createResult;
+        }
+
+        public static function logDebug($message)
+        {
+            self::$logs[] = $message;
+        }
+    }
+}

--- a/tests/plugins/rutracker_check/run.php
+++ b/tests/plugins/rutracker_check/run.php
@@ -1,0 +1,17 @@
+<?php
+
+$tests = array(
+    __DIR__ . '/CheckerTest.php',
+    __DIR__ . '/RuTrackerHandlerTest.php',
+    __DIR__ . '/NNMClubHandlerTest.php',
+    __DIR__ . '/../../php/SnoopyTest.php',
+);
+$failures = 0;
+
+foreach($tests as $test) {
+    $command = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($test);
+    passthru($command, $status);
+    if ($status !== 0) $failures++;
+}
+
+exit($failures === 0 ? 0 : 1);


### PR DESCRIPTION
Rework the rutracker_check update flow so it can handle current tracker behavior without treating reachable torrents as deleted.

For NNMClub, use tracker scrape as the fast path with a real passkey from the current torrent or another session torrent, then fall back to unauthenticated guest torrent downloads when the scrape does not find the current hash. Patch downloaded guest torrents with the real passkey before replacing the existing torrent, which avoids the Cloudflare-protected login flow and prevents false STE_DELETED results.

For RuTracker, keep the API hash check but fall back to direct torrent download and absorbed-topic detection when the API reports a missing/deleted topic or the download endpoint returns an HTML error page instead of a .torrent file.

Harden shared replacement handling by matching trackers via comment or announce URL, preserving existing start/label/throttle/ratio state, skipping state updates for hashes that no longer exist, and cleaning up obsolete files after a successful replacement when the new torrent file list differs from the old one.