### PR TITLE
rutracker_check: stop a page reload from postponing the hourly check

### DIFF
--- a/plugins/rutracker_check/init.php
+++ b/plugins/rutracker_check/init.php
@@ -12,7 +12,16 @@ else
 {
 	if($updateInterval)
 	{
-		$req = new rXMLRPCRequest( $theSettings->getAbsScheduleCommand('rutracker_check',$updateInterval*60,
+		// getScheduleCommand, not getAbsScheduleCommand: this file runs on every
+		// full load of the web interface, and rTorrent's scheduler replaces an
+		// entry that reuses a key (CommandScheduler::insert deletes the old item
+		// and re-enables the new one at now+start). The absolute form starts its
+		// countdown at registration time, so each reload pushed the next check a
+		// whole hour away and a user who kept refreshing never got one at all.
+		// This form aligns the start to the next wall-clock boundary, which a
+		// reload recomputes to the same instant. Same choice as plugins/trafic;
+		// note it takes the interval in minutes rather than seconds.
+		$req = new rXMLRPCRequest( $theSettings->getScheduleCommand('rutracker_check',$updateInterval,
 			getCmd('execute').'={sh,-c,'.escapeshellarg(Utility::getPHP()).' '.escapeshellarg(dirname(__FILE__).'/update.php').' '.escapeshellarg(User::getUser()).' &}' ));
 		if($req->success())
 			$theSettings->registerPlugin($plugin["name"],$pInfo["perms"]);


### PR DESCRIPTION

**Problem.** The plugin registers its hourly check with `getAbsScheduleCommand`,
whose countdown starts at registration. `init.php` runs on every full UI load and
rTorrent's `CommandScheduler::insert` re-creates an entry it already knows — so every
page reload pushes the next check a full hour away. Keep the tab open and refresh now
and then, and the automatic check never fires at all.

**Fix.** Register with `getScheduleCommand` (wall-clock aligned; the form `trafic`
and `rss` already use), which a reload recomputes to the same boundary.
`$updateInterval` is documented in `conf.php` as minutes — the unit this API takes —
so the `*60` goes away. One file, ~4 lines.

**How to verify.** Before: reload the UI a few times within an hour — the debug log
never shows `update: cycle start` (the countdown keeps restarting). After: reloads do
not move the boundary; the cycle fires each interval.