### PR TITLE
Give the test runner an absolute __DIR__, and say so when a fixture i…

### DIFF
--- a/tests/php-test.sh
+++ b/tests/php-test.sh
@@ -23,7 +23,9 @@ status=0
 for t in $(find php plugins -type f -name '*Test.php')
 do
 	echo '> php' $t
-	DIR=$(dirname "$t")
+	# Absolute: this stands in for __DIR__ below, and a relative path makes a
+	# fixture symlink resolve against the wrong directory.
+	DIR=$(cd "$(dirname "$t")" && pwd)
 	out=$(php -c php-test.ini -f <(cat <(sed "s@__DIR__@\"$DIR\"@g" "$t") <(echo "$TEST_RUN")) 2>&1)
 	code=$?
 	printf '%s\n' "$out"

--- a/tests/php/PermissionTest.php
+++ b/tests/php/PermissionTest.php
@@ -79,6 +79,11 @@ class PermissionTest extends TestCase
 		// depend on which uid runs it.
 		$uid = posix_getuid();
 		$gids = array_merge([posix_getgid()], posix_getgroups());
+		// A symlink target is resolved against the link's own directory, so a
+		// fixture built from a relative base points nowhere and every answer
+		// below would be about a broken link rather than about permissions.
+		$this->assertTrue(is_dir($this->getDir('dir3')), 'Symlinked fixture resolves');
+		$this->assertTrue(is_dir($this->getDir('dir4')), 'Relative symlinked fixture resolves');
 		$this->assertTrue(Permission::doesUserHave($uid, $gids, $this->getDir('dir1'), 0x0007), 'User has permission for directory');
 		$this->assertTrue(Permission::doesUserHave($uid, $gids, $this->getDir('dir3'), 0x0007), 'User has permission for symlinked directory');
 		$this->assertTrue(Permission::doesUserHave($uid, $gids, $this->getDir('dir4'), 0x0007), 'User has permission for relative symlinked directory');


### PR DESCRIPTION
…s broken

php-test.sh substitutes the test's directory for __DIR__ before running it, but substituted a relative path. PermissionTest builds its fixtures from it, and a symlink target is resolved against the link's own directory, not the working directory - so the "absolute symlink" fixture pointed at php/fixtures/dir1/php/fixtures/dir2 and did not exist.

The suite was red because of it, but only when run as root: Permission::doesUserHave short-circuits for uid 0 and answers from stat(), which fails on a broken link, while a non-root run reaches the readlink() path and stats the target relative to the working directory, where it does exist. That is why CI never showed it.

PermissionTest now asserts its fixtures resolve before asking anything about permissions, so the next such breakage names itself instead of being reported as a permission failure.