### PR TITLE
rss: normalize legacy XML document encodings before parsing

### DIFF
--- a/plugins/rss/rss_reader.php
+++ b/plugins/rss/rss_reader.php
@@ -1,6 +1,77 @@
 <?php
 require_once(dirname(__FILE__) . "/../../php/util.php");
 
+function rssIsValidUTF8($data)
+{
+	if (function_exists('mb_check_encoding')) {
+		return mb_check_encoding($data, 'UTF-8');
+	}
+	if (function_exists('iconv')) {
+		return @iconv('UTF-8', 'UTF-8', $data) === $data;
+	}
+	// PCRE is always available: the /u modifier rejects invalid UTF-8.
+	return preg_match('//u', $data) === 1;
+}
+
+function rssConvertToUTF8($data, $encoding)
+{
+	if (strcasecmp($encoding, 'UTF-8') == 0 || strcasecmp($encoding, 'UTF8') == 0) {
+		return $data;
+	}
+	// Misconfigured aggregators declare a legacy encoding over bytes that are
+	// already UTF-8; converting those a second time would garble every
+	// non-ASCII character, so trust the bytes over the declared encoding.
+	if (rssIsValidUTF8($data)) {
+		return $data;
+	}
+	if (function_exists('mb_convert_encoding')) {
+		try {
+			$converted = @mb_convert_encoding($data, 'UTF-8', $encoding);
+		} catch (Throwable $error) {
+			$converted = false;
+		}
+		if ($converted !== false) {
+			return $converted;
+		}
+	}
+	if (function_exists('iconv')) {
+		$converted = @iconv($encoding, 'UTF-8', $data);
+		if ($converted !== false) {
+			return $converted;
+		}
+	}
+	return false;
+}
+
+function rssNormalizeXMLDocumentEncoding($data)
+{
+	$declaration = '/^\s*<\?xml\s+[^>]*\bencoding\s*=\s*(?<quote>["\'])(?<encoding>[^"\']+)\k<quote>[^>]*\?>/i';
+	if (!preg_match($declaration, $data, $matches)) {
+		return $data;
+	}
+	$encoding = $matches['encoding'];
+	if (strcasecmp($encoding, 'UTF-8') == 0 || strcasecmp($encoding, 'UTF8') == 0) {
+		return $data;
+	}
+
+	$converted = rssConvertToUTF8($data, $encoding);
+	if ($converted === false) {
+		return $data;
+	}
+	// DOM uses UTF-8 internally, so keep the declaration consistent with the
+	// converted bytes — also when a lying declaration left already-UTF-8
+	// bytes untouched above, so libxml decodes the document as the UTF-8 it is.
+	$normalized = preg_replace_callback(
+		'/^(\s*<\?xml\s+[^>]*\bencoding\s*=\s*)(["\'])[^"\']+\2/i',
+		function ($parts) {
+			return $parts[1] . $parts[2] . 'UTF-8' . $parts[2];
+		},
+		$converted,
+		1
+	);
+	return $normalized === null ? $data : $normalized;
+}
+
 class RegexRSSReader
 {
 	private $encoding = 'utf-8';
@@ -103,10 +174,9 @@ class RegexRSSReader
 				$text = trim($c['value']);
 			}
 			if ($this->encoding != 'utf-8') {
-				if (function_exists('iconv'))
-					$text = iconv($this->encoding, 'UTF-8//TRANSLIT', $text);
-				elseif (function_exists('mb_convert_encoding'))
-					$text = mb_convert_encoding($text, 'UTF-8', $this->encoding);
+				$converted = rssConvertToUTF8($text, $this->encoding);
+				if ($converted !== false)
+					$text = $converted;
 				else
 					$text = UTF::win2utf($text);
 			}
@@ -128,6 +198,7 @@ function rssXpath($data)
 			libxml_disable_entity_loader(true);
 		}
 		libxml_use_internal_errors(true);
+		$data = rssNormalizeXMLDocumentEncoding($data);
 		$doc->loadXML(str_replace('xmlns=', 'ns=', $data), LIBXML_NOBLANKS | LIBXML_COMPACT);
 		$errs = [];
 		foreach (libxml_get_errors() as $error) {

--- a/tests/plugins/rss/RSSTest.php
+++ b/tests/plugins/rss/RSSTest.php
@@ -167,4 +167,116 @@ final class RSSTest extends TestCase
 			"hash" => ""
 		), $contents['items'][0]);
 	}
