### PR TITLE
Update vendored JShrink to v1.8.1 (fixes regex character-class minification)

### DIFF
--- a/php/getplugins.php
+++ b/php/getplugins.php
@@ -558,7 +558,7 @@ $cacheResults=(isset($cachedPluginLoading) && $cachedPluginLoading);
 global $pluginMinification;
 if (isset($pluginMinification) && $pluginMinification)
 {
-	$jResult = Minifier::minify($jResult);
+	$jResult = \JShrink\Minifier::minify($jResult);
 }
 
 CachedEcho::send($jResult,"application/javascript",$cacheResults);

--- a/php/utility/minifier.php
+++ b/php/utility/minifier.php
@@ -1,36 +1,4 @@
 <?php
-
-/*BSD 3-Clause License
-
-Copyright (c) 2009, Robert Hafner
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
-
-
 /*
  * This file is part of the JShrink package.
  *
@@ -48,6 +16,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.*/
  * @author     Robert Hafner <tedivm@tedivm.com>
  */
 
+namespace JShrink;
 
 /**
  * Minifier
@@ -659,10 +628,24 @@ class Minifier
         }
 
         $this->echo($this->b);
+        // Flag to make sure that we don't end the regex too early because of
+        // unescaped forward slashes inside a character class. e.g /[/]/
+        // In non-v-mode, The only characters that cannot appear literally are \, ], and -
+        // In v-mode more characters are reserved and forbidden from appearing literally
+        // including but not limited to [ ] \ /
+        $character_class = false;
+        $character_class_index = null;
 
         while (($this->a = $this->getChar()) !== false) {
-            if ($this->a === '/') {
+            if ($this->a === '/' && !$character_class) {
                 break;
+            }
+
+            if ($this->a === '[') {
+                $character_class = true;
+                $character_class_index = $this->index;
+            } elseif ($this->a === ']') {
+                $character_class = false;
             }
 
             if ($this->a === '\\') {
@@ -671,6 +654,9 @@ class Minifier
             }
 
             if ($this->a === "\n") {
+                if ($character_class) {
+                    throw new \RuntimeException('Unclosed character class at position: ' . $character_class_index);
+                }
                 throw new \RuntimeException('Unclosed regex pattern at position: ' . $this->index);
             }
 

--- a/tests/php/MinifierTest.php
+++ b/tests/php/MinifierTest.php
@@ -1,0 +1,69 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/utility/minifier.php');
+
+// Regression tests for JShrink regex minification.
+//
+// A '/' that appears inside a regex character class ([...]) is a literal
+// slash, not the end of the regex literal. Older JShrink treated the first
+// unescaped '/' as the terminator, so a pattern like /[^/]/ was cut mid-regex
+// and everything after it was mangled -- producing an "unterminated regular
+// expression literal" SyntaxError in the browser. Because getplugins.php
+// minifies the whole concatenated plugin bundle in one pass, a single such
+// regex in any plugin took the entire UI down (empty torrent list).
+//
+// v1.8.1 tracks the character class and only ends the regex on a '/' that is
+// outside a class. These tests lock that behaviour in.
+class MinifierTest extends TestCase
+{
+	private function minify($js)
+	{
+		return \JShrink\Minifier::minify($js);
+	}
+
+	public function testClassInternalSlashIsNotTheRegexTerminator()
+	{
+		$min = $this->minify("var m = String(x).match(/a\\/([^/]+)\\//);\nvar SENTINEL = 1;");
+		$this->assertTrue(strpos($min, 'SENTINEL') !== false,
+			'code after a class-internal-slash regex must survive minification (no truncation)');
+		$this->assertTrue(strpos($min, '([^/]+)') !== false,
+			'the character class must be preserved intact');
+	}
+
+	public function testAutodlThemesRegex()
+	{
+		// The exact regex that broke plugin loading in production.
+		$min = $this->minify("var p = theme.path.match(/themes\\/([^/]+)\\//);\nvar AFTER = 2;");
+		$this->assertTrue(strpos($min, 'AFTER') !== false,
+			'the themes regex must not truncate the following code');
+		$this->assertTrue(strpos($min, 'themes\\/([^/]+)\\/') !== false,
+			'the themes regex literal must be preserved');
+	}
+
+	public function testUriParserCharacterClasses()
+	{
+		// Announce-URL parser used by several plugins: multiple '/'-in-class.
+		$min = $this->minify("var u = s.match(/^(?:([^:/?#]+):)?([^?#/]*)/);\nvar TAIL = 3;");
+		$this->assertTrue(strpos($min, 'TAIL') !== false,
+			'the URI-parser regex must not truncate the following code');
+		$this->assertTrue(strpos($min, '[^:/?#]') !== false,
+			'the URI character class must be preserved');
+	}
+
+	public function testPlainRegexStillMinifies()
+	{
+		// Regression guard: an ordinary regex (no character class) is unaffected.
+		$min = $this->minify("var r = x.replace(/foo\\/bar/g, '');\nvar Z = 4;");
+		$this->assertTrue(strpos($min, 'Z') !== false && strpos($min, 'foo\\/bar') !== false,
+			'a plain regex still minifies and the following code survives');
+	}
+
+	public function testDivisionIsNotMistakenForRegex()
+	{
+		// Regression guard: '/' used as division must not begin a regex parse.
+		$min = $this->minify("var q = (a + b) / c / d;\nvar W = 5;");
+		$this->assertTrue(strpos($min, 'W') !== false,
+			'division operators must not be parsed as a regex literal');
+	}
+}


### PR DESCRIPTION


The bundled JShrink minifier's saveRegex() treated the first unescaped '/' as the end of a regex literal, but a '/' inside a character class ([...]) is a literal slash. So a pattern like /[^/]/ was cut mid-regex and the rest of the file mangled, producing an "unterminated regular expression literal" SyntaxError in the browser.

getplugins.php minifies the entire concatenated plugin bundle in a single pass, so one such regex in any plugin breaks the whole minified bundle and leaves the UI unable to load (empty torrent list). Several bundled plugins use class-internal slashes, e.g. /themes\/([^/]+)\// and the [^:/?#] announce-URL parser.

JShrink v1.8.1 tracks the character class and only ends the regex on a '/' outside a class. It is namespaced (JShrink\Minifier), so getplugins.php now references \JShrink\Minifier::minify(); the class autoloader already strips namespaces, so nothing else needs to change.

Adds tests/php/MinifierTest.php locking in the character-class behaviour and guarding plain regexes and division operators from being mis-parsed.