### PR TITLE
rtorrent: fix the 0.10.2 alias gate and d.multicall routing, pin the command tables with a regression test

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -863,7 +863,9 @@ function correctContent()
 			"load"			:	{ name: "load.normal", prm: 1 }
 		});
 	}
-	if(theWebUI.systemInfo.rTorrent.iVersion>=0x1002)
+	// iVersion packs one version component per byte, so 0.10.2 is 0x0a02
+	// (0x1002 would be 0.16.2). Newer daemons inherit these.
+	if(theWebUI.systemInfo.rTorrent.iVersion>=0x0a02)
 	{
 		$.extend(theRequestManager.aliases,
 		{
@@ -917,6 +919,9 @@ function correctContent()
 			"get_max_open_http"      : { name: "system.sockets.http.max_size",           prm: 0 },
 			"set_max_open_http"      : { name: "system.sockets.http.max_alloc.set",      prm: 1 },
 			"set_max_open_files"     : { name: "system.sockets.files.max_alloc.set",     prm: 1 },
+			// The d.multicall entry overrides the d.multicall => d.multicall2
+			// remap from the 0.9.4 table above; d.multicall2 is gone in 0.16.16.
+			"d.multicall"            : { name: "d.multicall",                             prm: 1 },
 			"d.multicall2"           : { name: "d.multicall",                             prm: 1 },
 			"get_http_proxy"         : { name: "network.proxy.http",                     prm: 0 },
 			"set_http_proxy"         : { name: "network.proxy.http.set",                 prm: 1 },

--- a/php/methods-0.16.16.php
+++ b/php/methods-0.16.16.php
@@ -21,7 +21,9 @@ $this->aliases = array_merge($this->aliases, array(
 	// (was network.max_open_files.set — now warns)
 	"set_max_open_files" => array( "name"=>"system.sockets.files.max_alloc.set", "prm"=>1 ),
 
-	// d.multicall2 removed; d.multicall is canonical
+	// d.multicall2 removed; d.multicall is canonical. The d.multicall entry
+	// overrides the d.multicall => d.multicall2 remap from methods-0.9.4.php.
+	"d.multicall"  => array( "name"=>"d.multicall",  "prm"=>1 ),
 	"d.multicall2" => array( "name"=>"d.multicall",  "prm"=>1 ),
 
 	// Proxy addresses — removed in 0.16.16

--- a/php/settings.php
+++ b/php/settings.php
@@ -208,7 +208,9 @@ class rTorrentSettings
 			{
 				require_once( 'methods-0.9.4.php' );
 			}
-			if($this->iVersion>=0x1002)
+			// iVersion packs one version component per byte, so 0.10.2 is
+			// 0x0a02 (0x1002 would be 0.16.2). Newer daemons inherit these.
+			if($this->iVersion>=0x0a02)
 			{
 				require_once( 'methods-0.10.2.php' );
 			}

--- a/tests/js/rtorrent.spec.js
+++ b/tests/js/rtorrent.spec.js
@@ -42,6 +42,156 @@ function loadXML(action) {
 }
 
 describe("xmlrpc calls", () => {
+  function withRtorrentVersion(version, callback) {
+    const oldAliases = theRequestManager.aliases;
+    const oldVersion = theWebUI.systemInfo.rTorrent.iVersion;
+
+    theRequestManager.aliases = {};
+    theWebUI.systemInfo.rTorrent.iVersion = version;
+
+    try {
+      correctContent();
+      callback();
+    } finally {
+      theRequestManager.aliases = oldAliases;
+      theWebUI.systemInfo.rTorrent.iVersion = oldVersion;
+    }
+  }
+
+  it("maps rTorrent 0.16 commands without deprecated aliases", () => {
+    withRtorrentVersion(0x100e, () => {
+      expect(theRequestManager.map("execute")).toBe("execute");
+      expect(theRequestManager.map("schedule")).toBe("schedule");
+      expect(theRequestManager.map("schedule_remove")).toBe("schedule.remove");
+      expect(theRequestManager.map("ratio.min.set")).toBe(
+        "group.seeding.ratio.min.set"
+      );
+
+      const command = new rXMLRPCCommand("schedule");
+      expect(command.command).toBe("schedule");
+      expect(command.params[0]).toStrictEqual({ type: "string", value: "" });
+
+      // rtorrent 0.16's dispatcher parses the first param of any call as
+      // the target, so the ratio setters must send ('', value) — prm: 1
+      // makes rXMLRPCCommand prepend the empty target.
+      const ratioCommand = new rXMLRPCCommand("ratio.min.set");
+      ratioCommand.addParameter("i4", 100);
+      expect(ratioCommand.command).toBe("group.seeding.ratio.min.set");
+      expect(ratioCommand.params).toStrictEqual([
+        { type: "string", value: "" },
+        { type: "i4", value: 100 },
+      ]);
+    });
+  });
+
+  it("keeps rTorrent 0.10.2 aliases available on 0.16.0", () => {
+    withRtorrentVersion(0x1000, () => {
+      expect(theRequestManager.map("dht")).toBe("dht.mode.set");
+      expect(theRequestManager.map("connection_leech")).toBe(
+        "protocol.connection.leech.set"
+      );
+      expect(theRequestManager.map("ratio.min.set")).toBe(
+        "group.seeding.ratio.min.set"
+      );
+    });
+  });
+
+  it("maps rTorrent 0.16.16 commands to canonical names", () => {
+    withRtorrentVersion(0x1010, () => {
+      expect(theRequestManager.map("get_http_proxy")).toBe(
+        "network.proxy.http"
+      );
+      expect(theRequestManager.map("set_http_proxy")).toBe(
+        "network.proxy.http.set"
+      );
+      expect(theRequestManager.map("get_proxy_address")).toBe(
+        "network.proxy.global"
+      );
+      expect(theRequestManager.map("set_proxy_address")).toBe(
+        "network.proxy.global.set"
+      );
+      expect(theRequestManager.map("d.multicall")).toBe("d.multicall");
+      expect(theRequestManager.map("d.multicall2")).toBe("d.multicall");
+
+      const command = new rXMLRPCCommand("d.multicall");
+      expect(command.command).toBe("d.multicall");
+      expect(command.params[0]).toStrictEqual({ type: "string", value: "" });
+    });
+  });
+
+  it("switches port aliases at the rTorrent 0.16.18 boundary", () => {
+    withRtorrentVersion(0x1011, () => {
+      expect(theRequestManager.map("get_port_range")).toBe(
+        "network.port_range"
+      );
+      expect(theRequestManager.map("set_port_range")).toBe(
+        "network.port_range.set"
+      );
+      expect(theRequestManager.map("get_port_random")).toBe(
+        "network.port_random"
+      );
+      expect(theRequestManager.map("set_port_random")).toBe(
+        "network.port_random.set"
+      );
+      expect(theRequestManager.map("get_port_open")).toBe(
+        "network.port_open"
+      );
+      expect(theRequestManager.map("set_port_open")).toBe(
+        "network.port_open.set"
+      );
+      expect(theRequestManager.map("port_open")).toBe("network.port_open");
+    });
+
+    for (const version of [0x1012, 0x1013]) {
+      withRtorrentVersion(version, () => {
+        expect(theRequestManager.map("get_port_range")).toBe(
+          "network.listen.port.range"
+        );
+        expect(theRequestManager.map("set_port_range")).toBe(
+          "network.listen.port.range.set"
+        );
+        expect(theRequestManager.map("get_port_random")).toBe(
+          "network.listen.port.random"
+        );
+        expect(theRequestManager.map("set_port_random")).toBe(
+          "network.listen.port.random.set"
+        );
+        expect(theRequestManager.map("get_port_open")).toBe("cat");
+        expect(theRequestManager.map("set_port_open")).toBe("cat");
+        expect(theRequestManager.map("port_open")).toBe("cat");
+        expect(theRequestManager.map("get_max_open_sockets")).toBe(
+          "system.sockets.max_size"
+        );
+        expect(theRequestManager.map("set_max_open_files")).toBe(
+          "system.sockets.files.max_alloc.set"
+        );
+      });
+    }
+  });
+
+  it("loads rTorrent 0.10.2 aliases at the 0.10.2 boundary", () => {
+    // iVersion packs one version component per byte: 0.10.2 is 0x0a02.
+    // Daemons older than 0.10.2 must not get its aliases.
+    for (const version of [0x908, 0x0a01]) {
+      withRtorrentVersion(version, () => {
+        expect(theRequestManager.map("dht")).toBe("dht");
+        expect(theRequestManager.map("connection_seed")).toBe(
+          "connection_seed"
+        );
+      });
+    }
+
+    withRtorrentVersion(0x0a02, () => {
+      expect(theRequestManager.map("dht")).toBe("dht.mode.set");
+      expect(theRequestManager.map("connection_seed")).toBe(
+        "protocol.connection.seed.set"
+      );
+      expect(theRequestManager.map("ratio.min.set")).toBe(
+        "group2.seeding.ratio.min.set"
+      );
+    });
+  });
+
   it("should parse getprops response", () => {
     const stub = new rTorrentStub(`?action=getprops&hash=${h("A")}`);
     //console.log(stub.content);

--- a/tests/php/RequirementsTest.php
+++ b/tests/php/RequirementsTest.php
@@ -10,7 +10,7 @@ class RequirementsTest extends TestCase
 {
 	public function testRtorrentSupportedVersions()
 	{
-		foreach (array('0.9.8', '0.9.8-1', '0.16.0', '0.16.14', '0.16.17') as $v) {
+		foreach (array('0.9.8', '0.9.8-1', '0.16.0', '0.16.14', '0.16.17', '0.16.19') as $v) {
 			list($ok, ) = Requirements::rtorrentSupport($v);
 			$this->assertTrue($ok, "rtorrent $v should be supported");
 		}

--- a/tests/php/RtorrentCompatibilityTest.php
+++ b/tests/php/RtorrentCompatibilityTest.php
@@ -1,0 +1,191 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/settings.php');
+
+class RtorrentCompatibilityTest extends TestCase
+{
+	/**
+	 * settings.php loads the per-version method alias files from obtain(),
+	 * which interrogates a live daemon over XMLRPC before it reaches the
+	 * require_once ladder, so the ladder cannot be executed directly here.
+	 * Instead, parse the version => file gate table out of the source and
+	 * replay it, so the constants under test are the real ones and a wrong
+	 * gate in settings.php fails these tests.
+	 */
+	private function methodFileGates()
+	{
+		$source = file_get_contents(__DIR__ . '/../../php/settings.php');
+		preg_match_all(
+			'/if\s*\(\s*\$this->iVersion\s*>=\s*(0x[0-9A-Fa-f]+)\s*\)\s*\{\s*require_once\(\s*\'(methods-[^\']+\.php)\'\s*\);/',
+			$source,
+			$matches,
+			PREG_SET_ORDER
+		);
+		if (count($matches) < 4) {
+			throw new Exception('Could not parse the method alias gates out of php/settings.php');
+		}
+		$gates = array();
+		foreach ($matches as $match) {
+			$gates[] = array('version' => intval($match[1], 16), 'file' => $match[2]);
+		}
+		return $gates;
+	}
+
+	private function makeSettings($version)
+	{
+		$reflection = new ReflectionClass('rTorrentSettings');
+		$settings = $reflection->newInstanceWithoutConstructor();
+		$settings->iVersion = $version;
+		$settings->aliases = [];
+
+		foreach ($this->methodFileGates() as $gate) {
+			if ($version >= $gate['version']) {
+				$this->loadMethodAliases($settings, $gate['file']);
+			}
+		}
+
+		return $settings;
+	}
+
+	private function loadMethodAliases($settings, $file)
+	{
+		$loader = function () use ($file) {
+			require __DIR__ . '/../../php/' . $file;
+		};
+		$loader = $loader->bindTo($settings, get_class($settings));
+		$loader();
+	}
+
+	private function useSettingsSingleton($settings)
+	{
+		$property = new ReflectionProperty('rTorrentSettings', 'theSettings');
+		if (PHP_VERSION_ID < 80100) {
+			$property->setAccessible(true);
+		}
+		$property->setValue(null, $settings);
+	}
+
+	public function testRtorrent0102MethodAliasGateUsesBytewiseVersion()
+	{
+		// iVersion packs one version component per byte, so 0.10.2 is 0x0a02
+		// (0x1002 would be 0.16.2) and 0.10.1 is 0x0a01.
+		foreach (array(0x908 => '0.9.8', 0x0a01 => '0.10.1') as $version => $label) {
+			$settings = $this->makeSettings($version);
+			$this->assertEquals('dht', $settings->getCommand('dht'), 'rTorrent '.$label.' predates the 0.10.2 aliases so dht stays unmapped');
+			$this->assertEquals('connection_leech', $settings->getCommand('connection_leech'), 'rTorrent '.$label.' predates the 0.10.2 aliases so connection_leech stays unmapped');
+		}
+
+		$settings = $this->makeSettings(0x0a02);
+		$this->assertEquals('dht.mode.set', $settings->getCommand('dht'), 'rTorrent 0.10.2 itself gets its dht alias');
+		$this->assertEquals('group2.seeding.ratio.min.set', $settings->getCommand('ratio.min.set'), 'rTorrent 0.10.2 itself gets its ratio aliases');
+	}
+
+	public function testRtorrent016UsesNonDeprecatedRpcCommandNames()
+	{
+		$settings = $this->makeSettings(0x100e);
+		$this->useSettingsSingleton($settings);
+
+		$this->assertEquals('execute', $settings->getCommand('execute'), 'rTorrent 0.16 uses execute directly');
+		$this->assertEquals('schedule', $settings->getCommand('schedule'), 'rTorrent 0.16 uses schedule directly');
+		$this->assertEquals('schedule.remove', $settings->getCommand('schedule_remove'), 'rTorrent 0.16 uses schedule.remove directly');
+
+		$command = new rXMLRPCCommand('schedule', array('test_schedule', '0', '60', 'system.method'));
+		$this->assertEquals('schedule', $command->command, 'rTorrent 0.16 schedule command name stays direct');
+		$this->assertEquals('', $command->params[0]->value, 'rTorrent 0.16 schedule keeps an empty target parameter');
+		$this->assertEquals('test_schedule', $command->params[1]->value, 'rTorrent 0.16 schedule keeps requested parameters after the empty target');
+	}
+
+	public function testRtorrent0102AliasesAreLoadedFor0102AndInheritedBy016()
+	{
+		foreach (array(0x0a02 => '0.10.2', 0x1000 => '0.16.0') as $version => $label) {
+			$settings = $this->makeSettings($version);
+
+			$this->assertEquals('dht.mode.set', $settings->getCommand('dht'), 'rTorrent '.$label.' maps DHT mode command');
+			$this->assertEquals('protocol.connection.leech.set', $settings->getCommand('connection_leech'), 'rTorrent '.$label.' maps leech connection command');
+		}
+
+		$settings = $this->makeSettings(0x1000);
+		$this->assertEquals('group.seeding.ratio.min.set', $settings->getCommand('ratio.min.set'), 'rTorrent 0.16.0 overrides ratio aliases back to group commands');
+	}
+
+	public function testRtorrent016RatioSettersPrependAnEmptyTarget()
+	{
+		// rtorrent 0.16's XMLRPC dispatcher (src/rpc/xmlrpc_tinyxml2.cc)
+		// unconditionally parses the FIRST param of any call as the target,
+		// so group.NAME.ratio.*.set must be sent as ('', value); a bare
+		// (value) faults with "invalid parameters: target must be a string".
+		// getRatioGroupCommand in php/settings.php prepends '' for the same
+		// reason. This pins the shape on both the alias path (prm=1 makes
+		// rXMLRPCCommand prepend the empty target) and the group-command
+		// path — this fork once got the alias shape wrong (prm=0), which
+		// this test now guards against.
+		$settings = $this->makeSettings(0x100e);
+		$this->useSettingsSingleton($settings);
+
+		$aliasCommand = new rXMLRPCCommand('ratio.min.set', 100);
+		$this->assertEquals('group.seeding.ratio.min.set', $aliasCommand->command, 'rTorrent 0.16 maps bare ratio setters to group commands');
+		$this->assertEquals(2, count($aliasCommand->params), 'rTorrent 0.16 ratio setters send target and value arguments');
+		$this->assertEquals('', $aliasCommand->params[0]->value, 'rTorrent 0.16 ratio setters prepend the empty target the dispatcher requires');
+		$this->assertEquals('100', $aliasCommand->params[1]->value, 'rTorrent 0.16 ratio setters keep the requested value after the target');
+
+		$command = $settings->getRatioGroupCommand('rat_0', 'ratio.min.set', 100);
+
+		$this->assertEquals('group.rat_0.ratio.min.set', $command->command, 'rTorrent 0.16 uses group ratio command names');
+		$this->assertEquals(2, count($command->params), 'rTorrent 0.16 group ratio value setters send target and value arguments');
+		$this->assertEquals('', $command->params[0]->value, 'rTorrent 0.16 group ratio commands send an empty target argument');
+		$this->assertEquals('100', $command->params[1]->value, 'rTorrent 0.16 group ratio commands keep the requested value');
+	}
+
+	public function testRtorrent01616UsesCanonicalCommands()
+	{
+		$settings = $this->makeSettings(0x1010);
+		$this->useSettingsSingleton($settings);
+
+		$this->assertEquals('network.proxy.http', $settings->getCommand('get_http_proxy'), 'rTorrent 0.16.16 reads HTTP proxy through proxy manager');
+		$this->assertEquals('network.proxy.http.set', $settings->getCommand('set_http_proxy'), 'rTorrent 0.16.16 writes HTTP proxy through proxy manager');
+		$this->assertEquals('network.proxy.global', $settings->getCommand('get_proxy_address'), 'rTorrent 0.16.16 reads global proxy through proxy manager');
+		$this->assertEquals('network.proxy.global.set', $settings->getCommand('set_proxy_address'), 'rTorrent 0.16.16 writes global proxy through proxy manager');
+		$this->assertEquals('d.multicall', $settings->getCommand('d.multicall'), 'rTorrent 0.16.16 uses the canonical download multicall command');
+		$this->assertEquals('d.multicall', $settings->getCommand('d.multicall2'), 'rTorrent 0.16.16 maps the legacy download multicall command to the canonical command');
+
+		$command = new rXMLRPCCommand('d.multicall', array('main', 'd.hash='));
+		$this->assertEquals('d.multicall', $command->command, 'rTorrent 0.16.16 sends canonical download multicalls');
+		$this->assertEquals('', $command->params[0]->value, 'canonical download multicalls keep the required empty target argument');
+	}
+
+	public function testRtorrent01618AndLaterLoadCanonicalPortAliasesAtExactThreshold()
+	{
+		$legacyAliases = array(
+			'get_port_range' => 'network.port_range',
+			'set_port_range' => 'network.port_range.set',
+			'get_port_random' => 'network.port_random',
+			'set_port_random' => 'network.port_random.set',
+			'get_port_open' => 'network.port_open',
+			'set_port_open' => 'network.port_open.set',
+			'port_open' => 'network.port_open',
+		);
+		$settings = $this->makeSettings(0x1011);
+		foreach ($legacyAliases as $alias => $command) {
+			$this->assertEquals($command, $settings->getCommand($alias), 'rTorrent 0.16.17 keeps '.$alias.' on its legacy command');
+		}
+
+		$canonicalAliases = array(
+			'get_port_range' => 'network.listen.port.range',
+			'set_port_range' => 'network.listen.port.range.set',
+			'get_port_random' => 'network.listen.port.random',
+			'set_port_random' => 'network.listen.port.random.set',
+			'get_port_open' => 'cat',
+			'set_port_open' => 'cat',
+			'port_open' => 'cat',
+		);
+		foreach (array(0x1012 => '0.16.18', 0x1013 => '0.16.19') as $version => $label) {
+			$settings = $this->makeSettings($version);
+			foreach ($canonicalAliases as $alias => $command) {
+				$this->assertEquals($command, $settings->getCommand($alias), 'rTorrent '.$label.' maps '.$alias.' to its canonical command');
+			}
+			$this->assertEquals('system.sockets.max_size', $settings->getCommand('get_max_open_sockets'), 'rTorrent '.$label.' reads the generic socket ceiling without removed allocation commands');
+			$this->assertEquals('system.sockets.files.max_alloc.set', $settings->getCommand('set_max_open_files'), 'rTorrent '.$label.' keeps the file-category allocation setter');
+		}
+	}
+}


### PR DESCRIPTION
**Problem.** Two live defects in the version→alias tables, which had zero test
coverage. (a) `iVersion` packs one version component per byte, so 0.10.2 is
`0x0a02` — but the gate loading `methods-0.10.2.php` reads `>= 0x1002`, which is
0.16.2: every daemon from 0.10.2 to 0.16.1 runs without that whole alias table.
`js/content.js` mirrors the same mistake. (b) `methods-0.9.4.php` remaps
`d.multicall` → `d.multicall2`; 0.16.16 removed `d.multicall2` and aliases it back,
but a direct `d.multicall` spelling is still rewritten to the *removed* command.

**Fix.** Gate constant `0x0a02` (php + js mirror); a `d.multicall` self-entry in the
0.16.16 table overriding the 0.9.4 remap (php + js mirror). New table-driven
`tests/php/RtorrentCompatibilityTest.php` (replays the actual `require_once` ladder
parsed from `settings.php` — `obtain()` needs a live daemon, so the ladder cannot be
executed directly) plus jest cases. The tests also pin the `('', value)`
target-prepending shape of the group ratio setters — the 0.16 dispatcher reads the
first param of any call as the target, same reason `getRatioGroupCommand` prepends
`''`.

**How to verify.** Keep the tests, revert the source hunks
(`git checkout HEAD~1 -- js/content.js php/settings.php php/methods-0.16.16.php`):
8 PHP assertions + 3 jest tests fail, all naming the gate or `d.multicall`. Restore:
green.