### PR TITLE
CI: run the PHP test suite (and make it gate)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,18 @@ on:
   pull_request:
 
 jobs:
+  php:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: posix, dom, xml, mbstring, iconv, json, curl
+      - name: PHP test suite
+        run: bash php-test.sh
+        working-directory: tests
+
   jest:
     runs-on: ubuntu-latest
     steps:

--- a/tests/php-test.sh
+++ b/tests/php-test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 TEST_RUN='
 foreach(get_declared_classes() as $cls) {
@@ -17,9 +16,20 @@ foreach(get_declared_classes() as $cls) {
 	}
 }'
 
+# Exit non-zero if any test file fails, so the suite can gate CI. Two failure
+# signals are honoured: a non-zero exit (the self-running TestLib suites end
+# with exit($failures)) and failure output (the TestCase runner only prints).
+status=0
 for t in $(find php plugins -type f -name '*Test.php')
 do
 	echo '> php' $t
 	DIR=$(dirname "$t")
-	php -c php-test.ini -f <(cat <(sed "s@__DIR__@\"$DIR\"@g" "$t") <(echo "$TEST_RUN"))
+	out=$(php -c php-test.ini -f <(cat <(sed "s@__DIR__@\"$DIR\"@g" "$t") <(echo "$TEST_RUN")) 2>&1)
+	code=$?
+	printf '%s\n' "$out"
+	if [ "$code" -ne 0 ] || printf '%s\n' "$out" | grep -qE '^Failed:|^not ok|failed with error|PHP (Fatal|Parse) error|Uncaught'; then
+		status=1
+	fi
 done
+
+exit $status

--- a/tests/php/PermissionTest.php
+++ b/tests/php/PermissionTest.php
@@ -73,8 +73,14 @@ class PermissionTest extends TestCase
 
 	public function testPermission()
 	{
-		$this->assertTrue(Permission::doesUserHave(1000, [1000], $this->getDir('dir1'), 0x0007), 'User has permission for directory');
-		$this->assertTrue(Permission::doesUserHave(1000, [1000], $this->getDir('dir3'), 0x0007), 'User has permission for symlinked directory');
-		$this->assertTrue(Permission::doesUserHave(1000, [1000], $this->getDir('dir4'), 0x0007), 'User has permission for relative symlinked directory');
+		// doesUserHave() answers "would this uid/gids have rwx on the file" from
+		// the file's stat. Probe with the running process's own uid/gids -- it
+		// owns the fixtures -- rather than a hardcoded 1000, so the test does not
+		// depend on which uid runs it.
+		$uid = posix_getuid();
+		$gids = array_merge([posix_getgid()], posix_getgroups());
+		$this->assertTrue(Permission::doesUserHave($uid, $gids, $this->getDir('dir1'), 0x0007), 'User has permission for directory');
+		$this->assertTrue(Permission::doesUserHave($uid, $gids, $this->getDir('dir3'), 0x0007), 'User has permission for symlinked directory');
+		$this->assertTrue(Permission::doesUserHave($uid, $gids, $this->getDir('dir4'), 0x0007), 'User has permission for relative symlinked directory');
 	}
 }


### PR DESCRIPTION
The PHP tests under tests/ were never executed in CI -- only the Jest (JS) suite ran. Wire the PHP suite in and make it fail the build on failures:

- tests.yml: add a `php` job (setup-php 8.1) that runs tests/php-test.sh.
- php-test.sh: exit non-zero when any test file reports a failure. Two signals are honoured -- a non-zero process exit (the TestLib self-running suites end with exit($failures)) and failure output (the TestCase runner only prints Passed/Failed). Previously the script never gated, so failures were invisible to CI.
- PermissionTest::testPermission hardcoded uid 1000, so it only passed when the tests happened to run as uid 1000 -- never true in CI (uid 1001) or on most machines. Probe with the running process's own uid/gids instead.