### PR TITLE
ratio: apply default group on rtorrent >=0.16.16 (fix #3100)

### DIFF
--- a/plugins/ratio/ratio.php
+++ b/plugins/ratio/ratio.php
@@ -181,11 +181,9 @@ class rRatio
 			if($insertReq->getCommandsCount())
 				$insertReq->run();
 
-			$insCmd = getCmd('branch=');
 			$req = new rXMLRPCRequest();
 			for($i=0; $i<MAX_RATIO; $i++)
 			{
-				$insCmd .= (getCmd('d.views.has=').'rat_'.$i.',,');
 				$rat = $this->rat[$i];
 				if($this->isCorrect($i))
 				{
@@ -236,6 +234,18 @@ class rRatio
 				}
 			}
 
+			// Apply the default ratio group to newly added torrents, but only when
+			// the torrent is not already in one of the rat_* views (e.g. one assigned
+			// by the extratio rules plugin). The membership checks are grouped with
+			// the (or,...) object form: rtorrent >=0.16.16 made `branch` strictly
+			// ternary and silently drops surplus arguments, so the previous flat
+			// many-argument branch left the trailing view.set_visible unreachable and
+			// the default group was never applied (issue #3100). The object syntax is
+			// understood by rtorrent 0.9.8 and the 0.16.x series alike.
+			$insCmd = getCmd('branch').'=('.getCmd('or');
+			for($i=0; $i<MAX_RATIO; $i++)
+				$insCmd .= ',('.getCmd('d.views.has').',rat_'.$i.')';
+			$insCmd .= '),,';
 			if($this->isCorrect($this->default-1))
 				$req->addCommand(rTorrentSettings::get()->getOnInsertCommand(array('_ratio'.User::getUser(), 
 					$insCmd.getCmd('view.set_visible=').'rat_'.($this->default-1))));


### PR DESCRIPTION
The default ratio group was no longer applied to newly added torrents on rtorrent 0.16.16+ (it worked on 0.16.15 and earlier).

The on-insert handler registered by the plugin guards the default assignment with a flat, many-argument `branch`:

    branch=d.views.has=rat_0,,d.views.has=rat_1,,...,view.set_visible=rat_N

rtorrent 0.16.16 made `branch` strictly ternary (condition, if-true, if-false) and silently ignores any arguments past the third. The trailing view.set_visible -- the command that actually assigns the default group -- was therefore never reached, so new torrents got no group. Setting a group manually still worked because that path issues a direct two-argument view.set_visible.

Group the membership checks with the (or,...) object form and use a proper ternary branch, so the assignment runs only when the torrent is not already in a rat_* view (e.g. one assigned by the extratio rules plugin):

    branch=(or,(d.views.has,rat_0),...,(d.views.has,rat_N)),,view.set_visible=rat_N

Verified on rtorrent 0.9.8 and 0.16.17: the default group is applied to free torrents and skipped for torrents already in a rat_* view.