### PR TITLE
erasedata: record the delete list without httprpc (fix #3120)

### DIFF
--- a/plugins/erasedata/action.php
+++ b/plugins/erasedata/action.php
@@ -1,0 +1,38 @@
+<?php
+
+require_once( '../../php/xmlrpc.php' );
+require_once( 'removewithdata.php' );
+
+$hash = array();
+$vs = array();
+$mode = "";
+if (!isset($HTTP_RAW_POST_DATA))
+	$HTTP_RAW_POST_DATA = file_get_contents("php://input");
+if(isset($HTTP_RAW_POST_DATA))
+{
+	foreach(explode('&', $HTTP_RAW_POST_DATA) as $var)
+	{
+		$parts = explode("=", $var);
+		switch($parts[0])
+		{
+			case "hash": $hash[] = $parts[1]; break;
+			case "v":    $vs[]   = rawurldecode($parts[1]); break;
+			case "mode": $mode   = $parts[1]; break;
+		}
+	}
+}
+
+$result = null;
+if($mode == "removewithdata" && count($hash))
+{
+	$forceDelete = isset($vs[0]) ? $vs[0] : "1";
+	$result = erasedataRemoveWithData($hash, $forceDelete);
+}
+
+if(is_null($result))
+{
+	header("HTTP/1.0 500 Server Error");
+	CachedEcho::send("Link to XMLRPC failed. Maybe, rTorrent is down?", "text/html");
+}
+else
+	CachedEcho::send(JSON::safeEncode($result), "application/json");

--- a/plugins/erasedata/init.js
+++ b/plugins/erasedata/init.js
@@ -59,20 +59,18 @@ if(plugin.canChangeMenu())
 			this.vs[0] = (plugin.force_delete && plugin.enableForceDeletion ? "2" : "1");
 			this.getCommon("removewithdata");
 		} else {
-			if (plugin.debug) console.log("erasedata: using direct XMLRPC fallback");
+			if (plugin.debug) console.log("erasedata: routing through plugins/erasedata/action.php");
+			// No httprpc: POST to erasedata's own endpoint, which records the
+			// delete list and erases (same shared logic httprpc uses). Setting
+			// content without queuing commands makes the stub send it as-is,
+			// like httprpc's getCommon().
+			this.contentType = "application/x-www-form-urlencoded";
+			this.mountPoint = "plugins/erasedata/action.php";
+			this.dataType = "json";
+			this.content = "mode=removewithdata";
 			for( var i = 0; i < this.hashes.length; i++ )
-			{
-				var cmd = new rXMLRPCCommand( "d.set_custom5" );
-				cmd.addParameter( "string", this.hashes[i] );
-				cmd.addParameter( "string", (plugin.force_delete && plugin.enableForceDeletion ? "2" : "1") );
-				this.commands.push( cmd );
-				cmd = new rXMLRPCCommand( "d.delete_tied" );
-				cmd.addParameter( "string", this.hashes[i] );
-				this.commands.push( cmd );
-				cmd = new rXMLRPCCommand( "d.erase" );
-				cmd.addParameter( "string", this.hashes[i] );
-				this.commands.push( cmd );
-			}
+				this.content += "&hash=" + this.hashes[i];
+			this.content += "&v=" + (plugin.force_delete && plugin.enableForceDeletion ? "2" : "1");
 		}
 	}
 }

