### PR TITLE
rtorrent.js: reload to login on 401 instead of spamming parse errors

### DIFF
--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -1259,6 +1259,16 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout, partialD
 	{
 		Ajax_UpdateTime(jqXHR);
 		
+		if(jqXHR.status == 401)	// auth/session expired -- re-authenticate instead of spamming parse errors
+		{
+			if(!theWebUI.authExpired)
+			{
+				theWebUI.authExpired = true;
+				window.location.reload();	// navigation -> auth layer redirects to login
+			}
+			stub = null;
+			return;
+		}
 		if((textStatus=="timeout") && ($type(onTimeout) == "function"))
 			onTimeout();
 		else if($type(onError) == "function")


### PR DESCRIPTION
When ruTorrent is served behind an auth layer and the session expires, an unauthenticated request is usually redirected to a login page. ruTorrent's polling XHR follows that redirect and receives the login HTML with a 200, which jQuery (expecting XML/JSON) reports as a `parsererror` -- and because the list polls on an interval, every tick re-spams "Bad response from server (200 [parsererror,...])" into the log.

An auth layer can instead return a real 401 to XHR (e.g. keyed on `X-Requested-With: XMLHttpRequest` or a non-`text/html` `Accept`). Handle that in the Ajax failure handler: on a 401, reload the page once. The reload is a normal navigation, so the auth layer redirects it to its own login page -- no login URL is hardcoded here, so it works with any setup. A guard flag makes it fire once so the concurrent polls can't loop.