### PR TITLE
extratio: fix ratio/throttle rules not applied on torrent insert (0.16.x)

### DIFF
--- a/plugins/extratio/rules.php
+++ b/plugins/extratio/rules.php
@@ -251,14 +251,10 @@ class rRatioRulesList
 		}
 		if($ratioRulesExist)
 		{
-			eval(FileUtil::getPluginConf('ratio'));
-			$insCmd = '';
-			for($i=0; $i<MAX_RATIO; $i++)
-				$insCmd .= (getCmd('d.views.has=').'rat_'.$i.',,');
 			$ratCmd = 
                                 getCmd('d.set_custom').'=x-extratio1,"$'.getCmd('execute_capture').
                                 '={'.Utility::getPHP().','.$rootPath.'/plugins/extratio/update.php,\"$'.getCmd('t.multicall').'=$'.getCmd('d.get_hash').'=,'.getCmd('t.get_url').'=,'.getCmd('cat').'=#\",$'.getCmd('d.get_custom1').'=,ratio,'.User::getUser().'}" ; '.
-                                getCmd('branch').'=$'.getCmd('not').'=$'.getCmd('d.get_custom').'=x-extratio1,,'.$insCmd.
+                                getCmd('branch').'='.getCmd('d.get_custom').'=x-extratio1,'.
                                 getCmd('view.set_visible').'=$'.getCmd('d.get_custom').'=x-extratio1';
 		}
 		else
@@ -267,7 +263,7 @@ class rRatioRulesList
 			$thrCmd = 
                                 getCmd('d.set_custom').'=x-extratio2,"$'.getCmd('execute_capture').
                                 '={'.Utility::getPHP().','.$rootPath.'/plugins/extratio/update.php,\"$'.getCmd('t.multicall').'=$'.getCmd('d.get_hash').'=,'.getCmd('t.get_url').'=,'.getCmd('cat').'=#\",$'.getCmd('d.get_custom1').'=,channel,'.User::getUser().'}" ; '.
-                                getCmd('branch').'=$'.getCmd('not').'=$'.getCmd('d.get_custom').'=x-extratio2,,'.
+                                getCmd('branch').'='.getCmd('d.get_custom').'=x-extratio2,'.
                                 getCmd('d.set_throttle_name').'=$'.getCmd('d.get_custom').'=x-extratio2';
 		else
 			$thrCmd = getCmd('cat=');


### PR DESCRIPTION
setHandlers() registers event.download.inserted handlers that capture the matched ratio group / throttle channel into a custom field and then apply it with:

    branch=$not=$d.get_custom=x-extratioN,,<...>,<apply>=$d.get_custom=x-extratioN

$not=$d.get_custom=... is evaluated before branch runs, so branch gets the value (e.g. "rat_3") as its condition. On 0.16.x `not` no longer treats a non-empty non-numeric string as true, so the expression faults and branch never runs the apply command: the custom field is set but the torrent is never added to the ratio view / given the throttle channel. The rule silently does nothing on newly added torrents, while manual assignment (a different code path) still works.

Use the command itself as the branch condition instead of a pre-substituted value: branch=d.get_custom=x-extratioN,<apply>=$d.get_custom=x-extratioN. branch executes d.custom and treats the non-empty result as true, running the apply command when a rule matched and skipping it otherwise. Also removes the now-unused d.views.has scaffolding.

Verified on rtorrent 0.16.17: before, a matching torrent received the custom field but stayed out of the ratio view; after, it is added to the view on insert.

Fixes #3076.