### PR TITLE
mobile: remember the theme, accent color and sort order

### DIFF
--- a/plugins/mobile/README.md
+++ b/plugins/mobile/README.md
@@ -32,15 +32,18 @@ If in rutorrent you turned off 'Confirm when deleting torrents', this plugin wil
 
 #### plugin.sort
 'name' by default. Possible values: 'name', '-name', 'status', '-status', 'size', '-size', 'uploaded', '-uploaded', 'downloaded', '-downloaded', 'done', '-done', 'eta', '-eta', 'ul', '-ul', 'dl', '-dl', 'ratio', '-ratio', and if the seedingtime plugin is loaded 'addtime', '-addtime', 'seedingtime', '-seedingtime'.
-This option sets the default sort value of the torrent list. Without negative it's ascending, with negative it's descending.
+This option sets the default sort value of the torrent list. Without negative it's ascending, with negative it's descending. A sort order picked from the sort page is remembered for that user and takes precedence over this option.
 
 #### plugin.accentColor
 'primary' by default. Possible values: 'primary' (blue), 'secondary' (gray), 'success' (green), 'danger' (red), 'warning' (yellow), 'info' (cyan), 'dark' (contrast: near-black on the light theme, near-white on dark).
-This option sets the Bootstrap theme color used for buttons, progress bars, tab highlights and selections. The color can also be changed temporarily from the settings page; a page reload reverts to this option.
+This option sets the Bootstrap theme color used for buttons, progress bars, tab highlights and selections. An accent picked from the settings page is remembered for that user and takes precedence over this option.
 
 #### plugin.theme
 'light' by default. Possible values: 'light', 'dark', 'system'.
-This option sets the color scheme of the UI. 'system' follows the device's light/dark setting, live. The theme can also be changed temporarily from the settings page; a page reload reverts to this option.
+This option sets the color scheme of the UI. 'system' follows the device's light/dark setting, live. A theme picked from the settings page is remembered for that user and takes precedence over this option.
+
+### Remembered settings
+The theme, accent color and sort order picked from the UI are saved per user, alongside the rest of the ruTorrent settings, so they survive a page reload and a new login. They are stored under the `webui.mobile.*` keys and follow the account, not the device. The options above remain the defaults for users who have not picked their own.
 
 ### Utilization
 If you set plugin.enableAutodetect to true, the plugin will automaticaly load when detecting a mobile device. To force load the plugin in a desktop browser add '?mobile=1' to the end of the rutorrent url.

--- a/plugins/mobile/init.js
+++ b/plugins/mobile/init.js
@@ -2,9 +2,9 @@
 plugin.enableAutodetect = true;
 plugin.tabletsDetect = true;
 plugin.eraseWithDataDefault = false;
-plugin.sort = 'name'; /* 'name', 'status', 'size', 'uploaded', 'downloaded', 'done', 'eta', 'ul', 'dl', 'ratio', and with the seedingtime plugin 'addtime', 'seedingtime'. Add preceding negative for descending sort. */
-plugin.accentColor = 'primary'; /* Bootstrap theme color for buttons, progress bars and highlights: 'primary' (blue), 'secondary' (gray), 'success' (green), 'danger' (red), 'warning' (yellow), 'info' (cyan) or 'dark' (contrast: near-black on the light theme, near-white on dark). */
-plugin.theme = 'light'; /* 'light', 'dark', or 'system' to follow the device setting (live). Can also be changed temporarily from the settings page. */
+plugin.sort = 'name'; /* 'name', 'status', 'size', 'uploaded', 'downloaded', 'done', 'eta', 'ul', 'dl', 'ratio', and with the seedingtime plugin 'addtime', 'seedingtime'. Add preceding negative for descending sort. Default for a user who has not picked a sort order from the sort page. */
+plugin.accentColor = 'primary'; /* Bootstrap theme color for buttons, progress bars and highlights: 'primary' (blue), 'secondary' (gray), 'success' (green), 'danger' (red), 'warning' (yellow), 'info' (cyan) or 'dark' (contrast: near-black on the light theme, near-white on dark). Default for a user who has not picked an accent from the settings page. */
+plugin.theme = 'light'; /* 'light', 'dark', or 'system' to follow the device setting (live). Default for a user who has not picked a theme from the settings page. */
 /*** End Configurable Options ***/
 
 
@@ -621,6 +621,43 @@ plugin.showSettings = function() {
   });
 };
 
