### PR TITLE
Bump version to 5.3.5 and update cache-bust params

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,27 +21,27 @@
 		<meta name="msapplication-TileColor" content="#FFFFFF" />
 		<meta name="msapplication-TileImage" content="./images/mstile-144x144.png" />
 
-		<link href="./css/bootstrap.min.css?v=534" rel="stylesheet" type="text/css" />
-		<link href="./css/style.css?v=534" rel="stylesheet" type="text/css" />
-		<link href="./css/stable.css?v=534" rel="stylesheet" type="text/css" />
-		<link rel="preload" as="style" href="./css/category-panel.css?v=534" />
-		<link rel="preload" as="style" href="./css/panel-label.css?v=534" />
-		<script type="text/javascript" src="./js/jquery.js?v=534"></script>
-		<script type="text/javascript" src="./js/jquery.flot.js?v=534"></script>
-		<script type="text/javascript" src="./js/sanitize.js?v=534"></script>
-		<script type="text/javascript" src="./js/sanitize.config.js?v=534"></script>
-		<script type="text/javascript" src="./js/custom-elements.js?v=534"></script>
-		<script type="text/javascript" src="./lang/langs.js?v=534"></script>
-		<link rel="preload" as="script" href="./js/browser.js?v=534" />
-		<link rel="preload" as="script" href="./js/common.js?v=534" />
-		<link rel="preload" as="script" href="./js/objects.js?v=534" />
-		<link rel="preload" as="script" href="./js/options.js?v=534" />
-		<link rel="preload" as="script" href="./js/content.js?v=534" />
-		<link rel="preload" as="script" href="./js/stable.js?v=534" />
-		<link rel="preload" as="script" href="./js/graph.js?v=534" />
-		<link rel="preload" as="script" href="./js/plugins.js?v=534" />
-		<link rel="preload" as="script" href="./js/rtorrent.js?v=534" />
-		<link rel="preload" as="script" href="./js/webui.js?v=534" />
+		<link href="./css/bootstrap.min.css?v=535" rel="stylesheet" type="text/css" />
+		<link href="./css/style.css?v=535" rel="stylesheet" type="text/css" />
+		<link href="./css/stable.css?v=535" rel="stylesheet" type="text/css" />
+		<link rel="preload" as="style" href="./css/category-panel.css?v=535" />
+		<link rel="preload" as="style" href="./css/panel-label.css?v=535" />
+		<script type="text/javascript" src="./js/jquery.js?v=535"></script>
+		<script type="text/javascript" src="./js/jquery.flot.js?v=535"></script>
+		<script type="text/javascript" src="./js/sanitize.js?v=535"></script>
+		<script type="text/javascript" src="./js/sanitize.config.js?v=535"></script>
+		<script type="text/javascript" src="./js/custom-elements.js?v=535"></script>
+		<script type="text/javascript" src="./lang/langs.js?v=535"></script>
+		<link rel="preload" as="script" href="./js/browser.js?v=535" />
+		<link rel="preload" as="script" href="./js/common.js?v=535" />
+		<link rel="preload" as="script" href="./js/objects.js?v=535" />
+		<link rel="preload" as="script" href="./js/options.js?v=535" />
+		<link rel="preload" as="script" href="./js/content.js?v=535" />
+		<link rel="preload" as="script" href="./js/stable.js?v=535" />
+		<link rel="preload" as="script" href="./js/graph.js?v=535" />
+		<link rel="preload" as="script" href="./js/plugins.js?v=535" />
+		<link rel="preload" as="script" href="./js/rtorrent.js?v=535" />
+		<link rel="preload" as="script" href="./js/webui.js?v=535" />
 
 		<script>
 			loadUILang(() => {
@@ -57,10 +57,10 @@
 			});
 		</script>
 
-		<script type="module" src="./js/backgroundtask.js?v=534"></script>
-		<script type="module" src="./js/category-list.js?v=534"></script>
-		<script type="module" src="./js/panel.js?v=534"></script>
-		<script type="text/javascript" src="./js/category-list-elements.js?v=534" defer></script>
+		<script type="module" src="./js/backgroundtask.js?v=535"></script>
+		<script type="module" src="./js/category-list.js?v=535"></script>
+		<script type="module" src="./js/panel.js?v=535"></script>
+		<script type="text/javascript" src="./js/category-list-elements.js?v=535" defer></script>
 	</head>
 	<body>
 		<div id="preload" class="d-none"></div>
@@ -139,7 +139,7 @@
 				</div>
 				<div class="p-1 p-md-0 offcanvas-body">
 					<template id="panel-label-template">
-						<link href="./css/panel-label.css?v=534" rel="stylesheet" type="text/css" />
+						<link href="./css/panel-label.css?v=535" rel="stylesheet" type="text/css" />
 						<div part="prefix" hidden></div>
 						<div part="icon"></div>
 						<div part="text"></div>
@@ -148,7 +148,7 @@
 						<div part="size" style="display: none;"></div>
 					</template>
 					<template id="category-panel-template">
-						<link href="./css/category-panel.css?v=534" rel="stylesheet" type="text/css" />
+						<link href="./css/category-panel.css?v=535" rel="stylesheet" type="text/css" />
 						<div part="heading">
 							<span class="text"></span><slot name="decorator" class="decorator"></slot>
 						</div>
@@ -304,6 +304,6 @@
 		<div class="graph_tab_legend"></div>
 		<div id="dialog-container"></div>
 		<div id="dir-container"></div>
-		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=534"></script>
+		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=535"></script>
 	</body>
 </html>

--- a/js/webui.js
+++ b/js/webui.js
@@ -4,7 +4,7 @@
  */
 
 var theWebUI = {
-	version: "5.3.4",
+	version: "5.3.5",
 	tables: {
 		trt: {
 			obj: new dxSTable(),

--- a/lang/langs.js
+++ b/lang/langs.js
@@ -110,7 +110,7 @@ function loadUILang(onLoadFunc)
 			translateDOM();
 		}
 	};
-	langScript.src = `./lang/${lang}.js?v=534`;
+	langScript.src = `./lang/${lang}.js?v=535`;
 	document.head.appendChild(langScript);
 }
 


### PR DESCRIPTION
- **erasedata**: drop the stale `fin.sh` reference from `plugin.info`.  5.3.4 removed `fin.sh` (superseded by RPC file-list capture) but left it  in `rtorrent.script.error`, so getplugins disabled erasedata — and autoremove with it — on every 0.16.x install. (@adenwuts, #3078, fixes #3075)
- **throttle**: apply per-torrent throttle server-side via the plugin'  `action.php`. The client previously sent raw `d.stop`/`d.set_throttle_name`/ `d.start`, which rtorrent 0.16's whitelist rejects as untrusted. (@adenwuts, #3079)
- **datadir "Save To"**: fall back to `base_path` and route the lookup through  the trusted backend, fixing `TypeError: d.savepath is undefined` on  uninitiated torrents. (@adenwuts, #3081)
