### PR TITLE
ci: add linting (php -l blocking; editorconfig + eslint advisory)

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,0 +1,11 @@
+{
+  "Exclude": [
+    "\\.min\\.(js|css)$",
+    "jquery",
+    "flotr",
+    "bootstrap",
+    "codemirror",
+    "/vendor/",
+    "node_modules"
+  ]
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,php,css}]
+indent_style = tab
+
+[tests/**]
+indent_style = space
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,47 @@
+name: lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  php-syntax:
+    # Blocking: every PHP file must parse.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+      - name: php -l
+        run: |
+          fail=0
+          while IFS= read -r f; do
+            php -l "$f" > /dev/null || { echo "::error file=$f::PHP syntax error"; fail=1; }
+          done < <(find . -type f -name '*.php' -not -path './tests/*' -not -path './node_modules/*')
+          exit $fail
+
+  editorconfig:
+    # Advisory for now: the existing tree has a backlog of whitespace issues.
+    # The plan is to clear it in small per-file PRs, then make this blocking.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: editorconfig-checker
+        run: npx --yes editorconfig-checker@5
+
+  eslint:
+    # Advisory for now (same plan as editorconfig).
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: install eslint
+        run: npm install --no-save eslint@9 @eslint/js@9
+      - name: eslint
+        run: npx eslint "js/**/*.js" "plugins/**/*.js"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,37 @@
+import js from '@eslint/js';
+
+export default [
+	{
+		ignores: [
+			'**/*.min.js',
+			'**/jquery*.js',
+			'js/jquery.flot.js',
+			'**/flotr*/**',
+			'**/bootstrap*',
+			'**/codemirror*/**',
+			'**/vendor/**',
+			'tests/**',
+			'node_modules/**',
+		],
+	},
+	{
+		files: ['js/**/*.js', 'plugins/**/*.js'],
+		languageOptions: {
+			ecmaVersion: 2022,
+			sourceType: 'script',
+		},
+		rules: {
+			...js.configs.recommended.rules,
+			// ruTorrent relies on many implicit globals (jQuery, cross-file
+			// functions, per-plugin objects), so no-undef would be almost
+			// entirely false positives. Disable it rather than maintain an
+			// exhaustive globals list; the rest of eslint:recommended stays on.
+			'no-undef': 'off',
+		},
+	},
+	{
+		// Files that are ES modules (top-level import/export).
+		files: ['js/backgroundtask.js', 'js/category-list.js', 'js/panel.js', 'plugins/rss/bbcode.js'],
+		languageOptions: { sourceType: 'module' },
+	},
+];


### PR DESCRIPTION
Add a `lint` workflow plus shared config so style and quality problems show up in CI:

- php -l over every PHP file -- blocking; catches syntax errors.
- editorconfig-checker -- advisory; whitespace / end-of-line / final-newline, driven by a new .editorconfig (tabs for js/php/css). A .ecrc keeps third-party and generated files out of the report.
- eslint -- advisory; eslint:recommended minus no-undef (the codebase relies on many implicit globals, so no-undef would be almost all false positives), driven by eslint.config.mjs. The four ES-module files get sourceType:module.

The two style checks are advisory (continue-on-error) for now: the existing tree has a backlog (~240 eslint findings, incl. two real duplicate-key bugs, and a batch of whitespace issues). The plan is to clear it in small per-file PRs and then make them blocking.

.editorconfig and eslint.config.mjs live at the repo root so editors and local runs share the CI configuration.