### PR TITLE
Take the clock offset from the header meant for it, and cover the mobile panel

### DIFF
--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -1358,21 +1358,29 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout, partialD
 
 function Ajax_UpdateTime(jqXHR)
 {
+	// X-Server-Timestamp is emitted by CachedEcho::send for this purpose and is
+	// produced when the response is, including on the conditional-GET path.
+	// Date can arrive from any intermediary, so a cached or revalidated
+	// response carries the age of the cache into every duration on the page.
+	var timestamp = jqXHR.getResponseHeader("X-Server-Timestamp");
+	var serverDelta = (timestamp != null) ? new Date().getTime()-iv(timestamp)*1000 : null;
+
+	if(theWebUI.serverDeltaTime==0 && serverDelta!==null)
+		theWebUI.serverDeltaTime = serverDelta;
+
 	if(theWebUI.deltaTime==0)
 	{
-		var diff = 0;
-		try { diff = new Date().getTime()-Date.parse(jqXHR.getResponseHeader("Date")); } catch(e) { diff = 0; };
-		theWebUI.deltaTime = iv(diff);
-		diff = null; // Cleanup memory leak
+		if(serverDelta!==null)
+			theWebUI.deltaTime = serverDelta;
+		else
+		{
+			var diff = 0;
+			try { diff = new Date().getTime()-Date.parse(jqXHR.getResponseHeader("Date")); } catch(e) { diff = 0; };
+			theWebUI.deltaTime = iv(diff);
+			diff = null; // Cleanup memory leak
+		}
 	}
-
-	if(theWebUI.serverDeltaTime==0)
-	{
-		var timestamp = jqXHR.getResponseHeader("X-Server-Timestamp");
-		if(timestamp != null)
-			theWebUI.serverDeltaTime = new Date().getTime()-iv(timestamp)*1000;
-		timestamp = null; // Cleanup memory leak
-	}
+	timestamp = null; // Cleanup memory leak
 	jqXHR = null; // Cleanup memory leak
 }
 

