### PR TITLE
Bump version to 5.3.8 and update cache-bust params

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,27 +21,27 @@
 		<meta name="msapplication-TileColor" content="#FFFFFF" />
 		<meta name="msapplication-TileImage" content="./images/mstile-144x144.png" />
 
-		<link href="./css/bootstrap.min.css?v=537" rel="stylesheet" type="text/css" />
-		<link href="./css/style.css?v=537" rel="stylesheet" type="text/css" />
-		<link href="./css/stable.css?v=537" rel="stylesheet" type="text/css" />
-		<link rel="preload" as="style" href="./css/category-panel.css?v=537" />
-		<link rel="preload" as="style" href="./css/panel-label.css?v=537" />
-		<script type="text/javascript" src="./js/jquery.js?v=537"></script>
-		<script type="text/javascript" src="./js/jquery.flot.js?v=537"></script>
-		<script type="text/javascript" src="./js/sanitize.js?v=537"></script>
-		<script type="text/javascript" src="./js/sanitize.config.js?v=537"></script>
-		<script type="text/javascript" src="./js/custom-elements.js?v=537"></script>
-		<script type="text/javascript" src="./lang/langs.js?v=537"></script>
-		<link rel="preload" as="script" href="./js/browser.js?v=537" />
-		<link rel="preload" as="script" href="./js/common.js?v=537" />
-		<link rel="preload" as="script" href="./js/objects.js?v=537" />
-		<link rel="preload" as="script" href="./js/options.js?v=537" />
-		<link rel="preload" as="script" href="./js/content.js?v=537" />
-		<link rel="preload" as="script" href="./js/stable.js?v=537" />
-		<link rel="preload" as="script" href="./js/graph.js?v=537" />
-		<link rel="preload" as="script" href="./js/plugins.js?v=537" />
-		<link rel="preload" as="script" href="./js/rtorrent.js?v=537" />
-		<link rel="preload" as="script" href="./js/webui.js?v=537" />
+		<link href="./css/bootstrap.min.css?v=538" rel="stylesheet" type="text/css" />
+		<link href="./css/style.css?v=538" rel="stylesheet" type="text/css" />
+		<link href="./css/stable.css?v=538" rel="stylesheet" type="text/css" />
+		<link rel="preload" as="style" href="./css/category-panel.css?v=538" />
+		<link rel="preload" as="style" href="./css/panel-label.css?v=538" />
+		<script type="text/javascript" src="./js/jquery.js?v=538"></script>
+		<script type="text/javascript" src="./js/jquery.flot.js?v=538"></script>
+		<script type="text/javascript" src="./js/sanitize.js?v=538"></script>
+		<script type="text/javascript" src="./js/sanitize.config.js?v=538"></script>
+		<script type="text/javascript" src="./js/custom-elements.js?v=538"></script>
+		<script type="text/javascript" src="./lang/langs.js?v=538"></script>
+		<link rel="preload" as="script" href="./js/browser.js?v=538" />
+		<link rel="preload" as="script" href="./js/common.js?v=538" />
+		<link rel="preload" as="script" href="./js/objects.js?v=538" />
+		<link rel="preload" as="script" href="./js/options.js?v=538" />
+		<link rel="preload" as="script" href="./js/content.js?v=538" />
+		<link rel="preload" as="script" href="./js/stable.js?v=538" />
+		<link rel="preload" as="script" href="./js/graph.js?v=538" />
+		<link rel="preload" as="script" href="./js/plugins.js?v=538" />
+		<link rel="preload" as="script" href="./js/rtorrent.js?v=538" />
+		<link rel="preload" as="script" href="./js/webui.js?v=538" />
 
 		<script>
 			loadUILang(() => {
@@ -57,10 +57,10 @@
 			});
 		</script>
 
-		<script type="module" src="./js/backgroundtask.js?v=537"></script>
-		<script type="module" src="./js/category-list.js?v=537"></script>
-		<script type="module" src="./js/panel.js?v=537"></script>
-		<script type="text/javascript" src="./js/category-list-elements.js?v=537" defer></script>
+		<script type="module" src="./js/backgroundtask.js?v=538"></script>
+		<script type="module" src="./js/category-list.js?v=538"></script>
+		<script type="module" src="./js/panel.js?v=538"></script>
+		<script type="text/javascript" src="./js/category-list-elements.js?v=538" defer></script>
 	</head>
 	<body>
 		<div id="preload" class="d-none"></div>
@@ -139,7 +139,7 @@
 				</div>
 				<div class="p-1 p-md-0 offcanvas-body">
 					<template id="panel-label-template">
-						<link href="./css/panel-label.css?v=537" rel="stylesheet" type="text/css" />
+						<link href="./css/panel-label.css?v=538" rel="stylesheet" type="text/css" />
 						<div part="prefix" hidden></div>
 						<div part="icon"></div>
 						<div part="text"></div>
@@ -148,7 +148,7 @@
 						<div part="size" style="display: none;"></div>
 					</template>
 					<template id="category-panel-template">
-						<link href="./css/category-panel.css?v=537" rel="stylesheet" type="text/css" />
+						<link href="./css/category-panel.css?v=538" rel="stylesheet" type="text/css" />
 						<div part="heading">
 							<span class="text"></span><slot name="decorator" class="decorator"></slot>
 						</div>
@@ -304,6 +304,6 @@
 		<div class="graph_tab_legend"></div>
 		<div id="dialog-container"></div>
 		<div id="dir-container"></div>
-		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=537"></script>
+		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=538"></script>
 	</body>
 </html>

--- a/js/webui.js
+++ b/js/webui.js
@@ -4,7 +4,7 @@
  */
 
 var theWebUI = {
-	version: "5.3.7",
+	version: "5.3.8",
 	tables: {
 		trt: {
 			obj: new dxSTable(),

--- a/lang/langs.js
+++ b/lang/langs.js
@@ -110,7 +110,7 @@ function loadUILang(onLoadFunc)
 			translateDOM();
 		}
 	};
-	langScript.src = `./lang/${lang}.js?v=537`;
+	langScript.src = `./lang/${lang}.js?v=538`;
 	document.head.appendChild(langScript);
 }
 


### PR DESCRIPTION
Fixes
  - Auth-expiry handling: when the session/credentials expire, ruTorrent now reloads to the login page on an HTTP 401 instead of flooding the log with Bad response from server (200
  [parsererror,…]). Works with any auth layer that returns 401 to XHR (no hardcoded login URL).
  - Default ratio group is applied to newly-added torrents again on rtorrent 0.16.16+ (regression from the stricter branch arg handling).
  - Table renderer: fixed an inverted debounce timer in stable.js (list updates were leaning on the throttle fallback → laggier redraws).
  - Duplicate-key bugs in the cpuload/diskspace refresh requests, and a broken nullish-fallback in the RSS/graph legend (… ?? label rendered undefined).

  Internal / maintenance
  - Added a CI lint workflow (php -l blocking; editorconfig + eslint advisory) with shared .editorconfig/eslint.config.mjs.
  - Whitespace normalization across the tree (trailing whitespace, final newlines, LF) and a batch of safe eslint cleanups (useless escapes, redundant casts, hasOwnProperty calls, etc.).
  - .gitignore for deployment-local config.local.php / plugin conf.local.php overrides.
  -