### PR TITLE
content.js: mirror methods-0.16.18.php for the 0.16.18 port renames

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -918,6 +918,25 @@ function correctContent()
 			"network.max_open_sockets": { name: "system.sockets.max_size",               prm: 0 },
 		});
 	}
+	if(theWebUI.systemInfo.rTorrent.iVersion>=0x1012)
+	{
+		// rtorrent >= 0.16.18: the listening-port commands were renamed
+		// (network.port_range/.random -> network.listen.port.range/.random) and
+		// network.port_open was removed. On a normal launch (no -D) the old names
+		// are absent and fault; mirror php/methods-0.16.18.php so any client-side
+		// XMLRPC keeps working. network.port_open has no replacement -> route it
+		// to the harmless "cat" no-op.
+		$.extend(theRequestManager.aliases,
+		{
+			"get_port_range"  : { name: "network.listen.port.range",      prm: 0 },
+			"set_port_range"  : { name: "network.listen.port.range.set",  prm: 1 },
+			"get_port_random" : { name: "network.listen.port.random",     prm: 0 },
+			"set_port_random" : { name: "network.listen.port.random.set", prm: 1 },
+			"get_port_open"   : { name: "cat", prm: 0 },
+			"set_port_open"   : { name: "cat", prm: 1 },
+			"port_open"       : { name: "cat", prm: 0 },
+		});
+	}
 	if(theWebUI.systemInfo.rTorrent.iVersion < 0x907) {
 		const title = theUILang.requiresAtLeastRtorrent.replace('{version}', 'v0.9.7');
 		$($$('webui.show_open_status')).attr({ disabled: '', title });


### PR DESCRIPTION
Add the iVersion >= 0x1012 override block to theRequestManager.aliases, the JS counterpart of php/methods-0.16.18.php. Any code path that builds an XMLRPC command client-side resolves names through this map, so it needs the same 0.16.18 remaps the PHP side already got: network.port_range/.random -> network.listen.port.range/.random, and the removed network.port_open -> the "cat" no-op.

Follows the existing methods-0.16.0.php / methods-0.16.16.php <-> the content.js 0x1000 / 0x1010 alias-block pairing.