### PR TITLE
Add an opt-in guard against fetches into private networks

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -13,6 +13,14 @@
 		'host'	=> 'PROXY_HOST_HERE',
 		'port'	=> 3128
 	);
+	// Refuse to fetch URLs that resolve to a private or otherwise non-public
+	// address. Off by default: feeds and torrent links commonly point at an
+	// indexer on localhost or the LAN. Turn it on where the URLs come from
+	// someone you do not want reaching services the web server can see.
+	$httpBlockPrivateNetworks = false;
+	// Hosts exempt from the check above, matched against the URL host verbatim,
+	// e.g. array( '127.0.0.1', 'jackett.lan' ).
+	$httpPrivateNetworkAllowlist = array();
 
 	// for xmlrpc actions
 	$rpcTimeOut = 5;			// in seconds

--- a/php/Snoopy.class.inc
+++ b/php/Snoopy.class.inc
@@ -82,6 +82,11 @@ class Snoopy
 	var $IP			=	null;
 	var $useIpv4		=	false;
 
+	// refuse targets that resolve to a private or otherwise non-routable address
+	var $block_private	=	false;
+	// hosts exempt from the check above, matched against the URL host verbatim
+	var $private_allowlist	=	array();
+
 	/**** Private variables ****/
 
 	var $_maxlinelen	=	4096;			// max line length (headers)
@@ -93,6 +98,7 @@ class Snoopy
 
 	var $_isproxy		=	false;			// set if using a proxy server
 	var $_fp_timeout	=	30;			// timeout for socket connection
+	var $_pinnedaddr	=	false;			// address the guard validated, connected to verbatim
 
 	public function __construct()
 	{
@@ -101,6 +107,8 @@ class Snoopy
 		global $httpUserAgent;
 		global $httpTimeOut;
 		global $httpUseGzip;
+		global $httpBlockPrivateNetworks;
+		global $httpPrivateNetworkAllowlist;
 
 		if(isset($httpUserAgent))
 			$this->agent = $httpUserAgent;
@@ -117,6 +125,10 @@ class Snoopy
 		}
 		if (isset($httpUseGzip))
 			$this->use_gzip = $httpUseGzip;
+		if(isset($httpBlockPrivateNetworks))
+			$this->block_private = $httpBlockPrivateNetworks;
+		if(isset($httpPrivateNetworkAllowlist) && is_array($httpPrivateNetworkAllowlist))
+			$this->private_allowlist = $httpPrivateNetworkAllowlist;
 		if(isset($httpIP))
 			$this->IP = $httpIP;
 	}
@@ -264,6 +276,9 @@ class Snoopy
 			$this->pass = $parts["pass"];
 		$this->host = $parts["host"];
 		$this->_isproxy = (!empty($this->proxy_host) && !empty($this->proxy_port));
+		$this->_pinnedaddr = false;
+		if($this->block_private && ($parts["scheme"]=="http" || $parts["scheme"]=="https") && !$this->checkTarget($this->host))
+			return(false);
 		$ret = true;
 		switch($parts["scheme"])
 		{
@@ -323,6 +338,76 @@ class Snoopy
 			}
 		}
 		return($ret);
+	}
+
+	protected function checkTarget($host)
+	{
+		if(in_array($host,$this->private_allowlist,true))
+			return(true);
+		$literal = filter_var(trim($host,"[]"),FILTER_VALIDATE_IP)!==false;
+		$addresses = static::resolveHost($host);
+		if(empty($addresses))
+		{
+			$this->error = 'Refusing to fetch: cannot resolve host "'.$host.'".';
+			return(false);
+		}
+		foreach($addresses as $address)
+			if(!self::isPublicAddress($address))
+			{
+				$this->error = 'Refusing to fetch: host "'.$host.'" resolves to the non-public address '.$address.'.';
+				return(false);
+			}
+		// A second lookup at connect time could answer differently, so the
+		// address that passed the check is the one the request goes to.
+		if(!$literal && !$this->_isproxy)
+			$this->_pinnedaddr = $addresses[0];
+		return(true);
+	}
+
+	static public function resolveHost($host)
+	{
+		$host = trim($host,"[]");
+		if(filter_var($host,FILTER_VALIDATE_IP)!==false)
+			return(array($host));
+		$addresses = array();
+		$records = @dns_get_record($host,DNS_A|DNS_AAAA);
+		if(is_array($records))
+			foreach($records as $record)
+			{
+				if(isset($record["ip"]))
+					$addresses[] = $record["ip"];
+				if(isset($record["ipv6"]))
+					$addresses[] = $record["ipv6"];
+			}
+		if(empty($addresses))
+		{
+			$byname = @gethostbynamel($host);
+			if(is_array($byname))
+				$addresses = $byname;
+		}
+		return(array_values(array_unique($addresses)));
+	}
+
+	static public function isPublicAddress($address)
+	{
+		if(filter_var($address,FILTER_VALIDATE_IP,FILTER_FLAG_NO_PRIV_RANGE|FILTER_FLAG_NO_RES_RANGE)===false)
+			return(false);
+		// Ranges filter_var accepts but that are not reachable on the public internet
+		foreach(array("100.64.0.0/10","192.0.0.0/24","192.88.99.0/24","198.18.0.0/15") as $cidr)
+			if(self::addressInCIDR($address,$cidr))
+				return(false);
+		return(true);
+	}
+
+	static protected function addressInCIDR($address,$cidr)
+	{
+		$ip = ip2long($address);
+		list($network,$bits) = explode("/",$cidr);
+		$network = ip2long($network);
+		if($ip===false || $network===false)
+			return(false);
+		$mask = -1 << (32-intval($bits));
+		return(($ip & $mask)===($network & $mask));
 	}
 
 	function get_header( $name )
