### PR TITLE
throttle: apply throttle server-side so raw commands need no whitelisting

### DIFF
--- a/plugins/throttle/action.php
+++ b/plugins/throttle/action.php
@@ -2,5 +2,12 @@
 require_once( 'throttle.php' );
 
 $thr = new rThrottle();
-$thr->set();
-CachedEcho::send($thr->get(),"application/javascript");
+if(isset($_REQUEST['apply']))
+{
+	$thr->apply();
+}
+else
+{
+	$thr->set();
+	CachedEcho::send($thr->get(),"application/javascript");
+}

--- a/plugins/throttle/init.js
+++ b/plugins/throttle/init.js
@@ -169,34 +169,19 @@ if(plugin.canChangeMenu())
 		var req = '';
 		for(var k in sr)
        			if(sr[k] && (k.length==40))
-				req += ("&hash=" + k + "&v="+throttle);
+				req += ("&hash=" + k);
 		if(req.length>0)
-			this.request("?action=setthrottle"+req+"&list=1",[this.addTorrents, this]);
+			this.request("?action=setthrottle&v="+throttle+req+"&list=1",[this.addTorrents, this]);
 	}
 
 	rTorrentStub.prototype.setthrottle = function()
 	{
-		for(var i=0; i<this.vs.length; i++)
-		{
-			var needRestart = (theWebUI.torrents[this.hashes[i]].status==theUILang.Seeding) || (theWebUI.torrents[this.hashes[i]].status==theUILang.Downloading);
-			var name = (this.vs[i]>=0) ? "thr_"+this.vs[i] : "";
-			if(needRestart)
-			{
-				cmd = new rXMLRPCCommand('d.stop');
-				cmd.addParameter("string",this.hashes[i]);
-				this.commands.push( cmd );
-			}
-			cmd = new rXMLRPCCommand('d.set_throttle_name');
-			cmd.addParameter("string",this.hashes[i]);
-			cmd.addParameter("string",name);
-			this.commands.push( cmd );
-			if(needRestart)
-			{
-				cmd = new rXMLRPCCommand('d.start');
-				cmd.addParameter("string",this.hashes[i]);
-				this.commands.push( cmd );
-			}
-		}
+		this.content = "apply=1&v="+encodeURIComponent(this.vs[0]);
+		for(var i=0; i<this.hashes.length; i++)
+			this.content += ("&hash%5B%5D="+encodeURIComponent(this.hashes[i]));
+		this.contentType = "application/x-www-form-urlencoded";
+		this.mountPoint = "plugins/throttle/action.php";
+		this.dataType = "script";
 	}
 }
 

--- a/plugins/throttle/throttle.php
+++ b/plugins/throttle/throttle.php
@@ -118,6 +118,28 @@ class rThrottle
         	}
 		return(false);
 	}
+	public function apply()
+	{
+		$hashes = isset($_REQUEST['hash']) ? $_REQUEST['hash'] : array();
+		if(!is_array($hashes))
+			$hashes = array($hashes);
+		$v = isset($_REQUEST['v']) ? intval($_REQUEST['v']) : -1;
+		$name = ($v>=0) ? ("thr_".$v) : "";
+		$req = new rXMLRPCRequest();
+		foreach($hashes as $hash)
+		{
+			if((strlen($hash)!=40) || !ctype_xdigit($hash))
+				continue;
+			$req->addCommand(new rXMLRPCCommand( "branch", array(
+				$hash,
+				getCmd("d.is_active="),
+				getCmd('cat').'=$'.getCmd("d.stop").'=,$'.getCmd("d.set_throttle_name=").$name.',$'.getCmd('d.start='),
+				getCmd('d.set_throttle_name=').$name )));
+		}
+		if($req->getCommandsCount())
+			return($req->run() && !$req->fault);
+		return(true);
+	}
 	public function obtain()
 	{
 		$req = new rXMLRPCRequest( array(


### PR DESCRIPTION
Since raw XMLRPC from the client is now forwarded as untrusted (subject to rtorrent's command whitelist), the throttle plugin's per-torrent apply broke: it built d.stop / d.set_throttle_name / d.start commands in the browser and sent them as raw RPC. Making that work again would mean whitelisting stop/start/throttle-name for all untrusted callers.

Instead, route the action through the plugin's own action.php: the client posts only the throttle value and a hash list, and the new rThrottle::apply() validates each hash (40 hex chars) and issues the commands over the trusted connection