### PR TITLE
mobile: add a theme setting: light, dark, or follow the system

### DIFF
--- a/plugins/mobile/README.md
+++ b/plugins/mobile/README.md
@@ -19,7 +19,7 @@ These plugins add additional functionality when installed:
 * tracklabels: Shows label icons and tracker favicons on the filter page.
 
 ### Configuration
-There are three configurable boolean options and two multi-value options that you may set at the top of init.js.
+There are three configurable boolean options and three multi-value options that you may set at the top of init.js.
 #### plugin.enableAutodetect
 true by default. This option sets whether mobile devices will be autodetected to enable the plugin.
 
@@ -35,8 +35,12 @@ If in rutorrent you turned off 'Confirm when deleting torrents', this plugin wil
 This option sets the default sort value of the torrent list. Without negative it's ascending, with negative it's descending.
 
 #### plugin.accentColor
-'primary' by default. Possible values: 'primary' (blue), 'secondary' (gray), 'success' (green), 'danger' (red), 'warning' (yellow), 'info' (cyan), 'dark' (near-black).
+'primary' by default. Possible values: 'primary' (blue), 'secondary' (gray), 'success' (green), 'danger' (red), 'warning' (yellow), 'info' (cyan), 'dark' (contrast: near-black on the light theme, near-white on dark).
 This option sets the Bootstrap theme color used for buttons, progress bars, tab highlights and selections. The color can also be changed temporarily from the settings page; a page reload reverts to this option.
+
+#### plugin.theme
+'light' by default. Possible values: 'light', 'dark', 'system'.
+This option sets the color scheme of the UI. 'system' follows the device's light/dark setting, live. The theme can also be changed temporarily from the settings page; a page reload reverts to this option.
 
 ### Utilization
 If you set plugin.enableAutodetect to true, the plugin will automaticaly load when detecting a mobile device. To force load the plugin in a desktop browser add '?mobile=1' to the end of the rutorrent url.

--- a/plugins/mobile/init.js
+++ b/plugins/mobile/init.js
@@ -3,7 +3,8 @@ plugin.enableAutodetect = true;
 plugin.tabletsDetect = true;
 plugin.eraseWithDataDefault = false;
 plugin.sort = 'name'; /* 'name', 'status', 'size', 'uploaded', 'downloaded', 'done', 'eta', 'ul', 'dl', 'ratio', and with the seedingtime plugin 'addtime', 'seedingtime'. Add preceding negative for descending sort. */
-plugin.accentColor = 'primary'; /* Bootstrap theme color for buttons, progress bars and highlights: 'primary' (blue), 'secondary' (gray), 'success' (green), 'danger' (red), 'warning' (yellow), 'info' (cyan) or 'dark' (near-black). */
+plugin.accentColor = 'primary'; /* Bootstrap theme color for buttons, progress bars and highlights: 'primary' (blue), 'secondary' (gray), 'success' (green), 'danger' (red), 'warning' (yellow), 'info' (cyan) or 'dark' (contrast: near-black on the light theme, near-white on dark). */
+plugin.theme = 'light'; /* 'light', 'dark', or 'system' to follow the device setting (live). Can also be changed temporarily from the settings page. */
 /*** End Configurable Options ***/
 
 
@@ -599,20 +600,71 @@ plugin.showSettings = function() {
   });
 };
 
