### PR TITLE
feat(webui): make HTTP/HTTPS URLs clickable in Tracker Status

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -243,9 +243,33 @@ function linked(obj, _33, lst) {
 
 function escapeHTML(str)
 {
-//	return( $("<div>").text(str).html() );
-	return( String(str).split('&').join('&amp;').split('<').join('&lt;').split('>').join('&gt;') );
+	if (str === null || str === undefined) return '';
+	return String(str)
+		.split('&').join('&amp;')
+		.split('<').join('&lt;')
+		.split('>').join('&gt;')
+		.split('"').join('&quot;')
+		.split("'").join('&#039;');
 }
+
+/**
+ * Converts HTTP and HTTPS URLs in tracker status messages to safe, clickable HTML links.
+ * Excludes trailing '.', ')', and ',' punctuation from the link.
+ *
+ * @param {string} text Raw tracker status message
+ * @returns {string} Safe HTML string with clickable links
+ */
+function getClickableTrackerStatus(text)
+{
+	if (!text) return '';
+	var sanitized = escapeHTML(text);
+	return sanitized.replace(/https?:\/\/[^\s<>"']+/gi, function(match) {
+		var cleanUrl = match.replace(/[\.,\)]+$/, '');
+		var trailing = match.substring(cleanUrl.length);
+		return '<a href="' + cleanUrl + '" target="_blank" rel="noopener noreferrer">' + cleanUrl + '</a>' + trailing;
+	});
+}
+
 
 /**
  * Confirm again before taking action.

--- a/js/common.js
+++ b/js/common.js
@@ -264,7 +264,7 @@ function getClickableTrackerStatus(text)
 	if (!text) return '';
 	var sanitized = escapeHTML(text);
 	return sanitized.replace(/https?:\/\/[^\s<>"']+/gi, function(match) {
-		var cleanUrl = match.replace(/[\.,\)]+$/, '');
+		var cleanUrl = match.replace(/[.,)]+$/, '');
 		var trailing = match.substring(cleanUrl.length);
 		return '<a href="' + cleanUrl + '" target="_blank" rel="noopener noreferrer">' + cleanUrl + '</a>' + trailing;
 	});

--- a/js/webui.js
+++ b/js/webui.js
@@ -2098,7 +2098,7 @@ var theWebUI = {
 			const trackers = this.trackers[this.dID] ?? [];
 			$("#tu").text(trackers.length ? (trackers[0].name  + (trackers.length > 1 ? ` ${theUILang.of} ${d.tracker_size}` : '')) : `${d.tracker_size}`);
 	        	$("#hs").text(this.dID.substring(0,40));
-			$("#ts").text(d.msg);
+			$("#ts").html(getClickableTrackerStatus(d.msg));
 			var url = d.comment.trim();
 			if(!url.match(/<a href/i))
 			{

--- a/tests/js/trackerstatus.spec.js
+++ b/tests/js/trackerstatus.spec.js
@@ -1,0 +1,47 @@
+import { readFileSync } from "fs";
+
+window.$ = require("jquery");
+
+for (const src of ["../lang/en.js", "../js/common.js"]) {
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = readFileSync(src, { encoding: "utf-8" });
+  document.body.appendChild(scriptEl);
+}
+
+describe("getClickableTrackerStatus", () => {
+  it("returns empty string for null, undefined, or empty input", () => {
+    expect(window.getClickableTrackerStatus(null)).toBe("");
+    expect(window.getClickableTrackerStatus(undefined)).toBe("");
+    expect(window.getClickableTrackerStatus("")).toBe("");
+  });
+
+  it("converts http and https URLs to clickable links", () => {
+    const input = "Tracker status: http://example.com/torrent/123";
+    const expected = 'Tracker status: <a href="http://example.com/torrent/123" target="_blank" rel="noopener noreferrer">http://example.com/torrent/123</a>';
+    expect(window.getClickableTrackerStatus(input)).toBe(expected);
+  });
+
+  it("handles embedded URLs with surrounding text and trailing period", () => {
+    const input = "text text text https://tracker.foo/torrent.php?id=12345. text text text.";
+    const expected = 'text text text <a href="https://tracker.foo/torrent.php?id=12345" target="_blank" rel="noopener noreferrer">https://tracker.foo/torrent.php?id=12345</a>. text text text.';
+    expect(window.getClickableTrackerStatus(input)).toBe(expected);
+  });
+
+  it("excludes trailing punctuation like '.', ')', or ',' from link", () => {
+    const input = "(see https://example.com/foo, or http://example.com/bar).";
+    const expected = '(see <a href="https://example.com/foo" target="_blank" rel="noopener noreferrer">https://example.com/foo</a>, or <a href="http://example.com/bar" target="_blank" rel="noopener noreferrer">http://example.com/bar</a>).';
+    expect(window.getClickableTrackerStatus(input)).toBe(expected);
+  });
+
+  it("sanitizes HTML and script tags to prevent XSS", () => {
+    const input = "<script>alert('xss')</script> http://example.com/item?a=1&b=2";
+    const expected = '&lt;script&gt;alert(&#039;xss&#039;)&lt;/script&gt; <a href="http://example.com/item?a=1&amp;b=2" target="_blank" rel="noopener noreferrer">http://example.com/item?a=1&amp;b=2</a>';
+    expect(window.getClickableTrackerStatus(input)).toBe(expected);
+  });
+
+  it("does not convert non-http/https links to hyperlinks", () => {
+    const input = "ftp://files.example.com/torrent or javascript:alert(1)";
+    const expected = "ftp://files.example.com/torrent or javascript:alert(1)";
+    expect(window.getClickableTrackerStatus(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

This PR enables automatic conversion of `http://` and `https://` URLs in the **Tracker status** field (under the "General" torrent details tab) into safe, clickable links that open in a new tab.

## Key Changes

- **Helper Function (`getClickableTrackerStatus`)**:
  - Added a type-hinted JSDoc helper `getClickableTrackerStatus(text)` in [`js/common.js`](file:///Users/jakobbg/Local/code/ruTorrent/js/common.js).
  - **XSS Prevention**: Sanitizes raw input with `escapeHTML()` (escaping `&`, `<`, `>`, `"`, `'`) before parsing links.
  - **URL Parsing**: Matches `http://` and `https://` links embedded in text (e.g., `"New torrent at https://tracker.example.com/torrent.php?id=123. Please update."`).
  - **Trailing Punctuation**: Excludes trailing `.`, `)`, and `,` punctuation from the hyperlink tag so they remain as normal trailing text.
  - **Security Attributes**: Opens links with `target="_blank"` and `rel="noopener noreferrer"`.

- **WebUI Details Tab**:
  - Updated `#ts` element rendering in [`js/webui.js`](file:///Users/jakobbg/Local/code/ruTorrent/js/webui.js#L2101) to use `getClickableTrackerStatus(d.msg)`.

- **Automated Tests**:
  - Added unit test suite in [`tests/js/trackerstatus.spec.js`](file:///Users/jakobbg/Local/code/ruTorrent/tests/js/trackerstatus.spec.js) testing link generation, text surrounding URLs, trailing punctuation stripping, XSS sanitization, and protocol filtering.

## Verification

Run Jest test suite:
```bash
cd tests
npm test
