### PR TITLE
tests: repair the JS suite and add CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  jest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: tests/package-lock.json
+      - run: npm ci
+        working-directory: tests
+      - run: npm test
+        working-directory: tests

--- a/tests/global.mock.js
+++ b/tests/global.mock.js
@@ -2,3 +2,15 @@ CSSStyleSheet.prototype.replaceSync = function (text) {
   this.textContent = text;
 };
 global.structuredClone = (v) => JSON.parse(JSON.stringify(v));
+
+// js/browser.js is a classic <script> (class browserDetect) in production, not an
+// ES module. Specs neither inject nor import it, so common.js's `new browserDetect()`
+// throws (which also aborts common.js before theURLs is defined). Expose the real
+// class and the `browser` instance globally for both inject-script and import specs.
+const { readFileSync } = require("fs");
+const { join } = require("path");
+const browserDetect = new Function(
+  readFileSync(join(__dirname, "../js/browser.js"), "utf-8") + "\nreturn browserDetect;"
+)();
+global.browserDetect = browserDetect;
+global.browser = new browserDetect();

--- a/tests/js/category-list-elements.spec.js
+++ b/tests/js/category-list-elements.spec.js
@@ -153,7 +153,7 @@ describe("panel-label", () => {
     const ic = label.parts.icon;
     label.icon = "url:name";
     await new Promise(process.nextTick);
-    expect(ic.style.backgroundImage).toEqual(`url(name)`);
+    expect(ic.style.backgroundImage).toEqual(`url("name")`);
     expect(ic.children.length).toBe(0);
     expect([...ic.classList]).toEqual(["icon-by-url"]);
     label.icon = "name";

--- a/tests/js/category-list.spec.js
+++ b/tests/js/category-list.spec.js
@@ -67,14 +67,14 @@ describe("Category list", () => {
       Object.fromEntries(
         [
           ["AA", "", "[Test] less", 16, 100 << 20, 0, 0],
-          ["BB", "Software", "[Banana] green", 0, 12 << 20, 5000, 10],
+          ["BB", "Software", "[Banana] green", 1, 12 << 20, 5000, 10],
           ["CC", "Image/Banana", "[Banana] ripe", 15, 1 << 30, 0, 10000],
           ["DD", "Image/Peach", "[Peach] rotten", 1, 500 << 20, 3000, 5000],
           ["EE", "Misc/Other/More", "[More] or less", 2, 300 << 20, 200, 0],
           ["FF", "Misc/Other/Less", "[Less] or more", 16, 200 << 20, 0, 0],
-        ].map(([hash, label, name, status, size, ul, dl]) => [
+        ].map(([hash, label, name, state, size, ul, dl]) => [
           hash,
-          { label, name, status, size, ul, dl },
+          { label, name, state, size, ul, dl },
         ])
       )
     );
@@ -86,7 +86,7 @@ describe("Category list", () => {
       borrowTorrentsFn,
       onConfigChangeFn,
       byteSizeToStringFn: (size) => `${(size / (1 << 20)).toFixed(2)} MiB`,
-      dStatus: { error: 16 },
+      dStatus: { started: 1, paused: 2, checking: 4, hashing: 8, error: 16 },
     });
   });
   it("should restore selection and searches on config", () => {

--- a/tests/plugins/rss/init.spec.js
+++ b/tests/plugins/rss/init.spec.js
@@ -4,6 +4,7 @@ import * as bbcodeModule from "../../../plugins/rss/bbcode";
 
 window.$ = require("jquery");
 window.theWebUI = {
+  version: "0.0.0",
   settings: {
     "webui.needmessage": true,
   },


### PR DESCRIPTION
The Jest suite had bit-rotted: 12 of 36 tests failed on a clean master (independent of Node version), so nothing was actually being verified. Fixes, all test-only:

- global.mock.js: expose browserDetect/browser globally. js/browser.js is a classic <script>, not a module, so common.js's `new browserDetect()` threw, which also aborted common.js before theURLs was defined -- cascading into the 9 xmlrpc parse failures.
- plugins/rss/init.spec.js: give theWebUI a version so cacheBust() doesn't throw during the plugin's loadMainCSS.
- js/category-list-elements.spec.js: jsdom serialises background-image url(name) as url("name") -- update the expectation.
- js/category-list.spec.js: align stale statistic fixtures with the rewritten pstate logic (torrents carry `state` not `status`, Active now requires the started bit, and provide the full dStatus).

Add a GitHub Actions workflow running `npm ci && npm test` in tests/ on Node 20 for pushes to master and all pull requests, so the suite is checked automatically. Verified green (36/36) on Node 20 and 24.