-plugin.currentAccent = 'primary';
+plugin.currentTheme = 'light';
+
+plugin.applyTheme = function(theme) {
+  plugin.currentTheme = theme;
+  // Everything themes off Bootstrap's data-bs-theme: the core's
+  // Bootstrap 5 assets flip their own components, and mobile.css uses
+  // the corresponding CSS variables for its colors
+  var dark = (theme == 'dark') ||
+    ((theme == 'system') && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  $('html').attr('data-bs-theme', dark ? 'dark' : 'light');
+  // The near-black accent resolves differently per theme (see
+  // effectiveAccent); re-resolve it for the new theme
+  plugin.applyAccentColor(plugin.currentAccent);
+};
+
+plugin.themes = [['light', 'Light'], ['dark', 'Dark'], ['system', 'System']];
+
+// Like the accent switcher below: not persisted, a reload reverts to
+// the configured plugin.theme
+plugin.loadThemeSelect = function() {
+  var sel = $('#themeSelect').empty();
+  $.each(this.themes, function(i, t) {
+    sel.append($('<option></option>').attr('value', t[0]).text(t[1]));
+  });
+  sel.val(this.currentTheme);
+};
+
+plugin.currentAccent = 'primary'; /* the selected accent */
+plugin.appliedAccent = 'primary'; /* the Bootstrap color actually applied */
+
+// The near-black accent would be invisible on the dark theme's
+// near-black background, so there it resolves to its counterpart,
+// near-white; "near-black" really means "maximum-contrast neutral"
+plugin.effectiveAccent = function(color) {
+  return (color == 'dark' && $('html').attr('data-bs-theme') == 'dark') ? 'light' : color;
+};
 
 plugin.applyAccentColor = function(color) {
-  if (color == 'primary') {
+  plugin.currentAccent = color;
+  var effective = plugin.effectiveAccent(color);
+  if (effective == 'primary') {
     document.documentElement.style.removeProperty('--mobile-accent');
     document.documentElement.style.removeProperty('--mobile-accent-rgb');
   } else {
-    document.documentElement.style.setProperty('--mobile-accent', 'var(--bs-' + color + ')');
-    document.documentElement.style.setProperty('--mobile-accent-rgb', 'var(--bs-' + color + '-rgb)');
+    document.documentElement.style.setProperty('--mobile-accent', 'var(--bs-' + effective + ')');
+    document.documentElement.style.setProperty('--mobile-accent-rgb', 'var(--bs-' + effective + '-rgb)');
   }
-  if (color != plugin.currentAccent) {
-    $('.btn-' + plugin.currentAccent).addClass('btn-' + color).removeClass('btn-' + plugin.currentAccent);
+  // White text and stripes are invisible on near-white accent fills;
+  // flip them dark there (the progress label's halo inverts with it,
+  // keeping it legible where it overhangs onto the track)
+  if (effective == 'light') {
+    document.documentElement.style.setProperty('--mobile-stripe', 'rgba(0, 0, 0, 0.15)');
+    document.documentElement.style.setProperty('--mobile-progress-label', '#000');
+    document.documentElement.style.setProperty('--mobile-progress-halo', '#fff');
+    document.documentElement.style.setProperty('--mobile-accent-contrast', '#000');
+  } else {
+    document.documentElement.style.removeProperty('--mobile-stripe');
+    document.documentElement.style.removeProperty('--mobile-progress-label');
+    document.documentElement.style.removeProperty('--mobile-progress-halo');
+    document.documentElement.style.removeProperty('--mobile-accent-contrast');
   }
-  plugin.currentAccent = color;
+  if (effective != plugin.appliedAccent) {
+    $('.btn-' + plugin.appliedAccent).addClass('btn-' + effective).removeClass('btn-' + plugin.appliedAccent);
+  }
+  plugin.appliedAccent = effective;
 };
 
 plugin.renderOpenStatus = function(d) {
@@ -624,7 +676,7 @@ plugin.renderOpenStatus = function(d) {
 
 plugin.accentColors = [
   ['primary', 'Blue'], ['secondary', 'Gray'], ['success', 'Green'], ['danger', 'Red'],
-  ['warning', 'Yellow'], ['info', 'Cyan'], ['dark', 'Near-black']
+  ['warning', 'Yellow'], ['info', 'Cyan'], ['dark', 'Contrast']
 ];
 
 // Try-before-you-buy accent switcher; not persisted, a reload reverts
@@ -635,15 +687,16 @@ plugin.loadAccentSelect = function() {
     // The colored swatch shows in the option list where the browser
     // supports styled options (iOS's native picker does not)
     sel.append($('<option></option>').attr('value', c[0])
-      .css('color', 'var(--bs-' + c[0] + ')')
+      .css('color', 'var(--bs-' + plugin.effectiveAccent(c[0]) + ')')
       .text('\u25cf ' + c[1] + ' (' + c[0] + ')'));
   });
   sel.val(this.currentAccent);
-  sel.css('color', 'var(--bs-' + this.currentAccent + ')');
+  sel.css('color', 'var(--bs-' + plugin.effectiveAccent(this.currentAccent) + ')');
 };
 
 // Server details akin to the desktop status bar
 plugin.loadServerInfo = function() {
+  this.loadThemeSelect();
   this.loadAccentSelect();
   $('#verRutorrent td:last').text('v' + theWebUI.version);
   var rt = theWebUI.systemInfo.rTorrent;
@@ -1488,7 +1541,7 @@ plugin.drawGetDir = function(path, first) {
     success: function(data) {
       var container = $('#getDirList').empty();
       container.append($('<h5></h5>').text(data.path));
-      container.append($('<button type="button" class="btn btn-' + plugin.currentAccent + '"></button>').text(theUILang.ok).click(function() {mobile.chooseGetDir(data.path);}));
+      container.append($('<button type="button" class="btn btn-' + plugin.appliedAccent + '"></button>').text(theUILang.ok).click(function() {mobile.chooseGetDir(data.path);}));
       container.append($('<button type="button" class="btn btn-outline-secondary"></button>').text(theUILang.Cancel).click(function() {mobile.goBack();}));
 
       var tbody = $('<tbody></tbody>');
@@ -2149,8 +2202,19 @@ plugin.init = function() {
         }
         diskspacePlugin.check = function() { };
       }
-      // The mobile UI is designed for the light scheme
-      $('html').attr('data-bs-theme', 'light');
+      // Apply the configured theme (see plugin.theme at the top); in
+      // 'system' mode, keep following the device's scheme live
+      plugin.applyTheme(plugin.theme);
+      if (window.matchMedia) {
+        var colorScheme = window.matchMedia('(prefers-color-scheme: dark)');
+        if (colorScheme.addEventListener) {
+          colorScheme.addEventListener('change', function() {
+            if (plugin.currentTheme == 'system') {
+              plugin.applyTheme('system');
+            }
+          });
+        }
+      }
       // Apply the configured accent color (see plugin.accentColor at the top)
       plugin.applyAccentColor(plugin.accentColor);
       plugin.loadLang();
@@ -2195,9 +2259,15 @@ plugin.init = function() {
 
       $('#dlLimit').change(function(){plugin.setDLLimit();});
       $('#ulLimit').change(function(){plugin.setULLimit();});
+      $('#themeSelect').change(function(){
+        plugin.applyTheme(this.value);
+        // The accent swatches resolve per theme (near-black flips to
+        // near-white on dark); refresh them for the new theme
+        plugin.loadAccentSelect();
+      });
       $('#accentSelect').change(function(){
         plugin.applyAccentColor(this.value);
-        $(this).css('color', 'var(--bs-' + this.value + ')');
+        $(this).css('color', 'var(--bs-' + plugin.effectiveAccent(this.value) + ')');
       });
 
       $('input[id=torrent_file]').change(function() {
@@ -2386,6 +2456,7 @@ plugin.onLangLoaded = function() {
 
   $('#dlLimit').parent().children('label').children('h5').text(theUILang.Glob_max_downl);
   $('#ulLimit').parent().children('label').children('h5').text(theUILang.Global_max_upl);
+  $('#themeSelect').parent().children('label').children('h5').text('Theme');
   $('#accentSelect').parent().children('label').children('h5').text('Accent color');
   $('#serverInfoHeader').text('Server');
   $('#verRutorrent td:first').text('ruTorrent');

--- a/plugins/mobile/mobile.css
+++ b/plugins/mobile/mobile.css
@@ -52,13 +52,29 @@
 :root {
   --mobile-accent: var(--bs-primary);
   --mobile-accent-rgb: var(--bs-primary-rgb);
+  /* Bootstrap's stripe overlay color; applyAccentColor switches it to
+     a dark one when the accent resolves to near-white (dark theme +
+     near-black accent), where white stripes would be invisible */
+  --mobile-stripe: rgba(255, 255, 255, 0.15);
+  /* Progress-label text and its halo; applyAccentColor inverts them for
+     the near-white accent, where dark-on-light reads better. The label
+     can overhang onto the track, so the halo does the work there */
+  --mobile-progress-label: #fff;
+  --mobile-progress-halo: #000;
+  /* Text on solid accent fills (selected filter rows); applyAccentColor
+     flips it to black when the accent resolves to near-white */
+  --mobile-accent-contrast: #fff;
 }
 .progress-bar {
   background-color: var(--mobile-accent);
 }
+.progress-bar-striped {
+  background-image: linear-gradient(45deg, var(--mobile-stripe) 25%, transparent 25%, transparent 50%, var(--mobile-stripe) 50%, var(--mobile-stripe) 75%, transparent 75%, transparent);
+}
 .list-group {
   --bs-list-group-active-bg: var(--mobile-accent);
   --bs-list-group-active-border-color: var(--mobile-accent);
+  --bs-list-group-active-color: var(--mobile-accent-contrast);
 }
 .accordion {
   /* Expanded header follows the accent color as a light tint */
@@ -163,20 +179,22 @@ select {
   position: sticky;
   position: -webkit-sticky;
   top: 0;
-  background: #eee;
+  background: var(--bs-secondary-bg);
 }
+/* On the bottom navbar, which stays dark in both themes */
 .icon-white {
   color: white;
 }
+/* Follows the theme (near-black on light, near-white on dark) */
 .icon-black {
-  color: black;
+  color: var(--bs-body-color);
 }
 a:hover, a:focus {
   outline: none;
   text-decoration: none;
 }
 #mainContainer {
-  background-color: #fff;
+  background-color: var(--bs-body-bg);
   padding: 45px 3px calc(74px + env(safe-area-inset-bottom, 0px)) 3px;
   margin: 0;
 }
@@ -204,10 +222,10 @@ a:hover, a:focus {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #fff;
-  font-weight: 500;
+  color: var(--mobile-progress-label);
+  font-weight: 700;
   white-space: nowrap;
-  text-shadow: 0 0 2px #000, 0 0 2px #000, 1px 1px 2px rgba(0, 0, 0, 0.9);
+  text-shadow: 0 0 2px var(--mobile-progress-halo), 0 0 2px var(--mobile-progress-halo), 1px 1px 2px var(--mobile-progress-halo);
 }
 h5, #detailsTrackersPage a, #detailsTrackersPage .accordion-button, #detailsFilesPage a, #detailsDetailsPage #label td, .nav a, #getDirList td {
   word-break:break-all;
@@ -297,9 +315,9 @@ h5, #detailsTrackersPage a, #detailsTrackersPage .accordion-button, #detailsFile
   /* BS5's .nav wraps by default, which would push the toolbar icons to
      a second line when the filter text is long; truncate instead */
   flex-wrap: nowrap;
-  background-color: #fff;
+  background-color: var(--bs-body-bg);
   padding: 3px 3px 0 3px;
-  border-bottom: 1px solid #ddd;
+  border-bottom: 1px solid var(--bs-border-color);
 }
 .nav-tabs > li {
   flex: 0 0 auto;
@@ -354,8 +372,8 @@ h5, #detailsTrackersPage a, #detailsTrackersPage .accordion-button, #detailsFile
   left: 0;
   right: 0;
   z-index: 1029;
-  background-color: #fff;
-  border-bottom: 1px solid #ddd;
+  background-color: var(--bs-body-bg);
+  border-bottom: 1px solid var(--bs-border-color);
   display: flex;
   gap: 5px;
   padding: 5px 3px;

--- a/plugins/mobile/mobile.html
+++ b/plugins/mobile/mobile.html
@@ -183,6 +183,10 @@
       <select id="ulLimit" class="form-select"></select>
     </div>
     <div class="form-group">
+      <label class="select" for="themeSelect"><h5></h5></label>
+      <select id="themeSelect" class="form-select"></select>
+    </div>
+    <div class="form-group">
       <label class="select" for="accentSelect"><h5></h5></label>
       <select id="accentSelect" class="form-select"></select>
     </div>


### PR DESCRIPTION
## Summary
- Adds a `plugin.theme` option ('light', 'dark' or 'system') plus a live theme selector on the settings page, working like the existing accent selector: not persisted, a reload reverts to the configured option. 'system' follows the device's light/dark preference live via `prefers-color-scheme`.
- Everything themes off Bootstrap's `data-bs-theme`: the core's Bootstrap 5 assets flip their own components, and the hardcoded light colors in mobile.css move to the corresponding Bootstrap CSS variables.
- The near-black accent would be invisible on the dark theme's near-black background, so there it resolves to its counterpart, near-white — it was always really "maximum-contrast neutral", and its dropdown label becomes "Contrast" to match. On the near-white fills, the progress-bar stripes, progress labels and selected-filter text flip dark to stay legible.
- Progress-bar labels also get a bolder weight (500 → 700) in all themes for readability over the bar.

## Test plan
- [ ] Settings → Theme: switch between Light / Dark / System and confirm every page (list, details, add, filter, settings, directory picker) follows
- [ ] With theme 'system', flip the device's dark mode and confirm the UI follows without a reload
- [ ] Dark theme + Contrast accent: buttons, tab highlights, selected filter rows, progress bars (stripes and labels) all stay legible
- [ ] Light theme unchanged with the default config

Made with [Cursor](https://cursor.com)