### PR TITLE
webui: drop the details pane when its torrent disappears, and let detail polls fail quietly

### DIFF
--- a/js/webui.js
+++ b/js/webui.js
@@ -1652,6 +1652,16 @@ var theWebUI = {
 				table.setRowById(torrent, hash, sInfo[0], {})
 			})
 			.enqueueFunc(() => {
+				if (theWebUI.dID && !(theWebUI.dID in dataTorrents)) {
+					const staleDetailsHash = theWebUI.dID;
+					delete theWebUI.files[staleDetailsHash];
+					delete theWebUI.dirs[staleDetailsHash];
+					delete theWebUI.peers[staleDetailsHash];
+					delete theWebUI.trackers[staleDetailsHash];
+					theWebUI.dID = "";
+					theWebUI.clearDetails();
+				}
+
 				// update details page
 				const detailsTorrent = dataTorrents[theWebUI.dID];
 				const oldDetailsTorrent = this.torrents[theWebUI.dID];
@@ -1672,6 +1682,7 @@ var theWebUI = {
 						delete theWebUI.files[hash];
 						delete theWebUI.dirs[hash];
 						delete theWebUI.peers[hash];
+						delete theWebUI.trackers[hash];
 						table.removeRow(hash);
 					}
 				}

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -63,6 +63,9 @@ function makeMulticall($cmds,$hash,$add,$prefix)
 		$cmd->addParameter($prm);
 	$cnt = count($cmds)+count($add);
 	$req = new rXMLRPCRequest($cmd);
+	// Detail polling can race with torrent erase/replacement.
+	if(($prefix === 'f') || ($prefix === 'p') || ($prefix === 't'))
+		$req->important = false;
 	if($req->success(true))
 	{
 	        $result = array();
@@ -218,6 +221,8 @@ switch($mode)
 		$result = makeMulticall(array(
 			"f.get_path=", "f.get_completed_chunks=", "f.get_size_chunks=", "f.get_size_bytes=", "f.get_priority="
 			),$hash[0],$add,'f');
+		if($result === false)
+			$result = array();
 		break;
 	}
 	case "prs":	/**/
@@ -227,6 +232,8 @@ switch($mode)
 			"p.is_snubbed=", "p.get_completed_percent=", "p.get_down_total=", "p.get_up_total=", "p.get_down_rate=",
 			"p.get_up_rate=", "p.get_id_html=", "p.get_peer_rate=", "p.get_peer_total=", "p.get_port="
 			),$hash[0],$add,'p');
+		if($result === false)
+			$result = array();
 		break;
 	}
 	case "trk":	/**/
@@ -236,6 +243,8 @@ switch($mode)
 			"t.get_scrape_incomplete=", "t.get_scrape_downloaded=",
 			"t.get_normal_interval=", "t.get_scrape_time_last="
 			),$hash[0],$add,'t');
+		if($result === false)
+			$result = array();
 		break;
 	}
 	case "stg":	/**/

