### PR TITLE
Bump version to 5.3.4 and update cache-bust params

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,27 +21,27 @@
 		<meta name="msapplication-TileColor" content="#FFFFFF" />
 		<meta name="msapplication-TileImage" content="./images/mstile-144x144.png" />
 
-		<link href="./css/bootstrap.min.css?v=533" rel="stylesheet" type="text/css" />
-		<link href="./css/style.css?v=533" rel="stylesheet" type="text/css" />
-		<link href="./css/stable.css?v=533" rel="stylesheet" type="text/css" />
-		<link rel="preload" as="style" href="./css/category-panel.css?v=533" />
-		<link rel="preload" as="style" href="./css/panel-label.css?v=533" />
-		<script type="text/javascript" src="./js/jquery.js?v=533"></script>
-		<script type="text/javascript" src="./js/jquery.flot.js?v=533"></script>
-		<script type="text/javascript" src="./js/sanitize.js?v=533"></script>
-		<script type="text/javascript" src="./js/sanitize.config.js?v=533"></script>
-		<script type="text/javascript" src="./js/custom-elements.js?v=533"></script>
-		<script type="text/javascript" src="./lang/langs.js?v=533"></script>
-		<link rel="preload" as="script" href="./js/browser.js?v=533" />
-		<link rel="preload" as="script" href="./js/common.js?v=533" />
-		<link rel="preload" as="script" href="./js/objects.js?v=533" />
-		<link rel="preload" as="script" href="./js/options.js?v=533" />
-		<link rel="preload" as="script" href="./js/content.js?v=533" />
-		<link rel="preload" as="script" href="./js/stable.js?v=533" />
-		<link rel="preload" as="script" href="./js/graph.js?v=533" />
-		<link rel="preload" as="script" href="./js/plugins.js?v=533" />
-		<link rel="preload" as="script" href="./js/rtorrent.js?v=533" />
-		<link rel="preload" as="script" href="./js/webui.js?v=533" />
+		<link href="./css/bootstrap.min.css?v=534" rel="stylesheet" type="text/css" />
+		<link href="./css/style.css?v=534" rel="stylesheet" type="text/css" />
+		<link href="./css/stable.css?v=534" rel="stylesheet" type="text/css" />
+		<link rel="preload" as="style" href="./css/category-panel.css?v=534" />
+		<link rel="preload" as="style" href="./css/panel-label.css?v=534" />
+		<script type="text/javascript" src="./js/jquery.js?v=534"></script>
+		<script type="text/javascript" src="./js/jquery.flot.js?v=534"></script>
+		<script type="text/javascript" src="./js/sanitize.js?v=534"></script>
+		<script type="text/javascript" src="./js/sanitize.config.js?v=534"></script>
+		<script type="text/javascript" src="./js/custom-elements.js?v=534"></script>
+		<script type="text/javascript" src="./lang/langs.js?v=534"></script>
+		<link rel="preload" as="script" href="./js/browser.js?v=534" />
+		<link rel="preload" as="script" href="./js/common.js?v=534" />
+		<link rel="preload" as="script" href="./js/objects.js?v=534" />
+		<link rel="preload" as="script" href="./js/options.js?v=534" />
+		<link rel="preload" as="script" href="./js/content.js?v=534" />
+		<link rel="preload" as="script" href="./js/stable.js?v=534" />
+		<link rel="preload" as="script" href="./js/graph.js?v=534" />
+		<link rel="preload" as="script" href="./js/plugins.js?v=534" />
+		<link rel="preload" as="script" href="./js/rtorrent.js?v=534" />
+		<link rel="preload" as="script" href="./js/webui.js?v=534" />
 
 		<script>
 			loadUILang(() => {
@@ -57,10 +57,10 @@
 			});
 		</script>
 
-		<script type="module" src="./js/backgroundtask.js?v=533"></script>
-		<script type="module" src="./js/category-list.js?v=533"></script>
-		<script type="module" src="./js/panel.js?v=533"></script>
-		<script type="text/javascript" src="./js/category-list-elements.js?v=533" defer></script>
+		<script type="module" src="./js/backgroundtask.js?v=534"></script>
+		<script type="module" src="./js/category-list.js?v=534"></script>
+		<script type="module" src="./js/panel.js?v=534"></script>
+		<script type="text/javascript" src="./js/category-list-elements.js?v=534" defer></script>
 	</head>
 	<body>
 		<div id="preload" class="d-none"></div>
@@ -139,7 +139,7 @@
 				</div>
 				<div class="p-1 p-md-0 offcanvas-body">
 					<template id="panel-label-template">
-						<link href="./css/panel-label.css?v=533" rel="stylesheet" type="text/css" />
+						<link href="./css/panel-label.css?v=534" rel="stylesheet" type="text/css" />
 						<div part="prefix" hidden></div>
 						<div part="icon"></div>
 						<div part="text"></div>
@@ -148,7 +148,7 @@
 						<div part="size" style="display: none;"></div>
 					</template>
 					<template id="category-panel-template">
-						<link href="./css/category-panel.css?v=533" rel="stylesheet" type="text/css" />
+						<link href="./css/category-panel.css?v=534" rel="stylesheet" type="text/css" />
 						<div part="heading">
 							<span class="text"></span><slot name="decorator" class="decorator"></slot>
 						</div>
@@ -304,6 +304,6 @@
 		<div class="graph_tab_legend"></div>
 		<div id="dialog-container"></div>
 		<div id="dir-container"></div>
-		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=533"></script>
+		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=534"></script>
 	</body>
 </html>

--- a/js/webui.js
+++ b/js/webui.js
@@ -4,7 +4,7 @@
  */
 
 var theWebUI = {
-	version: "5.3.3",
+	version: "5.3.4",
 	tables: {
 		trt: {
 			obj: new dxSTable(),

--- a/lang/langs.js
+++ b/lang/langs.js
@@ -110,7 +110,7 @@ function loadUILang(onLoadFunc)
 			translateDOM();
 		}
 	};
-	langScript.src = `./lang/${lang}.js?v=533`;
+	langScript.src = `./lang/${lang}.js?v=534`;
 	document.head.appendChild(langScript);
 }
 


### PR DESCRIPTION
Bug fixes since v5.3.3.

### Ratio plugin
- Gate the `group.*.ratio.*.set` call shape by rtorrent version so the ratio
  plugin works on rtorrent **0.15.x** as well as 0.16.x. 0.16 strictly requires
  `(target, value)` while 0.15.x strictly requires the bare value; the
  adaptation now lives in `rTorrentSettings::getRatioGroupCommand` and is chosen
  by `iVersion`. Also drops the `group2.*` prefix path (stubbed on 0.15.x,
  removed in 0.16) and the now-unused `$ratioCmds` whitelist.
  (@xirvik, #3071 — fixes the 0.15.x regression reported by @ml-1 in #3065)

### erasedata / httprpc
- "Remove and delete data" now records the file list over RPC using canonical
  commands (`d.base_path`, `d.is_multi_file`, `f.multicall`/`f.frozen_path`)
  and writes the erasedata `.list` file directly, instead of relying on the
  `file.append` erase event. Stock rtorrent 0.16.x does not register
  `file.append` (it's gated behind `method.use_deprecated`, which the rc can no
  longer enable in time), so the torrent was removed but its data silently
  orphaned. The new path works on every rtorrent version.
  (@xirvik, #3073)



