### PR TITLE
Fix stale time deltas after browser sleep/tab suspension

### DIFF
--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -1376,6 +1376,16 @@ function Ajax_UpdateTime(jqXHR)
 	jqXHR = null; // Cleanup memory leak
 }
 
+// Recalculate time deltas after browser sleep/tab suspension
+document.addEventListener("visibilitychange", function()
+{
+	if(!document.hidden)
+	{
+		theWebUI.deltaTime = 0;
+		theWebUI.serverDeltaTime = 0;
+	}
+});
+
 $(document).ready(function()
 {
 	var timer = null;

--- a/tests/js/rtorrent.spec.js
+++ b/tests/js/rtorrent.spec.js
@@ -162,3 +162,59 @@ describe("xmlrpc calls", () => {
     }
   });
 });
+
+describe("visibilitychange handler", () => {
+  let hiddenDescriptor;
+
+  beforeEach(() => {
+    // Save original descriptor so we can restore it after each test
+    hiddenDescriptor = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      "hidden"
+    );
+  });
+
+  afterEach(() => {
+    // Restore original document.hidden behavior
+    if (hiddenDescriptor) {
+      Object.defineProperty(Document.prototype, "hidden", hiddenDescriptor);
+    }
+    // Reset state
+    theWebUI.deltaTime = 0;
+    theWebUI.serverDeltaTime = 0;
+  });
+
+  it("should reset deltaTime and serverDeltaTime when tab becomes visible", () => {
+    // Simulate cached deltas from a previous Ajax_UpdateTime call
+    theWebUI.deltaTime = 5000;
+    theWebUI.serverDeltaTime = 3000;
+
+    // Mock document.hidden to return false (tab is now visible)
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => false,
+    });
+
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(theWebUI.deltaTime).toBe(0);
+    expect(theWebUI.serverDeltaTime).toBe(0);
+  });
+
+  it("should NOT reset deltas when tab becomes hidden", () => {
+    theWebUI.deltaTime = 5000;
+    theWebUI.serverDeltaTime = 3000;
+
+    // Mock document.hidden to return true (tab is now hidden)
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => true,
+    });
+
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    // Values should remain unchanged
+    expect(theWebUI.deltaTime).toBe(5000);
+    expect(theWebUI.serverDeltaTime).toBe(3000);
+  });
+});

--- a/tests/js/rtorrent.spec.js
+++ b/tests/js/rtorrent.spec.js
@@ -176,6 +176,7 @@ describe("visibilitychange handler", () => {
 
   afterEach(() => {
     // Restore original document.hidden behavior
+    delete document.hidden;
     if (hiddenDescriptor) {
       Object.defineProperty(Document.prototype, "hidden", hiddenDescriptor);
     }


### PR DESCRIPTION
deltaTime and serverDeltaTime are computed once on the first AJAX response and cached for the lifetime of the page. When the browser sleeps or the tab is suspended, the cached values become stale, causing all displayed timestamps to be offset by the sleep duration.

Reset both values to 0 on visibilitychange so Ajax_UpdateTime recalculates them from the next fresh response.

Co-authored-by: AI (Gemini via Antigravity IDE)