### PR TITLE
content.js: hide the vestigial port_open checkbox on rtorrent 0.16.x

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -455,6 +455,16 @@ function correctContent()
 		rPlugin.prototype.removePageFromOptions("st_dl");
 	if(!(theWebUI.showFlags & showEnum.showConnectionPage))
 		rPlugin.prototype.removePageFromOptions("st_con");
+	// rtorrent 0.16.x: network.port_open is an unused no-op (nothing in rtorrent
+	// reads it; an explicit deprecated no-op since 0.16.18). Drop its checkbox
+	// from the Connection page, and add an empty grid cell after the "randomize"
+	// checkbox so the two-column layout stays even and the port-range label + its
+	// field remain paired on one row. rtorrent <= 0.9.x keeps the checkbox.
+	if(theWebUI.systemInfo.rTorrent.iVersion>=0x1000)
+	{
+		$("#port_open").closest(".col-md-6").remove();
+		$("#port_random").closest(".col-md-6").after($("<div>").addClass("col-md-6"));
+	}
 	if(!(theWebUI.showFlags & showEnum.showBittorentPage))
 		rPlugin.prototype.removePageFromOptions("st_bt");
 	if(!(theWebUI.showFlags & showEnum.showAdvancedPage))


### PR DESCRIPTION
network.port_open is an unused no-op on the 0.16 line (nothing in rtorrent reads it; it became an explicit deprecated no-op in 0.16.18), so the "Enable incoming port" checkbox on the Connection settings page does nothing. Remove it on rtorrent >= 0.16.0, and add an empty grid cell after the "randomize port" checkbox so the two-column layout stays even and the port-range label keeps its input field on the same row. rtorrent <= 0.9.x keeps the checkbox.