### PR TITLE
editorconfig: enforce hygiene only, not indentation style

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,10 +1,14 @@
 {
   "Exclude": [
     "\\.min\\.(js|css)$",
-    "jquery",
-    "flotr",
+    "\\.phar$",
+    "js/jquery\\.js$",
+    "js/jquery\\.flot\\.js$",
     "bootstrap",
+    "flotr",
     "codemirror",
+    "prototype",
+    "scriptaculous",
     "/vendor/",
     "node_modules"
   ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,15 +6,9 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{js,php,css}]
-indent_style = tab
-
-[tests/**]
-indent_style = space
+[*.md]
+trim_trailing_whitespace = false
 
 [*.{yml,yaml,json}]
 indent_style = space
 indent_size = 2
-
-[*.md]
-trim_trailing_whitespace = false


### PR DESCRIPTION
The initial config enforced `indent_style = tab` for js/php/css, but the codebase mixes tabs (older code) and spaces (newer code, tests), so that rule flags thousands of lines and would require a large, contentious reindentation that is wrong for the space-styled files.

Drop indentation enforcement and keep the uncontroversial hygiene rules: final newline, trailing-whitespace trim (except Markdown), and LF line endings. Also exclude compiled/vendored artifacts (*.phar and the bundled JS libraries) from the checker.