### PR TITLE
mobile: log swallowed request failures to the console

### DIFF
--- a/plugins/mobile/init.js
+++ b/plugins/mobile/init.js
@@ -181,7 +181,27 @@ plugin.backListener = function() {
 };
 
 plugin.request = function(url, func) {
-  theWebUI.requestWithTimeout(url, function(d){if (func != undefined) func(d);}, function(){}, function(){});
+  theWebUI.requestWithTimeout(url,
+    function(d) {
+      if (func == undefined) {
+        return;
+      }
+      try {
+        func(d);
+      } catch (e) {
+        // Log which request's handler blew up, without user-facing
+        // noise; silent failures here have hidden real bugs
+        console.error('mobile: handler for ' + url + ' failed:', e);
+      }
+    },
+    function() {
+      // Failures are swallowed by design — the next poll retries — but
+      // leave a trace in the console
+      console.warn('mobile: request timed out: ' + url);
+    },
+    function(status, text) {
+      console.warn('mobile: request failed: ' + url + ' (' + status + (text ? ': ' + text : '') + ')');
+    });
 };
 
 plugin.setHash = function(page) {

--- a/plugins/mobile/init.js
+++ b/plugins/mobile/init.js
@@ -1968,9 +1968,11 @@ plugin.processTorrents = function(torrents, singleUpdate) {
 };
 
 plugin.update = function(singleUpdate) {
-  theWebUI.requestWithTimeout("?list=1&getmsg=1", function(data) {
+  // Through plugin.request, so a throwing processTorrents leaves a
+  // console breadcrumb instead of silently blanking the list
+  plugin.request('?list=1&getmsg=1', function(data) {
     plugin.processTorrents(data.torrents, singleUpdate);
-  }, function() {}, function() {});
+  });
 };
 
 /*** Bootstrapping: device detection, plugin takeover and initialization ***/
@@ -2122,7 +2124,13 @@ plugin.init = function() {
       theWebUI.addTorrents = function(listData) {
         plugin.desktopAddTorrents.call(this, listData);
         if (listData && listData.torrents) {
-          plugin.processTorrents(listData.torrents);
+          // Not a plugin.request path, so it needs its own guard for
+          // the same console breadcrumb (see plugin.request)
+          try {
+            plugin.processTorrents(listData.torrents);
+          } catch (e) {
+            console.error('mobile: processTorrents (addTorrents hook) failed:', e);
+          }
         }
       };
 


### PR DESCRIPTION
## Summary

`plugin.request` drops timeouts and errors by design (the next poll retries), and an exception thrown inside a response handler died invisibly in the ajax machinery. Each of the recent blank-torrent-list bugs was hidden by exactly this silence: the disabled-backend 500s from the #3128 review, the label-panel TypeError (#3133), and the direct-mount tracker fetch (#3134) all produced a blank list with nothing to go on.

This logs all three cases to the console, tagged with the request that owned them:

* `mobile: handler for <url> failed: <error>` (handler exceptions, with stack)
* `mobile: request timed out: <url>`
* `mobile: request failed: <url> (<status>: <text>)`

Console-only diagnostic breadcrumbs — no notifications, no behavior change (failed requests are still retried by the next poll cycle).

## Test plan

* Normal use: console stays quiet
* Point a request at a bogus action or stop the backend: each poll logs a warning naming the failing request
* Throw inside a response handler: logged with stack, poll loop keeps running

Made with [Cursor](https://cursor.com)