### PR TITLE
Stop using rtorrent deprecated command aliases on 0.16.x

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -872,6 +872,30 @@ function correctContent()
 			"connection_seed"               : { name: "protocol.connection.seed.set", prm: 1 },
 		});
 	}
+	if(theWebUI.systemInfo.rTorrent.iVersion>=0x1000)
+	{
+		// rtorrent 0.16.x: deprecated aliases (schedule2, schedule_remove2,
+		// execute2, network.http.max_open*, group2.*) are gated behind
+		// method.use_deprecated which since 0.16.14 can no longer be enabled
+		// from the rc file — only via the -D launch flag. Override the JS
+		// alias map so theRequestManager.map() returns the canonical names
+		// for any code path that builds an XMLRPC command client-side and
+		// sends it via httprpc/multirpc. Mirrors php/methods-0.16.0.php.
+		$.extend(theRequestManager.aliases,
+		{
+			"schedule"          : { name: "schedule",                              prm: 1 },
+			"schedule_remove"   : { name: "schedule.remove",                       prm: 1 },
+			"execute"           : { name: "execute",                               prm: 1 },
+			"get_max_open_http" : { name: "network.http.max_total_connections",    prm: 0 },
+			"set_max_open_http" : { name: "network.http.max_total_connections.set",prm: 1 },
+			"ratio.min"         : { name: "group.seeding.ratio.min",               prm: 0 },
+			"ratio.max"         : { name: "group.seeding.ratio.max",               prm: 0 },
+			"ratio.upload"      : { name: "group.seeding.ratio.upload",            prm: 0 },
+			"ratio.min.set"     : { name: "group.seeding.ratio.min.set",           prm: 1 },
+			"ratio.max.set"     : { name: "group.seeding.ratio.max.set",           prm: 1 },
+			"ratio.upload.set"  : { name: "group.seeding.ratio.upload.set",        prm: 1 },
+		});
+	}
 	if(theWebUI.systemInfo.rTorrent.iVersion < 0x907) {
 		const title = theUILang.requiresAtLeastRtorrent.replace('{version}', 'v0.9.7');
 		$($$('webui.show_open_status')).attr({ disabled: '', title });

--- a/php/methods-0.16.0.php
+++ b/php/methods-0.16.0.php
@@ -1,0 +1,36 @@
+<?php
+
+// rtorrent 0.16.x: deprecated command aliases (schedule2, schedule_remove2,
+// execute2, network.http.max_open, throttle.ip, dht.throttle.name, ...) are
+// gated behind method.use_deprecated, which since 0.16.14 cannot be enabled
+// from the rc file — only via the -D launch flag. Stock 0.16.14 therefore
+// does NOT register these aliases, so anything sending them faults with
+// "Method '<name>' not defined".
+//
+// This file overrides the offending entries from methods-0.9.4.php with
+// the canonical command names that exist on every 0.16.x build. Loaded
+// from settings.php when iVersion >= 0x1000.
+
+$this->aliases = array_merge($this->aliases, array(
+
+	// Scheduling
+	"schedule"        => array( "name"=>"schedule",        "prm"=>1 ),
+	"schedule_remove" => array( "name"=>"schedule.remove", "prm"=>1 ),
+
+	// Command execution
+	"execute"         => array( "name"=>"execute",         "prm"=>1 ),
+
+	// HTTP connection cap (was network.http.max_open in 0.9.x)
+	"get_max_open_http" => array( "name"=>"network.http.max_total_connections",     "prm"=>0 ),
+	"set_max_open_http" => array( "name"=>"network.http.max_total_connections.set", "prm"=>1 ),
+
+	// Per-group ratio commands — bare seeding group remap (0.10.2 map sent
+	// group2.seeding.* which is gone in 0.16). Use group.seeding.* now.
+	"ratio.min"         => array( "name"=>"group.seeding.ratio.min",         "prm"=>0 ),
+	"ratio.max"         => array( "name"=>"group.seeding.ratio.max",         "prm"=>0 ),
+	"ratio.upload"      => array( "name"=>"group.seeding.ratio.upload",      "prm"=>0 ),
+	"ratio.min.set"     => array( "name"=>"group.seeding.ratio.min.set",     "prm"=>1 ),
+	"ratio.max.set"     => array( "name"=>"group.seeding.ratio.max.set",     "prm"=>1 ),
+	"ratio.upload.set"  => array( "name"=>"group.seeding.ratio.upload.set",  "prm"=>1 ),
+
+));

--- a/php/settings.php
+++ b/php/settings.php
@@ -224,6 +224,10 @@ class rTorrentSettings
 			{
 				require_once( 'methods-0.10.2.php' );
 			}
+			if($this->iVersion>=0x1000)
+			{
+				require_once( 'methods-0.16.0.php' );
+			}
 			$this->apiVersion = 0;
 			if($this->iVersion>=0x901)
 			{
@@ -311,7 +315,15 @@ class rTorrentSettings
 	}
 	public function getRatioGroupCommand($ratio,$cmd,$args)
 	{
-		$prefix = ($this->iVersion >= 0x904) && in_array($cmd,$this->ratioCmds) ? "group2." : "group.";
+		// rtorrent 0.16 removed the group2.* aliases (deprecated and gated
+		// behind method.use_deprecated, which on 0.16.14+ cannot be enabled
+		// from the rc file — only via the -D launch flag). Use group.* for
+		// every cmd on 0.16+; the older split is kept for pre-0.16 slots.
+		if($this->iVersion >= 0x1000) {
+			$prefix = "group.";
+		} else {
+			$prefix = ($this->iVersion >= 0x904) && in_array($cmd,$this->ratioCmds) ? "group2." : "group.";
+		}
 		return( new rXMLRPCCommand( $prefix.$ratio.".".$cmd, $args ) );
 	}
 	public function getEventCommand($cmd1,$cmd2,$args)


### PR DESCRIPTION
rtorrent 0.16.14 (rakshasa/rtorrent 7537781) gates deprecated command aliases behind method.use_deprecated. The guard is evaluated before the rc file is parsed, so method.use_deprecated.set=true in the rc no longer takes effect — only the -D launch flag enables them. Stock 0.16.14 therefore does not register schedule2, schedule_remove2, execute2, network.http.max_open[.set], throttle.ip, dht.throttle.name[.set], or the per-group group2.* ratio aliases. Any consumer still sending those faults with "Method 'NAME' not defined".

Upstream maintainer rejected un-guarding them: the alias deprecation is a removal path. Consumers must move to the canonical names.

Changes (gated to iVersion >= 0x1000 so 0.9.x slots are untouched):

* php/methods-0.16.0.php -- new override file loaded from settings.php for any rtorrent 0.16+. Maps schedule -> schedule, schedule_remove -> schedule.remove, execute -> execute, set/get_max_open_http -> network.http.max_total_connections[.set], and ratio.{min,max,upload} [.set] -> group.seeding.ratio.* (was group2.seeding.ratio.* in methods-0.10.2.php, which 0.16 also dropped).

* php/settings.php -- getRatioGroupCommand uses "group." prefix unconditionally on 0.16+; pre-0.16 keeps the existing group2./group. split. Same canonical names are constructed for custom groups (group.rat_N.ratio.* instead of group2.rat_N.ratio.*).

* js/content.js -- mirror PHP overrides in theRequestManager.aliases so JS-built XMLRPC commands sent via httprpc/multirpc also use canonical names. Other JS files (options.js, rtorrent.js, webui.js) only reference the internal alias *keys* and need no change.

Verified end-to-end on a live 0.16.14 box (nlfeast002 / Xirvik): schedule, schedule.remove, group.rat_N.ratio.min.set all accepted by rtorrent; previously-spammed Method-not-defined faults stop.