### PR TITLE
Remove stale reference to fin.sh in EraseData plugin

### DIFF
--- a/plugins/erasedata/plugin.info
+++ b/plugins/erasedata/plugin.info
@@ -2,5 +2,4 @@ plugin.description: This plugin allows to delete torrent data along with .torren
 plugin.author: Novik
 plugin.version: 5.1
 rtorrent.remote: error
-rtorrent.script.error: fin.sh
 plugin.help: https://github.com/Novik/ruTorrent/wiki/PluginErasedata


### PR DESCRIPTION
This file was removed in commit 54165cb5, but the stale reference means erasedata still looks for it at launch, and fails to launch if its not detected. Since this is no longer used anywhere, its safe to remove.