### PR TITLE
no-redeclare: drop redundant var on re-declarations

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -231,7 +231,7 @@ function linked(obj, _33, lst) {
 		var d = _33 ? obj.checked : !obj.checked;
 	else if (tn === "select") {
 		var v = obj.options[obj.selectedIndex].value;
-		var d = (v === _33) ? true : false;
+		d = (v === _33) ? true : false;
 	} else {
 		return;
 	}
@@ -1022,7 +1022,7 @@ rDirectory.prototype.addFile = function(aData,no)
 		}
 		else
 		{
-			var sId = "_d_"+name;
+			sId = "_d_"+name;
 			if(!this.dirs[file.path][sId])
 				this.dirs[file.path][sId] = { data: { name: file.name, size: 0, done: 0, percent: 0.0, priority: -1, prioritize: -1 }, icon: "Icon_Dir", link: name };
 		}
@@ -1283,7 +1283,7 @@ var theBTClientVersion =
 						ret = cli+" "+str.charAt(3)+"."+str.charAt(4);
 						break;
 					default:
-						var ch = str.charAt(6);
+						ch = str.charAt(6);
 						ret = cli+" "+str.charAt(3)+"."+parseInt(str.substr(4,2),10);
 						if((ch=='Z') || (ch=='X'))
 							ret+='+';
@@ -1448,7 +1448,7 @@ var theBTClientVersion =
 		{
 			if(str.match(/^[A-Z]([A-Z0-9\-.]{1,5})/i))
 			{
-				var cli = this.shLikeClients[str.charAt(0)];
+				cli = this.shLikeClients[str.charAt(0)];
 				if(cli)
 					ret = cli+" "+shChar(str.charAt(1))+"."+shChar(str.charAt(2))+"."+shChar(str.charAt(3));
 			}
@@ -1498,7 +1498,7 @@ function RGBackground( selector )
 		var cs;
                 var rule = getCSSRule(selector);
 		if(rule)
-			var cs = rule.style.backgroundColor;
+			cs = rule.style.backgroundColor;
 		else
 			cs = selector;
 		if(cs.charAt(0) == '#')

--- a/js/objects.js
+++ b/js/objects.js
@@ -351,7 +351,7 @@ var theContextMenu =
 			args.splice(0, 1);
 		}
 		else
