### PR TITLE
check_port: add "Force specific port" (network.listen.port.set)

### DIFF
--- a/plugins/check_port/action.php
+++ b/plugins/check_port/action.php
@@ -166,6 +166,20 @@ function get_and_check_ip($ip_version, $use_website, $rtorrent_ip, $rtorrent_por
 $port = rTorrentSettings::get()->port;
 $ip_glob = rTorrentSettings::get()->ip;
 
+// Optional: force a specific listening port before checking it. rtorrent
+// >= 0.16.18 exposes network.listen.port.set, which changes the live listening
+// port with no restart. Requires a trusted connection (the default here). The
+// port check below then runs against the new port so the user can immediately
+// confirm reachability.
+if (isset($_REQUEST['setport'])) {
+	$newport = (int)$_REQUEST['setport'];
+	if ($newport >= 1 && $newport <= 65535) {
+		$sreq = new rXMLRPCRequest(new rXMLRPCCommand("network.listen.port.set", array("", $newport)));
+		if ($sreq->success())
+			$port = $newport;
+	}
+}
+
 // Initialize the response structure that will be sent to the client
 $response = [
 	"ipv4" => "-", "ipv4_port" => (int)$port, "ipv4_status" => -1,

--- a/plugins/check_port/init.js
+++ b/plugins/check_port/init.js
@@ -64,6 +64,7 @@ function updateProtocolStatus(data, proto, getStatusText) {
 }
 
 plugin.getPortStatus = function(d) {
+	plugin.currentPort = d.ipv4_port || d.ipv6_port || plugin.currentPort;
 	const getStatusText = function(statusCode) {
 		return theUILang.portStatus[statusCode] || theUILang.portStatus[0] || "Unknown";
 	};
@@ -100,10 +101,35 @@ rTorrentStub.prototype.updateportcheck = function() {
 	this.dataType = "json";
 };
 
+plugin.forcePort = function() {
+	const cur = plugin.currentPort || "";
+	const v = prompt(theUILang.forcePortPrompt || "Set the listening port (1-65535):", cur);
+	if (v === null)
+		return;
+	const port = parseInt(v, 10);
+	if (!(port >= 1 && port <= 65535)) {
+		alert(theUILang.forcePortInvalid || "Invalid port number.");
+		return;
+	}
+	plugin.pendingPort = port;
+	plugin.resetStatus(true);
+	theWebUI.request("?action=forceport", [plugin.getPortStatus, plugin]);
+};
+
+rTorrentStub.prototype.forceport = function() {
+	this.contentType = "application/x-www-form-urlencoded";
+	this.mountPoint = "plugins/check_port/action.php?setport=" + encodeURIComponent(plugin.pendingPort);
+	this.dataType = "json";
+};
+
 plugin.createPortMenu = function(e) {
 	if (e.which === 3) {
 		theContextMenu.clear();
 		theContextMenu.add([(theUILang.checkPort || "Refresh Port Status"), plugin.update]);
+		// rtorrent >= 0.16.18 (iVersion 0x1012) added network.listen.port.set,
+		// which changes the live listening port with no restart.
+		if (theWebUI.systemInfo && theWebUI.systemInfo.rTorrent.iVersion >= 0x1012)
+			theContextMenu.add([(theUILang.forcePort || "Force specific port..."), plugin.forcePort]);
 		theContextMenu.show();
 	}
 	return false;

--- a/plugins/check_port/lang/cs.js
+++ b/plugins/check_port/lang/cs.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Vynutit konkrétní port...";
+ theUILang.forcePortPrompt	= "Nastavte naslouchací port (1-65535):";
+ theUILang.forcePortInvalid	= "Neplatné číslo portu.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/da.js
+++ b/plugins/check_port/lang/da.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Gennemtving bestemt port...";
+ theUILang.forcePortPrompt	= "Angiv lytteporten (1-65535):";
+ theUILang.forcePortInvalid	= "Ugyldigt portnummer.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/de.js
+++ b/plugins/check_port/lang/de.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Bestimmten Port erzwingen...";
+ theUILang.forcePortPrompt	= "Lausch-Port festlegen (1-65535):";
+ theUILang.forcePortInvalid	= "Ungültige Portnummer.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/el.js
+++ b/plugins/check_port/lang/el.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Επιβολή συγκεκριμένης θύρας...";
+ theUILang.forcePortPrompt	= "Ορισμός θύρας ακρόασης (1-65535):";
+ theUILang.forcePortInvalid	= "Μη έγκυρος αριθμός θύρας.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/en.js
+++ b/plugins/check_port/lang/en.js
@@ -17,4 +17,8 @@
  theUILang.notAvailable = "-";
  theUILang.portNotConfigured = "Not available on this server";
 
+ theUILang.forcePort		= "Force specific port...";
+ theUILang.forcePortPrompt	= "Set the listening port (1-65535):";
+ theUILang.forcePortInvalid	= "Invalid port number.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/es.js
+++ b/plugins/check_port/lang/es.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Forzar puerto específico...";
+ theUILang.forcePortPrompt	= "Establecer el puerto de escucha (1-65535):";
+ theUILang.forcePortInvalid	= "Número de puerto no válido.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/fi.js
+++ b/plugins/check_port/lang/fi.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Pakota tietty portti...";
+ theUILang.forcePortPrompt	= "Aseta kuunteluportti (1-65535):";
+ theUILang.forcePortInvalid	= "Virheellinen portin numero.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/fr.js
+++ b/plugins/check_port/lang/fr.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Forcer un port spécifique...";
+ theUILang.forcePortPrompt	= "Définir le port d'écoute (1-65535) :";
+ theUILang.forcePortInvalid	= "Numéro de port invalide.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/hu.js
+++ b/plugins/check_port/lang/hu.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Adott port kényszerítése...";
+ theUILang.forcePortPrompt	= "Figyelő port beállítása (1-65535):";
+ theUILang.forcePortInvalid	= "Érvénytelen portszám.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/it.js
+++ b/plugins/check_port/lang/it.js
@@ -17,4 +17,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Forza una porta specifica...";
+ theUILang.forcePortPrompt	= "Imposta la porta di ascolto (1-65535):";
+ theUILang.forcePortInvalid	= "Numero di porta non valido.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/ko.js
+++ b/plugins/check_port/lang/ko.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "특정 포트 강제 지정...";
+ theUILang.forcePortPrompt	= "수신 포트 설정 (1-65535):";
+ theUILang.forcePortInvalid	= "잘못된 포트 번호입니다.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/lv.js
+++ b/plugins/check_port/lang/lv.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Piespiest noteiktu portu...";
+ theUILang.forcePortPrompt	= "Iestatīt klausīšanās portu (1-65535):";
+ theUILang.forcePortInvalid	= "Nederīgs porta numurs.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/nl.js
+++ b/plugins/check_port/lang/nl.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Specifieke poort forceren...";
+ theUILang.forcePortPrompt	= "Luisterpoort instellen (1-65535):";
+ theUILang.forcePortInvalid	= "Ongeldig poortnummer.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/no.js
+++ b/plugins/check_port/lang/no.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Tving bestemt port...";
+ theUILang.forcePortPrompt	= "Angi lytteporten (1-65535):";
+ theUILang.forcePortInvalid	= "Ugyldig portnummer.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pl.js
+++ b/plugins/check_port/lang/pl.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Wymuś określony port...";
+ theUILang.forcePortPrompt	= "Ustaw port nasłuchiwania (1-65535):";
+ theUILang.forcePortInvalid	= "Nieprawidłowy numer portu.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pt-br.js
+++ b/plugins/check_port/lang/pt-br.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Forçar porta específica...";
+ theUILang.forcePortPrompt	= "Definir a porta de escuta (1-65535):";
+ theUILang.forcePortInvalid	= "Número de porta inválido.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/pt-pt.js
+++ b/plugins/check_port/lang/pt-pt.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Forçar porta específica...";
+ theUILang.forcePortPrompt	= "Definir a porta de escuta (1-65535):";
+ theUILang.forcePortInvalid	= "Número de porta inválido.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/ru.js
+++ b/plugins/check_port/lang/ru.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Задать конкретный порт...";
+ theUILang.forcePortPrompt	= "Укажите порт прослушивания (1-65535):";
+ theUILang.forcePortInvalid	= "Недопустимый номер порта.";
+
 thePlugins.get("check_port").langLoaded();

--- a/plugins/check_port/lang/sk.js
+++ b/plugins/check_port/lang/sk.js
@@ -16,4 +16,8 @@
  				  ];
  theUILang.notAvailable = "-";
 
+ theUILang.forcePort		= "Vynútiť konkrétny port...";
+ theUILang.forcePortPrompt	= "Nastavte počúvací port (1-65535):";
+ theUILang.forcePortInvalid	= "Neplatné číslo portu.";
+
 thePlugins.get("check_port").langLoaded();


### PR DESCRIPTION
rtorrent 0.16.18 added network.listen.port.set, which changes the live listening port with no restart. Expose it from the check_port plugin so users (e.g. behind a VPN offering port forwarding) can set the incoming port from the UI and immediately confirm whether it is reachable.

- action.php: when a `setport` parameter is given, validate it (1-65535) and call network.listen.port.set over the trusted connection, then run the existing port check against the new port.
- init.js: add a "Force specific port" item to the status-bar context menu, shown only on rtorrent >= 0.16.18 (iVersion >= 0x1012); it prompts for a port and refreshes the status.
- lang: add forcePort / forcePortPrompt / forcePortInvalid to every shipped language file.

Closes #3095.