### PR TITLE
XMLRPC proxy with configurable sanitization for raw pass-through

### DIFF
--- a/php/xmlrpc_proxy.php
+++ b/php/xmlrpc_proxy.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * XMLRPC Proxy — handles raw XMLRPC pass-through with configurable trust.
+ *
+ * Modes:
+ *   "off"                — reject all raw XMLRPC
+ *   "passthrough_unsafe" — send all raw XMLRPC as trusted (dangerous)
+ *   "sanitize"           — parse and sanitize known methods, send safe
+ *                          payload as trusted; pass unknown methods as
+ *                          untrusted (rtorrent whitelist decides)
+ */
+
+class XMLRPCProxy
+{
+	// Methods that need trusted connections but can carry command
+	// parameters. We rebuild these from scratch, keeping only safe params.
+	private static $sanitizeMethods = array(
+		'load.start', 'load.raw_start', 'load.raw', 'load.normal',
+		'load_start', 'load_raw_start', 'load_raw',
+	);
+
+	private static $log = true;
+	private static $safeParams = array();
+
+	private static function log($msg)
+	{
+		if(self::$log)
+			FileUtil::toLog("xmlrpc-proxy: ".$msg);
+	}
+
+	/**
+	 * Process a raw XMLRPC payload according to the configured mode.
+	 *
+	 * @param string $rawData       Raw XMLRPC XML from the client
+	 * @param string $mode          "off", "passthrough_unsafe", or "sanitize"
+	 * @param bool   $enableLog     Enable/disable logging
+	 * @param array  $safeParams    Whitelisted command prefixes for load.* params
+	 * @return string|null          SCGI response, or null on error/rejection
+	 */
+	public static function process($rawData, $mode = 'sanitize', $enableLog = true, $safeParams = array())
+	{
+		self::$log = $enableLog;
+		self::$safeParams = $safeParams;
+
+		if($mode === 'off')
+		{
+			self::log("rejected (proxy disabled)");
+			return null;
+		}
+
+		if($mode === 'passthrough_unsafe')
+		{
+			self::log("passthrough (UNSAFE mode)");
+			return rXMLRPCRequest::send($rawData, true);
+		}
+
+		// sanitize mode
+		$xml = @simplexml_load_string($rawData);
+		if($xml === false || !isset($xml->methodName))
+		{
+			self::log("rejected (invalid XML)");
+			return rXMLRPCRequest::send($rawData, false);
+		}
+
+		$methodName = (string)$xml->methodName;
+
+		if(in_array($methodName, self::$sanitizeMethods))
+			return self::sanitizeLoad($xml, $methodName);
+
+		// Unknown method — pass through as untrusted.
+		// rtorrent's own whitelist will allow/reject.
+		self::log("untrusted: ".$methodName);
+		return rXMLRPCRequest::send($rawData, false);
+	}
+
+	/**
+	 * Check if a load.* command parameter is safe.
+	 */
+	private static function isSafeLoadParam($paramValue)
+	{
+		foreach(self::$safeParams as $prefix)
+		{
+			if(strpos($paramValue, $prefix) === 0)
+				return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Rebuild a load.* call keeping only safe parameters.
+	 * param 0: target (empty string)
+	 * param 1: URL or raw torrent data
+	 * param 2+: command strings — keep safe ones, strip dangerous ones
+	 */
+	private static function sanitizeLoad($xml, $methodName)
+	{
+		$cleanXml = '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+		$cleanXml .= '<methodCall><methodName>' . htmlspecialchars($methodName) . '</methodName>';
+		$cleanXml .= '<params>';
+
+		$kept = 0;
+		$stripped = array();
+
+		if(isset($xml->params->param))
+		{
+			$index = 0;
+			foreach($xml->params->param as $param)
+			{
+				if($index < 2)
+				{
+					// Always keep target and URL/data
+					$cleanXml .= '<param>' . $param->value->asXML() . '</param>';
+					$kept++;
+				}
+				else
+				{
+					// Command parameter — check whitelist
+					$value = (string)$param->value->string;
+					if(empty($value))
+						$value = (string)$param->value;
+
+					if(self::isSafeLoadParam($value))
+					{
+						$cleanXml .= '<param>' . $param->value->asXML() . '</param>';
+						$kept++;
+					}
+					else
+					{
+						$stripped[] = $value;
+					}
+				}
+				$index++;
+			}
+		}
+
+		$cleanXml .= '</params></methodCall>';
+
+		if(count($stripped) > 0)
+			self::log("sanitized: ".$methodName." (kept ".$kept." params, stripped: ".implode(', ', $stripped).")");
+		else
+			self::log("trusted: ".$methodName." (".$kept." params)");
+
+		return rXMLRPCRequest::send($cleanXml, true);
+	}
+}

--- a/php/xmlrpc_proxy.php
+++ b/php/xmlrpc_proxy.php
@@ -8,6 +8,11 @@
  *   "sanitize"           — parse and sanitize known methods, send safe
  *                          payload as trusted; pass unknown methods as
  *                          untrusted (rtorrent whitelist decides)
+ *
+ * Dependencies (loaded by the production caller before non-"off" modes):
+ *   php/util.php    — FileUtil::toLog
+ *   php/xmlrpc.php  — rXMLRPCRequest::send
+ * (Both are required by plugins/httprpc/action.php, the production caller.)
  */
 
 class XMLRPCProxy
@@ -20,7 +25,6 @@ class XMLRPCProxy
 	);
 
 	private static $log = true;
-	private static $safeParams = array();
 
 	private static function log($msg)
 	{
@@ -29,18 +33,35 @@ class XMLRPCProxy
 	}
 
 	/**
+	 * Parse untrusted XMLRPC XML with entity loading disabled.
+	 *
+	 * PHP 8+ libxml2 defaults external-entity loading off; PHP 7.x does
+	 * not, and ruTorrent still supports PHP 7. We disable it explicitly to
+	 * prevent XXE on client-supplied XML.
+	 */
+	private static function parseXml($rawData)
+	{
+		$prev = null;
+		if(PHP_VERSION_ID < 80000 && function_exists('libxml_disable_entity_loader'))
+			$prev = libxml_disable_entity_loader(true);
+		$xml = @simplexml_load_string($rawData, 'SimpleXMLElement', LIBXML_NONET);
+		if($prev !== null)
+			libxml_disable_entity_loader($prev);
+		return $xml;
+	}
+
+	/**
 	 * Process a raw XMLRPC payload according to the configured mode.
 	 *
-	 * @param string $rawData       Raw XMLRPC XML from the client
-	 * @param string $mode          "off", "passthrough_unsafe", or "sanitize"
-	 * @param bool   $enableLog     Enable/disable logging
-	 * @param array  $safeParams    Whitelisted command prefixes for load.* params
-	 * @return string|null          SCGI response, or null on error/rejection
+	 * @param string $rawData     Raw XMLRPC XML from the client
+	 * @param string $mode        "off", "passthrough_unsafe", or "sanitize"
+	 * @param bool   $enableLog   Enable/disable logging
+	 * @param array  $safeParams  Whitelisted command prefixes for load.* params
+	 * @return string|null        SCGI response, or null on rejection
 	 */
 	public static function process($rawData, $mode = 'sanitize', $enableLog = true, $safeParams = array())
 	{
 		self::$log = $enableLog;
-		self::$safeParams = $safeParams;
 
 		if($mode === 'off')
 		{
@@ -55,17 +76,24 @@ class XMLRPCProxy
 		}
 
 		// sanitize mode
-		$xml = @simplexml_load_string($rawData);
+		$xml = self::parseXml($rawData);
 		if($xml === false || !isset($xml->methodName))
 		{
-			self::log("rejected (invalid XML)");
+			self::log("untrusted (invalid XML)");
 			return rXMLRPCRequest::send($rawData, false);
 		}
 
 		$methodName = (string)$xml->methodName;
 
-		if(in_array($methodName, self::$sanitizeMethods))
-			return self::sanitizeLoad($xml, $methodName);
+		if(in_array($methodName, self::$sanitizeMethods, true))
+		{
+			$rebuilt = self::rebuildLoadParams($xml, $methodName, $safeParams);
+			if(count($rebuilt['stripped']) > 0)
+				self::log("sanitized: ".$methodName." (kept ".$rebuilt['kept']." params, stripped: ".implode(', ', $rebuilt['stripped']).")");
+			else
+				self::log("trusted: ".$methodName." (".$rebuilt['kept']." params)");
+			return rXMLRPCRequest::send($rebuilt['xml'], true);
+		}
 
 		// Unknown method — pass through as untrusted.
 		// rtorrent's own whitelist will allow/reject.
@@ -74,11 +102,11 @@ class XMLRPCProxy
 	}
 
 	/**
-	 * Check if a load.* command parameter is safe.
+	 * Check if a load.* command parameter matches the safe-prefix whitelist.
 	 */
-	private static function isSafeLoadParam($paramValue)
+	private static function isSafeLoadParam($paramValue, $safeParams)
 	{
-		foreach(self::$safeParams as $prefix)
+		foreach($safeParams as $prefix)
 		{
 			if(strpos($paramValue, $prefix) === 0)
 				return true;
@@ -87,12 +115,34 @@ class XMLRPCProxy
 	}
 
 	/**
-	 * Rebuild a load.* call keeping only safe parameters.
-	 * param 0: target (empty string)
-	 * param 1: URL or raw torrent data
-	 * param 2+: command strings — keep safe ones, strip dangerous ones
+	 * Extract a load.* command-param value from its <value> element.
+	 *
+	 * Handles both the typed form <value><string>foo</string></value> and
+	 * the implicit-string form <value>foo</value>. For non-string types
+	 * (<int>, <base64>) the raw text is returned; it simply won't match
+	 * any whitelist prefix and will be stripped — safe default.
 	 */
-	private static function sanitizeLoad($xml, $methodName)
+	private static function extractParamValue($paramElement)
+	{
+		if(isset($paramElement->string))
+			return (string)$paramElement->string;
+		return trim((string)$paramElement);
+	}
+
+	/**
+	 * Rebuild a load.* call keeping only safe parameters.
+	 *
+	 *   Param 0: target           (always kept)
+	 *   Param 1: URL or raw data  (always kept)
+	 *   Param 2+: command strings (kept iff prefix-matches the whitelist,
+	 *                              otherwise stripped)
+	 *
+	 * Public for unit testing — production callers should go through
+	 * process().
+	 *
+	 * @return array ['xml' => string, 'kept' => int, 'stripped' => array]
+	 */
+	public static function rebuildLoadParams($xml, $methodName, $safeParams = array())
 	{
 		$cleanXml = '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
 		$cleanXml .= '<methodCall><methodName>' . htmlspecialchars($methodName) . '</methodName>';
@@ -114,12 +164,8 @@ class XMLRPCProxy
 				}
 				else
 				{
-					// Command parameter — check whitelist
-					$value = (string)$param->value->string;
-					if(empty($value))
-						$value = (string)$param->value;
-
-					if(self::isSafeLoadParam($value))
+					$value = self::extractParamValue($param->value);
+					if(self::isSafeLoadParam($value, $safeParams))
 					{
 						$cleanXml .= '<param>' . $param->value->asXML() . '</param>';
 						$kept++;
@@ -135,11 +181,6 @@ class XMLRPCProxy
 
 		$cleanXml .= '</params></methodCall>';
 
-		if(count($stripped) > 0)
-			self::log("sanitized: ".$methodName." (kept ".$kept." params, stripped: ".implode(', ', $stripped).")");
-		else
-			self::log("trusted: ".$methodName." (".$kept." params)");
-
-		return rXMLRPCRequest::send($cleanXml, true);
+		return array('xml' => $cleanXml, 'kept' => $kept, 'stripped' => $stripped);
 	}
 }

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once( '../../php/xmlrpc.php' );
+require_once( '../../php/xmlrpc_proxy.php' );
 require_once( 'rpccache.php' );
 
 $mode = "raw";
@@ -496,7 +497,11 @@ switch($mode)
 	{
 		if(isset($HTTP_RAW_POST_DATA))
 		{
-			$result = rXMLRPCRequest::send($HTTP_RAW_POST_DATA,false);
+			eval(FileUtil::getPluginConf('httprpc'));
+			$proxyMode = isset($XMLRPCProxy) ? $XMLRPCProxy : 'sanitize';
+			$proxyLog = isset($XMLRPCProxyLog) ? $XMLRPCProxyLog : true;
+			$proxySafeParams = isset($XMLRPCProxySafeParams) ? $XMLRPCProxySafeParams : array();
+			$result = XMLRPCProxy::process($HTTP_RAW_POST_DATA, $proxyMode, $proxyLog, $proxySafeParams);
 			if(!empty($result))
 			{
 				$pos = strpos($result, "\r\n\r\n");

--- a/plugins/httprpc/conf.php
+++ b/plugins/httprpc/conf.php
@@ -1,0 +1,34 @@
+<?php
+
+// Raw XMLRPC proxy mode for external clients (Prowlarr, Sonarr, etc.)
+// Options:
+//   "sanitize"           — (default) allow load.* with safe params only,
+//                          pass other methods as untrusted
+//   "passthrough_unsafe" — send all raw XMLRPC as trusted (DANGEROUS)
+//   "off"                — reject all raw XMLRPC pass-through
+$XMLRPCProxy = "sanitize";
+
+// Log raw XMLRPC proxy activity (default: true)
+// Logs accepted, sanitized, and rejected methods to help diagnose
+// external client integration issues.
+$XMLRPCProxyLog = true;
+
+// Command prefixes allowed as load.* parameters in sanitize mode.
+// External clients (Prowlarr, Sonarr, Radarr, Transdroid) attach these
+// to load.start to set labels, directories, priorities, etc.
+// Any command param not matching these prefixes will be stripped.
+// Add entries here if your external client needs additional commands.
+$XMLRPCProxySafeParams = array(
+	'd.custom1.set',            // label
+	'd.custom2.set',            // custom field
+	'd.custom3.set',            // custom field
+	'd.custom4.set',            // custom field
+	'd.custom5.set',            // used by erasedata
+	'd.custom.set',             // generic custom field
+	'd.directory.set',          // download directory
+	'd.directory_base.set',     // base directory
+	'd.priority.set',           // priority
+	'd.throttle_name.set',      // throttle group
+	'd.views.push_back_unique', // view membership
+	'd.delete_tied',            // delete .torrent on remove
+);

--- a/plugins/httprpc/conf.php
+++ b/plugins/httprpc/conf.php
@@ -30,5 +30,7 @@ $XMLRPCProxySafeParams = array(
 	'd.priority.set',           // priority
 	'd.throttle_name.set',      // throttle group
 	'd.views.push_back_unique', // view membership
+
+	// Actions (not setters):
 	'd.delete_tied',            // delete .torrent on remove
 );

--- a/tests/php/XMLRPCProxyTest.php
+++ b/tests/php/XMLRPCProxyTest.php
@@ -1,0 +1,53 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/xmlrpc_proxy.php');
+
+class XMLRPCProxyTest extends TestCase
+{
+    public function testOffModeRejectsAll()
+    {
+        $xml = '<?xml version="1.0"?><methodCall><methodName>system.client_version</methodName><params></params></methodCall>';
+        $result = XMLRPCProxy::process($xml, 'off');
+        $this->assertTrue($result === null, 'off mode should return null');
+    }
+
+    public function testSanitizeMethodsList()
+    {
+        $ref = new ReflectionProperty('XMLRPCProxy', 'sanitizeMethods');
+        $ref->setAccessible(true);
+        $methods = $ref->getValue();
+        $this->assertTrue(in_array('load.start', $methods), 'load.start should be in sanitize list');
+        $this->assertTrue(in_array('load.raw_start', $methods), 'load.raw_start should be in sanitize list');
+        $this->assertTrue(!in_array('execute', $methods), 'execute should NOT be in sanitize list');
+        $this->assertTrue(!in_array('system.multicall', $methods), 'system.multicall should NOT be in sanitize list');
+        $this->assertTrue(!in_array('execute2', $methods), 'execute2 should NOT be in sanitize list');
+    }
+
+    public function testInvalidXmlParsesToFalse()
+    {
+        $xml = @simplexml_load_string('not xml');
+        $this->assertTrue($xml === false, 'invalid XML should return false');
+    }
+
+    public function testValidXmlMethodExtraction()
+    {
+        $xml = simplexml_load_string('<?xml version="1.0"?><methodCall><methodName>load.start</methodName><params></params></methodCall>');
+        $this->assertEquals('load.start', (string)$xml->methodName, 'should extract method name');
+    }
+
+    public function testParamCountPreservedForSafeLoad()
+    {
+        $xml = simplexml_load_string('<?xml version="1.0"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.com/t.torrent</string></value></param><param><value><string>execute=evil</string></value></param></params></methodCall>');
+        // Original has 3 params
+        $this->assertEquals(3, count($xml->params->param), 'original should have 3 params');
+        // Sanitizer should keep only 2 (tested via integration)
+    }
+
+    public function testMethodNameInParamsNotConfused()
+    {
+        $xml = simplexml_load_string('<?xml version="1.0"?><methodCall><methodName>execute</methodName><params><param><value><string>load.start</string></value></param></params></methodCall>');
+        $methodName = (string)$xml->methodName;
+        $this->assertEquals('execute', $methodName, 'should read actual methodName, not params');
+    }
+}

--- a/tests/php/XMLRPCProxyTest.php
+++ b/tests/php/XMLRPCProxyTest.php
@@ -1,53 +1,148 @@
 <?php
 
 require_once(__DIR__ . '/TestCase.php');
+
+// Stub the dependencies that production callers (httprpc/action.php) load
+// before invoking XMLRPCProxy. We don't exercise the real SCGI path here —
+// we verify XMLRPCProxy's own logic.
+if(!class_exists('FileUtil'))
+{
+	class FileUtil
+	{
+		public static $log = array();
+		public static function toLog($msg) { self::$log[] = $msg; }
+	}
+}
+if(!class_exists('rXMLRPCRequest'))
+{
+	class rXMLRPCRequest
+	{
+		public static $lastPayload = null;
+		public static $lastTrusted = null;
+		public static function send($data, $trusted)
+		{
+			self::$lastPayload = $data;
+			self::$lastTrusted = $trusted;
+			return '';
+		}
+	}
+}
+
 require_once(__DIR__ . '/../../php/xmlrpc_proxy.php');
 
 class XMLRPCProxyTest extends TestCase
 {
-    public function testOffModeRejectsAll()
-    {
-        $xml = '<?xml version="1.0"?><methodCall><methodName>system.client_version</methodName><params></params></methodCall>';
-        $result = XMLRPCProxy::process($xml, 'off');
-        $this->assertTrue($result === null, 'off mode should return null');
-    }
+	private function resetMocks()
+	{
+		rXMLRPCRequest::$lastPayload = null;
+		rXMLRPCRequest::$lastTrusted = null;
+		FileUtil::$log = array();
+	}
 
-    public function testSanitizeMethodsList()
-    {
-        $ref = new ReflectionProperty('XMLRPCProxy', 'sanitizeMethods');
-        $ref->setAccessible(true);
-        $methods = $ref->getValue();
-        $this->assertTrue(in_array('load.start', $methods), 'load.start should be in sanitize list');
-        $this->assertTrue(in_array('load.raw_start', $methods), 'load.raw_start should be in sanitize list');
-        $this->assertTrue(!in_array('execute', $methods), 'execute should NOT be in sanitize list');
-        $this->assertTrue(!in_array('system.multicall', $methods), 'system.multicall should NOT be in sanitize list');
-        $this->assertTrue(!in_array('execute2', $methods), 'execute2 should NOT be in sanitize list');
-    }
+	// ---- Mode dispatch ----
 
-    public function testInvalidXmlParsesToFalse()
-    {
-        $xml = @simplexml_load_string('not xml');
-        $this->assertTrue($xml === false, 'invalid XML should return false');
-    }
+	public function testOffModeReturnsNull()
+	{
+		$this->resetMocks();
+		$xml = '<?xml version="1.0"?><methodCall><methodName>load.start</methodName><params></params></methodCall>';
+		$this->assertTrue(XMLRPCProxy::process($xml, 'off') === null, 'off mode returns null');
+	}
 
-    public function testValidXmlMethodExtraction()
-    {
-        $xml = simplexml_load_string('<?xml version="1.0"?><methodCall><methodName>load.start</methodName><params></params></methodCall>');
-        $this->assertEquals('load.start', (string)$xml->methodName, 'should extract method name');
-    }
+	public function testOffModeRejectsGarbage()
+	{
+		$this->resetMocks();
+		$this->assertTrue(XMLRPCProxy::process('not xml at all', 'off') === null, 'off mode rejects garbage too');
+	}
 
-    public function testParamCountPreservedForSafeLoad()
-    {
-        $xml = simplexml_load_string('<?xml version="1.0"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.com/t.torrent</string></value></param><param><value><string>execute=evil</string></value></param></params></methodCall>');
-        // Original has 3 params
-        $this->assertEquals(3, count($xml->params->param), 'original should have 3 params');
-        // Sanitizer should keep only 2 (tested via integration)
-    }
+	public function testPassthroughUnsafeForwardsTrusted()
+	{
+		$this->resetMocks();
+		$xml = '<?xml version="1.0"?><methodCall><methodName>execute</methodName><params></params></methodCall>';
+		XMLRPCProxy::process($xml, 'passthrough_unsafe');
+		$this->assertTrue(rXMLRPCRequest::$lastTrusted === true, 'passthrough_unsafe forwards as trusted');
+		$this->assertEquals($xml, rXMLRPCRequest::$lastPayload, 'passthrough_unsafe forwards payload verbatim');
+	}
 
-    public function testMethodNameInParamsNotConfused()
-    {
-        $xml = simplexml_load_string('<?xml version="1.0"?><methodCall><methodName>execute</methodName><params><param><value><string>load.start</string></value></param></params></methodCall>');
-        $methodName = (string)$xml->methodName;
-        $this->assertEquals('execute', $methodName, 'should read actual methodName, not params');
-    }
+	public function testInvalidXmlForwardsUntrusted()
+	{
+		$this->resetMocks();
+		XMLRPCProxy::process('not xml at all', 'sanitize');
+		$this->assertTrue(rXMLRPCRequest::$lastTrusted === false, 'invalid XML forwards as untrusted');
+	}
+
+	public function testNonLoadMethodForwardsUntrusted()
+	{
+		$this->resetMocks();
+		$xml = '<?xml version="1.0"?><methodCall><methodName>system.client_version</methodName><params></params></methodCall>';
+		XMLRPCProxy::process($xml, 'sanitize');
+		$this->assertTrue(rXMLRPCRequest::$lastTrusted === false, 'non-load method forwarded as untrusted');
+	}
+
+	// ---- Sanitize-mode whitelist (the security-critical path) ----
+
+	public function testSanitizeStripsDangerousCommandParam()
+	{
+		$xml = simplexml_load_string('<?xml version="1.0"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.com/t.torrent</string></value></param><param><value><string>execute=evil</string></value></param></params></methodCall>');
+		$result = XMLRPCProxy::rebuildLoadParams($xml, 'load.start', array('d.directory.set', 'd.custom1.set'));
+		$this->assertEquals(2, $result['kept'], 'should keep target + URL only');
+		$this->assertEquals(1, count($result['stripped']), 'should strip one param');
+		$this->assertTrue(strpos($result['xml'], 'execute=evil') === false, 'rebuilt XML must not contain execute=evil');
+	}
+
+	public function testSanitizeKeepsWhitelistedCommandParam()
+	{
+		$xml = simplexml_load_string('<?xml version="1.0"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.com/t.torrent</string></value></param><param><value><string>d.directory.set=/srv/torrents</string></value></param></params></methodCall>');
+		$result = XMLRPCProxy::rebuildLoadParams($xml, 'load.start', array('d.directory.set', 'd.custom1.set'));
+		$this->assertEquals(3, $result['kept'], 'should keep target + URL + safe param');
+		$this->assertEquals(0, count($result['stripped']), 'should strip nothing');
+		$this->assertTrue(strpos($result['xml'], 'd.directory.set=/srv/torrents') !== false, 'safe param survives');
+	}
+
+	public function testSanitizeAlwaysKeepsFirstTwoParams()
+	{
+		$xml = simplexml_load_string('<?xml version="1.0"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>execute=looks_evil_but_is_url</string></value></param></params></methodCall>');
+		$result = XMLRPCProxy::rebuildLoadParams($xml, 'load.start', array());
+		$this->assertEquals(2, $result['kept'], 'positional params always kept');
+	}
+
+	public function testEmptyWhitelistStripsAllCommandParams()
+	{
+		$xml = simplexml_load_string('<?xml version="1.0"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.com/t.torrent</string></value></param><param><value><string>d.directory.set=/srv</string></value></param><param><value><string>d.custom1.set=label</string></value></param></params></methodCall>');
+		$result = XMLRPCProxy::rebuildLoadParams($xml, 'load.start', array());
+		$this->assertEquals(2, $result['kept'], 'empty whitelist keeps only positional');
+		$this->assertEquals(2, count($result['stripped']), 'both command params stripped');
+	}
+
+	public function testRebuiltXmlIsValid()
+	{
+		$xml = simplexml_load_string('<?xml version="1.0"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.com/t.torrent</string></value></param></params></methodCall>');
+		$result = XMLRPCProxy::rebuildLoadParams($xml, 'load.start', array());
+		$reparsed = @simplexml_load_string($result['xml']);
+		$this->assertTrue($reparsed !== false, 'rebuilt XML round-trips through simplexml');
+		$this->assertEquals('load.start', (string)$reparsed->methodName, 'method name preserved');
+	}
+
+	public function testSanitizeEndToEndForwardsCleanedPayload()
+	{
+		$this->resetMocks();
+		$xml = '<?xml version="1.0"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.com/t.torrent</string></value></param><param><value><string>execute=evil</string></value></param></params></methodCall>';
+		XMLRPCProxy::process($xml, 'sanitize', false, array('d.directory.set'));
+		$this->assertTrue(rXMLRPCRequest::$lastTrusted === true, 'sanitized load.start forwarded as trusted');
+		$this->assertTrue(strpos(rXMLRPCRequest::$lastPayload, 'execute=evil') === false, 'forwarded payload must not contain malicious param');
+		$this->assertTrue(strpos(rXMLRPCRequest::$lastPayload, 'http://example.com/t.torrent') !== false, 'URL preserved');
+	}
+
+	// ---- Sanity ----
+
+	public function testSanitizeMethodsList()
+	{
+		$ref = new ReflectionProperty('XMLRPCProxy', 'sanitizeMethods');
+		$ref->setAccessible(true);
+		$methods = $ref->getValue();
+		$this->assertTrue(in_array('load.start', $methods), 'load.start in sanitize list');
+		$this->assertTrue(in_array('load.raw_start', $methods), 'load.raw_start in sanitize list');
+		$this->assertTrue(!in_array('execute', $methods), 'execute NOT in sanitize list');
+		$this->assertTrue(!in_array('system.multicall', $methods), 'system.multicall NOT in sanitize list');
+		$this->assertTrue(!in_array('execute2', $methods), 'execute2 NOT in sanitize list');
+	}
 }


### PR DESCRIPTION
External XMLRPC clients (Prowlarr, Sonarr, the *arr stack) send raw XMLRPC to  `httprpc/action.php`'s default case. Previously all such raw XMLRPC was forwarded to rtorrent as **untrusted**, which on **rtorrent 0.16.9+** blocks `load.start`  — breaking those integrations with no supported workaround inside ruTorrent.

This PR allows configuring this proxy with 3 modes.

sanitize (default) => Parse the XMLRPC method name with simplexml (entity loading disabled, LIBXML_NONET). For load.* methods: always keep the positional target + URL/data params; for any extra command params, keep only those whose prefix matches $XMLRPCProxySafeParams and strip the rest. Other methods continue to pass as untrusted.
 `passthrough_unsafe` => Forward everything as trusted. Operator accepts the risk. 
 `off` => Reject all raw XMLRPC.
`$XMLRPCProxyLog` (bool, default `true`) logs trusted, sanitized (with the count of stripped params), and untrusted method calls to help diagnose external client integration without exposing payload contents.

$XMLRPCProxySafeParams (array) — operator-tunable whitelist of command-prefix strings allowed as extra load.* params. Default ships with the common *arr-stack set (d.directory.set, d.custom1-5.set, d.priority.set, d.throttle_name.set, d.views.push_back_unique, d.delete_tied); extend in httprpc/conf.php if your client needs more.


Closes #3046.