### PR TITLE
Feat: Convert URLs in torrent comments into clickable links

### DIFF
--- a/plugins/feeds/action.php
+++ b/plugins/feeds/action.php
@@ -105,8 +105,15 @@ function formatItemDescription($torrent)
 	if(!empty($torrent["mesage"]))
 		$desc.='<fieldset><legend>'.$theUILang["Track_status"].'</legend>'.htmlspecialchars($torrent["mesage"],ENT_COMPAT,"UTF-8").'</fieldset>';
 	if(!empty($torrent["comment"]))
-		$desc.='<fieldset><legend>'.$theUILang["Comment"].'</legend>'.htmlspecialchars($torrent["comment"],ENT_COMPAT,"UTF-8").'</fieldset>';
+		$desc.='<fieldset><legend>'.$theUILang["Comment"].'</legend>'.getClickableComment(htmlspecialchars($torrent["comment"],ENT_COMPAT,"UTF-8")).'</fieldset>';
 	return($desc);
+}
+
+function getClickableComment( string $comment ): string
+{
+    $pattern = '/(https?|ftp):\/\/[^\s<>"]+/i';
+    $result = preg_replace($pattern, '<a href="$0" target="_blank" rel="noopener noreferrer">$0</a>', $comment);
+    return $result ?? $comment;
 }
 
 function sortByPubDate( $a, $b )


### PR DESCRIPTION
## Description
This PR updates the torrent description view to automatically identify plaintext URLs (`http` or `https`) within the torrent comments and convert them into clickable HTML hyperlinks.

## Changes
- Created a safe, type-hinted helper function `getClickableComment()` to handle URL regex replacement.
- Sanitizes raw user input with `htmlspecialchars()` before parsing links to prevent XSS vulnerabilities.
- Applied secure link attributes (`target="_blank"` and `rel="noopener noreferrer"`) so links safely open in a new tab without navigating away from the application.

## Testing Instructions
1. View a torrent containing a plain URL in its comment (e.g., `Trump: https://torrent.site/torrent.php?id=12345`).
2. Verify that the URL turns into a clickable link.
3. Confirm that clicking the link opens the target page in a new browser tab.
4. Verify that normal text in the comment remains unaffected and safe.
