### PR TITLE
Add alias finished and started

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -618,6 +618,8 @@ function correctContent()
 			"d.get_skip_total"	:	{ name: "d.skip.total", prm: 0 },
 			"d.get_state"		:	{ name: "d.state", prm: 0 },
 			"d.get_state_changed"	:	{ name: "d.state_changed", prm: 0 },
+			"d.get_timestamp_finished"      : { name: "d.timestamp.finished", prm: 0 },
+			"d.get_timestamp_started"      : { name: "d.timestamp.started", prm: 0 },
 			"d.get_state_counter"	:	{ name: "d.state_counter", prm: 0 },
 			"d.get_throttle_name"	:	{ name: "d.throttle_name", prm: 0 },
 			"d.get_tied_to_file"	:	{ name: "d.tied_to_file", prm: 0 },

--- a/php/methods-0.9.4.php
+++ b/php/methods-0.9.4.php
@@ -58,6 +58,8 @@ $this->aliases = array_merge($this->aliases,array(
 "d.get_skip_total"	=>	array( "name"=>"d.skip.total", "prm"=>0 ),
 "d.get_state"		=>	array( "name"=>"d.state", "prm"=>0 ),
 "d.get_state_changed"	=>	array( "name"=>"d.state_changed", "prm"=>0 ),
+"d.get_timestamp_finished"      => array( "name"=>"d.timestamp.finished", "prm"=>0 ),
+"d.get_timestamp_started"      => array( "name"=>"d.timestamp.started", "prm"=>0 ),
 "d.get_state_counter"	=>	array( "name"=>"d.state_counter", "prm"=>0 ),
 "d.get_throttle_name"	=>	array( "name"=>"d.throttle_name", "prm"=>0 ),
 "d.get_tied_to_file"	=>	array( "name"=>"d.tied_to_file", "prm"=>0 ),


### PR DESCRIPTION
I looked sins what version of rtorrent these were in rtorrent and added these. Example timestamp.finished is exactly the same thing then seedingtime in seedingtime plugin. Seems like should have used that for this from the beginning not add new custom value into rtorrent session file. After that is added could rewrite seedingtime plugin to use timestamp.finished instead of custom_seedingtime and remove adding this seedingtime value in the session file. Sadly did not find a replacement for addtime so that we need to keep.