### PR TITLE
Bump version to 5.3.11

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,27 +21,27 @@
 		<meta name="msapplication-TileColor" content="#FFFFFF" />
 		<meta name="msapplication-TileImage" content="./images/mstile-144x144.png" />
 
-		<link href="./css/bootstrap.min.css?v=5310" rel="stylesheet" type="text/css" />
-		<link href="./css/style.css?v=5310" rel="stylesheet" type="text/css" />
-		<link href="./css/stable.css?v=5310" rel="stylesheet" type="text/css" />
-		<link rel="preload" as="style" href="./css/category-panel.css?v=5310" />
-		<link rel="preload" as="style" href="./css/panel-label.css?v=5310" />
-		<script type="text/javascript" src="./js/jquery.js?v=5310"></script>
-		<script type="text/javascript" src="./js/jquery.flot.js?v=5310"></script>
-		<script type="text/javascript" src="./js/sanitize.js?v=5310"></script>
-		<script type="text/javascript" src="./js/sanitize.config.js?v=5310"></script>
-		<script type="text/javascript" src="./js/custom-elements.js?v=5310"></script>
-		<script type="text/javascript" src="./lang/langs.js?v=5310"></script>
-		<link rel="preload" as="script" href="./js/browser.js?v=5310" />
-		<link rel="preload" as="script" href="./js/common.js?v=5310" />
-		<link rel="preload" as="script" href="./js/objects.js?v=5310" />
-		<link rel="preload" as="script" href="./js/options.js?v=5310" />
-		<link rel="preload" as="script" href="./js/content.js?v=5310" />
-		<link rel="preload" as="script" href="./js/stable.js?v=5310" />
-		<link rel="preload" as="script" href="./js/graph.js?v=5310" />
-		<link rel="preload" as="script" href="./js/plugins.js?v=5310" />
-		<link rel="preload" as="script" href="./js/rtorrent.js?v=5310" />
-		<link rel="preload" as="script" href="./js/webui.js?v=5310" />
+		<link href="./css/bootstrap.min.css?v=5311" rel="stylesheet" type="text/css" />
+		<link href="./css/style.css?v=5311" rel="stylesheet" type="text/css" />
+		<link href="./css/stable.css?v=5311" rel="stylesheet" type="text/css" />
+		<link rel="preload" as="style" href="./css/category-panel.css?v=5311" />
+		<link rel="preload" as="style" href="./css/panel-label.css?v=5311" />
+		<script type="text/javascript" src="./js/jquery.js?v=5311"></script>
+		<script type="text/javascript" src="./js/jquery.flot.js?v=5311"></script>
+		<script type="text/javascript" src="./js/sanitize.js?v=5311"></script>
+		<script type="text/javascript" src="./js/sanitize.config.js?v=5311"></script>
+		<script type="text/javascript" src="./js/custom-elements.js?v=5311"></script>
+		<script type="text/javascript" src="./lang/langs.js?v=5311"></script>
+		<link rel="preload" as="script" href="./js/browser.js?v=5311" />
+		<link rel="preload" as="script" href="./js/common.js?v=5311" />
+		<link rel="preload" as="script" href="./js/objects.js?v=5311" />
+		<link rel="preload" as="script" href="./js/options.js?v=5311" />
+		<link rel="preload" as="script" href="./js/content.js?v=5311" />
+		<link rel="preload" as="script" href="./js/stable.js?v=5311" />
+		<link rel="preload" as="script" href="./js/graph.js?v=5311" />
+		<link rel="preload" as="script" href="./js/plugins.js?v=5311" />
+		<link rel="preload" as="script" href="./js/rtorrent.js?v=5311" />
+		<link rel="preload" as="script" href="./js/webui.js?v=5311" />
 
 		<script>
 			loadUILang(() => {
@@ -57,10 +57,10 @@
 			});
 		</script>
 
-		<script type="module" src="./js/backgroundtask.js?v=5310"></script>
-		<script type="module" src="./js/category-list.js?v=5310"></script>
-		<script type="module" src="./js/panel.js?v=5310"></script>
-		<script type="text/javascript" src="./js/category-list-elements.js?v=5310" defer></script>
+		<script type="module" src="./js/backgroundtask.js?v=5311"></script>
+		<script type="module" src="./js/category-list.js?v=5311"></script>
+		<script type="module" src="./js/panel.js?v=5311"></script>
+		<script type="text/javascript" src="./js/category-list-elements.js?v=5311" defer></script>
 	</head>
 	<body>
 		<div id="preload" class="d-none"></div>
@@ -139,7 +139,7 @@
 				</div>
 				<div class="p-1 p-md-0 offcanvas-body">
 					<template id="panel-label-template">
-						<link href="./css/panel-label.css?v=5310" rel="stylesheet" type="text/css" />
+						<link href="./css/panel-label.css?v=5311" rel="stylesheet" type="text/css" />
 						<div part="prefix" hidden></div>
 						<div part="icon"></div>
 						<div part="text"></div>
@@ -148,7 +148,7 @@
 						<div part="size" style="display: none;"></div>
 					</template>
 					<template id="category-panel-template">
-						<link href="./css/category-panel.css?v=5310" rel="stylesheet" type="text/css" />
+						<link href="./css/category-panel.css?v=5311" rel="stylesheet" type="text/css" />
 						<div part="heading">
 							<span class="text"></span><slot name="decorator" class="decorator"></slot>
 						</div>
@@ -304,6 +304,6 @@
 		<div class="graph_tab_legend"></div>
 		<div id="dialog-container"></div>
 		<div id="dir-container"></div>
-		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=5310"></script>
+		<script type="text/javascript" src="./js/bootstrap.bundle.min.js?v=5311"></script>
 	</body>
 </html>

--- a/js/webui.js
+++ b/js/webui.js
@@ -4,7 +4,7 @@
  */
 
 var theWebUI = {
-	version: "5.3.10",
+	version: "5.3.11",
 	tables: {
 		trt: {
 			obj: new dxSTable(),

--- a/lang/langs.js
+++ b/lang/langs.js
@@ -110,7 +110,7 @@ function loadUILang(onLoadFunc)
 			translateDOM();
 		}
 	};
-	langScript.src = `./lang/${lang}.js?v=5310`;
+	langScript.src = `./lang/${lang}.js?v=5311`;
 	document.head.appendChild(langScript);
 }
 


### PR DESCRIPTION
  - Mobile: light / dark / system theme (#3136, @xombiemp) — new Theme setting; System follows the device's dark-mode live. The near-black accent is relabeled Contrast and resolves to near-white on the dark theme.
  - Mobile: fix the empty torrent list on the direct XML-RPC mount (#3134, @xombiemp) — plus new torrents inserted at their sorted position, a toast for torrents added from another session/rss/automation, keyboard-dismiss-on-scroll across all fields, and label-edit commit/cancel fixes.
  - Mobile: don't blank the torrent list when every torrent is labeled (#3133, @xirvik) — the label panel's "no label" bucket is absent when nothing is unlabeled; guard the lookup.
  - Mobile: log swallowed request failures to the console (#3135, @xombiemp) — diagnostic breadcrumbs for the silent failures that hid the blank-list bugs.