### PR TITLE
Fix Save To menu item

### DIFF
--- a/plugins/datadir/init.js
+++ b/plugins/datadir/init.js
@@ -42,6 +42,11 @@ theWebUI.showDataDirDlg = function( d )
 
 rTorrentStub.prototype.getsavepath = function()
 {
+	if(typeof this.getCommon === "function") {
+		this.getCommon("getsavepath");
+		return;
+	}
+
 	var cmd = new rXMLRPCCommand( "d.open" );
 	cmd.addParameter( "string", this.hashes[0] );
 	this.commands.push( cmd );
@@ -55,14 +60,22 @@ rTorrentStub.prototype.getsavepath = function()
 
 rTorrentStub.prototype.getsavepathResponse = function( xml )
 {
-	var datas = xml.getElementsByTagName( 'data' );
-	var data = datas[0];
-	var values = data.getElementsByTagName( 'value' );
 	var torrent = theWebUI.torrents[this.hashes[0]];
+	var base_path = '';
 	var save_path = '';
+
+	if(Array.isArray(xml))
+		base_path = xml.length > 1 ? String(xml[1]) : '';
+	else {
+		var datas = xml.getElementsByTagName( 'data' );
+		var data = datas[0];
+		var values = data.getElementsByTagName( 'value' );
+		base_path = this.getXMLValue( values, 3 );
+	}
+
 	if(torrent)
 	{
-		torrent.base_path = this.getXMLValue( values, 3 );
+		torrent.base_path = base_path;
 		var pos = torrent.base_path.lastIndexOf('/');
 		torrent.save_path = (torrent.base_path.substring(pos+1) === torrent.name) ? 
 			torrent.base_path.substring(0,pos) : torrent.base_path;

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -258,6 +258,20 @@ switch($mode)
         	$result = makeSimpleCall(array("d.check_hash"), $hash);
 		break;
 	}
+	case "getsavepath":	/**/
+	{
+		if(isset($hash[0]))
+		{
+			$req = new rXMLRPCRequest( array(
+				new rXMLRPCCommand( "d.open", $hash[0] ),
+				new rXMLRPCCommand( "d.get_base_path", $hash[0] ),
+				new rXMLRPCCommand( "d.close", $hash[0] )
+			) );
+			if($req->success(true))
+				$result = $req->val;
+		}
+		break;
+	}
 	case "start":	/**/
 	{
 		$result = makeSimpleCall(array("d.open","d.start","d.resume"), $hash);


### PR DESCRIPTION
Fixes a bug where the 'Save To' context menu item triggers the 'TypeError: can't access property "trim", d.savepath is undefined' when used on an uninitiated torrent. We solve this by falling back on base_path, which is set even for uninitialised torrents.