### PR TITLE
cache: merge concurrent writes under a per-key lock

### DIFF
--- a/php/cache.php
+++ b/php/cache.php
@@ -4,7 +4,8 @@ require_once( 'util.php' );
 class rCache
 {
 	protected $dir;
-	protected static $modifiedTimes = [];
+	// How each cache file looked when this process loaded it, keyed by cache key.
+	protected static $loadStamps = [];
 
 	public function __construct( $name = '' )
 	{
@@ -27,57 +28,105 @@ class rCache
 	{
 		return(get_class($rss).':'.$rss->hash);
 	}
+	// A cache file's identity, used to tell whether it is still the one this
+	// process loaded. filemtime resolves only to the second, so two writes
+	// inside one second look identical -- and that is the common case here:
+	// replacing a torrent fires three writers within the same second. set()
+	// always publishes through rename(), which gives the file a fresh inode,
+	// so the inode is what actually separates them.
+	protected static function stampOf( $name )
+	{
+		clearstatcache(true, $name);
+		$st = @stat($name);
+		return($st===false ? null : $st['ino'].':'.$st['mtime'].':'.$st['size']);
+	}
+	// True when the file on disk is no longer the one this process loaded.
+	protected static function hasChangedSinceLoad( $name, $stamp )
+	{
+		if(!is_null($stamp))
+			return($stamp !== self::stampOf($name));
+		// This process loaded nothing: the file was absent or unreadable when
+		// get() ran. Any file present now was published by someone else, and
+		// merging what is on disk is always safe for the merge-capable
+		// classes that are the only callers of this check.
+		return(is_file($name));
+	}
 	public function set( $rss, $arg = null )
 	{
 		global $profileMask;
 		$name = $this->getName($rss);
-		$cacheKey = is_object($rss) ? self::getCacheKey($rss) : null;
-		$modTime = $cacheKey ? (self::$modifiedTimes[$cacheKey] ?? (isset($rss->modified) ? $rss->modified : 0)) : 0;
-		if(     is_object($rss) &&
-			$modTime &&
-			method_exists($rss,"merge") &&
-			($modTime < filemtime($name)))
+		$lockName = $name.'.lock';
+		// One writer per cache key. The changed-since-load check, the merge
+		// and the publishing rename must form a single critical section: two
+		// writers that both check before either publishes both conclude
+		// nothing changed, both skip merging, and the later rename erases the
+		// earlier writer's data. The lock is a sidecar file because the cache
+		// file itself is replaced by rename() on every store.
+		$lock = fopen( $lockName, "c" );
+		if($lock===false)
+			return(false);
+		@chmod($lockName,$profileMask & 0666);
+		if(!self::flock( $lock ))
 		{
-		        $className = get_class($rss);
+			fclose($lock);
+			return(false);
+		}
+
+		$cacheKey = is_object($rss) ? self::getCacheKey($rss) : null;
+		$stamp = ($cacheKey !== null) ? (self::$loadStamps[$cacheKey] ?? null) : null;
+		if(     is_object($rss) &&
+			method_exists($rss,"merge") &&
+			self::hasChangedSinceLoad($name, $stamp))
+		{
+			$className = get_class($rss);
 			$newInstance = new $className();
 			if($this->get($newInstance) &&
 				!$rss->merge($newInstance, $arg))
+			{
+				flock( $lock, LOCK_UN );
+				fclose( $lock );
 				return(false);
+			}
 		}
-		$fp = fopen( $name.'.tmp', "a" );
+		// Use a per-process temporary file and publish it atomically under the key lock.
+		$tmpName = $name.'.'.getmypid().'.'.uniqid('', true).'.tmp';
+		$fp = fopen( $tmpName, "wb" );
 		if($fp!==false)
 		{
-			if(self::flock( $fp ))
+			$str = serialize( $rss );
+			if((fwrite( $fp, $str ) == strlen($str)) && fflush( $fp ))
 			{
-				ftruncate( $fp, 0 );
-				$str = serialize( $rss );
-	        		if((fwrite( $fp, $str ) == strlen($str)) && fflush( $fp ))
-	        		{
-					flock( $fp, LOCK_UN );
-        				if(fclose( $fp ) !== false)
-        				{
-	       					@rename( $name.'.tmp', $name );
+				if(fclose( $fp ) !== false)
+				{
+					@chmod($tmpName,$profileMask & 0666);
+					if(@rename( $tmpName, $name ))
+					{
 						@chmod($name,$profileMask & 0666);
-	        				return(true);
+						flock( $lock, LOCK_UN );
+						fclose( $lock );
+						return(true);
 					}
-					else
-						unlink( $name.'.tmp' );
 				}
 				else
-				{
-					flock( $fp, LOCK_UN );
-        				fclose( $fp );
-        				unlink( $name.'.tmp' );
-				}
-	        	}
-	        	else
-		        	fclose( $fp );
+					@unlink( $tmpName );
+			}
+			else
+				fclose( $fp );
 		}
+		@unlink( $tmpName );
+		flock( $lock, LOCK_UN );
+		fclose( $lock );
 	        return(false);
 	}
 	public function get( &$rss )
 	{
 		$fname = $this->getName($rss);
+		// Stamp before reading. If a concurrent rename lands between the stat
+		// and the read, this process holds new content under an old stamp and
+		// its set() merely performs one redundant merge. Stamping after the
+		// read inverts that: a rename between read and stat pairs old content
+		// with the new identity, and that concurrent write is never merged.
+		$stamp = self::stampOf($fname);
 		$ret = @file_get_contents($fname);
 		if($ret!==false)
 		{
@@ -96,7 +145,7 @@ class rCache
 				{
 					$rss = $tmp;
 					$cacheKey = self::getCacheKey($rss);
-					self::$modifiedTimes[$cacheKey] = filemtime($fname);
+					self::$loadStamps[$cacheKey] = $stamp;
 					$ret = true;
 				}
 				else
@@ -107,7 +156,25 @@ class rCache
 	}
 	public function remove( $rss )
 	{
-		return(@unlink($this->getName($rss)));
+		global $profileMask;
+		$name = $this->getName($rss);
+		$lockName = $name.'.lock';
+		// Delete cache data and its sidecar lock while holding the same key lock used by writers.
+		$lock = fopen( $lockName, "c" );
+		if($lock!==false)
+		{
+			@chmod($lockName,$profileMask & 0666);
+			if(self::flock( $lock ))
+			{
+				$ret = @unlink($name);
+				flock( $lock, LOCK_UN );
+				fclose( $lock );
+				@unlink($lockName);
+				return($ret);
+			}
+			fclose($lock);
+		}
+		return(@unlink($name));
 	}
 	protected function getName($rss)
 	{

--- a/plugins/history/history.php
+++ b/plugins/history/history.php
@@ -12,6 +12,19 @@ class rHistoryData
 	public $modified = false;
 	public $data = array();
 
+	// What this process itself changed since it loaded the file. Kept apart
+	// from $data so that merge() can replay exactly these changes on top of a
+	// file another process has moved on in the meantime. Deliberately left out
+	// of __sleep(): the stored format stays byte for byte what it always was.
+	protected $ownAdditions = array();
+	protected $ownRemovals = array();
+	protected $limit = 0;
+
+	public function __sleep()
+	{
+		return(array('hash', 'modified', 'data'));
+	}
+
 	static public function load()
 	{
 		$cache = new rCache();
@@ -27,29 +40,73 @@ class rHistoryData
 	public function delete( $hashes )
 	{
 		foreach( $hashes as $hash )
-			unset($this->data[$hash]);
+		{
+			unset($this->data[$hash], $this->ownAdditions[$hash]);
+			$this->ownRemovals[$hash] = true;
+		}
 		$this->store();
 	}
 	static protected function sortByActionTime( $a, $b )
 	{
 		return($b["action_time"]-$a["action_time"]);
 	}
+	// Newest first, then capped: unchanged from what add() always did, lifted
+	// out so merge() orders a reconciled set exactly the same way.
+	static protected function ordered( $data, $limit )
+	{
+		uasort($data, array(__CLASS__,"sortByActionTime"));
+		$count = count($data);
+		if($limit<3)
+			$limit = 500;
+		if($count>$limit)
+		{
+			$keys = array_keys($data);
+			$values = array_values($data);
+			$offset = $limit / 2;
+			$data = array_combine(array_splice($keys,0,$offset),array_splice($values,0,$offset));
+		}
+		return($data);
+	}
+
+	// Reconciles this process's own changes with a file that another one has
+	// written since load(). Every history event is recorded by its own
+	// detached update.php, and replacing a torrent fires three of them within
+	// the same second -- the old download erased, its metadata stub erased and
+	// the replacement inserted. Each process runs load(), add(), store(), so
+	// whoever wrote last used to publish a file without the rows the others
+	// had just added; measured on a live fleet, the "added" row of every
+	// replacement was the one that vanished. rCache::set() already re-reads a
+	// file that moved under the writer, but it only reconciles classes that
+	// define this method, and this one did not.
+	//
+	// Records are keyed by a hash of their own content, so replaying this
+	// process's additions and removals onto the fresher copy is exact: a row
+	// another process added stays, and one this process deleted does not come
+	// back from the dead.
+	public function merge( $instance, $arg )
+	{
+		$data = (is_object($instance) && is_array($instance->data)) ? $instance->data : array();
+		foreach($this->ownAdditions as $key => $record)
+			$data[$key] = $record;
+		foreach($this->ownRemovals as $key => $ignored)
+			unset($data[$key]);
+		// Only a recorded event knows the configured cap; a delete carries no
+		// limit and must not fall back to the default one, which would trim a
+		// longer history the user deliberately asked for.
+		$this->data = $this->limit ? self::ordered($data, $this->limit)
+			: self::ordered($data, count($data));
+		return(true);
+	}
+
 	public function add( $e, $limit )
 	{
 		$e["action_time"] = time();
 		$e["hash"] = md5(serialize($e));
 		$this->data[$e["hash"]] = $e;
-		uasort($this->data, array(__CLASS__,"sortByActionTime"));
-		$count = count($this->data);
-		if($limit<3)
-			$limit = 500;
-		if($count>$limit)
-		{
-			$keys = array_keys($this->data);
-			$values = array_values($this->data);
-			$offset = $limit / 2;
-			$this->data = array_combine(array_splice($keys,0,$offset),array_splice($values,0,$offset));
-		}
+		$this->ownAdditions[$e["hash"]] = $e;
+		unset($this->ownRemovals[$e["hash"]]);
+		$this->limit = $limit;
+		$this->data = self::ordered($this->data, $limit);
 		$this->store();
 	}
 	public function get( $mark )

--- a/tests/php/CacheMergePayloadFixture.php
+++ b/tests/php/CacheMergePayloadFixture.php
@@ -1,0 +1,38 @@
+<?php
+
+// A cache record that reconciles concurrent writers the way rHistoryData does:
+// it remembers what this process itself added and replays exactly that on top
+// of whatever another process published in the meantime. Kept in its own file
+// because CacheTest runs a second, genuinely separate PHP process that has to
+// unserialize the very same class.
+class CacheMergePayload
+{
+	public $hash = 'merge-cache-test.dat';
+	public $modified = false;
+	public $rows = array();
+
+	// Deliberately left out of __sleep(), exactly like rHistoryData's own
+	// bookkeeping: the stored format stays what it always was.
+	protected $ownAdditions = array();
+
+	public function __sleep()
+	{
+		return(array('hash', 'modified', 'rows'));
+	}
+
+	public function addRow($key)
+	{
+		$this->rows[$key] = $key;
+		$this->ownAdditions[$key] = $key;
+		return((new rCache())->set($this));
+	}
+
+	public function merge($instance, $arg)
+	{
+		$rows = (is_object($instance) && is_array($instance->rows)) ? $instance->rows : array();
+		foreach($this->ownAdditions as $key => $value)
+			$rows[$key] = $value;
+		$this->rows = $rows;
+		return(true);
+	}
+}

--- a/tests/php/CacheTest.php
+++ b/tests/php/CacheTest.php
@@ -1,0 +1,240 @@
+<?php
+
+$_ENV['RU_PROFILE_PATH'] = sys_get_temp_dir() . '/rutorrent-cache-test-' . getmypid();
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/cache.php');
+require_once(__DIR__ . '/CacheMergePayloadFixture.php');
+
+// Its own class rather than an instance with a reassigned hash: when set()
+// reconciles a concurrent write it reloads the file through a freshly
+// constructed instance of the same class, so a merge-capable payload has to
+// carry its identity in the class, the way rHistoryData does.
+class CacheGhostLoadPayload extends CacheMergePayload
+{
+	public $hash = 'ghost-load-test.dat';
+}
+
+class CacheTest extends TestCase
+{
+	private $profilePath;
+
+	public function setUp()
+	{
+		$this->profilePath = $_ENV['RU_PROFILE_PATH'];
+		if (is_dir($this->profilePath)) {
+			$this->removeDir($this->profilePath);
+		}
+		FileUtil::makeDirectory(FileUtil::getSettingsPath());
+	}
+
+	public function tearDown()
+	{
+		if (is_dir($this->profilePath)) {
+			$this->removeDir($this->profilePath);
+		}
+	}
+
+	private function removeDir($dir)
+	{
+		foreach (array_diff(scandir($dir), ['.', '..']) as $entry) {
+			$path = $dir . '/' . $entry;
+			if (is_dir($path) && !is_link($path)) {
+				$this->removeDir($path);
+			} else {
+				unlink($path);
+			}
+		}
+		rmdir($dir);
+	}
+
+	// Writes a helper that does what a second update.php does -- load the
+	// cache, record one row, store it -- as a genuinely separate process. It
+	// has to be a real process: rCache remembers the loaded file's stamp in a
+	// static, so a second writer inside this one would share it.
+	private function makeWriterScript()
+	{
+		$path = FileUtil::getSettingsPath() . '/concurrent-writer.php';
+		$code = "<?php\n"
+			. '$_ENV[\'RU_PROFILE_PATH\'] = ' . var_export($this->profilePath, true) . ";\n"
+			. 'require_once(' . var_export(realpath(__DIR__ . '/../../php/cache.php'), true) . ");\n"
+			. 'require_once(' . var_export(realpath(__DIR__ . '/CacheMergePayloadFixture.php'), true) . ");\n"
+			. "\$payload = new CacheMergePayload();\n"
+			. "(new rCache())->get(\$payload);\n"
+			. "exit(\$payload->addRow(\$argv[1]) ? 0 : 1);\n";
+		file_put_contents($path, $code);
+		return $path;
+	}
+
+	// Writes the helper for the overlap test: load the cache, then rendezvous
+	// with the peer writer -- announce readiness through one file, spin until
+	// the peer's file appears -- so both processes enter set() at the same
+	// moment, then store one row.
+	private function makeBarrierWriterScript()
+	{
+		$path = FileUtil::getSettingsPath() . '/overlapping-writer.php';
+		$code = "<?php\n"
+			. '$_ENV[\'RU_PROFILE_PATH\'] = ' . var_export($this->profilePath, true) . ";\n"
+			. 'require_once(' . var_export(realpath(__DIR__ . '/../../php/cache.php'), true) . ");\n"
+			. 'require_once(' . var_export(realpath(__DIR__ . '/CacheMergePayloadFixture.php'), true) . ");\n"
+			. "list(, \$row, \$readyMine, \$readyOther) = \$argv;\n"
+			. "\$payload = new CacheMergePayload();\n"
+			. "(new rCache())->get(\$payload);\n"
+			. "touch(\$readyMine);\n"
+			. "\$deadline = microtime(true) + 10;\n"
+			. "for (;;) {\n"
+			. "\tclearstatcache(true, \$readyOther);\n"
+			. "\tif (file_exists(\$readyOther)) break;\n"
+			. "\tif (microtime(true) > \$deadline) exit(2);\n"
+			. "\tusleep(200);\n"
+			. "}\n"
+			. "// Both writers saw each other; spinning to the same clock boundary\n"
+			. "// puts their set() calls within microseconds of each other.\n"
+			. "\$go = ceil((microtime(true) + 0.05) * 4) / 4;\n"
+			. "while (microtime(true) < \$go);\n"
+			. "exit(\$payload->addRow(\$row) ? 0 : 1);\n";
+		file_put_contents($path, $code);
+		return $path;
+	}
+
+	// The live failure this guards: replacing a torrent fires three update.php
+	// processes inside one second, and filemtime only resolves to the second,
+	// so a writer that reloaded after a same-second write saw an unchanged
+	// timestamp, skipped merging and republished the file without the other
+	// process's row. On a live fleet the row that vanished was the "added" one
+	// of every replacement.
+	public function testRowFromAnotherProcessSurvivesAWriteInTheSameSecond()
+	{
+		// Start near the top of a second so the seed, this process's load and
+		// the other process's write all share one mtime.
+		usleep((int) ((1 - fmod(microtime(true), 1)) * 1000000));
+
+		$seed = new CacheMergePayload();
+		$this->assertTrue($seed->addRow('seed'), 'the seeding write succeeds');
+
+		// This process loads the file; rCache records how the file looked.
+		$mine = new CacheMergePayload();
+		(new rCache())->get($mine);
+
+		// Another process records its own row in the very same second.
+		$writer = $this->makeWriterScript();
+		exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($writer) . ' other-process', $output, $code);
+		$this->assertEquals(0, $code, 'the second writer process stores its row');
+
+		// Only now does this process store its own row.
+		$this->assertTrue($mine->addRow('mine'), 'this process stores its row');
+
+		$check = new CacheMergePayload();
+		(new rCache())->get($check);
+		$this->assertTrue(isset($check->rows['mine']), 'this process keeps its own row');
+		$this->assertTrue(isset($check->rows['other-process']),
+			'the row another process wrote in the same second is not overwritten');
+		$this->assertTrue(isset($check->rows['seed']), 'the pre-existing row is untouched');
+	}
+
+	// Unlike the sequential test above, here the two writers overlap inside
+	// set(): both have loaded the same file when they start storing. Checking
+	// the stamp outside the writer lock loses a row here -- both compare
+	// against the pre-write state, both skip merging, and whichever publishes
+	// last erases the other's row. Only a check-merge-publish critical
+	// section makes this deterministic, which is why the rounds are asserted
+	// individually instead of retried.
+	public function testTwoOverlappingWritersBothKeepTheirRows()
+	{
+		$writer = $this->makeBarrierWriterScript();
+		$settings = FileUtil::getSettingsPath();
+		$cacheFile = $settings . '/' . (new CacheMergePayload())->hash;
+		$readyFirst = $settings . '/first-writer.ready';
+		$readySecond = $settings . '/second-writer.ready';
+
+		// One round can miss the race by scheduling luck; ten in a row do not.
+		for ($round = 1; $round <= 10; $round++) {
+			@unlink($cacheFile);
+			@unlink($readyFirst);
+			@unlink($readySecond);
+
+			$seed = new CacheMergePayload();
+			$this->assertTrue($seed->addRow('seed'), "round {$round}: the seeding write succeeds");
+
+			$php = escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($writer);
+			$first = proc_open($php . ' first '
+				. escapeshellarg($readyFirst) . ' ' . escapeshellarg($readySecond), [], $pipesFirst);
+			$second = proc_open($php . ' second '
+				. escapeshellarg($readySecond) . ' ' . escapeshellarg($readyFirst), [], $pipesSecond);
+			$this->assertEquals(0, proc_close($first), "round {$round}: the first writer stores its row");
+			$this->assertEquals(0, proc_close($second), "round {$round}: the second writer stores its row");
+
+			$check = new CacheMergePayload();
+			(new rCache())->get($check);
+			$this->assertTrue(
+				isset($check->rows['first']) && isset($check->rows['second']) && isset($check->rows['seed']),
+				"round {$round}: both overlapping writers' rows and the seed survive");
+		}
+	}
+
+	// A writer whose get() found nothing -- the file did not exist yet -- has
+	// no stamp to compare against. It must still notice a file that appeared
+	// before its own store and merge with it instead of clobbering it.
+	public function testWriterThatLoadedNothingMergesAFileThatAppearedMeanwhile()
+	{
+		// This writer asks for a cache entry that does not exist yet.
+		$mine = new CacheGhostLoadPayload();
+		$this->assertEquals(false, (new rCache())->get($mine), 'nothing to load yet');
+
+		// Before it stores, another writer publishes the file.
+		$other = new CacheGhostLoadPayload();
+		$this->assertTrue($other->addRow('other'), 'the other writer stores its row');
+
+		// The first writer's store must merge with the file that appeared.
+		$this->assertTrue($mine->addRow('mine'), 'this writer stores its row');
+
+		$check = new CacheGhostLoadPayload();
+		(new rCache())->get($check);
+		$this->assertTrue(isset($check->rows['mine']), 'this writer keeps its own row');
+		$this->assertTrue(isset($check->rows['other']),
+			'the row that appeared while this writer held nothing is merged, not clobbered');
+	}
+
+	public function testSetAppliesProfileMaskToLockFile()
+	{
+		global $profileMask;
+
+		$oldMask = umask(0077);
+		$oldProfileMask = $profileMask;
+		$profileMask = 0666;
+		$payload = new CacheMergePayload();
+		$payload->hash = 'masked-cache-test.dat';
+
+		try {
+			$stored = (new rCache())->set($payload);
+		} finally {
+			umask($oldMask);
+			$profileMask = $oldProfileMask;
+		}
+
+		$lockFile = FileUtil::getSettingsPath() . '/' . $payload->hash . '.lock';
+		clearstatcache(true, $lockFile);
+
+		$this->assertTrue($stored, 'Cache set succeeds with a restrictive process umask');
+		$this->assertEquals(0666, fileperms($lockFile) & 0666, 'Cache lock file follows the configured profile mask');
+	}
+
+	public function testRemoveAlsoRemovesLockFile()
+	{
+		$payload = new CacheMergePayload();
+		$payload->hash = 'remove-cache-test.dat';
+		$cache = new rCache();
+		$cacheFile = FileUtil::getSettingsPath() . '/' . $payload->hash;
+		$lockFile = $cacheFile . '.lock';
+
+		$this->assertTrue($cache->set($payload), 'Cache set creates the cache file');
+		$this->assertTrue(file_exists($lockFile), 'Cache set creates the lock file');
+
+		$cache->remove($payload);
+
+		clearstatcache(true, $cacheFile);
+		clearstatcache(true, $lockFile);
+		$this->assertEquals(false, file_exists($cacheFile), 'Cache remove deletes the cache file');
+		$this->assertEquals(false, file_exists($lockFile), 'Cache remove deletes the lock file');
+	}
+}

--- a/tests/plugins/history/HistoryDataTest.php
+++ b/tests/plugins/history/HistoryDataTest.php
@@ -1,0 +1,166 @@
+<?php
+
+// Deliberately not using tests/plugins/rutracker_check/TestLib.php here:
+// history.php transitively loads php/Snoopy.class.inc and php/settings.php,
+// whose real classes collide with TestLib's doubles in either require order.
+// A minimal local runner keeps the real classes intact, the same way
+// tests/php/SnoopyTest.php does.
+require_once(__DIR__ . '/../../../plugins/history/history.php');
+
+function historyAssertSame($expected, $actual, $message)
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException(
+            $message . '; expected ' . var_export($expected, true)
+            . ', got ' . var_export($actual, true)
+        );
+    }
+}
+
+// A record shaped like the ones update.php builds, keyed the way add() keys
+// them. Built by hand so a test can place one straight into $data without
+// going through add(), which would try to write the cache file.
+function historyRecord($key, $actionTime, $action = 1)
+{
+    return array(
+        'action' => $action,
+        'name' => 'torrent-' . $key,
+        'action_time' => $actionTime,
+        'hash' => $key,
+    );
+}
+
+// A history object holding exactly $records, with no pending changes: this is
+// what a process has right after load().
+function historyLoaded($records)
+{
+    $data = new rHistoryData();
+    $data->data = $records;
+    return $data;
+}
+
+// Replays what a writer does between load() and store() without touching the
+// filesystem: add() and delete() both call store(), which this test has no
+// cache for, so the two bookkeeping arrays are filled through reflection.
+function historyRecordAddition($object, $record, $limit)
+{
+    $object->data[$record['hash']] = $record;
+    historySetProtected($object, 'ownAdditions',
+        historyGetProtected($object, 'ownAdditions') + array($record['hash'] => $record));
+    historySetProtected($object, 'limit', $limit);
+}
+
+function historyRecordRemoval($object, $key)
+{
+    unset($object->data[$key]);
+    historySetProtected($object, 'ownRemovals',
+        historyGetProtected($object, 'ownRemovals') + array($key => true));
+}
+
+function historyGetProtected($object, $property)
+{
+    $reflection = new ReflectionProperty('rHistoryData', $property);
+    if (PHP_VERSION_ID < 80100) {
+        $reflection->setAccessible(true);
+    }
+    return $reflection->getValue($object);
+}
+
+function historySetProtected($object, $property, $value)
+{
+    $reflection = new ReflectionProperty('rHistoryData', $property);
+    if (PHP_VERSION_ID < 80100) {
+        $reflection->setAccessible(true);
+    }
+    $reflection->setValue($object, $value);
+}
+
+$tests = array(
+    // The live failure: three events land in the same second when a torrent is
+    // replaced, each in its own process, and the last writer used to publish a
+    // file without the rows the others had added.
+    'a row another process added while this one was writing survives' => function () {
+        $ours = historyLoaded(array('a' => historyRecord('a', 100)));
+        historyRecordAddition($ours, historyRecord('b', 101), 500);
+
+        // Meanwhile a second process recorded its own event and stored it.
+        $onDisk = historyLoaded(array(
+            'a' => historyRecord('a', 100),
+            'c' => historyRecord('c', 102),
+        ));
+
+        historyAssertSame(true, $ours->merge($onDisk, null), 'merge reports success');
+        historyAssertSame(array('c', 'b', 'a'), array_keys($ours->data),
+            'both writers keep their row, newest first');
+    },
+
+    'a row this process deleted does not come back from the fresher copy' => function () {
+        $ours = historyLoaded(array(
+            'a' => historyRecord('a', 100),
+            'b' => historyRecord('b', 101),
+        ));
+        historyRecordRemoval($ours, 'b');
+
+        $onDisk = historyLoaded(array(
+            'a' => historyRecord('a', 100),
+            'b' => historyRecord('b', 101),
+        ));
+
+        $ours->merge($onDisk, null);
+        historyAssertSame(array('a'), array_keys($ours->data),
+            'the deletion is replayed on top of the fresher copy');
+    },
+
+    'a delete never trims a history longer than the default cap' => function () {
+        $records = array();
+        for ($i = 0; $i < 600; $i++) {
+            $records['k' . $i] = historyRecord('k' . $i, 1000 + $i);
+        }
+        $ours = historyLoaded($records);
+        historyRecordRemoval($ours, 'k0');
+
+        $ours->merge(historyLoaded($records), null);
+        historyAssertSame(599, count($ours->data),
+            'a delete carries no configured limit and must not impose the default one');
+    },
+
+    'a recorded event still applies the configured cap' => function () {
+        $records = array();
+        for ($i = 0; $i < 10; $i++) {
+            $records['k' . $i] = historyRecord('k' . $i, 1000 + $i);
+        }
+        $ours = historyLoaded($records);
+        historyRecordAddition($ours, historyRecord('new', 2000), 4);
+
+        $ours->merge(historyLoaded($records), null);
+        historyAssertSame(2, count($ours->data), 'over the cap, half of it is kept');
+        historyAssertSame('new', array_keys($ours->data)[0], 'the newest row is kept');
+    },
+
+    'the stored format carries nothing but what it always carried' => function () {
+        $ours = historyLoaded(array('a' => historyRecord('a', 100)));
+        historyRecordAddition($ours, historyRecord('b', 101), 500);
+
+        $restored = unserialize(serialize($ours));
+        historyAssertSame(array('hash', 'modified', 'data'), $ours->__sleep(),
+            'only the three long-standing properties are serialised');
+        historyAssertSame(array('a', 'b'), array_keys($restored->data),
+            'the records survive a round trip');
+        historyAssertSame(array(), historyGetProtected($restored, 'ownAdditions'),
+            'bookkeeping does not outlive the process that did the writing');
+    },
+);
+
+$failures = 0;
+foreach ($tests as $name => $callback) {
+    try {
+        $callback();
+        echo "ok - {$name}\n";
+    } catch (Throwable $error) {
+        $failures++;
+        echo "not ok - {$name}\n";
+        echo '  ' . get_class($error) . ': ' . $error->getMessage() . "\n";
+    }
+}
+echo count($tests) . ' tests, ' . $failures . " failures\n";
+exit($failures === 0 ? 0 : 1);


### PR DESCRIPTION
**Problem.** History rows vanish on an active box: a torrent replacement fires three
detached `update.php` writers within one second, and the last writer publishes a
file without the others' rows. Two layers. `rHistoryData` had no reconciliation at
all — plain read-modify-write. And `rCache`'s merge trigger compares `filemtime`,
which resolves to one second (a same-second write is invisible) and runs outside any
lock — two writers overlapping in `set()` both conclude nothing changed, both skip
merging, and the later rename erases the earlier row (measured: 40 of 40
barrier-synchronized rounds lose a row).

**Fix.** Commit 1: `rHistoryData::merge()` replays this process's own additions and
removals onto a fresher copy; stored format unchanged (asserted). Commit 2: a
per-key `.lock` sidecar makes check+merge+publish one critical section; the change
detector becomes an `(inode, mtime, size)` stamp (every publish goes through
`rename()`, so the inode always changes); the stamp is captured before the read; a
writer that loaded nothing merges whenever a file exists at store time.

**How to verify.** `tests/php/CacheTest.php`: the same-second test and a
barrier-synchronized two-writer overlap test (10 rounds) — both lose rows on the
unpatched `cache.php`, both deterministic-green after.
`tests/plugins/history/HistoryDataTest.php` covers the merge semantics (5 tests).
