### PR TITLE
Clear small eslint tail (empty catch, prototype-builtins, sparse arrays, etc.)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,6 +27,9 @@ export default [
 			// entirely false positives. Disable it rather than maintain an
 			// exhaustive globals list; the rest of eslint:recommended stays on.
 			'no-undef': 'off',
+			// Empty catch blocks are used intentionally here (feature
+			// detection, eval fallbacks); other empty blocks are still flagged.
+			'no-empty': ['error', { allowEmptyCatch: true }],
 		},
 	},
 	{

--- a/js/common.js
+++ b/js/common.js
@@ -187,6 +187,7 @@ $.fn.extend(
 
 function addslashes(str)
 {
+	// eslint-disable-next-line no-control-regex -- intentional: escape NUL, LF and CR
 	return( (str + '').replace(/[\\"']/g, '\\$&').replace(/\u0000/g, '\\0').replace(/\u000A/g, '\\n').replace(/\u000D/g, '\\r') );
 }
 
@@ -273,7 +274,7 @@ function cloneObject( srcObj )
 		{
 			newObject = new srcObj.constructor();
 			for( var property in srcObj )
-				if( srcObj.hasOwnProperty(property) || typeof( srcObj[property] ) === 'object' )
+				if( Object.prototype.hasOwnProperty.call(srcObj, property) || typeof( srcObj[property] ) === 'object' )
 					newObject[property]= cloneObject( srcObj[property] );
 			break;
        		}

--- a/js/custom-elements.js
+++ b/js/custom-elements.js
@@ -36,7 +36,7 @@ class CustomHTMLElement extends HTMLElement {
   customDefineAttributes() {
     this._restartMutationObserver((pendingMutations) => {
       for (const attrName of this.constructor.stringAttributeNames) {
-        if (!this.hasOwnProperty(attrName)) {
+        if (!Object.prototype.hasOwnProperty.call(this, attrName)) {
           Object.defineProperty(this, attrName, {
             set(value) {
               if (value !== this.getAttribute(attrName)) {
@@ -55,7 +55,7 @@ class CustomHTMLElement extends HTMLElement {
         }
       }
       for (const attrName of this.constructor.booleanAttributeNames) {
-        if (!this.hasOwnProperty(attrName)) {
+        if (!Object.prototype.hasOwnProperty.call(this, attrName)) {
           Object.defineProperty(this, attrName, {
             set(value) {
               this.toggleAttribute(attrName, value);

--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -70,7 +70,7 @@ plugin.start = function()
 			{
 				for( var property in  parameter )
 				{
-					if( parameter.hasOwnProperty(property) )
+					if( Object.prototype.hasOwnProperty.call(parameter, property) )
 						req+=('&v='+i+'['+property+']&s='+encodeURIComponent(parameter[property]));
 				}
 				break;

--- a/plugins/chunks/init.js
+++ b/plugins/chunks/init.js
@@ -121,10 +121,10 @@ plugin.onLangLoaded = function() {
 		$("<div>").attr("id","Chunks").append(
 			$("<div>").addClass("d-flex flex-row justify-content-between align-items-center").append(
 				...[
-					[theUILang.chunksCount, , "ccount"],
-					[theUILang.chunkSize, , "csize"],
+					[theUILang.chunksCount, undefined, "ccount"],
+					[theUILang.chunkSize, undefined, "csize"],
 					[theUILang.cDownloaded, "cinfohdr", "cinfo"],
-					[theUILang.cLegend, , "clegend"],
+					[theUILang.cLegend, undefined, "clegend"],
 				].flatMap(([headerName, headerId, valueId]) => [
 					$("<div>").addClass("sthdr").append(
 						$("<span>").attr({id:headerId}).text(headerName + ":"),

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -599,7 +599,6 @@ theWebUI.tegItemDblClick = function(obj)
 			var tmp = new Object();
 	                tmp.id = nfo.data.hash;
         		theWebUI.getTable("trt").ondblclick( tmp );
-        		delete tmp;
 		}
 		else
 			window.open(nfo.data.desc,"_blank");

--- a/plugins/rss/init.js
+++ b/plugins/rss/init.js
@@ -254,7 +254,6 @@ theWebUI.rssDblClick = function( obj )
 		var tmp = {};
                 tmp.id = theWebUI.rssItems[obj.id].hash
         	theWebUI.getTable("trt").ondblclick( tmp );
-        	delete tmp;
 	}
 	else
 		window.open(theWebUI.rssItems[obj.id].guid,"_blank");
@@ -1451,8 +1450,8 @@ plugin.onLangLoaded = function()
 			),
 			$("<div>").attr({id:"FLTchk_buttons"}).append(
 				...[
-					[theUILang.rssAddFilter, , "theWebUI.addNewFilter(); return false;"],
-					[theUILang.rssDelFilter, , "theWebUI.deleteCurrentFilter(); return false;"],
+					[theUILang.rssAddFilter, undefined, "theWebUI.addNewFilter(); return false;"],
+					[theUILang.rssDelFilter, undefined, "theWebUI.deleteCurrentFilter(); return false;"],
 					[theUILang.rssCheckFilter, "chkFilterBtn", "theWebUI.checkCurrentFilter(); return false;"],
 				].map(([text, id, onClick]) => $("<button>").attr(
 					{type:"button", id:id, onClick:onClick}


### PR DESCRIPTION


- no-empty: the ten flagged blocks are all intentional empty `catch` clauses (feature detection, eval fallbacks). Allow empty catch in the config while still flagging every other kind of empty block.
- no-control-regex: addslashes() intentionally matches NUL/LF/CR in order to escape them; add an eslint-disable-next-line with a reason.
- no-prototype-builtins: use Object.prototype.hasOwnProperty.call(obj, key) instead of obj.hasOwnProperty(key) (4 sites).
- no-sparse-arrays: the `[name, , id]` holes are destructured deliberately; make the omitted middle element an explicit `undefined` (5 sites).
- no-delete-var: `delete tmp` on a local variable is a no-op in non-strict mode; remove the dead statements (2 sites).

Behavior is unchanged. eslint drops from 210 to 186.