### PR TITLE
unpack: fix autounpack deadlock by detaching the finished handler

### DIFF
--- a/plugins/_task/task.php
+++ b/plugins/_task/task.php
@@ -46,16 +46,6 @@ class rTask
 	{
 		if(!rTorrentSettings::get()->linkExist)
 			$flags|=self::FLG_RUN_AS_WEB;
-		// A task is normally launched by asking rtorrent to run it (execute.nothrow.bg
-		// in run()), which is fine from a web request while rtorrent is idle. But when
-		// start() is reached from a script rtorrent invoked through an event handler's
-		// blocking `execute` (e.g. the unpack plugin's update.php on
-		// event.download.finished), that callback re-enters rtorrent while its main
-		// thread is blocked inside the very handler that triggered us -- a deadlock that
-		// stalls the client until the RPC socket times out and the task is discarded.
-		// Such scripts run under the CLI SAPI, so launch the task directly instead.
-		if(PHP_SAPI==='cli')
-			$flags|=self::FLG_RUN_AS_WEB;
 	        if(count($commands))
 	        {
 			$dir = $this->makeDirectory();

--- a/plugins/unpack/unpack.php
+++ b/plugins/unpack/unpack.php
@@ -437,7 +437,7 @@ class rUnpack
 		if($this->enabled)
 		{
 			$cmd =  rTorrentSettings::get()->getOnFinishedCommand( array('unpack'.User::getUser(), 
-					getCmd('execute').'={'.Utility::getPHP().','.$rootPath.'/plugins/unpack/update.php,$'.getCmd('d.get_directory').'=,$'.getCmd('d.get_base_filename').'=,$'.getCmd('d.is_multi_file').
+					getCmd('execute.nothrow.bg').'={'.Utility::getPHP().','.$rootPath.'/plugins/unpack/update.php,$'.getCmd('d.get_directory').'=,$'.getCmd('d.get_base_filename').'=,$'.getCmd('d.is_multi_file').
 					'=,$'.getCmd('d.get_custom1').'=,$'.getCmd('d.get_name').'=,$'.getCmd('d.get_hash').'=,$'.getCmd('d.get_custom').'=x-dest,'.User::getUser().'}'));
 		}
 		else


### PR DESCRIPTION
Follow-up to #3084. That fix made rTask launch its task directly (exec) under the CLI SAPI to avoid the deadlock where the auto-unpack task, started from update.php inside the blocking event.download.finished `execute`, calls back into the rtorrent that is frozen running that same handler.

Detach the handler instead: register it as `execute.nothrow.bg` rather than a blocking `execute`. rtorrent forks update.php and returns immediately, so it is no longer blocked when update.php calls back to launch the unpack task -- no deadlock and no ~60s stall. rTask keeps launching every task via execute.nothrow.bg, i.e. through rtorrent, so the task still runs on the rtorrent host and nothing assumes the web process can see the data (which the CLI-SAPI direct-exec did).

Reverts the PHP_SAPI special-case added to rTask::start in #3084.

Verified on rtorrent 0.16.17 (finished event returns instantly, archive extracted, task recorded with status 0) and 0.9.8 (execute.nothrow.bg exists, detaches, and the nested callback is serviced without deadlock).