+/*** Persisted UI choices ***/
+
+// The theme, accent color and sort order picked from the UI are stored
+// per user in the core's settings blob (any webui.* key is kept
+// verbatim, see js/webui.js save()), so they survive a reload and a new
+// login. The options at the top of this file are the defaults for a
+// user who has not picked anything.
+plugin.storedSetting = function(key, isValid, dflt) {
+  var v = theWebUI.settings['webui.mobile.' + key];
+  return ((typeof v == 'string') && isValid(v)) ? v : dflt;
+};
+
+// Re-fetch the stored settings and merge them in before saving, so this
+// long-lived mobile session doesn't overwrite newer settings saved from
+// the desktop UI (its own snapshot may be stale) -- same reason as the
+// add-torrent page's save.
+plugin.storeSetting = function(key, value) {
+  theWebUI.requestWithoutTimeout('?action=getuisettings', function(stored) {
+    if (stored) {
+      $.extend(theWebUI.settings, stored);
+    }
+    theWebUI.settings['webui.mobile.' + key] = value;
+    theWebUI.save();
+  }, true);
+};
+
+// The option tables below are [value, label] pairs
+plugin.isOption = function(pairs, value) {
+  var found = false;
+  $.each(pairs, function(i, p) {
+    if (p[0] == value) {
+      found = true;
+    }
+  });
+  return found;
+};
+
 plugin.currentTheme = 'light';
 
 plugin.applyTheme = function(theme) {
@@ -638,8 +675,6 @@ plugin.applyTheme = function(theme) {
 
 plugin.themes = [['light', 'Light'], ['dark', 'Dark'], ['system', 'System']];
 
-// Like the accent switcher below: not persisted, a reload reverts to
-// the configured plugin.theme
 plugin.loadThemeSelect = function() {
   var sel = $('#themeSelect').empty();
   $.each(this.themes, function(i, t) {
@@ -700,8 +735,6 @@ plugin.accentColors = [
   ['warning', 'Yellow'], ['info', 'Cyan'], ['dark', 'Contrast']
 ];
 
-// Try-before-you-buy accent switcher; not persisted, a reload reverts
-// to the configured plugin.accentColor
 plugin.loadAccentSelect = function() {
   var sel = $('#accentSelect').empty();
   $.each(this.accentColors, function(i, c) {
@@ -789,6 +822,21 @@ plugin.loadServerInfo = function() {
 };
 
 /*** Sort page ***/
+
+// [field, theUILang id]; the last two need the seedingtime plugin
+plugin.sortFields = [
+  ['name', 'Name'], ['status', 'Status'], ['size', 'Size'],
+  ['uploaded', 'Uploaded'], ['downloaded', 'Downloaded'], ['done', 'Done'],
+  ['eta', 'ETA'], ['ul', 'Ul_speed'], ['dl', 'Down_speed'], ['ratio', 'Ratio'],
+  ['addtime', 'addTime'], ['seedingtime', 'seedingTime']
+];
+
+plugin.seedingtimeSorts = ['addtime', 'seedingtime'];
+
+plugin.isKnownSort = function(sort) {
+  return plugin.isOption(plugin.sortFields, (sort[0] === '-') ? sort.substr(1) : sort);
+};
+
 plugin.showSort = function() {
   $('#sortOption option').prop('selected', false);
   $('#sort_asc').prop('checked', false);
@@ -803,21 +851,12 @@ plugin.showSort = function() {
     $('#sort_asc').prop('checked', true);
   }
 
-  var sortHtml = '<option value="name">' + theUILang.Name + '</option>' +
-              '<option value="status">' + theUILang.Status + '</option>' +
-              '<option value="size">' + theUILang.Size + '</option>' +
-              '<option value="uploaded">' + theUILang.Uploaded + '</option>' +
-              '<option value="downloaded">' + theUILang.Downloaded + '</option>' +
-              '<option value="done">' + theUILang.Done + '</option>' +
-              '<option value="eta">' + theUILang.ETA + '</option>' +
-              '<option value="ul">' + theUILang.Ul_speed + '</option>' +
-              '<option value="dl">' + theUILang.Down_speed + '</option>' +
-              '<option value="ratio">' + theUILang.Ratio + '</option>';
-
-  if (this.seedingtimeLoaded) {
-    sortHtml += '<option value="addtime">' + theUILang.addTime + '</option>' +
-                '<option value="seedingtime">' + theUILang.seedingTime + '</option>'
-  }
+  var sortHtml = '';
+  $.each(this.sortFields, function(i, f) {
+    if (($.inArray(f[0], plugin.seedingtimeSorts) == -1) || plugin.seedingtimeLoaded) {
+      sortHtml += '<option value="' + f[0] + '">' + theUILang[f[1]] + '</option>';
+    }
+  });
   $('#sortOption').html(sortHtml);
   $('#sortOption option[value=' + sort + ']').prop('selected', true);
 
@@ -843,6 +882,7 @@ plugin.setSort = function() {
   }
   if (sort != plugin.sort) {
     plugin.sort = sort;
+    plugin.storeSetting('sort', sort);
     // The list order changed; the remembered scroll position no longer
     // points at anything meaningful, so go back to the top
     plugin.scrollTop = 0;
@@ -2205,6 +2245,11 @@ plugin.init = function() {
 
   this.lastHref = window.location.href;
 
+  // The sort order saved from the sort page, else the configured
+  // plugin.sort. Restored before the first render so the list comes up
+  // in the order the user left it
+  this.sort = this.storedSetting('sort', this.isKnownSort, this.sort);
+
   // The desktop engine keeps running underneath the mobile UI and can
   // auto-save the whole webui.* settings snapshot without user interaction
   // (e.g. categoryList pruning a vanished label selection during the update
@@ -2299,9 +2344,12 @@ plugin.init = function() {
         }
         diskspacePlugin.check = function() { };
       }
-      // Apply the configured theme (see plugin.theme at the top); in
-      // 'system' mode, keep following the device's scheme live
-      plugin.applyTheme(plugin.theme);
+      // Apply the theme saved from the settings page, else the
+      // configured plugin.theme; in 'system' mode, keep following the
+      // device's scheme live
+      plugin.applyTheme(plugin.storedSetting('theme', function(v) {
+        return plugin.isOption(plugin.themes, v);
+      }, plugin.theme));
       if (window.matchMedia) {
         var colorScheme = window.matchMedia('(prefers-color-scheme: dark)');
         if (colorScheme.addEventListener) {
@@ -2312,8 +2360,10 @@ plugin.init = function() {
           });
         }
       }
-      // Apply the configured accent color (see plugin.accentColor at the top)
-      plugin.applyAccentColor(plugin.accentColor);
+      // Likewise for the accent color (see plugin.accentColor at the top)
+      plugin.applyAccentColor(plugin.storedSetting('accent', function(v) {
+        return plugin.isOption(plugin.accentColors, v);
+      }, plugin.accentColor));
       plugin.loadLang();
       plugin.loadMainCSS();
       $('head').append('<meta name="apple-mobile-web-app-capable" content="yes" />');
@@ -2361,12 +2411,14 @@ plugin.init = function() {
       $('#ulLimit').change(function(){plugin.setULLimit();});
       $('#themeSelect').change(function(){
         plugin.applyTheme(this.value);
+        plugin.storeSetting('theme', this.value);
         // The accent swatches resolve per theme (near-black flips to
         // near-white on dark); refresh them for the new theme
         plugin.loadAccentSelect();
       });
       $('#accentSelect').change(function(){
         plugin.applyAccentColor(this.value);
+        plugin.storeSetting('accent', this.value);
         $(this).css('color', 'var(--bs-' + plugin.effectiveAccent(this.value) + ')');
       });
 

--- a/tests/plugins/mobile/settings.spec.js
+++ b/tests/plugins/mobile/settings.spec.js
@@ -1,0 +1,156 @@
+import { readFileSync } from "fs";
+
+window.$ = window.jQuery = require("jquery");
+
+window.theUILang = {
+  Name: "Name", Status: "Status", Size: "Size", Uploaded: "Uploaded",
+  Downloaded: "Downloaded", Done: "Done", ETA: "ETA", Ul_speed: "UL",
+  Down_speed: "DL", Ratio: "Ratio", addTime: "Added", seedingTime: "Seeding",
+};
+
+// What the server holds; the plugin re-reads it before every save
+let storedOnServer = {};
+let saveCount = 0;
+
+window.theWebUI = {
+  settings: {},
+  requestWithoutTimeout: function (url, callback) {
+    expect(url).toBe("?action=getuisettings");
+    callback(JSON.parse(JSON.stringify(storedOnServer)));
+  },
+  save: function () {
+    saveCount++;
+    storedOnServer = JSON.parse(JSON.stringify(window.theWebUI.settings));
+  },
+};
+
+// $type and friends come from the core, as they do in the browser
+const coreEl = document.createElement("script");
+coreEl.textContent = readFileSync("../js/common.js", { encoding: "utf-8" });
+document.body.appendChild(coreEl);
+
+let code = readFileSync("../plugins/mobile/init.js", { encoding: "utf-8" });
+// The takeover call at the end of the file needs the whole desktop UI
+// (theWebUI, thePlugins, the page markup); this spec exercises the
+// settings helpers, which are plain assignments above it
+code = code.replace(/plugin\.disableOthers\(\);\s*$/, "");
+const scriptEl = document.createElement("script");
+scriptEl.textContent = `(function () { var plugin = {}; plugin.path = "../plugins/mobile/"; ${code} })();`;
+document.body.appendChild(scriptEl);
+
+const plugin = window.mobile;
+
+describe("mobile plugin settings", () => {
+  beforeEach(() => {
+    window.theWebUI.settings = {};
+    storedOnServer = {};
+    saveCount = 0;
+  });
+
+  describe("storedSetting", () => {
+    const isTheme = (v) => plugin.isOption(plugin.themes, v);
+
+    it("returns the stored value when it is a known option", () => {
+      window.theWebUI.settings["webui.mobile.theme"] = "dark";
+      expect(plugin.storedSetting("theme", isTheme, "light")).toBe("dark");
+    });
+
+    it("falls back to the default when nothing is stored", () => {
+      expect(plugin.storedSetting("theme", isTheme, "system")).toBe("system");
+    });
+
+    it("falls back to the default for an unknown value", () => {
+      window.theWebUI.settings["webui.mobile.theme"] = "neon";
+      expect(plugin.storedSetting("theme", isTheme, "light")).toBe("light");
+    });
+
+    it("falls back to the default for a non-string value", () => {
+      // The core coerces "true"/"false"/"on"/"auto" settings to 1/0
+      window.theWebUI.settings["webui.mobile.theme"] = 1;
+      expect(plugin.storedSetting("theme", isTheme, "light")).toBe("light");
+    });
+
+    it("accepts every accent color offered by the settings page", () => {
+      $.each(plugin.accentColors, (i, c) => {
+        window.theWebUI.settings["webui.mobile.accent"] = c[0];
+        expect(
+          plugin.storedSetting("accent", (v) => plugin.isOption(plugin.accentColors, v), "primary")
+        ).toBe(c[0]);
+      });
+    });
+  });
+
+  describe("isKnownSort", () => {
+    it("accepts every sort field, ascending and descending", () => {
+      $.each(plugin.sortFields, (i, f) => {
+        expect(plugin.isKnownSort(f[0])).toBe(true);
+        expect(plugin.isKnownSort("-" + f[0])).toBe(true);
+      });
+    });
+
+    it("rejects an unknown field", () => {
+      expect(plugin.isKnownSort("bogus")).toBe(false);
+      expect(plugin.isKnownSort("-bogus")).toBe(false);
+    });
+  });
+
+  describe("storeSetting", () => {
+    it("persists the value under its webui.mobile key", () => {
+      plugin.storeSetting("sort", "-addtime");
+      expect(saveCount).toBe(1);
+      expect(storedOnServer["webui.mobile.sort"]).toBe("-addtime");
+    });
+
+    it("keeps settings saved elsewhere while this session was open", () => {
+      // Snapshot from page load...
+      window.theWebUI.settings["webui.speedlistdl"] = "10,100";
+      // ...the desktop UI changed it in the meantime
+      storedOnServer = { "webui.speedlistdl": "20,200" };
+
+      plugin.storeSetting("theme", "dark");
+
+      expect(storedOnServer["webui.speedlistdl"]).toBe("20,200");
+      expect(storedOnServer["webui.mobile.theme"]).toBe("dark");
+    });
+  });
+
+  describe("showSort", () => {
+    beforeEach(() => {
+      $("body").append(
+        '<div id="sortPage"><select id="sortOption"></select>' +
+        '<input type="radio" id="sort_asc"><input type="radio" id="sort_desc"></div>'
+      );
+      plugin.showPage = function () {};
+    });
+    afterEach(() => $("#sortPage").remove());
+
+    it("offers the seedingtime fields only when that plugin is loaded", () => {
+      plugin.sort = "name";
+      plugin.seedingtimeLoaded = false;
+      plugin.showSort();
+      let values = $("#sortOption option").map((i, o) => o.value).get();
+      expect(values).not.toContain("addtime");
+      expect(values).toContain("ratio");
+
+      plugin.seedingtimeLoaded = true;
+      plugin.showSort();
+      values = $("#sortOption option").map((i, o) => o.value).get();
+      expect(values).toContain("addtime");
+      expect(values).toContain("seedingtime");
+    });
+
+    it("preselects the current sort field and direction", () => {
+      plugin.seedingtimeLoaded = true;
+      plugin.sort = "-addtime";
+      plugin.showSort();
+      expect($("#sortOption").val()).toBe("addtime");
+      expect($("#sort_desc").prop("checked")).toBe(true);
+      expect($("#sort_asc").prop("checked")).toBe(false);
+
+      plugin.sort = "size";
+      plugin.showSort();
+      expect($("#sortOption").val()).toBe("size");
+      expect($("#sort_asc").prop("checked")).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
The settings and sort pages only changed the running session, so a page reload or a new login fell back to the options at the top of init.js.

Store the chosen values per user under the webui.mobile.* keys, next to the rest of the ruTorrent settings, and restore them at startup; the options at the top of init.js stay the defaults for a user who has not picked anything, and a stored value that is not a known option is ignored. The stored settings are re-fetched and merged before each save, so a long-lived mobile session cannot overwrite settings saved from the desktop UI in the meantime.

The sort page now builds its option list from a field table, which the stored-value check shares.