### PR TITLE
Adding backup to addtime value if missing.

### DIFF
--- a/plugins/seedingtime/init.js
+++ b/plugins/seedingtime/init.js
@@ -88,4 +88,5 @@ plugin.onRemove = function()
 	}
 	theRequestManager.removeRequest( "trt", plugin.reqId1 );
 	theRequestManager.removeRequest( "trt", plugin.reqId2 );
+	theRequestManager.removeRequest( "trt", plugin.reqId3 );
 }

--- a/plugins/seedingtime/init.js
+++ b/plugins/seedingtime/init.js
@@ -27,10 +27,14 @@ if(plugin.canChangeColumns())
 			const epochSeconds = iv(value);
 			torrent.seedingtime = (epochSeconds > 3600*24*365) ? new Date().getTime()/1000-(epochSeconds+theWebUI.deltaTime/1000) : -1;
 		});
+		plugin.reqId3 = theRequestManager.addRequest("trt", theRequestManager.map("d.get_state_changed="),function(hash, torrent, value)
+		{
+			torrent.state_changed = iv(value);
+		});
 		plugin.reqId2 = theRequestManager.addRequest("trt", theRequestManager.map("d.get_custom=")+"addtime",function(hash,torrent,value)
 		{
 			const epochSeconds = iv(value);
-			torrent.addtime = (epochSeconds > 3600*24*365) ? epochSeconds+theWebUI.deltaTime/1000 : -1;
+			if(epochSeconds > 3600*24*365){ torrent.addtime = epochSeconds + theWebUI.deltaTime/1000; } else if(torrent.state_changed > 0) { torrent.addtime = torrent.state_changed + theWebUI.deltaTime/1000; } else { torrent.addtime = -1; }
 		});
 		plugin.trtRenameColumn();
 	}


### PR DESCRIPTION
Adding backup to addtime if its empty in torrent session file. It will do nothing it addtime gets added correctly into session files, but sometimes its missing and also ratiogroup is also missing. With that you at least see these torrents on top if you use addtime for ordering your torrents like me.