### PR TITLE
erasedata: delete the data of downloads rtorrent has not opened

### DIFF
--- a/plugins/erasedata/removewithdata.php
+++ b/plugins/erasedata/removewithdata.php
@@ -5,39 +5,90 @@
 // of files to delete -- read over RPC, which works on every rtorrent version --
 // into the erasedata list directory for the garbage collector, then erases the
 // torrents. The caller must have already loaded php/xmlrpc.php.
+if(!function_exists('erasedataCollectPaths'))
+{
+	// d.base_path and f.frozen_path are only filled in when rtorrent opens a
+	// download's file list, and are not restored from the session. A download
+	// that has not been opened since rtorrent started -- any torrent that was
+	// stopped when the session was loaded -- reports both as empty, so fall
+	// back to d.directory and f.path, which are always available.
+	function erasedataCollectPaths($hash)
+	{
+		// rXMLRPCRequest flattens every returned value into ->val, so query one
+		// torrent per request, and keep the variable-length f.multicall last:
+		// val[0] = directory, val[1] = is_multi, val[2..] = each file path.
+		$frozen = new rXMLRPCRequest( array(
+			new rXMLRPCCommand( getCmd("d.get_base_path"), $hash ),
+			new rXMLRPCCommand( getCmd("d.is_multi_file"), $hash ),
+			new rXMLRPCCommand( getCmd("f.multicall"), array($hash, "", getCmd("f.get_frozen_path")."=") )
+		) );
+		if($frozen->success() && count($frozen->val) >= 3)
+		{
+			$files = array();
+			foreach(array_slice($frozen->val, 2) as $path)
+				if(strlen($path))
+					$files[] = $path;
+			if(count($files))
+				return( array(
+					"base"  => $frozen->val[0],
+					"multi" => $frozen->val[1] ? "1" : "0",
+					"files" => $files ) );
+		}
+
+		$stored = new rXMLRPCRequest( array(
+			new rXMLRPCCommand( getCmd("d.get_directory"), $hash ),
+			new rXMLRPCCommand( getCmd("d.is_multi_file"), $hash ),
+			new rXMLRPCCommand( getCmd("f.multicall"), array($hash, "", getCmd("f.get_path")."=") )
+		) );
+		if(!$stored->success() || count($stored->val) < 3)
+			return(false);
+		$dir = rtrim($stored->val[0], '/');
+		if(!strlen($dir))
+			return(false);
+		$isMulti = $stored->val[1] ? "1" : "0";
+		$files = array();
+		foreach(array_slice($stored->val, 2) as $path)
+			if(strlen($path))
+				$files[] = $dir.'/'.$path;
+		if(!count($files))
+			return(false);
+		// d.directory is the download's root directory, which for a single-file
+		// torrent is the directory holding the file, not the file itself --
+		// d.base_path returns the file. Mirror that here.
+		return( array(
+			"base"  => $isMulti=="1" ? $dir : $files[0],
+			"multi" => $isMulti,
+			"files" => $files ) );
+	}
+}
 if(!function_exists('erasedataRemoveWithData'))
 {
 	function erasedataRemoveWithData($hashes, $forceDelete)
 	{
 		$listPath = FileUtil::getSettingsPath()."/erasedata";
 		@FileUtil::makeDirectory($listPath);
-		// rXMLRPCRequest flattens every returned value into ->val, so query one
-		// torrent per request to keep the layout unambiguous:
-		// val[0] = base path, val[1] = is_multi, val[2..] = each file path.
+		$erasable = array();
 		foreach($hashes as $h)
 		{
-			$info = new rXMLRPCRequest( array(
-				new rXMLRPCCommand( getCmd("d.get_base_path"), $h ),
-				new rXMLRPCCommand( getCmd("d.is_multi_file"), $h ),
-				new rXMLRPCCommand( getCmd("f.multicall"), array($h, "", getCmd("f.get_frozen_path")."=") )
-			) );
-			if($info->success() && count($info->val) >= 3)
+			$paths = erasedataCollectPaths($h);
+			if($paths === false)
 			{
-				$lines = array();
-				foreach(array_slice($info->val, 2) as $path)
-					if(strlen($path))
-						$lines[] = $path;
-				if(count($lines))
-				{
-					$lines[] = $info->val[0];
-					$lines[] = $info->val[1] ? "1" : "0";
-					$lines[] = $forceDelete;
-					@file_put_contents($listPath."/".$h.".list", implode("\n", $lines)."\n");
-				}
+				// Erasing now would drop the torrent and leave its data behind
+				// with nothing left to identify it, so keep the torrent.
+				FileUtil::toLog("erasedata: could not determine the files of ".$h.", torrent not erased");
+				continue;
 			}
+			$lines = $paths["files"];
+			$lines[] = $paths["base"];
+			$lines[] = $paths["multi"];
+			$lines[] = $forceDelete;
+			@file_put_contents($listPath."/".$h.".list", implode("\n", $lines)."\n");
+			$erasable[] = $h;
 		}
+		if(!count($erasable))
+			return(false);
 		$req = new rXMLRPCRequest();
-		foreach($hashes as $h)
+		foreach($erasable as $h)
 		{
 			$req->addCommand( new rXMLRPCCommand( getCmd("d.set_custom5"), array($h, "") ) );
 			$req->addCommand( new rXMLRPCCommand( getCmd("d.delete_tied"), $h ) );

--- a/tests/plugins/erasedata/RemoveWithDataTest.php
+++ b/tests/plugins/erasedata/RemoveWithDataTest.php
@@ -1,0 +1,223 @@
+<?php
+
+require_once(__DIR__ . '/../../php/TestCase.php');
+
+// Stub the dependencies the production callers (httprpc/action.php,
+// plugins/erasedata/action.php) load before invoking the helper. The RPC layer
+// is scripted per command so the helper's own logic is what gets exercised.
+if(!class_exists('FileUtil'))
+{
+	class FileUtil
+	{
+		public static $settingsPath = null;
+		public static $log = array();
+		public static function getSettingsPath() { return self::$settingsPath; }
+		public static function makeDirectory($dir) { return @mkdir($dir, 0777, true); }
+		public static function toLog($msg) { self::$log[] = $msg; }
+	}
+}
+if(!class_exists('rXMLRPCCommand'))
+{
+	class rXMLRPCCommand
+	{
+		public $command;
+		public $params;
+		public function __construct($command, $params = null)
+		{
+			$this->command = $command;
+			$this->params = $params;
+		}
+	}
+}
+if(!class_exists('rXMLRPCRequest'))
+{
+	class rXMLRPCRequest
+	{
+		public static $responses = array();	// first command name => array(ok, val)
+		public static $requested = array();	// first command name of each request, in order
+		public static $erased = array();	// hashes passed to d.erase
+
+		public $val = array();
+		private $commands = array();
+
+		public function __construct($commands = null)
+		{
+			if(is_array($commands))
+				$this->commands = $commands;
+			else if(!is_null($commands))
+				$this->commands = array($commands);
+		}
+		public function addCommand($command)
+		{
+			$this->commands[] = $command;
+		}
+		public function success($trusted = true)
+		{
+			if(!count($this->commands))
+				return(false);
+			$first = $this->commands[0]->command;
+			self::$requested[] = $first;
+			foreach($this->commands as $c)
+				if($c->command == "d.erase")
+					self::$erased[] = $c->params;
+			if(!array_key_exists($first, self::$responses))
+				return(false);
+			$this->val = self::$responses[$first]["val"];
+			return(self::$responses[$first]["ok"]);
+		}
+	}
+}
+if(!function_exists('getCmd'))
+{
+	function getCmd($cmd) { return($cmd); }
+}
+
+require_once(__DIR__ . '/../../../plugins/erasedata/removewithdata.php');
+
+class RemoveWithDataTest extends TestCase
+{
+	private $dir;
+
+	public function setUp()
+	{
+		$this->dir = sys_get_temp_dir().'/erasedata-test-'.getmypid();
+		@mkdir($this->dir, 0777, true);
+		FileUtil::$settingsPath = $this->dir;
+	}
+
+	// setUp() runs once per class, so each test starts from a clean slate here.
+	private function reset()
+	{
+		foreach(glob($this->dir.'/erasedata/*.list') as $f)
+			@unlink($f);
+		FileUtil::$log = array();
+		rXMLRPCRequest::$responses = array();
+		rXMLRPCRequest::$requested = array();
+		rXMLRPCRequest::$erased = array();
+	}
+
+	public function tearDown()
+	{
+		foreach(glob($this->dir.'/erasedata/*') as $f)
+			@unlink($f);
+		@rmdir($this->dir.'/erasedata');
+		@rmdir($this->dir);
+	}
+
+	// -- helpers ------------------------------------------------------------
+
+	private function frozen($ok, $val) { rXMLRPCRequest::$responses["d.get_base_path"] = array("ok"=>$ok, "val"=>$val); }
+	private function stored($ok, $val) { rXMLRPCRequest::$responses["d.get_directory"] = array("ok"=>$ok, "val"=>$val); }
+	private function eraseOk() { rXMLRPCRequest::$responses["d.set_custom5"] = array("ok"=>true, "val"=>array("","","")); }
+
+	private function listFor($hash)
+	{
+		$f = $this->dir.'/erasedata/'.$hash.'.list';
+		return(is_file($f) ? file($f, FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES) : false);
+	}
+
+	// -- frozen paths available (an opened download) ------------------------
+
+	public function testFrozenPathsUsedForMultiFile()
+	{
+		$this->reset();
+		$this->frozen(true, array("/d/name", 1, "/d/name/a.bin", "/d/name/sub/b.bin"));
+		$this->eraseOk();
+		erasedataRemoveWithData(array("A"), "1");
+		$this->assertEquals(array("/d/name/a.bin","/d/name/sub/b.bin","/d/name","1","1"), $this->listFor("A"), 'multi-file list from frozen paths');
+		$this->assertEquals(array("d.get_base_path","d.set_custom5"), rXMLRPCRequest::$requested, 'no fallback request when frozen paths exist');
+	}
+
+	public function testFrozenPathsUsedForSingleFile()
+	{
+		$this->reset();
+		$this->frozen(true, array("/d/movie.mkv", 0, "/d/movie.mkv"));
+		$this->eraseOk();
+		erasedataRemoveWithData(array("A"), "1");
+		$this->assertEquals(array("/d/movie.mkv","/d/movie.mkv","0","1"), $this->listFor("A"), 'single-file list from frozen paths');
+	}
+
+	// -- frozen paths empty (a download never opened this session) ----------
+
+	public function testFallsBackToStoredPathsForMultiFile()
+	{
+		$this->reset();
+		$this->frozen(true, array("", 1, "", ""));
+		$this->stored(true, array("/d/name", 1, "a.bin", "sub/b.bin"));
+		$this->eraseOk();
+		erasedataRemoveWithData(array("A"), "1");
+		$this->assertEquals(array("/d/name/a.bin","/d/name/sub/b.bin","/d/name","1","1"), $this->listFor("A"), 'multi-file list rebuilt from d.directory + f.path');
+		$this->assertEquals(array("d.get_base_path","d.get_directory","d.set_custom5"), rXMLRPCRequest::$requested, 'fallback request issued');
+	}
+
+	public function testFallsBackToStoredPathsForSingleFile()
+	{
+		$this->reset();
+		$this->frozen(true, array("", 0, ""));
+		$this->stored(true, array("/d", 0, "movie.mkv"));
+		$this->eraseOk();
+		erasedataRemoveWithData(array("A"), "1");
+		// d.base_path reports the file itself for a single-file torrent, while
+		// d.directory reports the directory holding it.
+		$this->assertEquals(array("/d/movie.mkv","/d/movie.mkv","0","1"), $this->listFor("A"), 'single-file base path is the file, not its directory');
+	}
+
+	public function testFallbackNormalisesTrailingSlash()
+	{
+		$this->reset();
+		$this->frozen(true, array("", 1, ""));
+		$this->stored(true, array("/d/name/", 1, "a.bin"));
+		$this->eraseOk();
+		erasedataRemoveWithData(array("A"), "1");
+		$this->assertEquals(array("/d/name/a.bin","/d/name","1","1"), $this->listFor("A"), 'no doubled separator from a trailing slash');
+	}
+
+	public function testFallbackUsedWhenFrozenRequestFails()
+	{
+		$this->reset();
+		$this->frozen(false, array());
+		$this->stored(true, array("/d/name", 1, "a.bin"));
+		$this->eraseOk();
+		erasedataRemoveWithData(array("A"), "1");
+		$this->assertEquals(array("/d/name/a.bin","/d/name","1","1"), $this->listFor("A"), 'a failed frozen request also falls back');
+	}
+
+	// -- the delete mode is recorded verbatim -------------------------------
+
+	public function testForceDeleteFlagRecorded()
+	{
+		$this->reset();
+		$this->frozen(true, array("/d/name", 1, "/d/name/a.bin"));
+		$this->eraseOk();
+		erasedataRemoveWithData(array("A"), "2");
+		$lines = $this->listFor("A");
+		$this->assertEquals("2", end($lines), 'delete-path mode recorded as the last line');
+	}
+
+	// -- refuse to erase what cannot be cleaned up ---------------------------
+
+	public function testTorrentNotErasedWhenNoPathsResolve()
+	{
+		$this->reset();
+		$this->frozen(true, array("", 1, "", ""));
+		$this->stored(true, array("", 1, "", ""));
+		$this->eraseOk();
+		$result = erasedataRemoveWithData(array("A"), "1");
+		$this->assertTrue($this->listFor("A") === false, 'no list written when no path resolves');
+		$this->assertEquals(array(), rXMLRPCRequest::$erased, 'torrent must not be erased when its files are unknown');
+		$this->assertTrue($result === false, 'caller is told the removal did not happen');
+		$this->assertEquals(1, count(FileUtil::$log), 'the refusal is logged');
+	}
+
+	public function testResolvableHashesStillErasedInAMixedBatch()
+	{
+		$this->reset();
+		// The scripted RPC layer answers per command, so both hashes see the
+		// same empty frozen reply; only the stored reply resolves.
+		$this->frozen(true, array("", 1, ""));
+		$this->stored(true, array("/d/name", 1, "a.bin"));
+		$this->eraseOk();
+		erasedataRemoveWithData(array("A","B"), "1");
+		$this->assertEquals(array("A","B"), rXMLRPCRequest::$erased, 'every resolvable hash is erased');
+	}
+}


### PR DESCRIPTION
d.base_path and f.frozen_path are filled in when rtorrent opens a download's file list, and are not restored from the session. A download that has not been opened since rtorrent started therefore reports both as empty -- which is every torrent that was stopped when the session was loaded.

removewithdata collected no paths for those, skipped writing the <hash>.list that the garbage collector consumes, and erased the torrent anyway, leaving the data on disk with nothing left to identify it. Both "Delete Data" and "Delete Path" were affected, because the list is skipped before the delete mode is read. Starting the torrent or forcing a recheck opens the file list and makes the next attempt succeed, which is why this looks like "old torrents do not delete their data".

Fall back to d.directory and f.path, which are always available, and keep the torrent when neither source resolves rather than erasing a download whose files can no longer be identified.