### PR TITLE
options: force a row break before the numeric settings fields

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -39,7 +39,7 @@ const theOptionsWindow = {
 						$("<input>").attr({type: "checkbox", id: id}),
 						$("<label>").attr({for: id}).text(label),
 					)),
-					$("<div>").addClass("col-md-6"),
+					$("<div>").addClass("w-100"),
 					...[
 						["webui.update_interval", theUILang.Update_GUI_every + ": ", theUILang.ms, 3000],
 						["webui.reqtimeout", theUILang.ReqTimeout + ": ", theUILang.ms, 5000],


### PR DESCRIPTION
The User Interface fieldset ends its checkbox list with an empty col-md-6, which only lands correctly when the number of half-width checkboxes is odd. The list is now even (16), so that div starts a fresh row instead of completing the last one, pushing "Update GUI every" into the right-hand column and misaligning every field below it.

Use a w-100 flex break instead: it forces the numeric fields onto their own row whatever the checkbox count, so adding or removing an option cannot reintroduce the misalignment.

Fixes #3142