### PR TITLE
Add "Compact list rows" user-interface option

### DIFF
--- a/css/stable.css
+++ b/css/stable.css
@@ -196,3 +196,8 @@
 .Icon_File {background: transparent url(../images/file.gif) no-repeat left center}
 .Icon_Dir {background: transparent url(../images/dir.gif) no-repeat left center}
 .Icon_Share {background: transparent url(../images/share.gif) no-repeat left center}
+
+/* Compact mode (Settings > General > User Interface): tighten list + sidebar rows */
+body.compact .stable tbody td div { padding-block: 0; margin-block: 0; }
+body.compact panel-label { padding-block: 0; }
+body.compact category-panel::part(heading) { padding-block: 0; }

--- a/js/options.js
+++ b/js/options.js
@@ -21,6 +21,7 @@ const theOptionsWindow = {
 					...[
 						['webui.confirm_when_deleting', theUILang.Confirm_del_torr],
 						['webui.alternate_color', theUILang.Alt_list_bckgnd],
+						['webui.compact_rows', theUILang.Compact_rows],
 						['webui.ignore_timeouts', theUILang.dontShowTimeouts],
 						['webui.fullrows', theUILang.fullTableRender],
 						['webui.no_delaying_draw', theUILang.showScrollTables],

--- a/js/webui.js
+++ b/js/webui.js
@@ -122,6 +122,7 @@ var theWebUI = {
 		"webui.reqtimeout":		10000,
 		"webui.confirm_when_deleting":	1,
 		"webui.alternate_color":	0,
+		"webui.compact_rows":		0,
 		"webui.side_panel_min_width": 	200,
 		"webui.side_panel_max_width_percent": 35,
 		"webui.list_table_min_height": 	300,
@@ -471,6 +472,7 @@ var theWebUI = {
 			}
 		});
 		$(".stable").toggleClass("alternate", !!theWebUI.settings["webui.alternate_color"]);
+		$("body").toggleClass("compact", !!theWebUI.settings["webui.compact_rows"]);
 		table = this.getTable("plg");
 		if(table)
 		{
@@ -729,6 +731,10 @@ var theWebUI = {
 							}
 							case "webui.alternate_color": {
 								$(".stable").toggleClass("alternate", !!nv);
+								break;
+							}
+							case "webui.compact_rows": {
+								$("body").toggleClass("compact", !!nv);
 								break;
 							}
 							case "webui.show_cats": {

--- a/lang/bn.js
+++ b/lang/bn.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "GUI আপডেট করুন প্রতি",
  ms				: "ms",
  Alt_list_bckgnd		: "বিকল্প তালিকার ব্যাকগ্রাউন্ড কালার",
+ Compact_rows			: "কম্প্যাক্ট সারি",
  Show_cat_start			: "স্টার্টআপে ক্যাটাগরি দেখান",
  Show_det_start			: "শুরুতে বিস্তারিত দেখান",
  KeepSearches			: "অনুসন্ধান রাখা",

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Obnovování GUI po",
  ms				: "ms",
  Alt_list_bckgnd		: "Šedé pozadí pro sudé řádky",
+ Compact_rows			: "Kompaktní řádky",
  Show_cat_start			: "Zobrazovat kategorie po spuštění",
  Show_det_start			: "Zobrazit detaily po spuštění",
  KeepSearches			: "Keep searches",

--- a/lang/da.js
+++ b/lang/da.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Opdater GUI hvert",
  ms				: "ms",
  Alt_list_bckgnd		: "Alternativ liste baggrundsfarve",
+ Compact_rows			: "Kompakte rækker",
  Show_cat_start			: "Vis kategorier ved start",
  Show_det_start			: "Vis details ved start",
  KeepSearches			: "Keep searches",

--- a/lang/de.js
+++ b/lang/de.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Aktualisierungsintervall",
  ms				: "ms",
  Alt_list_bckgnd		: "Abwechselnder Zeilenhintergrund",
+ Compact_rows			: "Kompakte Listenzeilen",
  Show_cat_start			: "Zeige Gruppen beim Start",
  Show_det_start			: "Zeige Details beim Start",
  KeepSearches			: "Keep searches",

--- a/lang/el.js
+++ b/lang/el.js
@@ -17,6 +17,7 @@ var theUILang =
  Update_GUI_every		: "Ανανέωση GUI κάθε",
  ms				: "ms",
  Alt_list_bckgnd		: "Αλλαγή φόντου προβολής λίστας",
+ Compact_rows			: "Συμπαγείς γραμμές",
  Show_cat_start			: "Προβολή κατηγοριών κατά την εκκίνηση",
  Show_det_start			: "Προβολή λεπτομερειών κατά την εκκίνηση",
  KeepSearches			: "Διατήρηση αναζητήσεων",

--- a/lang/en.js
+++ b/lang/en.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Update GUI every",
  ms				: "ms",
  Alt_list_bckgnd		: "Alternate list background colour",
+  Compact_rows			: "Compact list rows",
  Show_cat_start			: "Show categories on startup",
  Show_det_start			: "Show details on startup",
  KeepSearches			: "Keep searches",

--- a/lang/es.js
+++ b/lang/es.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Actualizar GUI cada",
  ms				: "ms",
  Alt_list_bckgnd		: "Alternar color de fondo en la lista",
+ Compact_rows			: "Filas compactas",
  Show_cat_start			: "Mostrar categorías al iniciar",
  Show_det_start			: "Mostrar detalles al iniciar",
  KeepSearches			: "Keep searches",

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Paivita käyttöliittymä joka",
  ms				: "ms",
  Alt_list_bckgnd		: "Riveittäin vaihteleva taustaväri",
+ Compact_rows			: "Tiiviit rivit",
  Show_cat_start			: "Näytä ryhmat käynnistettäessä",
  Show_det_start			: "Nayta yksityiskohdat käynnist.",
  KeepSearches			: "Keep searches",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Fréq. des MàJ de l’UI",
  ms				: "ms",
  Alt_list_bckgnd		: "Couleurs alternées pour la liste",
+ Compact_rows			: "Lignes compactes",
  Show_cat_start			: "Afficher les catégories au démarrage",
  Show_det_start			: "Afficher les détails au démarrage",
  KeepSearches			: "Conserver les recherches",

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "GUI frissítési ideje",
  ms				: "ms",
  Alt_list_bckgnd		: "Eltérő háttér színű lista",
+ Compact_rows			: "Kompakt sorok",
  Show_cat_start			: "Kategóriák mutatása indításkor",
  Show_det_start			: "Tulajdonságok mutatása indításkor",
  KeepSearches			: "Keep searches",

--- a/lang/it.js
+++ b/lang/it.js
@@ -20,6 +20,7 @@ var theUILang =
  Update_GUI_every		: "Aggiorna i dati ogni",
  ms				: "ms",
  Alt_list_bckgnd		: "Alterna i colori di sfondo nelle liste",
+ Compact_rows			: "Righe compatte",
  Show_cat_start			: "Mostra categorie all'avvio",
  Show_det_start			: "Mostra dettagli all'avvio",
  KeepSearches			: "Mantieni le ricerche",

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -17,6 +17,7 @@ var theUILang =
  Update_GUI_every		: "다음 시간마다 GUI 갱신",
  ms				: "ms",
  Alt_list_bckgnd		: "줄무늬 목록 배경색 사용",
+ Compact_rows			: "간격 좁은 목록",
  Show_cat_start			: "시작 시 카테고리 표시",
  Show_det_start			: "시작시 세부 정보 표시",
  KeepSearches			: "Keep searches",

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Atjaunot GUI ik pēc",
  ms				: "ms",
  Alt_list_bckgnd		: "Izmainīt saraksta fona krāsu",
+ Compact_rows			: "Kompaktas rindas",
  Show_cat_start			: "Rādīt kategorijas, kad startē WebUI",
  Show_det_start			: "Rādīt detaļas, kad startē WebUI",
  KeepSearches			: "Keep searches",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Vernieuw GUI iedere",
  ms				: "ms",
  Alt_list_bckgnd		: "Andere achtergrondkleur voor lijst",
+ Compact_rows			: "Compacte lijstregels",
  Show_cat_start			: "Bij opstarten categorieën weergeven",
  Show_det_start			: "Bij opstarten details weergeven",
  KeepSearches			: "Keep searches",

--- a/lang/no.js
+++ b/lang/no.js
@@ -18,6 +18,7 @@ var theUILang =
  Update_GUI_every		: "Oppdater brukergrensesnitt hvert",
  ms				: "ms",
  Alt_list_bckgnd		: "Alternativ listebakgrunnsfarge",
+ Compact_rows			: "Kompakte rader",
  Show_cat_start			: "Vis kategorier ved start",
  Show_det_start			: "Vis detaljer ved start",
  KeepSearches			: "Behold søk",

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -20,6 +20,7 @@ var theUILang =
  Update_GUI_every		: "Aktualizuj interfejs co",
  ms				: "ms",
  Alt_list_bckgnd		: "Alternatywny kolor tła listy",
+ Compact_rows			: "Kompaktowe wiersze",
  Show_cat_start			: "Pokaż kategorie na starcie",
  Show_det_start			: "Pokaż szczegóły na starcie",
  KeepSearches			: "Pamiętaj wyszukiwania",

--- a/lang/pt-br.js
+++ b/lang/pt-br.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Atualizar GUI a cada",
  ms				: "ms",
  Alt_list_bckgnd		: "Alternar a cor de fundo da lista",
+ Compact_rows			: "Linhas compactas",
  Show_cat_start			: "Mostrar categorias quando iniciar",
  Show_det_start			: "Mostrar detalhes quando iniciar",
  KeepSearches			: "Manter pesquisas",

--- a/lang/pt-pt.js
+++ b/lang/pt-pt.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Atualizar GUI a cada",
  ms				: "ms",
  Alt_list_bckgnd		: "Alternar a cor de fundo da lista",
+ Compact_rows			: "Linhas compactas",
  Show_cat_start			: "Mostrar categorias ao iniciar",
  Show_det_start			: "Mostrar detalhes ao iniciar",
  KeepSearches			: "Manter pesquisas",

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Обн. GUI каждые",
  ms				: "мс",
  Alt_list_bckgnd		: "Альтернативный цвет списка",
+ Compact_rows			: "Компактные строки",
  Show_cat_start			: "Показать категории при запуске",
  Show_det_start			: "Показать детали при запуске",
  KeepSearches			: "Сохранять результаты поиска",

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Aktualizovať GUI každych",
  ms				: "ms",
  Alt_list_bckgnd		: "Alternatívne pozadie zoznamu",
+ Compact_rows			: "Kompaktné riadky",
  Show_cat_start			: "Zobraziť kategórie po spusteni",
  Show_det_start			: "Zobraziť detaily po spustení",
  KeepSearches			: "Keep searches",

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -17,6 +17,7 @@ var theUILang =
  Update_GUI_every		: "Освежи графички интерфејс сваких",
  ms				: "милисекунди",
  Alt_list_bckgnd		: "Наизменично бојење редова у листи",
+ Compact_rows			: "Компактни редови",
  Show_cat_start			: "Покажи категорије на почетку",
  Show_det_start			: "Покажи детаље на почетку",
  KeepSearches			: "Keep searches",

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -17,6 +17,7 @@ var theUILang =
  Update_GUI_every		: "Uppdatera användargränssnitt varje",
  ms				: "ms",
  Alt_list_bckgnd		: "Alternera bakgrundsfärg i lista",
+ Compact_rows			: "Kompakta rader",
  Show_cat_start			: "Visa kategorier vid uppstart",
  Show_det_start			: "Visa detaljer vid upstart",
  KeepSearches			: "Keep searches",

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Arayüz yenileme süresi",
  ms				: "ms",
  Alt_list_bckgnd		: "Alternatif liste arka plan rengi",
+ Compact_rows			: "Sıkışık satırlar",
  Show_cat_start			: "Açılışta kategorileri göster",
  Show_det_start			: "Açılışta ayrıntıları göster",
  KeepSearches			: "Aramaları koru",

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "Оновл. GUI кожні",
  ms				: "мс",
  Alt_list_bckgnd		: "Альтернативний колір списку",
+ Compact_rows			: "Компактні рядки",
  Show_cat_start			: "Показати категорії під час запуску",
  Show_det_start			: "Показати деталі під час запуску",
  KeepSearches			: "Keep searches",

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -17,6 +17,7 @@ var theUILang =
  Update_GUI_every		: "Cập nhật sau mỗi",
  ms				: "ms",
  Alt_list_bckgnd		: "Xen kẽ màu nền trong danh sách",
+ Compact_rows			: "Hàng thu gọn",
  Show_cat_start			: "Hiển thị các mục khi khởi động",
  Show_det_start			: "Hiển thị đầy đủ khi khởi động",
  KeepSearches			: "Keep searches",

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -19,6 +19,7 @@ var theUILang =
  Update_GUI_every		: "GUI更新间隔",
  ms				: "ms",
  Alt_list_bckgnd		: "交替显示列表背景色",
+ Compact_rows			: "紧凑行距",
  Show_cat_start			: "启动时显示类别",
  Show_det_start			: "启动时显示详情",
  KeepSearches			: "Keep searches",

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -17,6 +17,7 @@ var theUILang =
  Update_GUI_every		: "更新圖形介面頻率",
  ms				: "ms",
  Alt_list_bckgnd		: "交替顯示列表背景色",
+ Compact_rows			: "緊湊行距",
  Show_cat_start			: "啟動時顯示類別",
  Show_det_start			: "啟動時顯示詳細內容",
  KeepSearches			: "Keep searches",


### PR DESCRIPTION
The 5.x list restyle increased row height compared with 4.x (extra per-cell vertical padding/margin plus a larger status-icon box), which several users found too spacious (#2995). Add an opt-in "Compact list rows" toggle under Settings > General > User Interface that removes the cell's vertical padding/margin and shrinks the status-icon box back to its native 1rem/16px (the sprite is 16px, so no scaling artifacts), restoring a compact 4.x-style density.

Off by default. Mirrors the existing alternate_color option (default in webui.js, apply-on-load, on-change handler, options-window row) with a new .stable.compact CSS class and the Compact_rows string translated across all bundled languages.