### PR TITLE
Fix Oblivion scrollbars in Firefox 153

### DIFF
--- a/plugins/theme/themes/Oblivion/style.css
+++ b/plugins/theme/themes/Oblivion/style.css
@@ -349,9 +349,11 @@ span.det {color:#fff;}
 
 .meter-value-start-color { background-color: #E05400 }
 .meter-value-end-color { background-color: #8FBC00 }
-::-webkit-scrollbar {
-    width: 15px;
-    height: 15px;
+@supports selector(::-webkit-scrollbar-thumb) {
+    ::-webkit-scrollbar {
+        width: 15px;
+        height: 15px;
+    }
 }
 ::-webkit-scrollbar-thumb {
     height: 12px;

--- a/plugins/theme/themes/OblivionBlue/style.css
+++ b/plugins/theme/themes/OblivionBlue/style.css
@@ -351,9 +351,11 @@ span.det {color:#fff;}
 .meter-value-start-color { background-color: #E05400 }
 .meter-value-end-color { background-color: #178FD1 }
 
-::-webkit-scrollbar {
-    width: 15px;
-    height: 15px;
+@supports selector(::-webkit-scrollbar-thumb) {
+    ::-webkit-scrollbar {
+        width: 15px;
+        height: 15px;
+    }
 }
 ::-webkit-scrollbar-thumb {
     height: 12px;


### PR DESCRIPTION
Fixes #3152

Firefox 153 recognizes `::-webkit-scrollbar` while reporting no support for `::-webkit-scrollbar-thumb`. This can apply the custom scrollbar dimensions without the corresponding thumb styling, causing the scrollbar thumb to disappear.

This patch guards only the scrollbar geometry rule with `@supports selector(::-webkit-scrollbar-thumb)`. The existing thumb, button, track-piece, and corner rules are unchanged.

Validated with Firefox 153 on Windows 10 against three ruTorrent instances using Oblivion, and with OblivionBlue on one instance. Chrome 151.0.7922.76 on Windows 10 was used as a regression check.