### PR TITLE
Fix final eslint findings (unsafe optional chaining, dead private member

### DIFF
--- a/js/graph.js
+++ b/js/graph.js
@@ -292,23 +292,6 @@ class rSpeedGraph extends rGraph {
     });
 
     super.create(aOwner, webuiView);
-    // this.#testData();
-  }
-
-  #testData() {
-    this.setMaxSeconds(10);
-    setInterval(() => {
-      const t = new Date().getTime() / 3000;
-      const mb = (Math.sin(t / 100) + 1) * (1 << 20);
-      this.addData(
-        (Math.sin(t) + 1) * mb,
-        ([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
-          .map((k) => Math.cos(k * t) / k)
-          .reduce((a, b) => a + b, 0) +
-          4) *
-          mb
-      );
-    }, 100);
   }
 
   yTickFormatter(n) {

--- a/js/panel.js
+++ b/js/panel.js
@@ -451,7 +451,7 @@ class CategoryListStatistic extends TorrentStatisticBucket {
     }
   }
   ids(panelId) {
-    return [...this._panels[panelId]?.buckets.keys()];
+    return [...this._panels[panelId].buckets.keys()];
   }
 
   selected(hash, panelLabelSelection) {

--- a/tests/js/panel.spec.js
+++ b/tests/js/panel.spec.js
@@ -318,4 +318,18 @@ describe("Category list statistic", () => {
     expect(viewBucket.upload).toBe(pstateBucket.upload);
     expect(viewBucket.download).toBe(pstateBucket.download);
   });
+
+  it("ids(): known panels return bucket keys; unknown panel throws (pinned across the optional-chaining fix)", () => {
+    const torrents = generateTorrents(50);
+    for (const [hash, torrent] of Object.entries(torrents)) {
+      statistic.scan(hash, torrent);
+    }
+    for (const panelId of ["plabel", "pstate", "psearch"]) {
+      const ids = statistic.ids(panelId);
+      expect(Array.isArray(ids)).toBe(true);
+      expect(ids.every((k) => typeof k === "string")).toBe(true);
+    }
+    expect(statistic.ids("plabel").length).toBeGreaterThan(0);
+    expect(() => statistic.ids("no_such_panel")).toThrow();
+  });
 });


### PR DESCRIPTION
- js/panel.js: ids() did `[...this._panels[panelId]?.buckets.keys()]`. The `?.` is misleading -- when the panel is missing it short-circuits to undefined and the spread then throws a TypeError anyway, so it offers no protection. Drop it; behavior is identical (known panel -> its bucket keys, unknown panel -> TypeError). A new unit test pins both cases, and passes unchanged with and without the `?.`.
- js/graph.js: remove the private #testData() debug generator -- its only caller was already commented out, so it was dead code.