@@ -538,6 +623,13 @@ class Snoopy
 		if($this->useIpv4)
 			$cmdline_params .= " --ipv4";
 
+		if($this->_pinnedaddr!==false)
+		{
+			$pinned = (filter_var($this->_pinnedaddr,FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)!==false)
+				? "[".$this->_pinnedaddr."]" : $this->_pinnedaddr;
+			$cmdline_params .= " --resolve ".escapeshellarg($this->host.":".$this->port.":".$pinned);
+		}
+
 		if($this->_isproxy)
 			$cmdline_params .= " --proxy-insecure --proxy ".(empty($this->proxy_proto) ? '' : $this->proxy_proto.'://').$this->proxy_host.":".$this->proxy_port;
 
@@ -664,9 +756,11 @@ class Snoopy
 		}
 		else
 		{
-			$host = $this->host;
+			$host = ($this->_pinnedaddr===false) ? $this->host : $this->_pinnedaddr;
 			$port = $this->port;
 		}
+		if(filter_var(trim($host,"[]"),FILTER_VALIDATE_IP,FILTER_FLAG_IPV6)!==false)
+			$host = "[".trim($host,"[]")."]";
 		$this->status = 0;
 		if(function_exists("stream_socket_client") && !is_null($this->IP))
 		{

--- a/tests/php/SnoopyTest.php
+++ b/tests/php/SnoopyTest.php
@@ -50,13 +50,32 @@ while [ "$#" -gt 0 ]; do
 	esac
 	shift
 done
-printf 'HTTP/1.1 200 OK\r\n\r\n' > "$header_file"
+printf '%b\r\n' "${SNOOPY_TEST_RESPONSE:-HTTP/1.1 200 OK\r\n}" > "$header_file"
 : > "$body_file"
 SH;
 file_put_contents($curlPath, $script);
 chmod($curlPath, 0700);
 putenv('SNOOPY_TEST_ARGS=' . $argsPath);
 $pathToExternals['curl'] = $curlPath;
+
+function snoopyRespondWith($response)
+{
+    putenv('SNOOPY_TEST_RESPONSE=' . $response);
+}
+
+// Hostname resolution is stubbed so the SSRF tests never depend on live DNS.
+// Literal addresses still go through the real path, so a redirect to one is
+// judged on its own merits.
+class SnoopyResolvesToPublic extends Snoopy
+{
+    static public function resolveHost($host)
+    {
+        if (filter_var(trim($host, '[]'), FILTER_VALIDATE_IP) !== false) {
+            return parent::resolveHost($host);
+        }
+        return array('93.184.216.34');
+    }
+}
 
 $tests = array(
     'explicit HTTPS POST forwards -X POST to curl' => function () {
@@ -105,11 +124,104 @@ $tests = array(
             'Explicit HTTPS GET method must not be changed to POST by curl -d'
         );
     },
+    'private targets stay reachable while the guard is off' => function () {
+        $client = new Snoopy();
+        snoopyAssertTrue(
+            $client->fetch('https://127.0.0.1/feed'),
+            'Default configuration must not block loopback targets'
+        );
+    },
+    'the guard blocks a literal private address' => function () {
+        $client = new Snoopy();
+        $client->block_private = true;
+        snoopyAssertSame(false, $client->fetch('https://127.0.0.1/feed'), 'Loopback target was fetched anyway');
+        snoopyAssertTrue(
+            strpos($client->error, '127.0.0.1') !== false,
+            'Blocked fetch must name the offending address, got: ' . $client->error
+        );
+    },
+    'the guard blocks the IPv6 loopback literal' => function () {
+        $client = new Snoopy();
+        $client->block_private = true;
+        snoopyAssertSame(false, $client->fetch('https://[::1]/feed'), 'IPv6 loopback target was fetched anyway');
+    },
+    'the guard leaves public literals alone' => function () {
+        $client = new Snoopy();
+        $client->block_private = true;
+        snoopyAssertTrue($client->fetch('https://93.184.216.34/feed'), 'Public literal was blocked: ' . $client->error);
+    },
+    'the allowlist exempts a host from the guard' => function () {
+        $client = new Snoopy();
+        $client->block_private = true;
+        $client->private_allowlist = array('127.0.0.1');
+        snoopyAssertTrue($client->fetch('https://127.0.0.1/feed'), 'Allowlisted host was blocked: ' . $client->error);
+    },
+    'the guard blocks a hostname that resolves to loopback' => function () {
+        $client = new Snoopy();
+        $client->block_private = true;
+        snoopyAssertSame(false, $client->fetch('https://localhost/feed'), 'localhost was fetched anyway');
+    },
+    'a host that cannot be resolved is blocked, and says so' => function () {
+        $client = new Snoopy();
+        $client->block_private = true;
+        snoopyAssertSame(
+            false,
+            $client->fetch('https://tracker.nonexistent.invalid/feed'),
+            'Unresolvable host was fetched anyway'
+        );
+        snoopyAssertTrue(
+            stripos($client->error, 'resolve') !== false,
+            'Unresolvable host must be reported as such, got: ' . $client->error
+        );
+    },
+    'the validated address is pinned for the HTTPS request' => function () {
+        $client = new SnoopyResolvesToPublic();
+        $client->block_private = true;
+        snoopyAssertTrue($client->fetch('https://tracker.test/feed'), 'Public host was blocked: ' . $client->error);
+        $args = snoopyCurlArgs();
+        $flag = array_search('--resolve', $args, true);
+        snoopyAssertTrue($flag !== false, 'Validated host must be pinned with --resolve');
+        snoopyAssertSame(
+            'tracker.test:443:93.184.216.34',
+            isset($args[$flag + 1]) ? $args[$flag + 1] : null,
+            'Pinned address must be the one the guard validated'
+        );
+    },
+    'the guard covers ranges filter_var calls public' => function () {
+        $client = new Snoopy();
+        $client->block_private = true;
+        snoopyAssertSame(false, $client->fetch('https://100.64.0.1/feed'), 'Carrier-grade NAT target was fetched anyway');
+        snoopyAssertSame(false, $client->fetch('https://192.0.0.1/feed'), 'IETF protocol assignment target was fetched anyway');
+    },
+    'the guard is configured from conf/config.php' => function () {
+        $GLOBALS['httpBlockPrivateNetworks'] = true;
+        $GLOBALS['httpPrivateNetworkAllowlist'] = array('127.0.0.1');
+        $client = new Snoopy();
+        unset($GLOBALS['httpBlockPrivateNetworks'], $GLOBALS['httpPrivateNetworkAllowlist']);
+        snoopyAssertTrue($client->block_private, 'Configured guard was not picked up');
+        snoopyAssertSame(false, $client->fetch('https://10.0.0.1/feed'), 'Configured guard did not block a private target');
+        snoopyAssertTrue($client->fetch('https://127.0.0.1/feed'), 'Configured allowlist was not picked up: ' . $client->error);
+    },
+    'a redirect into a private address is blocked too' => function () {
+        snoopyRespondWith('HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1/secret\r\n');
+        $client = new SnoopyResolvesToPublic();
+        $client->block_private = true;
+        snoopyAssertSame(
+            false,
+            $client->fetch('https://tracker.test/start'),
+            'Redirect to a private address was followed'
+        );
+        snoopyAssertTrue(
+            strpos($client->error, '127.0.0.1') !== false,
+            'Blocked redirect must name the offending address, got: ' . $client->error
+        );
+    },
 );
 
 $failures = 0;
 foreach ($tests as $name => $callback) {
     try {
+        snoopyRespondWith('HTTP/1.1 200 OK\r\n');
         $callback();
         echo "ok - {$name}\n";
     } catch (Throwable $error) {


### PR DESCRIPTION
Snoopy goes wherever the URL it is handed points, and several of those URLs come from outside: add-torrent-by-URL, RSS feed addresses, bulk magnet, tracklabels. On any install where the person supplying the URL is not the person running the server, that reaches services only the web server can see.

Add $httpBlockPrivateNetworks. It is off by default because feeds and torrent links legitimately point at an indexer on localhost or the LAN, and $httpPrivateNetworkAllowlist keeps those working once it is on.

The check sits in fetch(), which every caller and every redirect passes through, resolves both A and AAAA records, and refuses the request when any answer is private, reserved or otherwise not routable on the public internet. The address that passed the check is then the address the request goes to - pinned into the socket for http and into curl --resolve for https - so a second lookup cannot land somewhere else.