### PR TITLE
Bump version to 5.3.6 and update cache-bust params

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,27 +21,27 @@
 		<meta name="msapplication-TileColor" content="#FFFFFF" />
 		<meta name="msapplication-TileImage" content="./images/mstile-144x144.png" />
 
-		<link href="./css/bootstrap.min.css?v=535" rel="stylesheet" type="text/css" />
-		<link href="./css/style.css?v=535" rel="stylesheet" type="text/css" />
-		<link href="./css/stable.css?v=535" rel="stylesheet" type="text/css" />
-		<link rel="preload" as="style" href="./css/category-panel.css?v=535" />
-		<link rel="preload" as="style" href="./css/panel-label.css?v=535" />
-		<script type="text/javascript" src="./js/jquery.js?v=535"></script>
-		<script type="text/javascript" src="./js/jquery.flot.js?v=535"></script>
-		<script type="text/javascript" src="./js/sanitize.js?v=535"></script>
-		<script type="text/javascript" src="./js/sanitize.config.js?v=535"></script>
-		<script type="text/javascript" src="./js/custom-elements.js?v=535"></script>
-		<script type="text/javascript" src="./lang/langs.js?v=535"></script>
-		<link rel="preload" as="script" href="./js/browser.js?v=535" />
-		<link rel="preload" as="script" href="./js/common.js?v=535" />
-		<link rel="preload" as="script" href="./js/objects.js?v=535" />
-		<link rel="preload" as="script" href="./js/options.js?v=535" />
-		<link rel="preload" as="script" href="./js/content.js?v=535" />
-		<link rel="preload" as="script" href="./js/stable.js?v=535" />
-		<link rel="preload" as="script" href="./js/graph.js?v=535" />
-		<link rel="preload" as="script" href="./js/plugins.js?v=535" />
-		<link rel="preload" as="script" href="./js/rtorrent.js?v=535" />
-		<link rel="preload" as="script" href="./js/webui.js?v=535" />
+		<link href="./css/bootstrap.min.css?v=536" rel="stylesheet" type="text/css" />
+		<link href="./css/style.css?v=536" rel="stylesheet" type="text/css" />
+		<link href="./css/stable.css?v=536" rel="stylesheet" type="text/css" />
+		<link rel="preload" as="style" href="./css/category-panel.css?v=536" />
+		<link rel="preload" as="style" href="./css/panel-label.css?v=536" />
+		<script type="text/javascript" src="./js/jquery.js?v=536"></script>
+		<script type="text/javascript" src="./js/jquery.flot.js?v=536"></script>
+		<script type="text/javascript" src="./js/sanitize.js?v=536"></script>
+		<script type="text/javascript" src="./js/sanitize.config.js?v=536"></script>
+		<script type="text/javascript" src="./js/custom-elements.js?v=536"></script>
+		<script type="text/javascript" src="./lang/langs.js?v=536"></script>
+		<link rel="preload" as="script" href="./js/browser.js?v=536" />
+		<link rel="preload" as="script" href="./js/common.js?v=536" />
+		<link rel="preload" as="script" href="./js/objects.js?v=536" />
+		<link rel="preload" as="script" href="./js/options.js?v=536" />
+		<link rel="preload" as="script" href="./js/content.js?v=536" />
+		<link rel="preload" as="script" href="./js/stable.js?v=536" />
+		<link rel="preload" as="script" href="./js/graph.js?v=536" />
+		<link rel="preload" as="script" href="./js/plugins.js?v=536" />
+		<link rel="preload" as="script" href="./js/rtorrent.js?v=536" />
+		<link rel="preload" as="script" href="./js/webui.js?v=536" />
 
 		<script>
 			loadUILang(() => {
@@ -57,10 +57,10 @@
 			});
 		</script>
 
-		<script type="module" src="./js/backgroundtask.js?v=535"></script>
-		<script type="module" src="./js/category-list.js?v=535"></script>
-		<script type="module" src="./js/panel.js?v=535"></script>
-		<script type="text/javascript" src="./js/category-list-elements.js?v=535" defer></script>
+		<script type="module" src="./js/backgroundtask.js?v=536"></script>
+		<script type="module" src="./js/category-list.js?v=536"></script>
+		<script type="module" src="./js/panel.js?v=536"></script>
+		<script type="text/javascript" src="./js/category-list-elements.js?v=536" defer></script>
 	</head>
 	<body>
 		<div id="preload" class="d-none"></div>
@@ -139,7 +139,7 @@
 				</div>
 				<div class="p-1 p-md-0 offcanvas-body">
 					<template id="panel-label-template">
-						<link href="./css/panel-label.css?v=535" rel="stylesheet" type="text/css" />
+						<link href="./css/panel-label.css?v=536" rel="stylesheet" type="text/css" />
 						<div part="prefix" hidden></div>
 						<div part="icon"></div>
 						<div part="text"></div>
@@ -148,7 +148,7 @@
 						<div part="size" style="display: none;"></div>
 					</template>
 					<template id="category-panel-template">
-						<link href="./css/category-panel.css?v=535" rel="stylesheet" type="text/css" />
+						<link href="./css/category-panel.css?v=536" rel="stylesheet" type="text/css" />
 						<div part="heading">
 							<span class="text"></span><slot name="decorator" class="decorator"></slot>
 						</div>
@@ -304,6 +304,6 @@
 		<div class="graph_tab_legend"></div>
 		<div id="dialog-container"></div>
 		<div id="dir-container"></div>
-		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=535"></script>
+		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=536"></script>
 	</body>
 </html>

--- a/js/webui.js
+++ b/js/webui.js
@@ -4,7 +4,7 @@
  */
 
 var theWebUI = {
-	version: "5.3.5",
+	version: "5.3.6",
 	tables: {
 		trt: {
 			obj: new dxSTable(),

--- a/lang/langs.js
+++ b/lang/langs.js
@@ -110,7 +110,7 @@ function loadUILang(onLoadFunc)
 			translateDOM();
 		}
 	};
-	langScript.src = `./lang/${lang}.js?v=535`;
+	langScript.src = `./lang/${lang}.js?v=536`;
 	document.head.appendChild(langScript);
 }
 


### PR DESCRIPTION
 ## ruTorrent v5.3.6

  ### New
  - **Compact list rows** — an opt-in toggle under Settings → General → User Interface
    that tightens the torrent list *and* the sidebar spacing (#3087, closes #2995).
  - **env_check.php** — a standalone command-line prerequisites & install checker
    (PHP version/extensions, config sanity, connects to rtorrent). Run `php env_check.php`.

  ### Fixes
  - **Automatic unpacking works again on rtorrent 0.16.x** — the download-finished
    handler no longer deadlocks the client, so archives are unpacked on completion (#3084, #3088).
  - **Ratio/throttle rules (extratio "Rules Manager") apply on 0.16.x again** — they were
    silently not applied to newly added torrents (#3086, closes #3076).
  - **Non-UTF-8 JSON responses are sanitised** instead of failing to parse (#2996, closes #2977).

  ### Dev / infra
  - Repaired the JavaScript test suite (was 12/36 failing) and added GitHub Actions CI (#3090).
  - Test-tooling dependency bumps: @babel/core 7.29.6 (#3066), ws 8.21.0 (#3089).