### PR TITLE
Guard against undefined theUILang.diskUsage in diskspace plugin

### DIFF
--- a/plugins/diskspace/init.js
+++ b/plugins/diskspace/init.js
@@ -11,12 +11,14 @@ plugin.setValue = function( full, free )
 		visibility: !percent ? "hidden" : "visible" } );
 	if(plugin.freeBytesInMeter) $("#meter-disk-text").text(theConverter.bytes(free));
 	else $("#meter-disk-text").text(percent+'%');
-	$("#meter-disk-pane").prop("title",
-		theUILang.diskUsage
-			.replace(/%USED%/, theConverter.bytes(used))
-			.replace(/%TOTAL%/, theConverter.bytes(full))
-			.replace(/%FREE%/, theConverter.bytes(free))
-	);
+	if(theUILang.diskUsage) {
+		$("#meter-disk-pane").prop("title",
+			theUILang.diskUsage
+				.replace(/%USED%/, theConverter.bytes(used))
+				.replace(/%TOTAL%/, theConverter.bytes(full))
+				.replace(/%FREE%/, theConverter.bytes(free))
+		);
+	}
 
 	if($.noty && plugin.allStuffLoaded)
 	{


### PR DESCRIPTION
## Summary

Wrap `theUILang.diskUsage` access in a guard to prevent a `TypeError` when the language file hasn't finished loading before the first AJAX poll response from action.php arrives.

Fixes `line 2 > injectedScript : 266] TypeError: can't access property "replace", theUILang.diskUsage is undefined` in Firefox.