### PR TITLE
Bump version to 5.3.10 and update cache-bust params

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,27 +21,27 @@
 		<meta name="msapplication-TileColor" content="#FFFFFF" />
 		<meta name="msapplication-TileImage" content="./images/mstile-144x144.png" />
 
-		<link href="./css/bootstrap.min.css?v=539" rel="stylesheet" type="text/css" />
-		<link href="./css/style.css?v=539" rel="stylesheet" type="text/css" />
-		<link href="./css/stable.css?v=539" rel="stylesheet" type="text/css" />
-		<link rel="preload" as="style" href="./css/category-panel.css?v=539" />
-		<link rel="preload" as="style" href="./css/panel-label.css?v=539" />
-		<script type="text/javascript" src="./js/jquery.js?v=539"></script>
-		<script type="text/javascript" src="./js/jquery.flot.js?v=539"></script>
-		<script type="text/javascript" src="./js/sanitize.js?v=539"></script>
-		<script type="text/javascript" src="./js/sanitize.config.js?v=539"></script>
-		<script type="text/javascript" src="./js/custom-elements.js?v=539"></script>
-		<script type="text/javascript" src="./lang/langs.js?v=539"></script>
-		<link rel="preload" as="script" href="./js/browser.js?v=539" />
-		<link rel="preload" as="script" href="./js/common.js?v=539" />
-		<link rel="preload" as="script" href="./js/objects.js?v=539" />
-		<link rel="preload" as="script" href="./js/options.js?v=539" />
-		<link rel="preload" as="script" href="./js/content.js?v=539" />
-		<link rel="preload" as="script" href="./js/stable.js?v=539" />
-		<link rel="preload" as="script" href="./js/graph.js?v=539" />
-		<link rel="preload" as="script" href="./js/plugins.js?v=539" />
-		<link rel="preload" as="script" href="./js/rtorrent.js?v=539" />
-		<link rel="preload" as="script" href="./js/webui.js?v=539" />
+		<link href="./css/bootstrap.min.css?v=5310" rel="stylesheet" type="text/css" />
+		<link href="./css/style.css?v=5310" rel="stylesheet" type="text/css" />
+		<link href="./css/stable.css?v=5310" rel="stylesheet" type="text/css" />
+		<link rel="preload" as="style" href="./css/category-panel.css?v=5310" />
+		<link rel="preload" as="style" href="./css/panel-label.css?v=5310" />
+		<script type="text/javascript" src="./js/jquery.js?v=5310"></script>
+		<script type="text/javascript" src="./js/jquery.flot.js?v=5310"></script>
+		<script type="text/javascript" src="./js/sanitize.js?v=5310"></script>
+		<script type="text/javascript" src="./js/sanitize.config.js?v=5310"></script>
+		<script type="text/javascript" src="./js/custom-elements.js?v=5310"></script>
+		<script type="text/javascript" src="./lang/langs.js?v=5310"></script>
+		<link rel="preload" as="script" href="./js/browser.js?v=5310" />
+		<link rel="preload" as="script" href="./js/common.js?v=5310" />
+		<link rel="preload" as="script" href="./js/objects.js?v=5310" />
+		<link rel="preload" as="script" href="./js/options.js?v=5310" />
+		<link rel="preload" as="script" href="./js/content.js?v=5310" />
+		<link rel="preload" as="script" href="./js/stable.js?v=5310" />
+		<link rel="preload" as="script" href="./js/graph.js?v=5310" />
+		<link rel="preload" as="script" href="./js/plugins.js?v=5310" />
+		<link rel="preload" as="script" href="./js/rtorrent.js?v=5310" />
+		<link rel="preload" as="script" href="./js/webui.js?v=5310" />
 
 		<script>
 			loadUILang(() => {
@@ -57,10 +57,10 @@
 			});
 		</script>
 
-		<script type="module" src="./js/backgroundtask.js?v=539"></script>
-		<script type="module" src="./js/category-list.js?v=539"></script>
-		<script type="module" src="./js/panel.js?v=539"></script>
-		<script type="text/javascript" src="./js/category-list-elements.js?v=539" defer></script>
+		<script type="module" src="./js/backgroundtask.js?v=5310"></script>
+		<script type="module" src="./js/category-list.js?v=5310"></script>
+		<script type="module" src="./js/panel.js?v=5310"></script>
+		<script type="text/javascript" src="./js/category-list-elements.js?v=5310" defer></script>
 	</head>
 	<body>
 		<div id="preload" class="d-none"></div>
@@ -139,7 +139,7 @@
 				</div>
 				<div class="p-1 p-md-0 offcanvas-body">
 					<template id="panel-label-template">
-						<link href="./css/panel-label.css?v=539" rel="stylesheet" type="text/css" />
+						<link href="./css/panel-label.css?v=5310" rel="stylesheet" type="text/css" />
 						<div part="prefix" hidden></div>
 						<div part="icon"></div>
 						<div part="text"></div>
@@ -148,7 +148,7 @@
 						<div part="size" style="display: none;"></div>
 					</template>
 					<template id="category-panel-template">
-						<link href="./css/category-panel.css?v=539" rel="stylesheet" type="text/css" />
+						<link href="./css/category-panel.css?v=5310" rel="stylesheet" type="text/css" />
 						<div part="heading">
 							<span class="text"></span><slot name="decorator" class="decorator"></slot>
 						</div>
@@ -304,6 +304,6 @@
 		<div class="graph_tab_legend"></div>
 		<div id="dialog-container"></div>
 		<div id="dir-container"></div>
-		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=539"></script>
+		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=5310"></script>
 	</body>
 </html>

--- a/js/webui.js
+++ b/js/webui.js
@@ -4,7 +4,7 @@
  */
 
 var theWebUI = {
-	version: "5.3.9",
+	version: "5.3.10",
 	tables: {
 		trt: {
 			obj: new dxSTable(),

--- a/lang/langs.js
+++ b/lang/langs.js
@@ -110,7 +110,7 @@ function loadUILang(onLoadFunc)
 			translateDOM();
 		}
 	};
-	langScript.src = `./lang/${lang}.js?v=539`;
+	langScript.src = `./lang/${lang}.js?v=5310`;
 	document.head.appendChild(langScript);
 }
 


### PR DESCRIPTION
New
  - Mobile plugin — a mobile-optimized web UI, bundled and auto-activated on mobile devices (or ?mobile=1): torrent list with live quick-search, status/label/tracker filters, add/start/stop/delete, per-torrent details (files/trackers/peers), save-path browser, and settings. (#3128, @xombiemp)

Improvements
  - rutracker_check — smarter update detection for RuTracker and NNMClub (absorbed/merged topics, NNMClub passkey handling, guest-download fallback) and safer torrent replacement with rollback. (#3048, @IvanShift)

Fixes
  - httprpc — unpause now sends d.start, so an unpaused torrent leaves the paused state instead of staying "Pausing" (and isn't treated as user-stopped on the next rtorrent restart). (#3129, @xombiemp)
  - Minifier — updated the vendored JShrink to v1.8.1, fixing a regex character-class bug (/[^/]/) that truncated the minified plugin bundle and could break the UI. (#3130, @xirvik)

Internal
  - CI now runs the PHP test suite and gates on failures. (#3131, @xirvik)