### PR TITLE
_task: run event-triggered tasks directly instead of via rtorrent

### DIFF
--- a/plugins/_task/task.php
+++ b/plugins/_task/task.php
@@ -46,6 +46,16 @@ class rTask
 	{
 		if(!rTorrentSettings::get()->linkExist)
 			$flags|=self::FLG_RUN_AS_WEB;
+		// A task is normally launched by asking rtorrent to run it (execute.nothrow.bg
+		// in run()), which is fine from a web request while rtorrent is idle. But when
+		// start() is reached from a script rtorrent invoked through an event handler's
+		// blocking `execute` (e.g. the unpack plugin's update.php on
+		// event.download.finished), that callback re-enters rtorrent while its main
+		// thread is blocked inside the very handler that triggered us -- a deadlock that
+		// stalls the client until the RPC socket times out and the task is discarded.
+		// Such scripts run under the CLI SAPI, so launch the task directly instead.
+		if(PHP_SAPI==='cli')
+			$flags|=self::FLG_RUN_AS_WEB;
 	        if(count($commands))
 	        {
 			$dir = $this->makeDirectory();


### PR DESCRIPTION
rTask::run() launches a task by asking rtorrent to run it (execute.nothrow.bg). That is fine for a task started from a web request, while rtorrent is idle. But a task started from a script that rtorrent invoked through an event handler's blocking `execute` -- e.g. the unpack plugin's update.php, registered on event.download.finished -- calls back into rtorrent while its single main thread is still blocked inside that same handler. The nested call cannot be serviced, so it hangs until the RPC socket times out; the client is frozen for that whole window and the half-created task is then discarded, so nothing runs. This is why automatic unpacking silently does nothing (and the UI stalls on completion) while manual unpacking, a plain web request, works.

Detect that context via the CLI SAPI -- an event-handler script runs under php-cli, a web request does not -- and in that case launch the task directly (FLG_RUN_AS_WEB) rather than re-entering rtorrent. The script already runs as rtorrent's user, so the forked task keeps the same ownership.

Fixes #2976.