### PR TITLE
Update deprecated rTorrent commands for v0.16.16+

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -896,6 +896,27 @@ function correctContent()
 			"ratio.upload.set"  : { name: "group.seeding.ratio.upload.set",        prm: 1 },
 		});
 	}
+	if(theWebUI.systemInfo.rTorrent.iVersion>=0x1010)
+	{
+		// rtorrent >= 0.16.17: override aliases for commands that were
+		// removed or now log deprecation warnings. Mirrors php/methods-0.16.16.php.
+		$.extend(theRequestManager.aliases,
+		{
+			"get_max_open_http"      : { name: "system.sockets.http.min_alloc",          prm: 0 },
+			"set_max_open_http"      : { name: "system.sockets.http.min_alloc.set",      prm: 1 },
+			"set_max_open_files"     : { name: "system.sockets.files.min_alloc.set",     prm: 1 },
+			"d.multicall"            : { name: "d.multicall",                             prm: 1 },
+			"d.multicall2"           : { name: "d.multicall",                             prm: 1 },
+			"get_http_proxy"         : { name: "network.proxy.http",                     prm: 0 },
+			"set_http_proxy"         : { name: "network.proxy.http.set",                 prm: 1 },
+			"http_proxy"             : { name: "network.proxy.http",                     prm: 0 },
+			"get_proxy_address"      : { name: "network.proxy.global",                    prm: 0 },
+			"set_proxy_address"      : { name: "network.proxy.global.set",                prm: 1 },
+			"get_max_open_sockets"   : { name: "system.sockets.max_size",                prm: 0 },
+			"network.open_sockets"   : { name: "system.sockets.size",                    prm: 0 },
+			"network.max_open_sockets": { name: "system.sockets.max_size",               prm: 0 },
+		});
+	}
 	if(theWebUI.systemInfo.rTorrent.iVersion < 0x907) {
 		const title = theUILang.requiresAtLeastRtorrent.replace('{version}', 'v0.9.7');
 		$($$('webui.show_open_status')).attr({ disabled: '', title });

--- a/js/content.js
+++ b/js/content.js
@@ -898,7 +898,7 @@ function correctContent()
 	}
 	if(theWebUI.systemInfo.rTorrent.iVersion>=0x1010)
 	{
-		// rtorrent >= 0.16.17: override aliases for commands that were
+		// rtorrent >= 0.16.16: override aliases for commands that were
 		// removed or now log deprecation warnings. Mirrors php/methods-0.16.16.php.
 		$.extend(theRequestManager.aliases,
 		{

--- a/js/content.js
+++ b/js/content.js
@@ -902,9 +902,9 @@ function correctContent()
 		// removed or now log deprecation warnings. Mirrors php/methods-0.16.16.php.
 		$.extend(theRequestManager.aliases,
 		{
-			"get_max_open_http"      : { name: "system.sockets.http.min_alloc",          prm: 0 },
-			"set_max_open_http"      : { name: "system.sockets.http.min_alloc.set",      prm: 1 },
-			"set_max_open_files"     : { name: "system.sockets.files.min_alloc.set",     prm: 1 },
+			"get_max_open_http"      : { name: "system.sockets.http.max_alloc",          prm: 0 },
+			"set_max_open_http"      : { name: "system.sockets.http.max_alloc.set",      prm: 1 },
+			"set_max_open_files"     : { name: "system.sockets.files.max_alloc.set",     prm: 1 },
 			"d.multicall2"           : { name: "d.multicall",                             prm: 1 },
 			"get_http_proxy"         : { name: "network.proxy.http",                     prm: 0 },
 			"set_http_proxy"         : { name: "network.proxy.http.set",                 prm: 1 },

--- a/js/content.js
+++ b/js/content.js
@@ -905,7 +905,6 @@ function correctContent()
 			"get_max_open_http"      : { name: "system.sockets.http.min_alloc",          prm: 0 },
 			"set_max_open_http"      : { name: "system.sockets.http.min_alloc.set",      prm: 1 },
 			"set_max_open_files"     : { name: "system.sockets.files.min_alloc.set",     prm: 1 },
-			"d.multicall"            : { name: "d.multicall",                             prm: 1 },
 			"d.multicall2"           : { name: "d.multicall",                             prm: 1 },
 			"get_http_proxy"         : { name: "network.proxy.http",                     prm: 0 },
 			"set_http_proxy"         : { name: "network.proxy.http.set",                 prm: 1 },

--- a/php/methods-0.16.16.php
+++ b/php/methods-0.16.16.php
@@ -11,14 +11,14 @@
 
 $this->aliases = array_merge($this->aliases, array(
 
-	// HTTP connection cap → system.sockets.http.min_alloc
+	// HTTP connection cap → system.sockets.http.max_alloc (ceiling, not floor)
 	// (was network.http.max_total_connections — now warns)
-	"get_max_open_http" => array( "name"=>"system.sockets.http.min_alloc",     "prm"=>0 ),
-	"set_max_open_http" => array( "name"=>"system.sockets.http.min_alloc.set", "prm"=>1 ),
+	"get_max_open_http" => array( "name"=>"system.sockets.http.max_alloc",     "prm"=>0 ),
+	"set_max_open_http" => array( "name"=>"system.sockets.http.max_alloc.set", "prm"=>1 ),
 
-	// Max open files setter → system.sockets.files.min_alloc.set
+	// Max open files setter → system.sockets.files.max_alloc.set
 	// (was network.max_open_files.set — now warns)
-	"set_max_open_files" => array( "name"=>"system.sockets.files.min_alloc.set", "prm"=>1 ),
+	"set_max_open_files" => array( "name"=>"system.sockets.files.max_alloc.set", "prm"=>1 ),
 
 	// d.multicall2 removed; d.multicall is canonical
 	"d.multicall2" => array( "name"=>"d.multicall",  "prm"=>1 ),

--- a/php/methods-0.16.16.php
+++ b/php/methods-0.16.16.php
@@ -21,7 +21,6 @@ $this->aliases = array_merge($this->aliases, array(
 	"set_max_open_files" => array( "name"=>"system.sockets.files.min_alloc.set", "prm"=>1 ),
 
 	// d.multicall2 removed; d.multicall is canonical
-	"d.multicall"  => array( "name"=>"d.multicall",  "prm"=>1 ),
 	"d.multicall2" => array( "name"=>"d.multicall",  "prm"=>1 ),
 
 	// Proxy addresses — removed in 0.16.16

--- a/php/methods-0.16.16.php
+++ b/php/methods-0.16.16.php
@@ -1,0 +1,39 @@
+<?php
+
+// rtorrent >= 0.16.16: override aliases from methods-0.9.4.php and
+// methods-0.16.0.php for commands deprecated/removed in v0.16.17.
+//
+// Proxy addresses, open-socket queries, and d.multicall2 were removed.
+// network.http.max_total_connections.set and network.max_open_files.set
+// now log deprecation warnings — use system.sockets.* equivalents.
+//
+// Loaded from settings.php when iVersion >= 0x1010.
+
+$this->aliases = array_merge($this->aliases, array(
+
+	// HTTP connection cap → system.sockets.http.min_alloc
+	// (was network.http.max_total_connections — now warns)
+	"get_max_open_http" => array( "name"=>"system.sockets.http.min_alloc",     "prm"=>0 ),
+	"set_max_open_http" => array( "name"=>"system.sockets.http.min_alloc.set", "prm"=>1 ),
+
+	// Max open files setter → system.sockets.files.min_alloc.set
+	// (was network.max_open_files.set — now warns)
+	"set_max_open_files" => array( "name"=>"system.sockets.files.min_alloc.set", "prm"=>1 ),
+
+	// d.multicall2 removed; d.multicall is canonical
+	"d.multicall"  => array( "name"=>"d.multicall",  "prm"=>1 ),
+	"d.multicall2" => array( "name"=>"d.multicall",  "prm"=>1 ),
+
+	// Proxy addresses — removed in 0.16.17
+	"get_http_proxy"    => array( "name"=>"network.proxy.http",      "prm"=>0 ),
+	"set_http_proxy"    => array( "name"=>"network.proxy.http.set",  "prm"=>1 ),
+	"http_proxy"        => array( "name"=>"network.proxy.http",      "prm"=>0 ),
+	"get_proxy_address" => array( "name"=>"network.proxy.global",     "prm"=>0 ),
+	"set_proxy_address" => array( "name"=>"network.proxy.global.set", "prm"=>1 ),
+
+	// Socket queries — removed in 0.16.17
+	"get_max_open_sockets"     => array( "name"=>"system.sockets.max_size", "prm"=>0 ),
+	"network.open_sockets"     => array( "name"=>"system.sockets.size",     "prm"=>0 ),
+	"network.max_open_sockets" => array( "name"=>"system.sockets.max_size", "prm"=>0 ),
+
+));

--- a/php/methods-0.16.16.php
+++ b/php/methods-0.16.16.php
@@ -1,7 +1,7 @@
 <?php
 
 // rtorrent >= 0.16.16: override aliases from methods-0.9.4.php and
-// methods-0.16.0.php for commands deprecated/removed in v0.16.17.
+// methods-0.16.0.php for commands deprecated/removed in v0.16.16+.
 //
 // Proxy addresses, open-socket queries, and d.multicall2 were removed.
 // network.http.max_total_connections.set and network.max_open_files.set
@@ -24,14 +24,14 @@ $this->aliases = array_merge($this->aliases, array(
 	"d.multicall"  => array( "name"=>"d.multicall",  "prm"=>1 ),
 	"d.multicall2" => array( "name"=>"d.multicall",  "prm"=>1 ),
 
-	// Proxy addresses — removed in 0.16.17
+	// Proxy addresses — removed in 0.16.16
 	"get_http_proxy"    => array( "name"=>"network.proxy.http",      "prm"=>0 ),
 	"set_http_proxy"    => array( "name"=>"network.proxy.http.set",  "prm"=>1 ),
 	"http_proxy"        => array( "name"=>"network.proxy.http",      "prm"=>0 ),
 	"get_proxy_address" => array( "name"=>"network.proxy.global",     "prm"=>0 ),
 	"set_proxy_address" => array( "name"=>"network.proxy.global.set", "prm"=>1 ),
 
-	// Socket queries — removed in 0.16.17
+	// Socket queries — removed in 0.16.16
 	"get_max_open_sockets"     => array( "name"=>"system.sockets.max_size", "prm"=>0 ),
 	"network.open_sockets"     => array( "name"=>"system.sockets.size",     "prm"=>0 ),
 	"network.max_open_sockets" => array( "name"=>"system.sockets.max_size", "prm"=>0 ),

--- a/php/settings.php
+++ b/php/settings.php
@@ -216,6 +216,10 @@ class rTorrentSettings
 			{
 				require_once( 'methods-0.16.0.php' );
 			}
+			if($this->iVersion>=0x1010)
+			{
+				require_once( 'methods-0.16.16.php' );
+			}
 			$this->apiVersion = 0;
 			if($this->iVersion>=0x901)
 			{


### PR DESCRIPTION
## Summary

rTorrent v0.16.16 removed several commands in favor of new canonical names. This PR adds a new `php/methods-0.16.16.php` alias file loaded at `iVersion >= 0x1010` (rTorrent 0.16.16+) with matching JS aliases in `js/content.js`.

| Old | New |
|---|---|
| `network.http.proxy_address` / `.set` | `network.proxy.http` / `.set` |
| `network.proxy_address` / `.set` | `network.proxy.global` / `.set` |
| `d.multicall2` | `d.multicall` |
| `network.open_sockets` | `system.sockets.size` |
| `network.max_open_sockets` | `system.sockets.max_size` |
| `network.http.max_total_connections.set` | `system.sockets.http.max_alloc.set` |
| `network.max_open_files.set` | `system.sockets.files.max_alloc.set` |

Older rTorrent versions continue to use the original aliases from `methods-0.9.4.php` / `methods-0.16.0.php`. The new file only takes effect on 0.16.16+.