--- a/tests/js/webui-stale-details.spec.js
+++ b/tests/js/webui-stale-details.spec.js
@@ -1,0 +1,121 @@
+import { readFileSync } from "fs";
+
+window.$ = require("jquery");
+
+function h(char) {
+  return Array.from({ length: 40 }, () => char).join("");
+}
+
+function loadWebUI() {
+  window.theUILang = new Proxy(
+    {},
+    {
+      get: (_target, prop) => prop,
+    }
+  );
+  window.theFormatter = {};
+  window.TYPE_STRING = "string";
+  window.TYPE_NUMBER = "number";
+  window.TYPE_PROGRESS = "progress";
+  window.TYPE_PEERS = "peers";
+  window.TYPE_SEEDS = "seeds";
+  window.ALIGN_RIGHT = "right";
+  window.dxSTable = function () {};
+  window.rSpeedGraph = function () {};
+  window.rSpeedGraph.prototype.addData = jest.fn();
+  window.Timer = function () {};
+
+  let code = readFileSync("../js/webui.js", { encoding: "utf-8" });
+  code = code.replace(/\n\$\(document\)\.ready\(function\(\)\n\{[\s\S]*?\n\}\);\s*$/, "");
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = code;
+  document.body.appendChild(scriptEl);
+}
+
+function makeTaskQueue() {
+  const queue = {
+    reset: jest.fn(() => queue),
+    map: jest.fn((items, callback) => {
+      items.forEach(callback);
+      return queue;
+    }),
+    enqueueFunc: jest.fn((callback) => {
+      callback();
+      return queue;
+    }),
+    run: jest.fn(() => Promise.resolve()),
+  };
+  return queue;
+}
+
+describe("webui stale details", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    loadWebUI();
+    window.requestAnimationFrame = (callback) => {
+      callback();
+      return 1;
+    };
+    window.cancelAnimationFrame = jest.fn();
+  });
+
+  it("clears selected details when the selected torrent disappears from list updates", () => {
+    const oldHash = h("A");
+    const newHash = h("B");
+    const table = {
+      setLazy: jest.fn(),
+      setRowById: jest.fn(),
+      removeRow: jest.fn(),
+    };
+    const statistic = {
+      scan: jest.fn(),
+      upload: 0,
+      download: 0,
+    };
+
+    Object.assign(theWebUI, {
+      systemInfo: { rTorrent: { started: true } },
+      dID: oldHash,
+      activeView: "TrackerList",
+      torrents: {
+        [oldHash]: { name: "old", downloaded: 1 },
+      },
+      files: { [oldHash]: ["file"] },
+      dirs: { [oldHash]: ["dir"] },
+      peers: { [oldHash]: ["peer"] },
+      trackers: { [oldHash]: ["tracker"] },
+      taskAddTorrents: makeTaskQueue(),
+      categoryList: {
+        statistic: {
+          empty: () => statistic,
+        },
+        syncAfterScan: jest.fn(),
+      },
+      getTable: jest.fn(() => table),
+      getStatusIcon: jest.fn(() => ["icon", "status"]),
+      filterByLabel: jest.fn(),
+      getAllTrackers: jest.fn(),
+      getTotal: jest.fn(),
+      getOpenStatus: jest.fn(),
+      setInterval: jest.fn(),
+      updateViewRows: jest.fn(),
+      loadTorrents: jest.fn(),
+      updateTrackers: jest.fn(),
+      clearDetails: jest.fn(),
+    });
+
+    theWebUI.addTorrents({
+      torrents: {
+        [newHash]: { name: "new", downloaded: 2 },
+      },
+    });
+
+    expect(theWebUI.dID).toBe("");
+    expect(theWebUI.clearDetails).toHaveBeenCalledTimes(1);
+    expect(theWebUI.updateTrackers).not.toHaveBeenCalledWith(oldHash);
+    expect(theWebUI.files[oldHash]).toBeUndefined();
+    expect(theWebUI.dirs[oldHash]).toBeUndefined();
+    expect(theWebUI.peers[oldHash]).toBeUndefined();
+    expect(theWebUI.trackers[oldHash]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Problem.** When the torrent shown in the details pane is erased or replaced while
the pane is open, `theWebUI.dID` still points at a hash gone from `dataTorrents`:
the pane freezes on stale data and the cached files/dirs/peers/trackers for that
hash are never freed (the trackers map was missing from the normal removal path
too). The file/peer/tracker detail polls for the vanished hash fault, and being
flagged *important* they surface as a red XMLRPC error dialog — for a routine race
between polling and erase.

**Fix.** Clear the pane and its caches when the hash disappears from the list;
`httprpc` marks the f/p/t detail multicalls not-important and answers an empty
result instead of an error when they fail.

**How to verify.** New `tests/js/webui-stale-details.spec.js`. Manual: open a
torrent's details, erase that torrent from another tab — before: frozen pane and an
error popup; after: the pane clears silently.