--- a/plugins/mobile/init.js
+++ b/plugins/mobile/init.js
@@ -966,7 +966,7 @@ plugin.fillDetails = function(d) {
   $('#torrentDetails #timeElapsed td:last').text(theConverter.time(Math.floor((new Date().getTime()-theWebUI.deltaTime)/1000-iv(d.state_changed)),true));
   $('#torrentDetails #created td:last').text((d.created>3600*24*365) ? theConverter.date(iv(d.created)) : "");
   if (this.seedingtimeLoaded) {
-    $('#torrentDetails #seedtime td:last').text((d.seedingtime != -1) ? theConverter.time(d.seedingtime,true) : "");
+    $('#torrentDetails #seedtime td:last').text(((d.seedingtime !== undefined) && (d.seedingtime != -1)) ? theConverter.time(d.seedingtime,true) : "");
     $('#torrentDetails #dateAdded td:last').text((d.addtime>3600*24*365) ? theConverter.date(iv(d.addtime)) : "");
   }
   $('#torrentDetails #eta td:last').html((d.eta == -1) ? "&#8734;" : theConverter.time(d.eta));

--- a/tests/js/clock-offset.spec.js
+++ b/tests/js/clock-offset.spec.js
@@ -1,0 +1,88 @@
+import { readFileSync } from "fs";
+
+window.$ = require("jquery");
+window.theWebUI = {
+  settings: { "webui.needmessage": true },
+  showFlags: 0xffff,
+  systemInfo: { rTorrent: { apiVersion: 10, iVersion: 0x908, started: true } },
+};
+
+for (const src of [
+  "../lang/en.js",
+  "../js/common.js",
+  "../js/content.js",
+  "../js/rtorrent.js",
+]) {
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = readFileSync(src, { encoding: "utf-8" });
+  document.body.appendChild(scriptEl);
+}
+
+// A response handing out exactly the headers a test asks for.
+function response(headers) {
+  return {
+    getResponseHeader: (name) => (name in headers ? headers[name] : null),
+  };
+}
+
+// Real clocks, so no global Date mocking: assertions allow the second or so
+// that the Date header's whole-second resolution and the test itself cost.
+const SLACK = 2000;
+
+describe("clock offset", () => {
+  beforeEach(() => {
+    theWebUI.deltaTime = 0;
+    theWebUI.serverDeltaTime = 0;
+  });
+
+  it("prefers X-Server-Timestamp over a stale Date header", () => {
+    const twoDaysAgo = Date.now() - 2 * 24 * 3600 * 1000;
+
+    Ajax_UpdateTime(
+      response({
+        Date: new Date(twoDaysAgo).toUTCString(),
+        "X-Server-Timestamp": String(Math.floor(Date.now() / 1000)),
+      })
+    );
+
+    expect(Math.abs(theWebUI.deltaTime)).toBeLessThan(SLACK);
+    expect(Math.abs(theWebUI.serverDeltaTime)).toBeLessThan(SLACK);
+  });
+
+  it("still measures a genuine offset from X-Server-Timestamp", () => {
+    Ajax_UpdateTime(
+      response({
+        "X-Server-Timestamp": String(Math.floor(Date.now() / 1000) - 90),
+      })
+    );
+
+    expect(theWebUI.deltaTime).toBeGreaterThan(90000 - SLACK);
+    expect(theWebUI.deltaTime).toBeLessThan(90000 + SLACK);
+  });
+
+  it("falls back to the Date header when the server timestamp is absent", () => {
+    Ajax_UpdateTime(
+      response({ Date: new Date(Date.now() - 30000).toUTCString() })
+    );
+
+    expect(theWebUI.deltaTime).toBeGreaterThan(30000 - SLACK);
+    expect(theWebUI.deltaTime).toBeLessThan(30000 + SLACK);
+  });
+
+  it("leaves the offset alone when the response carries neither header", () => {
+    Ajax_UpdateTime(response({}));
+
+    expect(theWebUI.deltaTime).toBe(0);
+    expect(theWebUI.serverDeltaTime).toBe(0);
+  });
+
+  it("measures once and keeps that value until something resets it", () => {
+    const secondsNow = Math.floor(Date.now() / 1000);
+
+    Ajax_UpdateTime(response({ "X-Server-Timestamp": String(secondsNow - 30) }));
+    const first = theWebUI.deltaTime;
+    Ajax_UpdateTime(response({ "X-Server-Timestamp": String(secondsNow - 600) }));
+
+    expect(theWebUI.deltaTime).toBe(first);
+  });
+});

--- a/tests/plugins/mobile/details.spec.js
+++ b/tests/plugins/mobile/details.spec.js
@@ -1,0 +1,106 @@
+import { readFileSync } from "fs";
+
+window.$ = require("jquery");
+window.jQuery = window.$;
+
+for (const src of ["../lang/en.js", "../js/common.js"]) {
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = readFileSync(src, { encoding: "utf-8" });
+  document.body.appendChild(scriptEl);
+}
+
+// jsdom has no matchMedia, and the plugin probes it while detecting tablets.
+window.matchMedia =
+  window.matchMedia ||
+  (() => ({ matches: false, addEventListener: () => {}, addListener: () => {} }));
+
+window.theWebUI = {
+  deltaTime: 0,
+  settings: {},
+  torrents: {},
+  getTrackerName: (url) => url,
+  config: function () {},
+  // Consulted by theConverter.bytes when the pane renders sizes.
+  sizeDecimalPlaces: () => 2,
+  // fillDetails renders the status icon and the label row alongside the
+  // times; neither is what this spec is about.
+  getStatusIcon: () => "",
+};
+window.thePlugins = { isInstalled: () => false, get: () => null };
+window.theConverter = window.theConverter || {};
+
+// The plugin loader normally supplies `plugin`; expose ours so the test can
+// call the real fillDetails afterwards.
+window.__mobile = {
+  loadLang: function () {},
+  attachPageToMenu: function () {},
+  // Supplied by the plugin loader in the browser. jQuery.browser.mobile is
+  // false under jsdom, so the plugin disables itself as it loads and calls
+  // this; fillDetails itself does not depend on the plugin being active.
+  disable: function () {},
+  langLoaded: true,
+  allStuffLoaded: true,
+};
+
+{
+  const code = readFileSync("../plugins/mobile/init.js", { encoding: "utf-8" });
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent =
+    "(function () { var plugin = window.__mobile;\n" + code + "\n})();";
+  document.body.appendChild(scriptEl);
+}
+
+const plugin = window.__mobile;
+
+// The rows fillDetails writes into, with the ids the real markup uses.
+function detailsMarkup() {
+  document.body.insertAdjacentHTML(
+    "beforeend",
+    `<div id="torrentDetails">
+       <table>
+         <tr id="seedtime"><td>Seeding Time</td><td></td></tr>
+         <tr id="dateAdded"><td>Added</td><td></td></tr>
+         <tr id="created"><td>Created</td><td></td></tr>
+       </table>
+     </div>`
+  );
+}
+
+function seedtimeCell() {
+  return $("#torrentDetails #seedtime td:last").text();
+}
+
+describe("mobile details pane", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    detailsMarkup();
+    plugin.seedingtimeLoaded = true;
+  });
+
+  it("renders seeding time as the elapsed duration it already is", () => {
+    // The seedingtime plugin converts rTorrent's epoch into elapsed seconds
+    // before the details pane ever sees it (plugins/seedingtime/init.js).
+    plugin.fillDetails({ seedingtime: 7320, addtime: -1, created: 0 });
+
+    expect(seedtimeCell()).toBe(theConverter.time(7320, true));
+    expect(seedtimeCell()).not.toBe("");
+  });
+
+  it("renders a duration under a year, which the old year-guard hid", () => {
+    plugin.fillDetails({ seedingtime: 3600, addtime: -1, created: 0 });
+
+    expect(seedtimeCell()).toBe(theConverter.time(3600, true));
+  });
+
+  it("leaves the row empty when the torrent has never seeded", () => {
+    plugin.fillDetails({ seedingtime: -1, addtime: -1, created: 0 });
+
+    expect(seedtimeCell()).toBe("");
+  });
+
+  it("renders nothing rather than a 1970 date when the value is missing", () => {
+    plugin.fillDetails({ addtime: -1, created: 0 });
+
+    expect(seedtimeCell()).toBe("");
+  });
+});


### PR DESCRIPTION
#3166 removed the offset from absolute dates, which is where it did visible damage. Everything computed from the browser's own clock still needs it, and it is still read from the HTTP Date header: any intermediary can serve that from a cache, and the offset then carries the age of the cached response into every duration on the page. That is what made a two-day shift possible in the first place.

X-Server-Timestamp already exists for exactly this, emitted by CachedEcho::send on every response it sends - including the httprpc polling endpoint, and including the conditional-GET path, where it is regenerated while Date is not. Prefer it, and keep the Date header as the fallback for responses that do not carry it.

Also adds the mobile coverage #3166 went in without. Seeding time is already an elapsed duration when the details pane receives it, and the pane used to render it through the absolute-date path behind a "> 1 year" guard, so the row was blank for everyone rather than showing a 1970 date. The new spec drives the real plugins/mobile/init.js fillDetails and fails against the code as it was before #3166.

One correction to that PR while here: its new sentinel is d.seedingtime != -1, and an undefined value passes it, so the row rendered "0s" before the first seedingtime response arrived where it used to be blank. Guarded explicitly.