--- a/plugins/erasedata/removewithdata.php
+++ b/plugins/erasedata/removewithdata.php
@@ -1,0 +1,48 @@
+<?php
+
+// Shared "remove with data" logic used by both the httprpc RPC handler and the
+// direct (non-httprpc) endpoint plugins/erasedata/action.php. Records the list
+// of files to delete -- read over RPC, which works on every rtorrent version --
+// into the erasedata list directory for the garbage collector, then erases the
+// torrents. The caller must have already loaded php/xmlrpc.php.
+if(!function_exists('erasedataRemoveWithData'))
+{
+	function erasedataRemoveWithData($hashes, $forceDelete)
+	{
+		$listPath = FileUtil::getSettingsPath()."/erasedata";
+		@FileUtil::makeDirectory($listPath);
+		// rXMLRPCRequest flattens every returned value into ->val, so query one
+		// torrent per request to keep the layout unambiguous:
+		// val[0] = base path, val[1] = is_multi, val[2..] = each file path.
+		foreach($hashes as $h)
+		{
+			$info = new rXMLRPCRequest( array(
+				new rXMLRPCCommand( getCmd("d.get_base_path"), $h ),
+				new rXMLRPCCommand( getCmd("d.is_multi_file"), $h ),
+				new rXMLRPCCommand( getCmd("f.multicall"), array($h, "", getCmd("f.get_frozen_path")."=") )
+			) );
+			if($info->success() && count($info->val) >= 3)
+			{
+				$lines = array();
+				foreach(array_slice($info->val, 2) as $path)
+					if(strlen($path))
+						$lines[] = $path;
+				if(count($lines))
+				{
+					$lines[] = $info->val[0];
+					$lines[] = $info->val[1] ? "1" : "0";
+					$lines[] = $forceDelete;
+					@file_put_contents($listPath."/".$h.".list", implode("\n", $lines)."\n");
+				}
+			}
+		}
+		$req = new rXMLRPCRequest();
+		foreach($hashes as $h)
+		{
+			$req->addCommand( new rXMLRPCCommand( getCmd("d.set_custom5"), array($h, "") ) );
+			$req->addCommand( new rXMLRPCCommand( getCmd("d.delete_tied"), $h ) );
+			$req->addCommand( new rXMLRPCCommand( getCmd("d.erase"), $h ) );
+		}
+		return $req->success() ? $req->val : false;
+	}
+}

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -300,51 +300,24 @@ switch($mode)
 	case "removewithdata":	/**/
 	{
 		$forceDelete = isset($vs[0]) ? $vs[0] : "1";
-		// Record the files to delete before erasing the torrents. Older rtorrent
-		// captured this list from the erase event via file.append, but newer
-		// rtorrent does not register file.append unless method.use_deprecated is
-		// enabled at startup, so that event silently records nothing and the data
-		// is left on disk. Building the list here over RPC works on every rtorrent
-		// version. rXMLRPCRequest flattens every returned value into ->val, so
-		// query a single torrent per request to keep the layout unambiguous:
-		// val[0] = base path, val[1] = is_multi, val[2..] = each file path.
-		$listPath = FileUtil::getSettingsPath()."/erasedata";
-		@FileUtil::makeDirectory($listPath);
-		foreach($hash as $h)
+		// Delegate to the shared erasedata helper so the httprpc and direct
+		// (plugins/erasedata/action.php) paths record the identical delete list.
+		// removewithdata only originates from the erasedata plugin, so its helper
+		// is present; guard anyway and fall back to a plain erase if it is not.
+		$helper = dirname(__FILE__)."/../erasedata/removewithdata.php";
+		if(file_exists($helper))
 		{
-			$info = new rXMLRPCRequest( array(
-				new rXMLRPCCommand( getCmd("d.get_base_path"), $h ),
-				new rXMLRPCCommand( getCmd("d.is_multi_file"), $h ),
-				new rXMLRPCCommand( getCmd("f.multicall"), array($h, "", getCmd("f.get_frozen_path")."=") )
-			) );
-			if($info->success() && count($info->val) >= 3)
-			{
-				$lines = array();
-				foreach(array_slice($info->val, 2) as $path)
-					if(strlen($path))
-						$lines[] = $path;
-				if(count($lines))
-				{
-					$lines[] = $info->val[0];
-					$lines[] = $info->val[1] ? "1" : "0";
-					$lines[] = $forceDelete;
-					@file_put_contents($listPath."/".$h.".list", implode("\n", $lines)."\n");
-				}
-			}
+			require_once($helper);
+			$result = erasedataRemoveWithData($hash, $forceDelete);
 		}
-		// Clear the erase flag so the legacy file.append event stays inactive
-		// where it still exists (the list written above is authoritative), then
-		// drop the tied file and erase. The erasedata garbage collector removes
-		// the listed files on its next scheduled run.
-		$req = new rXMLRPCRequest();
-		foreach($hash as $h)
+		else
 		{
-			$req->addCommand( new rXMLRPCCommand( getCmd("d.set_custom5"), array($h, "") ) );
-			$req->addCommand( new rXMLRPCCommand( getCmd("d.delete_tied"), $h ) );
-			$req->addCommand( new rXMLRPCCommand( getCmd("d.erase"), $h ) );
+			$req = new rXMLRPCRequest();
+			foreach($hash as $h)
+				$req->addCommand( new rXMLRPCCommand( getCmd("d.erase"), $h ) );
+			if($req->success())
+				$result = $req->val;
 		}
-		if($req->success())
-			$result = $req->val;
 		break;
 	}
 	case "remove":	/**/


### PR DESCRIPTION
54165cb dropped the file.append erase event (broken on rtorrent without method.use_deprecated) and d95ae95 moved the replacement -- recording the delete-with-data file list over RPC -- into httprpc/action.php only. So with httprpc not installed, removewithdata erased the torrent but never wrote the list file, and erasedata's garbage collector deleted nothing: the data was silently left on disk.

Extract that logic into a shared helper (plugins/erasedata/removewithdata.php) and add plugins/erasedata/action.php as a direct endpoint. The erasedata fallback now posts to that endpoint (mirroring httprpc's getCommon: set content, queue no commands, so the stub sends it as-is) instead of firing bare erase commands, and httprpc's removewithdata case delegates to the same helper -- so both transports record an identical list by construction.

Works on every rtorrent version: verified the list build on 0.16.17, and the commands are the same getCmd() calls httprpc already uses on 0.9.8.