### PR TITLE
httprpc: restore d.state on unpause so torrents leave the paused state

### DIFF
--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -294,7 +294,11 @@ switch($mode)
 	}
 	case "unpause":	/**/
 	{
-		$result = makeSimpleCall(array("d.resume"), $hash);
+		// d.start (not just d.resume) so d.state is restored: d.resume alone
+		// leaves the torrent flagged paused in the UI forever and marked
+		// user-stopped for the next rtorrent restart (the direct XML-RPC
+		// mount's unpause stub sends d.start as well)
+		$result = makeSimpleCall(array("d.start"), $hash);
 		break;
 	}
 	case "removewithdata":	/**/


### PR DESCRIPTION
## Summary

The httprpc `unpause` action sends only `d.resume`, which restarts data transfer but leaves `d.state=0` from pause's `d.stop`. Since ruTorrent flags any open torrent with `d.state=0` as paused (`js/rtorrent.js`), an unpaused torrent:

* stays displayed as "Pausing" indefinitely while data actually flows, and
* is treated as user-stopped by rtorrent on its next restart (it won't auto-start).

This PR makes `unpause` send `d.start` instead, matching what the direct XML-RPC mount already does (`rTorrentStub.prototype.unpause` in `js/rtorrent.js` sends `d.start`), so the two transports agree.

## Repro

On a stock install using httprpc: click the toolbar Pause button twice on a downloading torrent. Transfers resume, but the status stays "Pausing" until the torrent is started and paused again.

## Test plan

* Pause a downloading torrent (status: Pausing, transfer stops)
* Pause it again (= unpause): transfer resumes **and** status returns to Downloading
* Restart rtorrent after an unpause: the torrent starts again as expected

Made with [Cursor](https://cursor.com)