### PR TITLE
Remove redundant double-negation (no-extra-boolean-cast)

### DIFF
--- a/plugins/_getdir/init.js
+++ b/plugins/_getdir/init.js
@@ -34,7 +34,7 @@ theWebUI.rDirBrowser = class {
 		// 3. `id` of the containing option page
 		const stgId = this.btn.parents(".stg_con").attr("id");
 		// 4. add an hide tab event handler if the button is within an option page
-		if (!!stgId) {
+		if (stgId) {
 			theOptionsWindow.addHandler(`mnu_${stgId}`, "beforeHide", () => this.hide());
 		}
 		// move dir list frame along with the containing dialog window

--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -128,14 +128,14 @@ plugin.readConsoleLog = function() {
 
 plugin.copyConsoleLog = function() {
 	const consoleLog = plugin.readConsoleLog();
-	if (!!consoleLog) {
+	if (consoleLog) {
 		copyToClipboard(consoleLog);
 	}
 }
 
 plugin.saveConsoleLog = function () {
 	const consoleLog = plugin.readConsoleLog();
-	if (!!consoleLog) {
+	if (consoleLog) {
 		const blob = new Blob([consoleLog], {type:"text/plain"});
 		const fileUrl = URL.createObjectURL(blob);
 		const link = document.createElement("a");


### PR DESCRIPTION
`!!x` inside an `if` condition is equivalent to `x` (both use the value's truthiness), so drop the redundant double-negation in two spots. Applied by `eslint --fix`; behavior-preserving.