### PR TITLE
no-unused-vars: scope to local variables + remove dead locals

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,10 @@ export default [
 			// Empty catch blocks are used intentionally here (feature
 			// detection, eval fallbacks); other empty blocks are still flagged.
 			'no-empty': ['error', { allowEmptyCatch: true }],
+			// Globals are cross-file here (utility helpers, per-plugin vars), so
+			// only flag genuinely dead *local* variables; unused positional
+			// callback params and catch bindings are left alone.
+			'no-unused-vars': ['error', { vars: 'local', args: 'none', caughtErrors: 'none' }],
 		},
 	},
 	{

--- a/js/category-list.js
+++ b/js/category-list.js
@@ -556,7 +556,7 @@ export class CategoryList {
   removeActiveTextSearches() {
     const removedSearchIndices = new Set(
       this.selection.ids("psearch").map((searchId) => {
-        const [_, searchIndex] = searchId.split("_", 2);
+        const [, searchIndex] = searchId.split("_", 2);
         return Number(searchIndex);
       })
     );

--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -1154,7 +1154,6 @@ rTorrentStub.prototype.listResponse = function(data)
 		var state = 0;
 		var is_open = iv(values[0]);
 		var is_hash_checking = iv(values[1]);
-		var is_hash_checked = iv(values[2]);
 		var get_state = iv(values[3]);
 		var get_hashing = iv(values[23]);
 		var is_active = iv(values[28]);

--- a/js/sanitize.js
+++ b/js/sanitize.js
@@ -21,7 +21,7 @@
  */
 
 function Sanitize(){
-  var i, e, options;
+  var i, options;
   options = arguments[0] || {};
   this.config = {};
   this.config.elements = options.elements ? options.elements : [];
@@ -129,7 +129,7 @@ Sanitize.prototype.clean_node = function(container) {
   }
 
   function _clean_element(elem) {
-    var i, j, clone, parent_element, name, allowed_attributes, attr, attr_name, attr_node, protocols, del, attr_ok;
+    var i, parent_element, name, allowed_attributes, attr, attr_name, attr_node, protocols, del, attr_ok;
     var transform = _transform_element.call(this, elem);
 
     elem = transform.node;

--- a/js/stable.js
+++ b/js/stable.js
@@ -766,11 +766,6 @@ dxSTable.prototype.refreshRows = function( height, fromScroll )
 	if (this.isScrolling || !this.created)
 		return;
 
-	const maxRows = height ? height / this.TR_HEIGHT : this.getMaxRows();
-	const topRow = Math.max(0, Math.min(
-		this.viewRows - maxRows,
-		Math.floor(this.dBody.scrollTop / this.TR_HEIGHT)
-	));
 	const extra = this.noDelayingDraw ? 16 : 4;
 	const mni = Math.max(
 		0,

--- a/plugins/diskspace/init.js
+++ b/plugins/diskspace/init.js
@@ -59,7 +59,7 @@ plugin.init = function()
 
 		plugin.check = function()
 		{
-			var AjaxReq = jQuery.ajax(
+			jQuery.ajax(
 			{
 				type: "GET",
 				timeout: theWebUI.settings["webui.reqtimeout"],

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -357,7 +357,6 @@ theWebUI.tegItemRemove = function()
 
 theWebUI.showTegURLInfo = function()
 {
-	var table = theWebUI.getTable("teg");
 	const tegId = theWebUI.activeExtTegId();
 	for(var i = 0; i<plugin.tegArray.length; i++)
 	{

--- a/plugins/geoip/init.js
+++ b/plugins/geoip/init.js
@@ -109,7 +109,7 @@ rTorrentStub.prototype.getpeersResponse = function(xml)
 		});
 		if(content.length)
 		{
-			var AjaxReq = jQuery.ajax(
+			jQuery.ajax(
 			{
 				type: "POST",
 				contentType: "application/x-www-form-urlencoded",

--- a/plugins/lookat/init.js
+++ b/plugins/lookat/init.js
@@ -81,7 +81,6 @@ if(plugin.canChangeMenu())
 		plugin.createMenu.call(this, e, id);
 		if(plugin.enabled && plugin.allStuffLoaded)
 		{
-			var table = this.getTable("trt");
 			var el = theContextMenu.get( theUILang.Properties );
 			if( el )
 			{


### PR DESCRIPTION
ESLint lints each file in isolation, so it reports cross-file globals (shared utility helpers, per-plugin vars) and positional callback params as "unused" -- false positives in this global-heavy codebase. Scope the rule to { vars: 'local', args: 'none', caughtErrors: 'none' } so only genuinely dead local variables are flagged.

That leaves eleven real dead locals, removed here:
- captured results of pure calls/expressions that are never read (is_hash_checked, topRow, two theWebUI.getTable() results, and maxRows, which only fed the removed topRow);
- two `var AjaxReq = jQuery.ajax(...)` -- the binding is unused, so drop it while keeping the call (it fires the request);
- variables declared but never assigned (e, j, clone in sanitize.js);
- an ignored array-destructuring slot in category-list.js.

Behavior is unchanged; the jest suite passes.