### PR TITLE
Bump version to 5.3.7 and update cache-bust params

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,27 +21,27 @@
 		<meta name="msapplication-TileColor" content="#FFFFFF" />
 		<meta name="msapplication-TileImage" content="./images/mstile-144x144.png" />
 
-		<link href="./css/bootstrap.min.css?v=536" rel="stylesheet" type="text/css" />
-		<link href="./css/style.css?v=536" rel="stylesheet" type="text/css" />
-		<link href="./css/stable.css?v=536" rel="stylesheet" type="text/css" />
-		<link rel="preload" as="style" href="./css/category-panel.css?v=536" />
-		<link rel="preload" as="style" href="./css/panel-label.css?v=536" />
-		<script type="text/javascript" src="./js/jquery.js?v=536"></script>
-		<script type="text/javascript" src="./js/jquery.flot.js?v=536"></script>
-		<script type="text/javascript" src="./js/sanitize.js?v=536"></script>
-		<script type="text/javascript" src="./js/sanitize.config.js?v=536"></script>
-		<script type="text/javascript" src="./js/custom-elements.js?v=536"></script>
-		<script type="text/javascript" src="./lang/langs.js?v=536"></script>
-		<link rel="preload" as="script" href="./js/browser.js?v=536" />
-		<link rel="preload" as="script" href="./js/common.js?v=536" />
-		<link rel="preload" as="script" href="./js/objects.js?v=536" />
-		<link rel="preload" as="script" href="./js/options.js?v=536" />
-		<link rel="preload" as="script" href="./js/content.js?v=536" />
-		<link rel="preload" as="script" href="./js/stable.js?v=536" />
-		<link rel="preload" as="script" href="./js/graph.js?v=536" />
-		<link rel="preload" as="script" href="./js/plugins.js?v=536" />
-		<link rel="preload" as="script" href="./js/rtorrent.js?v=536" />
-		<link rel="preload" as="script" href="./js/webui.js?v=536" />
+		<link href="./css/bootstrap.min.css?v=537" rel="stylesheet" type="text/css" />
+		<link href="./css/style.css?v=537" rel="stylesheet" type="text/css" />
+		<link href="./css/stable.css?v=537" rel="stylesheet" type="text/css" />
+		<link rel="preload" as="style" href="./css/category-panel.css?v=537" />
+		<link rel="preload" as="style" href="./css/panel-label.css?v=537" />
+		<script type="text/javascript" src="./js/jquery.js?v=537"></script>
+		<script type="text/javascript" src="./js/jquery.flot.js?v=537"></script>
+		<script type="text/javascript" src="./js/sanitize.js?v=537"></script>
+		<script type="text/javascript" src="./js/sanitize.config.js?v=537"></script>
+		<script type="text/javascript" src="./js/custom-elements.js?v=537"></script>
+		<script type="text/javascript" src="./lang/langs.js?v=537"></script>
+		<link rel="preload" as="script" href="./js/browser.js?v=537" />
+		<link rel="preload" as="script" href="./js/common.js?v=537" />
+		<link rel="preload" as="script" href="./js/objects.js?v=537" />
+		<link rel="preload" as="script" href="./js/options.js?v=537" />
+		<link rel="preload" as="script" href="./js/content.js?v=537" />
+		<link rel="preload" as="script" href="./js/stable.js?v=537" />
+		<link rel="preload" as="script" href="./js/graph.js?v=537" />
+		<link rel="preload" as="script" href="./js/plugins.js?v=537" />
+		<link rel="preload" as="script" href="./js/rtorrent.js?v=537" />
+		<link rel="preload" as="script" href="./js/webui.js?v=537" />
 
 		<script>
 			loadUILang(() => {
@@ -57,10 +57,10 @@
 			});
 		</script>
 
-		<script type="module" src="./js/backgroundtask.js?v=536"></script>
-		<script type="module" src="./js/category-list.js?v=536"></script>
-		<script type="module" src="./js/panel.js?v=536"></script>
-		<script type="text/javascript" src="./js/category-list-elements.js?v=536" defer></script>
+		<script type="module" src="./js/backgroundtask.js?v=537"></script>
+		<script type="module" src="./js/category-list.js?v=537"></script>
+		<script type="module" src="./js/panel.js?v=537"></script>
+		<script type="text/javascript" src="./js/category-list-elements.js?v=537" defer></script>
 	</head>
 	<body>
 		<div id="preload" class="d-none"></div>
@@ -139,7 +139,7 @@
 				</div>
 				<div class="p-1 p-md-0 offcanvas-body">
 					<template id="panel-label-template">
-						<link href="./css/panel-label.css?v=536" rel="stylesheet" type="text/css" />
+						<link href="./css/panel-label.css?v=537" rel="stylesheet" type="text/css" />
 						<div part="prefix" hidden></div>
 						<div part="icon"></div>
 						<div part="text"></div>
@@ -148,7 +148,7 @@
 						<div part="size" style="display: none;"></div>
 					</template>
 					<template id="category-panel-template">
-						<link href="./css/category-panel.css?v=536" rel="stylesheet" type="text/css" />
+						<link href="./css/category-panel.css?v=537" rel="stylesheet" type="text/css" />
 						<div part="heading">
 							<span class="text"></span><slot name="decorator" class="decorator"></slot>
 						</div>
@@ -304,6 +304,6 @@
 		<div class="graph_tab_legend"></div>
 		<div id="dialog-container"></div>
 		<div id="dir-container"></div>
-		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=536"></script>
+		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=537"></script>
 	</body>
 </html>

--- a/js/webui.js
+++ b/js/webui.js
@@ -4,7 +4,7 @@
  */
 
 var theWebUI = {
-	version: "5.3.6",
+	version: "5.3.7",
 	tables: {
 		trt: {
 			obj: new dxSTable(),

--- a/lang/langs.js
+++ b/lang/langs.js
@@ -110,7 +110,7 @@ function loadUILang(onLoadFunc)
 			translateDOM();
 		}
 	};
-	langScript.src = `./lang/${lang}.js?v=536`;
+	langScript.src = `./lang/${lang}.js?v=537`;
 	document.head.appendChild(langScript);
 }
 


### PR DESCRIPTION
 ## ruTorrent v5.3.7

### Fixes
 - **Settings panel opens again on rtorrent ≥ 0.16.16.** 0.16.16 removed/renamed several
    commands (proxy addresses, open-socket queries, `d.multicall2`), but ruTorrent still sent
    the old names — so `getsettings` faulted and the panel returned a 500. Added a
    `php/methods-0.16.16.php` alias layer (loaded when iVersion ≥ 0x1010) mapping them to the
    current names, mirrored client-side in `js/content.js` (#3085, closes #3092). — @drrako