### PR TITLE
webui: stop clock skew from shifting absolute dates

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -592,7 +592,7 @@ var theFormatter =
 					arr[i] = theFormatter.tPriority(arr[i]);
 					break;
 				case 14:
-					arr[i] = theConverter.date(iv(arr[i])+theWebUI.deltaTime/1000);
+					arr[i] = theConverter.date(iv(arr[i]));
 					break;
 			}
 		}

--- a/js/webui.js
+++ b/js/webui.js
@@ -2094,7 +2094,7 @@ var theWebUI = {
 			$("#et").text(theConverter.time(Math.floor((new Date().getTime()-theWebUI.deltaTime)/1000-iv(d.state_changed)),true));
 			$("#wa").text(theConverter.bytes(d.skip_total, 'details'));
 	        	$("#bf").text(d.base_path);
-	        	$("#co").text(theConverter.date(iv(d.created)+theWebUI.deltaTime/1000));
+	        	$("#co").text(theConverter.date(iv(d.created)));
 			const trackers = this.trackers[this.dID] ?? [];
 			$("#tu").text(trackers.length ? (trackers[0].name  + (trackers.length > 1 ? ` ${theUILang.of} ${d.tracker_size}` : '')) : `${d.tracker_size}`);
 	        	$("#hs").text(this.dID.substring(0,40));

--- a/plugins/_task/init.js
+++ b/plugins/_task/init.js
@@ -377,7 +377,7 @@ if(plugin.canChangeTabs())
 						case 'finish':
 						case 'start':
 						{
-							arr[i] = (arr[i]>3600*24*365) ? theConverter.date(iv(arr[i])+theWebUI.deltaTime/1000) : "";
+							arr[i] = (arr[i]>3600*24*365) ? theConverter.date(iv(arr[i])) : "";
 							break;
 						}
 						case 'elapsed':

--- a/plugins/extsearch/init.js
+++ b/plugins/extsearch/init.js
@@ -242,7 +242,7 @@ plugin.reloadData = function(id)
 				table.addRowById(
 				{
 					name: item.name,
-					created: item.time-theWebUI.deltaTime/1000,
+					created: item.time,
 					peers: item.peers,
 					seeds: item.seeds,
 					size: item.size,
@@ -524,7 +524,7 @@ theWebUI.loadTorrents = function(needSort)
 					updated = table.setValuesById(ndx,
 					{
 						name: item.name,
-						created: item.time-theWebUI.deltaTime/1000,
+						created: item.time,
 						peers: item.peers,
 						seeds: item.seeds,
 						size: item.size,

--- a/plugins/history/init.js
+++ b/plugins/history/init.js
@@ -150,7 +150,7 @@ if(plugin.canChangeTabs() || plugin.canChangeColumns())
 								case "time":
 								case "addtime":
 								case 'created' :
-									arr[i] = arr[i] ? theConverter.date(iv(arr[i])+theWebUI.deltaTime/1000) : '';
+									arr[i] = arr[i] ? theConverter.date(iv(arr[i])) : '';
 									break;
 								case 'downloaded' :
 								case 'uploaded' :

--- a/plugins/mobile/init.js
+++ b/plugins/mobile/init.js
@@ -966,7 +966,7 @@ plugin.fillDetails = function(d) {
   $('#torrentDetails #timeElapsed td:last').text(theConverter.time(Math.floor((new Date().getTime()-theWebUI.deltaTime)/1000-iv(d.state_changed)),true));
   $('#torrentDetails #created td:last').text((d.created>3600*24*365) ? theConverter.date(iv(d.created)) : "");
   if (this.seedingtimeLoaded) {
-    $('#torrentDetails #seedtime td:last').text((d.seedingtime>3600*24*365) ? theConverter.time(new Date().getTime()/1000-(iv(d.seedingtime)+theWebUI.deltaTime/1000),true) : "");
+    $('#torrentDetails #seedtime td:last').text((d.seedingtime != -1) ? theConverter.time(d.seedingtime,true) : "");
     $('#torrentDetails #dateAdded td:last').text((d.addtime>3600*24*365) ? theConverter.date(iv(d.addtime)) : "");
   }
   $('#torrentDetails #eta td:last').html((d.eta == -1) ? "&#8734;" : theConverter.time(d.eta));

--- a/plugins/mobile/init.js
+++ b/plugins/mobile/init.js
@@ -964,10 +964,10 @@ plugin.fillDetails = function(d) {
   $('#torrentDetails #size td:last').text(theConverter.bytes(d.size,2));
   $('#torrentDetails #remaining td:last').text(theConverter.bytes(d.remaining,2));
   $('#torrentDetails #timeElapsed td:last').text(theConverter.time(Math.floor((new Date().getTime()-theWebUI.deltaTime)/1000-iv(d.state_changed)),true));
-  $('#torrentDetails #created td:last').text((d.created>3600*24*365) ? theConverter.date(iv(d.created)+theWebUI.deltaTime/1000) : "");
+  $('#torrentDetails #created td:last').text((d.created>3600*24*365) ? theConverter.date(iv(d.created)) : "");
   if (this.seedingtimeLoaded) {
     $('#torrentDetails #seedtime td:last').text((d.seedingtime>3600*24*365) ? theConverter.time(new Date().getTime()/1000-(iv(d.seedingtime)+theWebUI.deltaTime/1000),true) : "");
-    $('#torrentDetails #dateAdded td:last').text((d.addtime>3600*24*365) ? theConverter.date(iv(d.addtime)+theWebUI.deltaTime/1000) : "");
+    $('#torrentDetails #dateAdded td:last').text((d.addtime>3600*24*365) ? theConverter.date(iv(d.addtime)) : "");
   }
   $('#torrentDetails #eta td:last').html((d.eta == -1) ? "&#8734;" : theConverter.time(d.eta));
   $('#torrentDetails #ratio td:last').html((d.ratio == -1) ? "&#8734;" : theConverter.round(d.ratio/1000,3));

--- a/plugins/rss/init.js
+++ b/plugins/rss/init.js
@@ -710,7 +710,7 @@ theWebUI.showErrors = function(errors)
 		const idHash = err.prm && Object.entries(theWebUI.rssLabels).find(([_,l]) => l.url === err.prm)?.[0];
 		const name = idHash && theWebUI.rssLabels[idHash].name;
 		const args = [
-			'['+theConverter.date('time' in err ? iv(err.time)+theWebUI.deltaTime : new Date().getTime()/1000)+'] '
+			'['+theConverter.date('time' in err ? iv(err.time) : new Date().getTime()/1000)+'] '
 			+ (name ? '<'+name+'> ' : '')
 			+ eval(err.desc)
 			+ (err.prm ? ' ('+err.prm+')' : ''),

--- a/plugins/seedingtime/init.js
+++ b/plugins/seedingtime/init.js
@@ -30,7 +30,7 @@ if(plugin.canChangeColumns())
 		plugin.reqId2 = theRequestManager.addRequest("trt", theRequestManager.map("d.get_custom=")+"addtime",function(hash,torrent,value)
 		{
 			const epochSeconds = iv(value);
-			torrent.addtime = (epochSeconds > 3600*24*365) ? epochSeconds+theWebUI.deltaTime/1000 : -1;
+			torrent.addtime = (epochSeconds > 3600*24*365) ? epochSeconds : -1;
 		});
 		plugin.trtRenameColumn();
 	}

--- a/tests/js/absolute-dates.spec.js
+++ b/tests/js/absolute-dates.spec.js
@@ -1,0 +1,123 @@
+import { readFileSync } from "fs";
+
+window.$ = require("jquery");
+
+// Constants and widget constructors that webui.js references at load time.
+// The real ones live in js/stable.js, which needs a full DOM to be useful.
+window.TYPE_STRING = "string";
+window.TYPE_NUMBER = "number";
+window.TYPE_PROGRESS = "progress";
+window.TYPE_PEERS = "peers";
+window.TYPE_SEEDS = "seeds";
+window.ALIGN_RIGHT = "right";
+window.dxSTable = function () {};
+window.rSpeedGraph = function () {};
+window.Timer = function () {};
+
+for (const src of ["../lang/en.js", "../js/common.js"]) {
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = readFileSync(src, { encoding: "utf-8" });
+  document.body.appendChild(scriptEl);
+}
+
+// webui.js redefines theWebUI wholesale; drop the $(document).ready block,
+// which needs the full page markup (same trick as webui-stale-details.spec.js).
+{
+  let code = readFileSync("../js/webui.js", { encoding: "utf-8" });
+  code = code.replace(/\n\$\(document\)\.ready\(function\(\)\n\{[\s\S]*?\n\}\);\s*$/, "");
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = code;
+  document.body.appendChild(scriptEl);
+}
+
+function h(char) {
+  return Array.from({ length: 40 }, () => char).join("");
+}
+
+// A creation timestamp measured on a live system and a clock skew large
+// enough (36 hours, in milliseconds) that adding it to a timestamp moves
+// the rendered date to another calendar day.
+const CREATED = 1786467616;
+const BIG_DELTA = 36 * 3600 * 1000;
+
+afterEach(() => {
+  theWebUI.deltaTime = 0;
+});
+
+describe("torrent list date formatter", () => {
+  function formatCreatedColumn(deltaTime) {
+    theWebUI.deltaTime = deltaTime;
+    const arr = [];
+    arr[14] = CREATED; // index of the "created" column in the trt table
+    return theFormatter.torrents(null, arr)[14];
+  }
+
+  it("renders the creation date from the raw timestamp regardless of deltaTime", () => {
+    expect(formatCreatedColumn(BIG_DELTA)).toBe(theConverter.date(CREATED));
+    expect(formatCreatedColumn(BIG_DELTA)).toBe(formatCreatedColumn(0));
+  });
+});
+
+describe("torrent details pane", () => {
+  const hash = h("A");
+  const NOW = (CREATED + 10 * 86400) * 1000; // pinned browser clock, ms
+  const ELAPSED = 3 * 86400; // seconds since state_changed at that clock
+
+  beforeEach(() => {
+    // Pin the clock so both renders share one "now" and the elapsed
+    // strings can be asserted exactly.
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+    document.body.innerHTML = '<span id="co"></span><span id="et"></span>';
+    theWebUI.settings = theWebUI.settings || {};
+    theWebUI.dID = hash;
+    theWebUI.trackers = {};
+    theWebUI.torrents = {
+      [hash]: {
+        downloaded: 0,
+        uploaded: 0,
+        ratio: 1000,
+        ul: 0,
+        dl: 0,
+        eta: 0,
+        seeds_actual: 0,
+        seeds_all: 0,
+        peers_actual: 0,
+        peers_all: 0,
+        state_changed: NOW / 1000 - ELAPSED,
+        skip_total: 0,
+        base_path: "",
+        created: CREATED,
+        tracker_size: 1,
+        msg: "",
+        comment: "",
+        free_diskspace: "0",
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function renderDetails(deltaTime) {
+    theWebUI.deltaTime = deltaTime;
+    theWebUI.updateDetails();
+    return { created: $("#co").text(), elapsed: $("#et").text() };
+  }
+
+  it("keeps the creation date fixed while elapsed time still compensates for clock skew", () => {
+    const skewed = renderDetails(BIG_DELTA);
+    const accurate = renderDetails(0);
+
+    // An absolute date names a moment; the browser renders it correctly
+    // from the raw timestamp alone, no matter how wrong its clock is.
+    expect(skewed.created).toBe(theConverter.date(CREATED));
+    expect(skewed.created).toBe(accurate.created);
+
+    // A duration compares a server timestamp with the browser's "now",
+    // so it must keep using deltaTime to cancel the clock skew.
+    expect(accurate.elapsed).toBe(theConverter.time(ELAPSED, true));
+    expect(skewed.elapsed).toBe(theConverter.time(ELAPSED - BIG_DELTA / 1000, true));
+  });
+});

--- a/tests/plugins/seedingtime/init.spec.js
+++ b/tests/plugins/seedingtime/init.spec.js
@@ -1,0 +1,106 @@
+import { readFileSync } from "fs";
+
+window.$ = require("jquery");
+
+for (const src of ["../lang/en.js", "../js/common.js"]) {
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = readFileSync(src, { encoding: "utf-8" });
+  document.body.appendChild(scriptEl);
+}
+
+// Minimal scaffolding for plugins/seedingtime/init.js: capture the request
+// callbacks it registers instead of running a real request manager.
+window.TYPE_NUMBER = "number";
+window.thePlugins = { isInstalled: () => false };
+const requestCallbacks = {};
+window.theRequestManager = {
+  map: (cmd) => cmd,
+  addRequest: (_table, cmd, callback) => {
+    requestCallbacks[cmd] = callback;
+    return cmd;
+  },
+  removeRequest: () => {},
+};
+window.theWebUI = {
+  deltaTime: 0,
+  settings: {},
+  config: function () {},
+  getTable: () => ({ renameColumnById: () => {}, removeColumnById: () => {} }),
+  tables: { trt: { columns: [], format: (_table, arr) => arr } },
+};
+
+{
+  // The plugin loader normally provides `plugin`; stub just what init.js uses.
+  const code = readFileSync("../plugins/seedingtime/init.js", {
+    encoding: "utf-8",
+  });
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent =
+    "(function () { var plugin = { loadLang: function () {}, " +
+    "canChangeColumns: function () { return true; }, allStuffLoaded: true }; " +
+    code +
+    "\n})();";
+  document.body.appendChild(scriptEl);
+}
+
+theWebUI.config(); // registers the columns, the format wrapper and both requests
+
+const seedingtimeCallback = requestCallbacks["d.get_custom=seedingtime"];
+const addtimeCallback = requestCallbacks["d.get_custom=addtime"];
+
+// Pinned clock and a torrent added three days before it. The consumers
+// (trt/rss/teg columns, mobile details) rely on this exact contract:
+// seedingtime is a duration in seconds, addtime is a raw epoch, -1 means
+// the custom field is absent.
+const NOW = 1787000000000;
+const EPOCH = NOW / 1000 - 3 * 86400;
+const BIG_DELTA = 36 * 3600 * 1000; // a large browser-vs-server clock skew, ms
+
+describe("seedingtime custom-field requests", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    theWebUI.deltaTime = 0;
+  });
+
+  it("stores seedingtime as a duration that compensates for clock skew", () => {
+    const torrent = {};
+    seedingtimeCallback("HASH", torrent, String(EPOCH));
+    expect(torrent.seedingtime).toBe(3 * 86400);
+
+    // The duration compares a server timestamp with the browser's "now",
+    // so a skewed browser clock must be corrected by deltaTime.
+    theWebUI.deltaTime = BIG_DELTA;
+    seedingtimeCallback("HASH", torrent, String(EPOCH));
+    expect(torrent.seedingtime).toBe(3 * 86400 - BIG_DELTA / 1000);
+  });
+
+  it("stores addtime as the raw epoch no matter how skewed the clock is", () => {
+    const torrent = {};
+    theWebUI.deltaTime = BIG_DELTA;
+    addtimeCallback("HASH", torrent, String(EPOCH));
+    expect(torrent.addtime).toBe(EPOCH);
+  });
+
+  it("flags an absent custom field with -1", () => {
+    const torrent = {};
+    seedingtimeCallback("HASH", torrent, "");
+    addtimeCallback("HASH", torrent, "");
+    expect(torrent.seedingtime).toBe(-1);
+    expect(torrent.addtime).toBe(-1);
+  });
+
+  it("renders the columns as a duration and a calendar date", () => {
+    const table = { getIdByCol: (i) => ["seedingtime", "addtime"][i] };
+    const rendered = theWebUI.tables.trt.format(table, [3 * 86400, EPOCH]);
+    expect(rendered).toEqual([
+      theConverter.time(3 * 86400, true),
+      theConverter.date(EPOCH),
+    ]);
+    expect(theWebUI.tables.trt.format(table, [-1, -1])).toEqual(["", ""]);
+  });
+});


### PR DESCRIPTION
**Problem.** `theWebUI.deltaTime` is the browser↔server clock offset and belongs
only to durations computed from the browser's `now()`. Several call sites add it to
absolute UNIX timestamps rTorrent already reported in server time (creation date,
added-on, finished-on, RSS item dates), so every absolute date renders shifted by
whatever skew exists — measured live: a creation date rendered two days off after a
stale cached `Date` header inflated the offset. Second commit, same bug class: the
mobile details pane feeds Seeding Time — already an elapsed duration — through the
absolute-date converter, showing a date in 1970.

**Fix.** Remove the offset from absolute-date rendering (8 one-line sites across
`js/` and plugin `init.js` files); keep it in duration arithmetic. Mobile renders
seeding time with the duration converter, as the desktop UI does.

**How to verify.** New `tests/js/absolute-dates.spec.js` (pins the rule per call
site) and `tests/plugins/seedingtime/init.spec.js` (desktop and mobile formatting of
the same value). Both fail on the unpatched sources. Manual: skew the container
clock a few hours from the browser's and compare any Created-on date before/after.