### PR TITLE
Ratio plugin: split persistent-view insert from settings multicall

### DIFF
--- a/plugins/ratio/ratio.php
+++ b/plugins/ratio/ratio.php
@@ -166,20 +166,37 @@ class rRatio
 		$req1 = new rXMLRPCRequest(new rXMLRPCCommand("view_list"));
 		if($req1->run() && !$req1->fault)
 		{
+			// Best-effort insert of the rat_* persistent views that view.list
+			// reports missing. Run as its own request so any fault here
+			// (typically "View with same name already inserted" when the
+			// session restored rat_* but our cached view.list lagged) does
+			// not propagate into the settings multicall below and sink the
+			// whole plugin start with a misleading "Plugin failed to start".
+			$insertReq = new rXMLRPCRequest();
+			for($i=0; $i<MAX_RATIO; $i++)
+			{
+				if(!in_array("rat_".$i,$req1->val))
+					$insertReq->addCommand(new rXMLRPCCommand("group.insert_persistent_view", array("", "rat_".$i)));
+			}
+			if($insertReq->getCommandsCount())
+				$insertReq->run();
+
 			$insCmd = getCmd('branch=');
 			$req = new rXMLRPCRequest();
 			for($i=0; $i<MAX_RATIO; $i++)
 			{
 				$insCmd .= (getCmd('d.views.has=').'rat_'.$i.',,');
 				$rat = $this->rat[$i];
-				if(!in_array("rat_".$i,$req1->val))
-					$req->addCommand(new rXMLRPCCommand("group.insert_persistent_view", array("", "rat_".$i)));
 				if($this->isCorrect($i))
 				{
 					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.enable',array("")) );
-					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.min.set',$rat["min"]) );
-					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.max.set',$rat["max"]) );
-					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.upload.set',floatval($rat["upload"]*1024*1024*1024)) );
+					// rtorrent 0.16+ requires (target, value) for group.*.ratio.*.set;
+					// pre-0.16 group2.* aliases tolerated a single scalar param. Always
+					// prepend the empty-string target so the call shape matches the
+					// strict 0.16 signature on every supported rtorrent.
+					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.min.set',array("",$rat["min"])) );
+					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.max.set',array("",$rat["max"])) );
+					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.upload.set',array("",floatval($rat["upload"]*1024*1024*1024))) );
 					switch($rat["action"])
 					{
 						case RAT_STOP:


### PR DESCRIPTION
flush() built a single system.multicall containing both the group.insert_persistent_view inserts for the rat_* views and the ratio settings (group.rat_N.ratio.{enable,min,max,upload}.set, plus the system.method.set for the per-group ratio.command). The "insert this view if view.list says it's missing" check exists to prevent re-inserting a view that already lives in the session, but the check is racy: when ruTorrent's cached view.list lags the live rtorrent state (e.g. a session that restored rat_* views and a ratio plugin obtain() that runs before that loads, or a stale cache returned to a parallel request) the insert command goes in anyway, rtorrent answers "View with same name already inserted", and the whole multicall is marked faulted.

Because that fault sinks the entire batch, rXMLRPCRequest::success() returns false, flush() returns false, obtain() returns false, and the ratio plugin reports "Plugin failed to start" -- even though every single one of the ratio settings commands in the same multicall ran successfully on rtorrent's side. The side effect on the UI is severe: the "Ratio Groups" page never gets attached to Settings and theWebUI.isCorrectRatio is never defined, so clicking "Ratio Rules" in the menu throws TypeError: theWebUI.isCorrectRatio is not a function.

Surfaced now because rakshasa/rtorrent 0.16.14 dropped the deprecated group2.* aliases (gated behind method.use_deprecated which since 0.16.14 cannot be enabled from the rc file). With #3061 routing getRatioGroupCommand through canonical group.* on 0.16+, the rest of the multicall actually executes and the latent fault sensitivity is exposed.

Fix: split the persistent-view inserts into their own request and do not gate the settings multicall on its success. Inserts are inherently idempotent for our purposes (we only care that the view exists when the settings run, regardless of who created it), so a fault here is benign and should not affect plugin startup. The settings multicall keeps its existing fault semantics -- a real problem with group.rat_N.ratio.*.set will still surface as flush() failure.

Reported by ranirahn in #3065. Reproduced and confirmed fixed on a 0.16.14 instance (note: still waiting for some feedback on this fix).