### PR TITLE
Fix defects surfaced by eslint (dupe keys, nullish fallback, fallthrough)

### DIFF
--- a/js/graph.js
+++ b/js/graph.js
@@ -82,7 +82,7 @@ class rGraph {
           ` onchange="rGraph.legendCheckboxChanged('${label}', event.target)" ${
             rGraph.legendLabels[label]?.labelIsChecked(label) ? "checked" : ""
           }/>` +
-          rGraph.legendLabelTranslations[label] ?? label
+          (rGraph.legendLabelTranslations[label] ?? label)
       );
     };
     this.badTextCache = true;

--- a/js/webui.js
+++ b/js/webui.js
@@ -684,7 +684,7 @@ var theWebUI = {
 					switch(i)
 					{
 					        case "max_memory_usage":
-              						v /= 1024;
+              						v /= 1024;  // falls through
 						case "upload_rate":
 						case "download_rate":
               						v /= 1024;
@@ -712,7 +712,7 @@ var theWebUI = {
 				var nv = o.is("input:checkbox") ? (o.prop('checked') ? 1 : 0) : o.val();
 				switch(i) {
 					case "max_memory_usage":
-						nv *= 1024;
+						nv *= 1024;  // falls through
 					case "upload_rate":
 					case "download_rate":
 						nv *= 1024;

--- a/plugins/cpuload/init.js
+++ b/plugins/cpuload/init.js
@@ -113,7 +113,6 @@ plugin.check = function () {
     cache: false,
     url: "plugins/cpuload/action.php",
     dataType: "json",
-    cache: false,
     success: function (data) {
       plugin.graph.addData(data.load);
     },

--- a/plugins/diskspace/init.js
+++ b/plugins/diskspace/init.js
@@ -67,7 +67,6 @@ plugin.init = function()
 			        cache: false,
 				url : "plugins/diskspace/action.php",
 				dataType : "json",
-				cache: false,
 				success : function(data)
 				{
 					plugin.setValue( data.total, data.free );


### PR DESCRIPTION
- plugins/cpuload/init.js, plugins/diskspace/init.js: the $.ajax options object set `cache: false` twice; drop the duplicate key.
- js/graph.js: `'...' + legendLabelTranslations[label] ?? label` parsed as `('...' + legendLabelTranslations[label]) ?? label`, so the `?? label` fallback was dead (the left operand is always a string) and a missing translation rendered "undefined". Parenthesise the nullish coalescing so the fallback applies.
- js/webui.js: the two settings switches intentionally fall through from the `max_memory_usage` case into the rate cases (the value is scaled twice on purpose); annotate with `// falls through` to document the intent.