+
+	public function testRSSWin1251(): void
+	{
+		// The fixture deliberately starts with a blank line before the XML
+		// declaration: real-world feeds emit such padding, and it makes
+		// libxml ignore the declared windows-1251 encoding and read the
+		// bytes as if they were UTF-8, garbling every non-ASCII title.
+		$exp_url = 'https://example.ru/rss';
+		$rssFetchURL = function ($url, $cookies, $headers) use ($exp_url) {
+			$this->assertEquals($exp_url, $url);
+			$this->assertEquals([], $cookies);
+			$this->assertEquals([], $headers);
+			$cliMock = new SnoopyMock();
+			$cliMock->results = file_get_contents(__DIR__ . '/rss-win1251-sample.xml');
+			return $cliMock;
+		};
+		$rRSS = new rRSS($exp_url, $rssFetchURL);
+		$history = new rRSSHistory();
+		$succ = $rRSS->fetch($history);
+		// libxml still reports the misplaced XML declaration, nothing else
+		$this->assertEquals(1, count($rRSS->lastErrorMsgs));
+		$this->assertTrue($succ);
+
+		$this->assertEquals('Русский торрент канал', $rRSS->channel['title']);
+		$this->assertEquals(strtotime('Fri, 31 Dec 2021 12:00:00 +0000'), $rRSS->channel['timestamp']);
+		$contents =  $rRSS->getContents("label", "1", "1", $history);
+		$this->assertEquals(1, count($contents['items']));
+
+		$this->assertEquals(array(
+			"time" => strtotime('Sat, 1 Jan 2022 12:00:00 +0000'),
+			"title" => 'Новый фильм — четвёртый сезон',
+			"href" => 'https://example.ru/path/to/torrent?torr=ABCD',
+			"guid" => 'https://example.ru/path/to/torrent?perm=ABCD',
+			"errcount" => 0,
+			"hash" => ""
+		), $contents['items'][0]);
+	}
+
+	public function testRSSUtf8(): void
+	{
+		// Same document as testRSSWin1251 (blank line before the XML
+		// declaration included), but already encoded in UTF-8: it must pass
+		// through unconverted and parse with unchanged titles.
+		$exp_url = 'https://example.ru/rss-utf8';
+		$rssFetchURL = function ($url, $cookies, $headers) use ($exp_url) {
+			$this->assertEquals($exp_url, $url);
+			$this->assertEquals([], $cookies);
+			$this->assertEquals([], $headers);
+			$cliMock = new SnoopyMock();
+			$cliMock->results = file_get_contents(__DIR__ . '/rss-utf8-sample.xml');
+			return $cliMock;
+		};
+		$rRSS = new rRSS($exp_url, $rssFetchURL);
+		$history = new rRSSHistory();
+		$succ = $rRSS->fetch($history);
+		// libxml still reports the misplaced XML declaration, nothing else
+		$this->assertEquals(1, count($rRSS->lastErrorMsgs));
+		$this->assertTrue($succ);
+
+		$this->assertEquals('Русский торрент канал', $rRSS->channel['title']);
+		$this->assertEquals(strtotime('Fri, 31 Dec 2021 12:00:00 +0000'), $rRSS->channel['timestamp']);
+		$contents =  $rRSS->getContents("label", "1", "1", $history);
+		$this->assertEquals(1, count($contents['items']));
+
+		$this->assertEquals(array(
+			"time" => strtotime('Sat, 1 Jan 2022 12:00:00 +0000'),
+			"title" => 'Новый фильм — четвёртый сезон',
+			"href" => 'https://example.ru/path/to/torrent?torr=ABCD',
+			"guid" => 'https://example.ru/path/to/torrent?perm=ABCD',
+			"errcount" => 0,
+			"hash" => ""
+		), $contents['items'][0]);
+	}
+
+	public function testRSSMislabeledWin1251(): void
+	{
+		// Same document again (blank line before the XML declaration
+		// included), but this time the declaration lies: it claims
+		// windows-1251 while the bytes are already UTF-8, as misconfigured
+		// aggregators commonly emit. The declared encoding must not trigger
+		// a second cp1251-to-UTF-8 conversion, or every non-ASCII title
+		// turns into mojibake.
+		$exp_url = 'https://example.ru/rss-mislabeled';
+		$rssFetchURL = function ($url, $cookies, $headers) use ($exp_url) {
+			$this->assertEquals($exp_url, $url);
+			$this->assertEquals([], $cookies);
+			$this->assertEquals([], $headers);
+			$cliMock = new SnoopyMock();
+			$cliMock->results = file_get_contents(__DIR__ . '/rss-mislabeled-win1251-sample.xml');
+			return $cliMock;
+		};
+		$rRSS = new rRSS($exp_url, $rssFetchURL);
+		$history = new rRSSHistory();
+		$succ = $rRSS->fetch($history);
+		// libxml still reports the misplaced XML declaration, nothing else
+		$this->assertEquals(1, count($rRSS->lastErrorMsgs));
+		$this->assertTrue($succ);
+
+		$this->assertEquals('Русский торрент канал', $rRSS->channel['title']);
+		$this->assertEquals(strtotime('Fri, 31 Dec 2021 12:00:00 +0000'), $rRSS->channel['timestamp']);
+		$contents =  $rRSS->getContents("label", "1", "1", $history);
+		$this->assertEquals(1, count($contents['items']));
+
+		$this->assertEquals(array(
+			"time" => strtotime('Sat, 1 Jan 2022 12:00:00 +0000'),
+			"title" => 'Новый фильм — четвёртый сезон',
+			"href" => 'https://example.ru/path/to/torrent?torr=ABCD',
+			"guid" => 'https://example.ru/path/to/torrent?perm=ABCD',
+			"errcount" => 0,
+			"hash" => ""
+		), $contents['items'][0]);
+	}
 }

