### PR TITLE
Detach plugin background spawns instead of using execute.nothrow.bg

### DIFF
--- a/plugins/_task/task.php
+++ b/plugins/_task/task.php
@@ -291,7 +291,7 @@ class rTask
 		{
 			$req = new rXMLRPCRequest(
 				((rTorrentSettings::get()->iVersion>=0x900) && !($flags & self::FLG_WAIT)) ?
-					new rXMLRPCCommand( "execute.nothrow.bg", array("","sh",$cmd) ) :
+					new rXMLRPCCommand( "execute.nothrow", array("","sh","-c",'"$0" "$1" </dev/null >/dev/null 2>&1 &',"sh",$cmd) ) :
 					new rXMLRPCCommand( "execute_nothrow", array("sh","-c",$cmd.$params) )
 				);
 			if($req->success() && count($req->val))

--- a/plugins/history/history.php
+++ b/plugins/history/history.php
@@ -135,7 +135,7 @@ class rHistory
 		global $rootPath;
 		if($this->log["addition"] || ($this->log["pushbullet_enabled"] && $this->log["pushbullet_addition"]))
 		{
-			$addCmd = getCmd('execute.nothrow.bg').'={'.Utility::getPHP().','.$rootPath.'/plugins/history/update.php'.',1,$'.
+			$addCmd = getCmd('execute.nothrow').'={sh,-c,\"$0\" \"$@\" </dev/null >/dev/null 2>&1 &,'.Utility::getPHP().','.$rootPath.'/plugins/history/update.php'.',1,$'.
 				getCmd('d.get_name').'=,$'.getCmd('d.get_size_bytes').'=,$'.getCmd('d.get_bytes_done').'=,$'.
 				getCmd('d.get_up_total').'=,$'.getCmd('d.get_ratio').'=,$'.getCmd('d.get_creation_date').'=,$'.
 				getCmd('d.get_custom').'=addtime,$'.getCmd('d.get_custom').'=seedingtime'.
@@ -146,7 +146,7 @@ class rHistory
 		else
 			$addCmd = getCmd('cat=');
 		if($this->log["finish"] || ($this->log["pushbullet_enabled"] && $this->log["pushbullet_finish"]))
-			$finCmd = getCmd('execute.nothrow.bg').'={'.Utility::getPHP().','.$rootPath.'/plugins/history/update.php'.',2,$'.
+			$finCmd = getCmd('execute.nothrow').'={sh,-c,\"$0\" \"$@\" </dev/null >/dev/null 2>&1 &,'.Utility::getPHP().','.$rootPath.'/plugins/history/update.php'.',2,$'.
 				getCmd('d.get_name').'=,$'.getCmd('d.get_size_bytes').'=,$'.getCmd('d.get_bytes_done').'=,$'.
 				getCmd('d.get_up_total').'=,$'.getCmd('d.get_ratio').'=,$'.getCmd('d.get_creation_date').'=,$'.
 				getCmd('d.get_custom').'=addtime,$'.getCmd('d.get_custom').'=seedingtime'.
@@ -156,7 +156,7 @@ class rHistory
 		else
 			$finCmd = getCmd('cat=');
 		if($this->log["deletion"] || ($this->log["pushbullet_enabled"] && $this->log["pushbullet_deletion"]))
-			$delCmd = getCmd('execute.nothrow.bg').'={'.Utility::getPHP().','.$rootPath.'/plugins/history/update.php'.',3,$'.
+			$delCmd = getCmd('execute.nothrow').'={sh,-c,\"$0\" \"$@\" </dev/null >/dev/null 2>&1 &,'.Utility::getPHP().','.$rootPath.'/plugins/history/update.php'.',3,$'.
 				getCmd('d.get_name').'=,$'.getCmd('d.get_size_bytes').'=,$'.getCmd('d.get_bytes_done').'=,$'.
 				getCmd('d.get_up_total').'=,$'.getCmd('d.get_ratio').'=,$'.getCmd('d.get_creation_date').'=,$'.
 				getCmd('d.get_custom').'=addtime,$'.getCmd('d.get_custom').'=seedingtime'.

--- a/plugins/unpack/unpack.php
+++ b/plugins/unpack/unpack.php
@@ -437,7 +437,7 @@ class rUnpack
 		if($this->enabled)
 		{
 			$cmd =  rTorrentSettings::get()->getOnFinishedCommand( array('unpack'.User::getUser(),
-					getCmd('execute.nothrow.bg').'={'.Utility::getPHP().','.$rootPath.'/plugins/unpack/update.php,$'.getCmd('d.get_directory').'=,$'.getCmd('d.get_base_filename').'=,$'.getCmd('d.is_multi_file').
+					getCmd('execute.nothrow').'={sh,-c,\"$0\" \"$@\" </dev/null >/dev/null 2>&1 &,'.Utility::getPHP().','.$rootPath.'/plugins/unpack/update.php,$'.getCmd('d.get_directory').'=,$'.getCmd('d.get_base_filename').'=,$'.getCmd('d.is_multi_file').
 					'=,$'.getCmd('d.get_custom1').'=,$'.getCmd('d.get_name').'=,$'.getCmd('d.get_hash').'=,$'.getCmd('d.get_custom').'=x-dest,'.User::getUser().'}'));
 		}
 		else

--- a/plugins/xmpp/xmpp.php
+++ b/plugins/xmpp/xmpp.php
@@ -131,7 +131,7 @@ class rXmpp
 		if ( $this->message !== '' && isset($this->jabberServer) && isset($this->jabberLogin) && isset($this->jabberPasswd) && isset($this->jabberFor))
 		{
 		    $cmd = $theSettings->getOnFinishedCommand(array('xmpp'.User::getUser(),
-			    getCmd('execute.nothrow.bg').'={'.Utility::getPHP().','.$pathToXmpp.'/notify.php,"$'.getCmd('d.name').'=","'.User::getUser().'"}'
+			    getCmd('execute.nothrow').'={sh,-c,\"$0\" \"$@\" </dev/null >/dev/null 2>&1 &,'.Utility::getPHP().','.$pathToXmpp.'/notify.php,"$'.getCmd('d.name').'=","'.User::getUser().'"}'
 			    ));
 		}
 		else


### PR DESCRIPTION
rtorrent 0.16.16+ spawns background execute children via posix_spawn and never waits on them, so every execute.nothrow.bg call leaves a permanent zombie: one per torrent added/finished/erased (history), per completed download (unpack, xmpp) and per started task (_task).

Use a foreground execute of sh -c with positional parameters instead: sh backgrounds the php child and exits immediately (foreground children are reaped), the child reparents to init, and the rtorrent-substituted arguments arrive unchanged (spaces, commas, quotes, empty values verified identical on 0.9.8 and 0.16.19).