-			var o = this.obj;
+			o = this.obj;
 		if(($type(args[0]) == "object") && args[0].hasClass && args[0].hasClass("menuitem"))
 		{
 			aft = args[0];

--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -506,7 +506,7 @@ rTorrentStub.prototype.setprioritize = function()
 			}
 			case '1':
 			{
-				var cmd = new rXMLRPCCommand( "f.prioritize_first.enable" );
+				cmd = new rXMLRPCCommand( "f.prioritize_first.enable" );
 				cmd.addParameter("string",this.hashes[0]+":f"+this.vs[i]);
 				this.commands.push( cmd );
 				cmd = new rXMLRPCCommand( "f.prioritize_last.disable" );
@@ -516,7 +516,7 @@ rTorrentStub.prototype.setprioritize = function()
 			}
 			case '2':
 			{
-				var cmd = new rXMLRPCCommand( "f.prioritize_first.disable" );
+				cmd = new rXMLRPCCommand( "f.prioritize_first.disable" );
 				cmd.addParameter("string",this.hashes[0]+":f"+this.vs[i]);
 				this.commands.push( cmd );
 				cmd = new rXMLRPCCommand( "f.prioritize_last.enable" );
@@ -707,12 +707,12 @@ rTorrentStub.prototype.makeNextMultiCall = function()
 		this.hashes = [];
 		for(; this.commandOffset < this.commands.length; this.commandOffset++)
 		{
-			var cmd = this.commands[this.commandOffset];
+			cmd = this.commands[this.commandOffset];
 			var cmd_string=('<value><struct><member><name>methodName</name><value><string>'+
 				cmd.command+'</string></value></member><member><name>params</name><value><array><data>');
 			for(var j=0; j<cmd.params.length; j++)
 			{
-				var prm = cmd.params[j];
+				prm = cmd.params[j];
 				cmd_string += ('<value><'+prm.type+'>'+
 					prm.value+'</'+prm.type+'></value>');
 			}
@@ -767,7 +767,7 @@ rTorrentStub.prototype.getResponse = function(data)
 		}
 		else
 		{
-			var names = data.getElementsByTagName('name');
+			names = data.getElementsByTagName('name');
 			if(names)
 				for(var i=0; i<names.length; i++)
 					if(names[i].childNodes[0].data=="faultString")

--- a/js/stable.js
+++ b/js/stable.js
@@ -1037,7 +1037,7 @@ dxSTable.prototype.clearRows = function()
 
 dxSTable.prototype.setAlignment = function() {
 	var i, aAlign, j, align;
-	var aAlign = [];
+	aAlign = [];
 	for (let i = 0; i < this.cols; i++) {
 		switch(this.colsdata[i].align) {
 			case ALIGN_LEFT:
@@ -1059,7 +1059,7 @@ dxSTable.prototype.setAlignment = function() {
 	var col = this.tBodyCols;
 	if(document.all || browser.isAppleWebKit || browser.isKonqueror)
 	{
-		for(var i = 0; i < col.length; i++)
+		for(i = 0; i < col.length; i++)
 			col[i].align = aAlign[i];
 	}
 	else
@@ -1078,12 +1078,12 @@ dxSTable.prototype.setAlignment = function() {
 			return;
 		if(!$type(this.colRules))
 			this.colRules = new Array();
-		for(var j = 0; j < col.length; j++)
+		for(j = 0; j < col.length; j++)
 		{
 			var k = this.colOrder[j];
 			if(!this.colRules[k])
 			{
-				for(var i = 0, l = rules.length; i < l; i++)
+				for(i = 0, l = rules.length; i < l; i++)
 				{
 					if((rules[i].type == CSSRule.STYLE_RULE) && (rules[i].selectorText == ".stable-" + this.dCont.attr("id") + "-col-" + k))
 					{

--- a/js/webui.js
+++ b/js/webui.js
@@ -1171,15 +1171,15 @@ var theWebUI = {
 			if(!this.settings["webui.fls.view"] && this.dirs[hash])
 			{
 				var dir = this.dirs[hash].getDirectory();
-				for(var i in dir)
+				for(i in dir)
 				{
 					var entry = dir[i];
 					if(entry.link!=null)
 						table.setRowById(entry.data, i, entry.icon, {link: entry.link});
 				}
-				for(var i in dir)
+				for(i in dir)
 				{
-					var entry = dir[i];
+					entry = dir[i];
 					if(entry.link==null)
 						table.setRowById(entry.data, i, entry.icon, {link: undefined});
 				}
@@ -1325,7 +1325,7 @@ var theWebUI = {
 				        var dir = theWebUI.dirs[id];
 				        var ids = new Array();
 				        dir.getFilesIds(ids,dir.current,k,p);
-				        for(var i in ids)
+				        for(i in ids)
 						str += "&f=" + ids[i];
 					needSort = true;
         			}

--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -558,7 +558,7 @@ plugin.onGetTasks = function(d)
 					plugin.callNotification("Finished",item,true);
 		}
 		var deleted = false;
-               	for( var id in plugin.background )
+               	for( id in plugin.background )
 		{
 			if(!$type(d[id]))
 			{

--- a/plugins/edit/init.js
+++ b/plugins/edit/init.js
@@ -216,7 +216,7 @@ rTorrentStub.prototype.edittorrent = function()
 		if(s.toLowerCase()!='dht://')
 			this.content += ("&tracker="+encodeURIComponent(s));
 	}
-	for( var i = 0; i < this.hashes.length; i++ )
+	for( i = 0; i < this.hashes.length; i++ )
 		this.content += ("&hash="+this.hashes[i]);
 	this.contentType = "application/x-www-form-urlencoded";
 	this.mountPoint = "plugins/edit/action.php";

--- a/plugins/extratio/init.js
+++ b/plugins/extratio/init.js
@@ -66,7 +66,7 @@ plugin.loadRules = function( rle )
 		fltRatio.append(
 			$("<option>").val("").text(theUILang.dontSet),
 		);
-		for(var i=0; i<theWebUI.maxRatio; i++)
+		for(i=0; i<theWebUI.maxRatio; i++)
 			if(theWebUI.isCorrectRatio(i))
 				fltRatio.append(
 					$("<option>").val("rat_" + i).text(theWebUI.ratios[i].name),
@@ -77,7 +77,7 @@ plugin.loadRules = function( rle )
 	list.empty();
 	plugin.rules = rle || [];
 	plugin.maxRuleNo = 0;
-	for(var i=0; i<plugin.rules.length; i++)
+	for(i=0; i<plugin.rules.length; i++)
 	{
 		var f = plugin.rules[i];
 		if(plugin.maxRuleNo<f.no)
@@ -91,9 +91,9 @@ plugin.loadRules = function( rle )
 			),
 		);
 	}
-	for(var i=0; i<plugin.rules.length; i++)
+	for(i=0; i<plugin.rules.length; i++)
 	{
-		var f = plugin.rules[i];
+		f = plugin.rules[i];
 		if(f.no<0)
 		{
 			plugin.maxRuleNo++;

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -413,7 +413,7 @@ plugin.createExtTegMenu = function(e, id)
 	if(trtArray.length)
 	{
 	        var table = theWebUI.getTable("trt");
-		for(var k in table.rowSel)
+		for(k in table.rowSel)
 			table.rowSel[k] = false;
 		table.selCount = trtArray.length;
 		for(var i = 0; i<trtArray.length; i++)
@@ -564,7 +564,7 @@ theWebUI.tegItemSelect = function(e,id)
 		}
 	}
 	var table = theWebUI.getTable("trt");
-	for(var k in table.rowSel)
+	for(k in table.rowSel)
 		table.rowSel[k] = false;
 	table.selCount = trtArray.length;
 	for(var i = 0; i<trtArray.length; i++)
@@ -730,7 +730,7 @@ plugin.refreshCategories = function()
 	else
         if($type(theSearchEngines.sites[theSearchEngines.current]))
 	{
-		for( var i=0; i<theSearchEngines.sites[theSearchEngines.current].cats.length; i++)
+		for( i=0; i<theSearchEngines.sites[theSearchEngines.current].cats.length; i++)
 			$('#exscategory').append("<option value='"+theSearchEngines.sites[theSearchEngines.current].cats[i]+"'>"+theSearchEngines.sites[theSearchEngines.current].cats[i]+"</option>");
 	}
 	$("#exscategory").prop("hidden", (theSearchEngines.current === -1));

--- a/plugins/httprpc/init.js
+++ b/plugins/httprpc/init.js
@@ -28,12 +28,12 @@ rTorrentStub.prototype.getCommon = function(cmd)
 		this.content = "mode="+cmd;
 		for(var i=0; i<this.hashes.length; i++)
 			this.content+=("&hash="+this.hashes[i]);
-		for(var i=0; i<this.vs.length; i++)
+		for(i=0; i<this.vs.length; i++)
 		        this.content+=("&v="+encodeURIComponent(this.vs[i]));
-		for(var i=0; i<this.ss.length; i++)
+		for(i=0; i<this.ss.length; i++)
 		        this.content+=("&s="+encodeURIComponent(this.ss[i]));
 		if($type(theRequestManager[cmd]))
-			for(var i=theRequestManager[cmd].count; i<theRequestManager[cmd].commands.length; i++)
+			for(i=theRequestManager[cmd].count; i<theRequestManager[cmd].commands.length; i++)
 				this.content+=("&cmd="+encodeURIComponent(theRequestManager.map(cmd,i)));
 	}
 	else

--- a/plugins/retrackers/init.js
+++ b/plugins/retrackers/init.js
@@ -24,7 +24,7 @@ if(plugin.canChangeOptions())
 			}
 			$('#eretrackers').val(s);
 			s = '';
-			for(var i=0; i<theWebUI.retrackers.todelete.length; i++)
+			for(i=0; i<theWebUI.retrackers.todelete.length; i++)
 			{
 				s+=theWebUI.retrackers.todelete[i];
 				s+='\r\n';
@@ -58,7 +58,7 @@ if(plugin.canChangeOptions())
 			groups.push(curGroup);
 		if(groups.length!=theWebUI.retrackers.list.length)
 			return(true);
-		for(var i = 0; i<groups.length; i++)
+		for(i = 0; i<groups.length; i++)
 		{
 			if(groups[i].length!=theWebUI.retrackers.list[i].length)
 				return(true);
@@ -68,15 +68,15 @@ if(plugin.canChangeOptions())
 		}
 		arr = $('#dretrackers').val().split("\n");
 		var todelete = [];
-		for(var i=0; i<arr.length; i++)
+		for(i=0; i<arr.length; i++)
 		{
-			var s = arr[i].trim();
+			s = arr[i].trim();
 			if(s.length)
 				todelete.push(s);
 		}
 		if(todelete.length!=theWebUI.retrackers.todelete.length)
 			return(true);
-		for(var i=0; i<theWebUI.retrackers.todelete.length; i++)
+		for(i=0; i<theWebUI.retrackers.todelete.length; i++)
 			if(theWebUI.retrackers.todelete[i]!=todelete[i])
 				return(true);
 		return(false);
@@ -102,9 +102,9 @@ if(plugin.canChangeOptions())
 				this.content = 	this.content+"&tracker="+encodeURIComponent(s);
 		}
 		arr = $('#dretrackers').val().split("\n");
-		for(var i = 0; i<arr.length; i++)
+		for(i = 0; i<arr.length; i++)
 		{
-			var s = arr[i].trim();
+			s = arr[i].trim();
 			if(s.length)
 				this.content = 	this.content+"&todelete="+encodeURIComponent(s);
 		}

--- a/plugins/rss/init.js
+++ b/plugins/rss/init.js
@@ -571,7 +571,7 @@ theWebUI.rssSelect = function(e, id)
 		}
 	}
 	var table = theWebUI.getTable("trt");
-	for(var k in table.rowSel)
+	for(k in table.rowSel)
 		table.rowSel[k] = false;
 	table.selCount = trtArray.length;
 	for(var i = 0; i<trtArray.length; i++)
@@ -909,7 +909,7 @@ theWebUI.loadFilters = function( flt, additions )
 	$('#FLT_rss').append("<option value=''>"+theUILang.allFeeds+"</option>");
 	for(var lbl in this.rssGroups)
 		$('#FLT_rss').append("<option value='"+lbl+"'>"+this.rssGroups[lbl].name+"</option>");
-	for(var lbl in this.rssLabels)
+	for(lbl in this.rssLabels)
 		$('#FLT_rss').append("<option value='"+lbl+"'>"+this.rssLabels[lbl].name+"</option>");
 	var fltThrottle = $('#FLT_throttle');
 	if(fltThrottle.length)
@@ -925,7 +925,7 @@ theWebUI.loadFilters = function( flt, additions )
 	{
 		$('#FLT_ratio option').remove();
 		fltRatio.append("<option value=''>"+theUILang.mnuRatioUnlimited+"</option>");
-		for(var i=0; i<theWebUI.maxRatio; i++)
+		for(i=0; i<theWebUI.maxRatio; i++)
 			if(theWebUI.isCorrectRatio(i))
 				fltRatio.append("<option value='rat_"+i+"'>"+theWebUI.ratios[i].name+"</option>");
 	}
@@ -933,7 +933,7 @@ theWebUI.loadFilters = function( flt, additions )
 	if(additions)
 		this.filters = additions.concat(this.filters);
 	theWebUI.maxFilterNo = 0;
-	for(var i=0; i<this.filters.length; i++)
+	for(i=0; i<this.filters.length; i++)
 	{
 		var f = this.filters[i];
 		if(theWebUI.maxFilterNo<f.no)
@@ -943,9 +943,9 @@ theWebUI.loadFilters = function( flt, additions )
 		if(f.enabled)
 			$("#_fe"+i).prop("checked",true);
 	}
-	for(var i=0; i<this.filters.length; i++)
+	for(i=0; i<this.filters.length; i++)
 	{
-		var f = this.filters[i];
+		f = this.filters[i];
 		if(f.no<0)
 		{
 			theWebUI.maxFilterNo++;

--- a/plugins/rssurlrewrite/init.js
+++ b/plugins/rssurlrewrite/init.js
@@ -118,7 +118,7 @@ theWebUI.loadRules = function( rle )
 	$('#RLS_rss').append("<option value=''>"+theUILang.allFeeds+"</option>");
 	for(var lbl in theWebUI.rssGroups)
 		$('#RLS_rss').append("<option value='"+lbl+"'>"+this.rssGroups[lbl].name+"</option>");
-	for(var lbl in theWebUI.rssLabels)
+	for(lbl in theWebUI.rssLabels)
 		$('#RLS_rss').append("<option value='"+lbl+"'>"+this.rssLabels[lbl].name+"</option>");
 	plugin.rules = rle;
 	plugin.maxRuleNo = 0;


### PR DESCRIPTION
Every finding is the same `var` re-declared within one function scope (mostly loop counters across sequential for-loops, plus a few temporaries). Since `var` is function-scoped and hoisted, each is the same single variable, so removing the redundant `var` keyword on the later declaration leaves behavior unchanged -- the assignment still runs against the existing binding.

Checked that no dropped declaration was the sole one for its variable (which would have made it an implicit global): e.g. stable.js's `l` is declared by an earlier loop in the same function, and a no-undef re-lint confirms nothing became undefined. The jest suite passes.