--- a/tests/plugins/rss/rss-mislabeled-win1251-sample.xml
+++ b/tests/plugins/rss/rss-mislabeled-win1251-sample.xml
@@ -1,0 +1,19 @@
+
+<?xml version="1.0" encoding="windows-1251"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>Русский торрент канал</title>
+        <link>https://example.ru</link>
+        <description>Новинки</description>
+        <language>ru-RU</language>
+        <lastBuildDate>Fri, 31 Dec 2021 12:00:00 +0000</lastBuildDate>
+        <ttl>60</ttl>
+        <item>
+            <title><![CDATA[Новый фильм — четвёртый сезон]]></title>
+            <description><![CDATA[Отличное качество]]></description>
+            <pubDate>Sat, 1 Jan 2022 12:00:00 +0000</pubDate>
+            <link>https://example.ru/path/to/torrent?torr=ABCD</link>
+            <guid>https://example.ru/path/to/torrent?perm=ABCD</guid>
+        </item>
+    </channel>
+</rss>

--- a/tests/plugins/rss/rss-utf8-sample.xml
+++ b/tests/plugins/rss/rss-utf8-sample.xml
@@ -1,0 +1,19 @@
+
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>Русский торрент канал</title>
+        <link>https://example.ru</link>
+        <description>Новинки</description>
+        <language>ru-RU</language>
+        <lastBuildDate>Fri, 31 Dec 2021 12:00:00 +0000</lastBuildDate>
+        <ttl>60</ttl>
+        <item>
+            <title><![CDATA[Новый фильм — четвёртый сезон]]></title>
+            <description><![CDATA[Отличное качество]]></description>
+            <pubDate>Sat, 1 Jan 2022 12:00:00 +0000</pubDate>
+            <link>https://example.ru/path/to/torrent?torr=ABCD</link>
+            <guid>https://example.ru/path/to/torrent?perm=ABCD</guid>
+        </item>
+    </channel>
+</rss>

--- a/tests/plugins/rss/rss-win1251-sample.xml
+++ b/tests/plugins/rss/rss-win1251-sample.xml
@@ -1,0 +1,19 @@
+
+<?xml version="1.0" encoding="windows-1251"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>Русский торрент канал</title>
+        <link>https://example.ru</link>
+        <description>Новинки</description>
+        <language>ru-RU</language>
+        <lastBuildDate>Fri, 31 Dec 2021 12:00:00 +0000</lastBuildDate>
+        <ttl>60</ttl>
+        <item>
+            <title><![CDATA[Новый фильм — четвёртый сезон]]></title>
+            <description><![CDATA[Отличное качество]]></description>
+            <pubDate>Sat, 1 Jan 2022 12:00:00 +0000</pubDate>
+            <link>https://example.ru/path/to/torrent?torr=ABCD</link>
+            <guid>https://example.ru/path/to/torrent?perm=ABCD</guid>
+        </item>
+    </channel>
+</rss>


### PR DESCRIPTION
**Problem.** Feeds still commonly declare windows-1251/koi8-r/iso-8859-x. A clean
such document parses fine — but real aggregators emit whitespace before the XML
declaration, and libxml then reports "XML declaration allowed only at the start",
recovers, and reads the cp1251 bytes as UTF-8: every non-ASCII title is mojibake
(`json_encode` of the result returns `false` outright).

**Fix.** Convert the document to UTF-8 up front and rewrite the declaration to match
the bytes handed to the parser — but only when the bytes are not already valid UTF-8:
feeds whose declaration *lies* (says windows-1251, bytes already UTF-8) must not be
converted twice. Detection falls back `mb_check_encoding` → strict `iconv`
round-trip → PCRE `//u`. The regex reader's per-item path shares the same helper
instead of its ad-hoc iconv/mb cascade. Unconvertible input is returned unchanged.

**How to verify.** Three fixtures in `tests/plugins/rss/` (all with the leading
blank line): declared-and-actual cp1251 — mojibake before the fix, correct
`Русский торрент канал` after; pure UTF-8 — byte-identical pass-through both ways;
declared cp1251 but actually UTF-8 — parsed correctly before (by libxml accident),
mojibake with a naive converter, correct with this guard.