### PR TITLE
Fix/max open files settings

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -914,7 +914,7 @@ function correctContent()
 		// removed or now log deprecation warnings. Mirrors php/methods-0.16.16.php.
 		$.extend(theRequestManager.aliases,
 		{
-			"get_max_open_http"      : { name: "system.sockets.http.max_alloc",          prm: 0 },
+			"get_max_open_http"      : { name: "system.sockets.http.max_size",           prm: 0 },
 			"set_max_open_http"      : { name: "system.sockets.http.max_alloc.set",      prm: 1 },
 			"set_max_open_files"     : { name: "system.sockets.files.max_alloc.set",     prm: 1 },
 			"d.multicall2"           : { name: "d.multicall",                             prm: 1 },

--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -145,6 +145,17 @@ var theRequestManager =
 		}
 		return( this.map(this[cmd].commands[no]) );
 	},
+	// See rTorrentSettings::getSocketAllocCategory() in php/settings.php.
+	getSocketAllocCategory: function( name )
+	{
+		if(theWebUI.systemInfo.rTorrent.iVersion<0x1013)
+			return(null);
+		if(name=="nmax_open_files")
+			return("files");
+		if(name=="nmax_open_http")
+			return("http");
+		return(null);
+	},
 	patchCommand: function( cmd, name )
 	{
 		if(this.aliases[name] && this.aliases[name].prm)
@@ -365,6 +376,7 @@ rTorrentStub.prototype.recheck = function()
 
 rTorrentStub.prototype.setsettings = function()
 {
+	var adjustAlloc = false;
 	for(var i=0; i<this.vs.length; i++)
 	{
 		var prmType = "string";
@@ -372,6 +384,7 @@ rTorrentStub.prototype.setsettings = function()
 			prmType = "i8";
 		var prm = this.vs[i];
 		var cmd = null;
+		var socketAlloc = theRequestManager.getSocketAllocCategory(this.ss[i]);
 		if(this.ss[i]=="ndht")
 		{
 			if(prm==0)
@@ -383,10 +396,25 @@ rTorrentStub.prototype.setsettings = function()
 			cmd.addParameter("string",'');
 		}
 		else
+		if(socketAlloc!==null)
+		{
+			var minCmd = new rXMLRPCCommand("system.sockets."+socketAlloc+".min_alloc.set");
+			minCmd.addParameter("string",'');
+			minCmd.addParameter(prmType,prm);
+			this.commands.push( minCmd );
+			cmd = new rXMLRPCCommand("system.sockets."+socketAlloc+".max_alloc.set");
+			cmd.addParameter("string",'');
+			adjustAlloc = true;
+		}
+		else
 			cmd = new rXMLRPCCommand('set_'+this.ss[i].substr(1));
 		cmd.addParameter(prmType,prm);
 		this.commands.push( cmd );
 	}
+	// The staged min_alloc/max_alloc values only take effect once the socket
+	// manager recomputes its allocation. Send it once per batch.
+	if(adjustAlloc)
+		this.commands.push( new rXMLRPCCommand("system.sockets.adjust_alloc") );
 }
 
 rTorrentStub.prototype.getsettings = function()

--- a/php/methods-0.16.16.php
+++ b/php/methods-0.16.16.php
@@ -11,9 +11,10 @@
 
 $this->aliases = array_merge($this->aliases, array(
 
-	// HTTP connection cap → system.sockets.http.max_alloc (ceiling, not floor)
+	// HTTP connection cap. The getter reports the allocation actually in
+	// effect: max_alloc is only the ceiling and commonly reads far above it.
 	// (was network.http.max_total_connections — now warns)
-	"get_max_open_http" => array( "name"=>"system.sockets.http.max_alloc",     "prm"=>0 ),
+	"get_max_open_http" => array( "name"=>"system.sockets.http.max_size",      "prm"=>0 ),
 	"set_max_open_http" => array( "name"=>"system.sockets.http.max_alloc.set", "prm"=>1 ),
 
 	// Max open files setter → system.sockets.files.max_alloc.set

--- a/php/settings.php
+++ b/php/settings.php
@@ -401,6 +401,27 @@ class rTorrentSettings
 		}
 		return(strpos(FileUtil::addslash($dir),$topDirectory)===0);
 	}
+	// The file and HTTP socket limits belong to libtorrent's socket manager:
+	// network.max_open_files.set is an inert stub, and
+	// system.sockets.<category>.max_alloc is a ceiling that can only lower the
+	// allocation. Landing on the exact requested value therefore needs both
+	// min_alloc and max_alloc, followed by a system.sockets.adjust_alloc
+	// recompute -- nothing takes effect until adjust_alloc runs.
+	//
+	// Restricted to 0.16.19+. Earlier versions abort the process on an
+	// over-budget adjust_alloc, and the budget cannot be checked beforehand
+	// because its reserve and min_generic terms are not exposed over RPC.
+	// 0.16.19 reports a regular XMLRPC fault instead.
+	public function getSocketAllocCategory( $name )
+	{
+		if($this->iVersion<0x1013)
+			return(null);
+		if($name=="nmax_open_files")
+			return("files");
+		if($name=="nmax_open_http")
+			return("http");
+		return(null);
+	}
 	public function patchDeprecatedCommand( $cmd, $name )
 	{
 		if((array_key_exists($name,$this->aliases) && $this->aliases[$name]["prm"]) ||

--- a/php/xmlrpc.php
+++ b/php/xmlrpc.php
@@ -76,6 +76,7 @@ class rXMLRPCRequest
 	public $strings = array();
 	public $val = array();
 	public $fault = false;
+	public $faultString = '';
 	public $parseByTypes = false;
 	public $important = true;
 
@@ -223,6 +224,7 @@ class rXMLRPCRequest
 					if(strstr($answer,"faultCode")!==false)
 					{
 						$this->fault = true;
+						$this->faultString = self::parseFaultString($answer);
 						global $rpcLogFaults;
 						if($rpcLogFaults && $this->important)
 						{
@@ -239,6 +241,17 @@ class rXMLRPCRequest
 		return($ret);
 	}
 
+	// rtorrent explains a refusal in faultString -- an allocation that will not
+	// fit, a path outside the permitted tree. Keep it so the caller can pass the
+	// reason on instead of reporting that something unspecified went wrong. Also
+	// matches a fault nested in a system.multicall array.
+	static protected function parseFaultString($answer)
+	{
+		if(preg_match("/<name>faultString<\/name>\s*<value>\s*(?:<string>)?(.*?)(?:<\/string>)?\s*<\/value>/s",
+			$answer,$matches))
+			return(trim(html_entity_decode($matches[1],ENT_COMPAT,"UTF-8")));
+		return('');
+	}
 	public function success($trusted = true)
 	{
 		return($this->run($trusted) && !$this->fault);

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -73,6 +73,44 @@ function makeMulticall($cmds,$hash,$add,$prefix)
 	return(false);
 }
 
+// The socket manager stages min_alloc/max_alloc until adjust_alloc recomputes
+// the allocation. A rejected recompute keeps the staged values, which then also
+// breaks every later recompute, so the bounds in effect are read before they are
+// touched and put back if the recompute is refused.
+function getSocketAlloc($categories)
+{
+	$req = new rXMLRPCRequest();
+	foreach($categories as $category)
+	{
+		$req->addCommand(new rXMLRPCCommand("system.sockets.".$category.".min_alloc"));
+		$req->addCommand(new rXMLRPCCommand("system.sockets.".$category.".max_alloc"));
+	}
+	$req->important = false;
+	if(!$req->success(true) || (count($req->val)!=2*count($categories)))
+		return(array());
+	$ret = array();
+	foreach($categories as $ndx=>$category)
+		$ret[$category] = array_slice($req->val,2*$ndx,2);
+	return($ret);
+}
+
+function restoreSocketAlloc($saved)
+{
+	$req = new rXMLRPCRequest();
+	foreach($saved as $category=>$bounds)
+	{
+		$req->addCommand(new rXMLRPCCommand(
+			"system.sockets.".$category.".min_alloc.set",array("",floatval($bounds[0]))));
+		$req->addCommand(new rXMLRPCCommand(
+			"system.sockets.".$category.".max_alloc.set",array("",floatval($bounds[1]))));
+	}
+	$req->addCommand(new rXMLRPCCommand("system.sockets.adjust_alloc"));
+	// These bounds were in effect moments ago, so the recompute has to accept
+	// them again. Report it rather than leave a stale allocation staged.
+	if(!$req->success(true))
+		FileUtil::toLog("setsettings: socket allocation left staged, restore was refused");
+}
+
 function makeSimpleCall($cmds,$hash)
 {
 	$req = new rXMLRPCRequest();
@@ -397,7 +435,7 @@ switch($mode)
 	case "setsettings":
 	{
 		$req = new rXMLRPCRequest();
-		$adjustAlloc = false;
+		$socketCategories = array();
 		foreach($vs as $ndx=>$v)
 		{
 			if($ss[$ndx][0]=='n')
@@ -414,20 +452,29 @@ switch($mode)
 					"system.sockets.".$socketAlloc.".min_alloc.set",array("",$v)));
 				$cmd = new rXMLRPCCommand(
 					"system.sockets.".$socketAlloc.".max_alloc.set",array("",$v));
-				$adjustAlloc = true;
+				$socketCategories[$socketAlloc] = true;
 			}
 			else
 				$cmd = new rXMLRPCCommand('set_'.substr($ss[$ndx],1),$v);
 			$req->addCommand($cmd);
 		}
+		$socketCategories = array_keys($socketCategories);
 		// The staged min_alloc/max_alloc values only take effect once the
-		// socket manager recomputes its allocation. Send it once per batch.
-		if($adjustAlloc)
+		// socket manager recomputes its allocation. Send it once per batch,
+		// having first read the bounds it would replace.
+		$savedAlloc = array();
+		if(count($socketCategories))
+		{
+			$savedAlloc = getSocketAlloc($socketCategories);
 			$req->addCommand(new rXMLRPCCommand("system.sockets.adjust_alloc"));
+		}
 		if($req->getCommandsCount())
 		{
 			if($req->success(true))
 		        	$result = $req->val;
+			else
+			if(count($savedAlloc))
+				restoreSocketAlloc($savedAlloc);
         	}
         	else
 	        	$result = array();

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -397,18 +397,33 @@ switch($mode)
 	case "setsettings":
 	{
 		$req = new rXMLRPCRequest();
+		$adjustAlloc = false;
 		foreach($vs as $ndx=>$v)
 		{
 			if($ss[$ndx][0]=='n')
 				$v = floatval($v);
 			if( ($ss[$ndx]=="sdirectory") && !rTorrentSettings::get()->correctDirectory($v) )
 				continue;
+			$socketAlloc = rTorrentSettings::get()->getSocketAllocCategory($ss[$ndx]);
 			if($ss[$ndx]=="ndht")
 				$cmd = new rXMLRPCCommand('dht',(($v==0) ? "disable" : "auto"));
+			else
+			if($socketAlloc!==null)
+			{
+				$req->addCommand(new rXMLRPCCommand(
+					"system.sockets.".$socketAlloc.".min_alloc.set",array("",$v)));
+				$cmd = new rXMLRPCCommand(
+					"system.sockets.".$socketAlloc.".max_alloc.set",array("",$v));
+				$adjustAlloc = true;
+			}
 			else
 				$cmd = new rXMLRPCCommand('set_'.substr($ss[$ndx],1),$v);
 			$req->addCommand($cmd);
 		}
+		// The staged min_alloc/max_alloc values only take effect once the
+		// socket manager recomputes its allocation. Send it once per batch.
+		if($adjustAlloc)
+			$req->addCommand(new rXMLRPCCommand("system.sockets.adjust_alloc"));
 		if($req->getCommandsCount())
 		{
 			if($req->success(true))

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -111,6 +111,55 @@ function restoreSocketAlloc($saved)
 		FileUtil::toLog("setsettings: socket allocation left staged, restore was refused");
 }
 
+// Every settings write is recorded: what was asked for, the value in effect
+// before and after, and whether rtorrent took it. A refused batch can leave a
+// value clamped or untouched, so the "to" side is read back rather than assumed.
+//
+// Everything on the settings page has a symmetric get_* alias except these: the
+// hash_* trio stopped being readable in 0.9.0, and dht is reported through
+// dht.statistics instead of a getter.
+function getSettingReadCommand($name)
+{
+	if($name=="dht")
+		return(null);
+	if((rTorrentSettings::get()->iVersion>=0x900) &&
+		in_array($name,array("hash_interval","hash_max_tries","hash_read_ahead")))
+		return(null);
+	return("get_".$name);
+}
+
+function readSettingValues($names)
+{
+	$ret = array_fill(0,count($names),null);
+	$ndxs = array();
+	$req = new rXMLRPCRequest();
+	foreach($names as $ndx=>$name)
+		if(($cmd = getSettingReadCommand($name))!==null)
+		{
+			$req->addCommand(new rXMLRPCCommand($cmd));
+			$ndxs[] = $ndx;
+		}
+	if(!count($ndxs))
+		return($ret);
+	$req->important = false;
+	if($req->success(true) && (count($req->val)==count($ndxs)))
+		foreach($ndxs as $pos=>$ndx)
+			$ret[$ndx] = $req->val[$pos];
+	return($ret);
+}
+
+function logSettingsWrite($names,$values,$before,$after,$accepted,$faultString)
+{
+	foreach($names as $ndx=>$name)
+		FileUtil::toLog("setsettings: ".$name.
+			" requested=".$values[$ndx].
+			" from=".(($before[$ndx]===null) ? "unavailable" : $before[$ndx]).
+			" to=".(($after[$ndx]===null) ? "unavailable" : $after[$ndx]).
+			" ".($accepted ? "accepted" : "rejected"));
+	FileUtil::toLog("setsettings: batch ".($accepted ? "accepted" : "rejected").
+		((!$accepted && ($faultString!=='')) ? " (".$faultString.")" : ""));
+}
+
 function makeSimpleCall($cmds,$hash)
 {
 	$req = new rXMLRPCRequest();
@@ -436,6 +485,8 @@ switch($mode)
 	{
 		$req = new rXMLRPCRequest();
 		$socketCategories = array();
+		$logNames = array();
+		$logValues = array();
 		foreach($vs as $ndx=>$v)
 		{
 			if($ss[$ndx][0]=='n')
@@ -457,6 +508,8 @@ switch($mode)
 			else
 				$cmd = new rXMLRPCCommand('set_'.substr($ss[$ndx],1),$v);
 			$req->addCommand($cmd);
+			$logNames[] = substr($ss[$ndx],1);
+			$logValues[] = $v;
 		}
 		$socketCategories = array_keys($socketCategories);
 		// The staged min_alloc/max_alloc values only take effect once the
@@ -470,11 +523,15 @@ switch($mode)
 		}
 		if($req->getCommandsCount())
 		{
-			if($req->success(true))
+			$before = readSettingValues($logNames);
+			$accepted = $req->success(true);
+			if($accepted)
 		        	$result = $req->val;
 			else
 			if(count($savedAlloc))
 				restoreSocketAlloc($savedAlloc);
+			logSettingsWrite($logNames,$logValues,$before,
+				readSettingValues($logNames),$accepted,$req->faultString);
         	}
         	else
 	        	$result = array();
@@ -606,7 +663,10 @@ switch($mode)
 if(is_null($result))
 {
 	header("HTTP/1.0 500 Server Error");
-	CachedEcho::send( (isset($req) && $req->fault) ? "Warning: XMLRPC call is failed." : "Link to XMLRPC failed. Maybe, rTorrent is down?","text/html");
+	$message = "Link to XMLRPC failed. Maybe, rTorrent is down?";
+	if(isset($req) && $req->fault)
+		$message = ($req->faultString==='') ? "Warning: XMLRPC call is failed." : $req->faultString;
+	CachedEcho::send($message,"text/html");
 }
 else
 	CachedEcho::send(JSON::safeEncode($result),"application/json");

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -663,9 +663,9 @@ switch($mode)
 if(is_null($result))
 {
 	header("HTTP/1.0 500 Server Error");
-	$message = "Link to XMLRPC failed. Maybe, rTorrent is down?";
+	$message = "Could not reach rTorrent over XMLRPC. Is rTorrent running?";
 	if(isset($req) && $req->fault)
-		$message = ($req->faultString==='') ? "Warning: XMLRPC call is failed." : $req->faultString;
+		$message = ($req->faultString==='') ? "Warning: the XMLRPC call failed." : $req->faultString;
 	CachedEcho::send($message,"text/html");
 }
 else

--- a/tests/js/setsettings.spec.js
+++ b/tests/js/setsettings.spec.js
@@ -98,6 +98,28 @@ describe("setsettings on rtorrent with adjustable socket allocation", () => {
   });
 });
 
+describe("settings read-back", () => {
+  function readCommands(iVersion) {
+    loadUI(iVersion);
+    return commandsFor("?action=getsettings").map(([name]) => name);
+  }
+
+  // max_alloc is only the ceiling and commonly sits orders of magnitude above
+  // the allocation in use, so reading it back would misreport the limit.
+  it("reads the allocation in effect once the socket manager owns the limits", () => {
+    const commands = readCommands(0x1010);
+    expect(commands).toContain("system.sockets.http.max_size");
+    expect(commands).not.toContain("system.sockets.http.max_alloc");
+    expect(commands).toContain("network.max_open_files");
+  });
+
+  it("keeps the legacy read-back commands on 0.9.8", () => {
+    const commands = readCommands(0x908);
+    expect(commands).toContain("network.max_open_files");
+    expect(commands).toContain("network.http.max_open");
+  });
+});
+
 // Sending these commands to an rtorrent that aborts on an over-budget
 // adjust_alloc would kill the process, so older versions keep the old command.
 describe("setsettings below the socket allocation version gate", () => {

--- a/tests/js/setsettings.spec.js
+++ b/tests/js/setsettings.spec.js
@@ -1,0 +1,120 @@
+import { readFileSync } from "fs";
+
+window.$ = require("jquery");
+
+const SOURCES = [
+  "../lang/en.js",
+  "../js/common.js",
+  "../js/content.js",
+  "../js/rtorrent.js",
+];
+
+// correctContent() builds theRequestManager.aliases by $.extend-ing one block per
+// rtorrent version, so the alias table can only ever grow. Reload the sources for
+// each version under test to get a table that matches that version exactly.
+function loadUI(iVersion) {
+  window.theWebUI = {
+    settings: { "webui.needmessage": true },
+    showFlags: 0xffff,
+    systemInfo: { rTorrent: { apiVersion: 24, iVersion, started: true } },
+  };
+  for (const src of SOURCES) {
+    const scriptEl = document.createElement("script");
+    scriptEl.textContent = readFileSync(src, { encoding: "utf-8" });
+    document.body.appendChild(scriptEl);
+  }
+  correctContent();
+}
+
+function commandsFor(query) {
+  return new rTorrentStub(query).commands.map((cmd) => [
+    cmd.command,
+    ...cmd.params.map((prm) => `${prm.type}:${prm.value}`),
+  ]);
+}
+
+// rtorrent 0.16.19.
+const V_SOCKET_ALLOC = 0x1013;
+
+describe("setsettings on rtorrent with adjustable socket allocation", () => {
+  beforeEach(() => loadUI(V_SOCKET_ALLOC));
+
+  it("sets both bounds and recomputes for max open files", () => {
+    expect(commandsFor("?action=setsettings&s=nmax_open_files&v=20000")).toStrictEqual([
+      ["system.sockets.files.min_alloc.set", "string:", "i8:20000"],
+      ["system.sockets.files.max_alloc.set", "string:", "i8:20000"],
+      ["system.sockets.adjust_alloc"],
+    ]);
+  });
+
+  it("sets both bounds and recomputes for max open http", () => {
+    expect(commandsFor("?action=setsettings&s=nmax_open_http&v=1024")).toStrictEqual([
+      ["system.sockets.http.min_alloc.set", "string:", "i8:1024"],
+      ["system.sockets.http.max_alloc.set", "string:", "i8:1024"],
+      ["system.sockets.adjust_alloc"],
+    ]);
+  });
+
+  // max_alloc alone is a ceiling and can only lower the allocation, so a raise
+  // needs min_alloc too. Neither takes effect before adjust_alloc runs.
+  it("emits adjust_alloc once at the end when both settings change together", () => {
+    const commands = commandsFor(
+      "?action=setsettings&s=nmax_open_files&v=20000&s=nmax_open_http&v=1024"
+    );
+    expect(commands).toStrictEqual([
+      ["system.sockets.files.min_alloc.set", "string:", "i8:20000"],
+      ["system.sockets.files.max_alloc.set", "string:", "i8:20000"],
+      ["system.sockets.http.min_alloc.set", "string:", "i8:1024"],
+      ["system.sockets.http.max_alloc.set", "string:", "i8:1024"],
+      ["system.sockets.adjust_alloc"],
+    ]);
+    expect(commands.filter(([name]) => name === "system.sockets.adjust_alloc")).toHaveLength(1);
+  });
+
+  it("does not recompute when no socket setting changed", () => {
+    expect(commandsFor("?action=setsettings&s=nmax_peers&v=100")).toStrictEqual([
+      ["throttle.max_peers.normal.set", "string:", "i8:100"],
+    ]);
+  });
+
+  it("keeps the dht setting on its own branch", () => {
+    expect(commandsFor("?action=setsettings&s=ndht&v=0")).toStrictEqual([
+      ["dht.mode.set", "string:", "string:disable"],
+    ]);
+    expect(commandsFor("?action=setsettings&s=ndht&v=1")).toStrictEqual([
+      ["dht.mode.set", "string:", "string:auto"],
+    ]);
+  });
+
+  it("leaves other settings in the batch untouched", () => {
+    expect(
+      commandsFor("?action=setsettings&s=nmax_open_files&v=20000&s=nmax_uploads&v=50")
+    ).toStrictEqual([
+      ["system.sockets.files.min_alloc.set", "string:", "i8:20000"],
+      ["system.sockets.files.max_alloc.set", "string:", "i8:20000"],
+      ["throttle.max_uploads.set", "string:", "i8:50"],
+      ["system.sockets.adjust_alloc"],
+    ]);
+  });
+});
+
+// Sending these commands to an rtorrent that aborts on an over-budget
+// adjust_alloc would kill the process, so older versions keep the old command.
+describe("setsettings below the socket allocation version gate", () => {
+  it("sends the single ceiling command on 0.16.18", () => {
+    loadUI(0x1012);
+    expect(commandsFor("?action=setsettings&s=nmax_open_files&v=20000")).toStrictEqual([
+      ["system.sockets.files.max_alloc.set", "string:", "i8:20000"],
+    ]);
+  });
+
+  it("sends the legacy command on 0.9.8", () => {
+    loadUI(0x908);
+    expect(commandsFor("?action=setsettings&s=nmax_open_files&v=20000")).toStrictEqual([
+      ["network.max_open_files.set", "string:", "i8:20000"],
+    ]);
+    expect(commandsFor("?action=setsettings&s=nmax_open_http&v=1024")).toStrictEqual([
+      ["network.http.max_open.set", "string:", "i8:1024"],
+    ]);
+  });
+});


### PR DESCRIPTION
● `network.max_open_files.set` has been an inert stub since 0.16.16 — it logs a
  deprecation warning and discards the value. The file and HTTP socket limits belong
  to libtorrent's socket manager instead, so the settings field silently does nothing.

  Remapping the setter to `system.sockets.<category>.max_alloc.set` is not enough on
  its own. `max_alloc` is a ceiling that can only lower the allocation, and nothing
  takes effect until the socket manager recomputes. Measured against 0.16.19 with a
  10240 file allocation: `max_alloc.set(20000)` leaves `max_size` at 10240 even after
  a recompute, while `min_alloc.set(20000)` raises it. Raising the limit is the only
  thing the setting is used for.

  This sends `min_alloc` and `max_alloc` together so the allocation lands on exactly
  the requested value in either direction, then emits `system.sockets.adjust_alloc`
  once per settings batch, only when one of the two settings was present.

  Restricted to 0.16.19 and later. Earlier versions abort on an over-budget
  `adjust_alloc`, and the client cannot check the budget beforehand because its
  `reserve` and `min_generic` terms are not exposed over RPC. 0.16.19 reports a
  regular XMLRPC fault instead. Older versions keep their current behaviour.

  Two related problems are fixed alongside it:

  `get_max_open_http` read `system.sockets.http.max_alloc`, the ceiling rather than
  the allocation in effect, so the dialog reported 1000000 against an effective 512.
  It now reads `system.sockets.http.max_size`, matching how `max_open_files` reads
  `network.max_open_files`. That command has existed since 0.16.15.

  The socket manager stages `min_alloc`/`max_alloc` until `adjust_alloc` runs, and a
  rejected recompute keeps the staged values — so one over-budget entry also broke
  every later recompute, including saves of unrelated settings. The bounds in effect
  are now read before being replaced and put back if the recompute is refused.
  libtorrent has no revert call of its own, but the bounds are readable and restoring
  a state valid moments earlier is accepted; a restore that is itself refused is
  logged rather than passed over. This applies to the httprpc path; the client path
  builds its batch up front and has no hook on the fault path, so it keeps the
  simpler behaviour.

  Verified end to end against 0.16.19: setting the field to 20000 raises
  `system.sockets.files.max_size` and `network.max_open_files` from 10240 to 20000 and
  the dialog reads back 20000; an over-budget value returns a clean fault with the
  bounds restored, the process alive, and a subsequent valid save on another field
  succeeding where it previously failed.

  Adds `tests/js/setsettings.spec.js` covering command construction on both sides of
  the version gate and the read-back mapping.

  Fixes #3140