### PR TITLE
Stop page reloads from postponing the remaining plugin schedules

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -381,6 +381,24 @@ class rTorrentSettings
 		$interval = $interval*60;
 		return( new rXMLRPCCommand("schedule", array( $name.User::getUser(), $startAt."", $interval."", $cmd )) );
 	}
+	static public function getAlignedStart($name,$interval,$now = null)	// $interval in seconds
+	{
+		global $schedule_rand;
+		if(!isset($schedule_rand))
+			$schedule_rand = 10;
+		if($interval<1)
+			return(0);
+		if(is_null($now))
+			$now = time();
+		$offset = ($schedule_rand>0) ? (abs(crc32($name.User::getUser())) % ($schedule_rand+1)) : 0;
+		$startAt = (($offset-$now) % $interval + $interval) % $interval;
+		return($startAt<1 ? $interval : $startAt);
+	}
+	public function getAlignedScheduleCommand($name,$interval,$cmd)	// $interval in seconds
+	{
+		return( new rXMLRPCCommand("schedule", array( $name.User::getUser(),
+			self::getAlignedStart($name,$interval)."", $interval."", $cmd )) );
+	}
 	public function getRemoveScheduleCommand($name)
 	{
 		return(	new rXMLRPCCommand("schedule_remove", $name.User::getUser()) );

--- a/plugins/autotools/autotools.php
+++ b/plugins/autotools/autotools.php
@@ -195,7 +195,7 @@ class rAutoTools
 			$cmd = $theSettings->getOnFinishedCommand(array('automove'.User::getUser(), getCmd('cat=')));
 		$req->addCommand($cmd);
 		if($this->enable_watch && (trim($this->path_to_watch)!=''))
-			$cmd = 	$theSettings->getAbsScheduleCommand('autowatch',$autowatch_interval,
+			$cmd = 	$theSettings->getAlignedScheduleCommand('autowatch',$autowatch_interval,
 				getCmd('execute').'={sh,-c,'.escapeshellarg(Utility::getPHP()).' '.escapeshellarg($pathToAutoTools.'/watch.php').' '.escapeshellarg(User::getUser()).' &}' );
 		else
 			$cmd = $theSettings->getRemoveScheduleCommand('autowatch');

--- a/plugins/erasedata/init.php
+++ b/plugins/erasedata/init.php
@@ -11,7 +11,7 @@ $thisDir = dirname(__FILE__);
 // straight into $listPath, so the plugin only needs to schedule the garbage
 // collector that applies and clears those lists.
 $req = new rXMLRPCRequest( array(
-	$theSettings->getAbsScheduleCommand("erasedata",$garbageCheckInterval,
+	$theSettings->getAlignedScheduleCommand("erasedata",$garbageCheckInterval,
 		getCmd('execute').'={sh,-c,'.escapeshellarg(Utility::getPHP()).' '.escapeshellarg($thisDir.'/update.php').' '.escapeshellarg(User::getUser()).' &}' )
 	) );
 if($req->success())

--- a/plugins/loginmgr/accounts.php
+++ b/plugins/loginmgr/accounts.php
@@ -264,7 +264,7 @@ class accountManager
 		if(rTorrentSettings::get()->linkExist)
 		{
 			$req =  new rXMLRPCRequest( $this->hasAuto() ?
-				rTorrentSettings::get()->getAbsScheduleCommand("loginmgr",86400,
+				rTorrentSettings::get()->getAlignedScheduleCommand("loginmgr",86400,
 					getCmd('execute').'={sh,-c,'.escapeshellarg(Utility::getPHP()).' '.escapeshellarg(dirname(__FILE__).'/update.php').' '.escapeshellarg(User::getUser()).' & exit 0}' ) :
 				rTorrentSettings::get()->getRemoveScheduleCommand("loginmgr") );
 			$req->success();

--- a/plugins/ratio/ratio.php
+++ b/plugins/ratio/ratio.php
@@ -124,7 +124,7 @@ class rRatio
 	{
 		global $checkTimesInterval;
 		$req =  new rXMLRPCRequest( $this->hasTimes() ?
-			rTorrentSettings::get()->getAbsScheduleCommand("ratio",$checkTimesInterval*60,
+			rTorrentSettings::get()->getAlignedScheduleCommand("ratio",$checkTimesInterval*60,
 				getCmd('execute').'={sh,-c,'.escapeshellarg(Utility::getPHP()).' '.escapeshellarg(dirname(__FILE__).'/update.php').' '.escapeshellarg(User::getUser()).' &}' ) :
 			rTorrentSettings::get()->getRemoveScheduleCommand("ratio") );
 		return($req->success());

--- a/plugins/scheduler/init.php
+++ b/plugins/scheduler/init.php
@@ -5,7 +5,7 @@ require_once( '../plugins/scheduler/scheduler.php' );
 $schd = rScheduler::load();
 $schd->apply();
 
-$req = new rXMLRPCRequest( $theSettings->getAbsScheduleCommand('scheduler',$updateInterval*60,
+$req = new rXMLRPCRequest( $theSettings->getAlignedScheduleCommand('scheduler',$updateInterval*60,
 	getCmd('execute').'={sh,-c,'.escapeshellarg(Utility::getPHP()).' '.escapeshellarg($rootPath.'/plugins/scheduler/update.php').' '.escapeshellarg(User::getUser()).' & exit 0}' ) );
 if($req->run() && !$req->fault)
 {

--- a/tests/php/ScheduleTest.php
+++ b/tests/php/ScheduleTest.php
@@ -1,0 +1,140 @@
+<?php
+
+// A minimal local runner, for the same reason as tests/php/SnoopyTest.php:
+// settings.php drags in the real rXMLRPC* classes, which collide with the
+// doubles in tests/plugins/rutracker_check/TestLib.php.
+require_once(__DIR__ . '/../../php/settings.php');
+
+function scheduleAssertTrue($condition, $message)
+{
+    if (!$condition) {
+        throw new RuntimeException($message);
+    }
+}
+
+function scheduleAssertSame($expected, $actual, $message)
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException(
+            $message . '; expected ' . var_export($expected, true)
+            . ', got ' . var_export($actual, true)
+        );
+    }
+}
+
+// The instant a registration made at $now would fire.
+function scheduleFiresAt($name, $interval, $now)
+{
+    return $now + rTorrentSettings::getAlignedStart($name, $interval, $now);
+}
+
+$hourly = 3600;
+$daily = 86400;
+$quarterMinute = 15;
+
+$tests = array(
+    'reloads do not move the fire time' => function () use ($hourly) {
+        $now = 1755200000;
+        $first = scheduleFiresAt('ratio', $hourly, $now);
+
+        for ($reload = $now; $reload < $first; $reload += 137) {
+            scheduleAssertSame(
+                $first,
+                scheduleFiresAt('ratio', $hourly, $reload),
+                'Re-registering ' . ($reload - $now) . 's later moved the fire time'
+            );
+        }
+    },
+    'intervals longer than an hour are stable too' => function () use ($daily) {
+        $now = 1755200000;
+        $first = scheduleFiresAt('loginmgr', $daily, $now);
+
+        for ($reload = $now; $reload < $first; $reload += 3607) {
+            scheduleAssertSame(
+                $first,
+                scheduleFiresAt('loginmgr', $daily, $reload),
+                'Re-registering ' . ($reload - $now) . 's later moved the daily fire time'
+            );
+        }
+    },
+    'intervals shorter than a minute are stable too' => function () use ($quarterMinute) {
+        $now = 1755200000;
+        $first = scheduleFiresAt('erasedata', $quarterMinute, $now);
+
+        for ($reload = $now; $reload < $first; $reload++) {
+            scheduleAssertSame(
+                $first,
+                scheduleFiresAt('erasedata', $quarterMinute, $reload),
+                'Re-registering ' . ($reload - $now) . 's later moved the 15s fire time'
+            );
+        }
+    },
+    'a task that already fired moves to the next slot, not a fresh interval' => function () use ($hourly) {
+        $now = 1755200000;
+        $first = scheduleFiresAt('ratio', $hourly, $now);
+
+        scheduleAssertSame(
+            $first + $hourly,
+            scheduleFiresAt('ratio', $hourly, $first + 1),
+            'The slot after a fire is not one interval later'
+        );
+        scheduleAssertSame(
+            $first + $hourly,
+            scheduleFiresAt('ratio', $hourly, $first + $hourly - 1),
+            'A reload just before the next fire moved it'
+        );
+    },
+    'the task keeps firing on its own period' => function () use ($hourly) {
+        $now = 1755200000;
+        $first = scheduleFiresAt('scheduler', $hourly, $now);
+        $next = scheduleFiresAt('scheduler', $hourly, $first + 1);
+
+        scheduleAssertSame($first + $hourly, $next, 'The period drifted after the task fired');
+    },
+    'a reload never asks for an immediate run' => function () use ($hourly) {
+        for ($second = 0; $second < 120; $second++) {
+            $start = rTorrentSettings::getAlignedStart('autowatch', $hourly, 1755200000 + $second * 29);
+            scheduleAssertTrue(
+                $start >= 1 && $start <= $hourly,
+                "Start {$start} is outside 1..{$hourly}, so a reload could fire the task at once"
+            );
+        }
+    },
+    'each task gets its own slot within the jitter window' => function () use ($hourly) {
+        global $schedule_rand;
+        $schedule_rand = 10;
+
+        $offsets = array();
+        foreach (array('ratio', 'scheduler', 'loginmgr', 'autowatch', 'erasedata') as $name) {
+            $offsets[$name] = scheduleFiresAt($name, $hourly, 1755200000) % $hourly;
+        }
+
+        foreach ($offsets as $name => $offset) {
+            scheduleAssertTrue(
+                $offset % $hourly <= $schedule_rand || $hourly - ($offset % $hourly) <= $schedule_rand,
+                "{$name} landed at offset {$offset}, outside the jitter window"
+            );
+            scheduleAssertSame(
+                $offset,
+                scheduleFiresAt($name, $hourly, 1755200000 + 900) % $hourly,
+                "{$name} did not keep its slot across a reload"
+            );
+        }
+        scheduleAssertTrue(count(array_unique($offsets)) > 1, 'Every task landed on the same second');
+    },
+);
+
+$failures = 0;
+foreach ($tests as $name => $callback) {
+    try {
+        $callback();
+        echo "ok - {$name}\n";
+    } catch (Throwable $error) {
+        $failures++;
+        echo "not ok - {$name}\n";
+        echo '  ' . get_class($error) . ': ' . $error->getMessage() . "\n";
+    }
+}
+echo count($tests) . ' tests, ' . $failures . " failures\n";
+
+exit($failures === 0 ? 0 : 1);


### PR DESCRIPTION
  Follow-up to #3163, which fixed rutracker_check. The same defect is in five more plugins: registering a schedule under a key rTorrent  already knows deletes the old item and re-arms it at now + start, and these all register from a path that runs on every full load of the  web interface.

  - scheduler — init.php, hourly
  - ratio — init.php → obtain() → setHandlers()
  - loginmgr — same path; its 24-hour re-login is reset by any visit, so it never runs for anyone who opens the UI daily
  - autotools autowatch — init.php → setHandlers(), 300s
  - erasedata — init.php, 15s (shares the pattern; rarely bites in practice)

Note: A better solution would be to have rtorrent not automatically replace preexisting schedules. Submitted a PR for that.
