### PR TITLE
Ratio plugin: gate group.*.set call shape by rtorrent version

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -32,18 +32,6 @@ class rTorrentSettings
 
 	static private $theSettings = null;
 
-	private $ratioCmds = array
-	(
-		"view",          
-		"view.set",
-		"ratio.min",
-		"ratio.min.set",
-		"ratio.max",
-		"ratio.max.set",
-		"ratio.upload",
-		"ratio.upload.set",
-	);
-
 	private function __construct()
     	{
     		if( array_key_exists("browser_timezone",$_COOKIE) )
@@ -315,16 +303,24 @@ class rTorrentSettings
 	}
 	public function getRatioGroupCommand($ratio,$cmd,$args)
 	{
-		// rtorrent 0.16 removed the group2.* aliases (deprecated and gated
-		// behind method.use_deprecated, which on 0.16.14+ cannot be enabled
-		// from the rc file — only via the -D launch flag). Use group.* for
-		// every cmd on 0.16+; the older split is kept for pre-0.16 slots.
-		if($this->iVersion >= 0x1000) {
-			$prefix = "group.";
-		} else {
-			$prefix = ($this->iVersion >= 0x904) && in_array($cmd,$this->ratioCmds) ? "group2." : "group.";
+		// Use group.* on every rtorrent. group2.* was a transient alias
+		// experiment: stubbed (non-functional) on 0.15.x and removed in
+		// 0.16. The canonical group.* commands work across the version
+		// range we care to support.
+		//
+		// rtorrent 0.16+ tightened the signature on group.NAME.*.set:
+		// it strictly requires (target_string, value), and rejects a
+		// bare value with "invalid parameters: target must be a string".
+		// 0.15.x is the opposite — strictly takes the bare value and
+		// rejects (target, value) with "Wrong object type". Adapt the
+		// args automatically by rtorrent version so callers do not
+		// have to track which signature applies.
+		if(($this->iVersion >= 0x1000) && (substr($cmd, -4) === ".set"))
+		{
+			if(!is_array($args)) $args = array($args);
+			array_unshift($args, "");
 		}
-		return( new rXMLRPCCommand( $prefix.$ratio.".".$cmd, $args ) );
+		return( new rXMLRPCCommand( "group.".$ratio.".".$cmd, $args ) );
 	}
 	public function getEventCommand($cmd1,$cmd2,$args)
 	{

--- a/plugins/ratio/ratio.php
+++ b/plugins/ratio/ratio.php
@@ -190,13 +190,9 @@ class rRatio
 				if($this->isCorrect($i))
 				{
 					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.enable',array("")) );
-					// rtorrent 0.16+ requires (target, value) for group.*.ratio.*.set;
-					// pre-0.16 group2.* aliases tolerated a single scalar param. Always
-					// prepend the empty-string target so the call shape matches the
-					// strict 0.16 signature on every supported rtorrent.
-					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.min.set',array("",$rat["min"])) );
-					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.max.set',array("",$rat["max"])) );
-					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.upload.set',array("",floatval($rat["upload"]*1024*1024*1024))) );
+					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.min.set',$rat["min"]) );
+					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.max.set',$rat["max"]) );
+					$req->addCommand( rTorrentSettings::get()->getRatioGroupCommand("rat_".$i,'ratio.upload.set',floatval($rat["upload"]*1024*1024*1024)) );
 					switch($rat["action"])
 					{
 						case RAT_STOP:


### PR DESCRIPTION
#3066 fixed the ratio plugin on rtorrent 0.16.x by always sending (target_string, value) to group.NAME.ratio.{min,max,upload}.set, which is what the strict 0.16 signature requires. On older rtorrent the same set commands are the opposite — strictly a bare value, and the (target, value) shape is rejected with "Wrong object type".

Encapsulate the call-shape adaptation in
rTorrentSettings::getRatioGroupCommand so callers (ratio plugin flush(), but also any future consumer) do not have to know which signature applies. The helper:

* always uses the canonical group.* prefix. group2.* was a transient alias name: stubbed and non-functional on 0.15.x and removed in 0.16. The old "if iVersion >= 0x904 and cmd in ratioCmds use group2." branch fell into both broken cases and produces fewer successful calls than the unconditional group.* path on every rtorrent version verified.

* prepends an empty-string target to *.set commands only when iVersion >= 0x1000, so 0.15.x callers continue to receive the single-value shape they require and 0.16+ callers receive the (target, value) shape they require.

ratio.php is reverted to passing the bare value to the helper for the .set commands; the helper does the version-aware wrapping.

The unused $ratioCmds whitelist is dropped — only the group2.* branch consulted it, and that branch is gone.

Reported by @ml-1 in #3065 after upgrading to v5.3.3 with rtorrent 0.15.7.