### PR TITLE
rutracker_check: let conf/config.php set the plugin's debug flag

### DIFF
--- a/plugins/rutracker_check/conf.php
+++ b/plugins/rutracker_check/conf.php
@@ -2,4 +2,9 @@
 
 $updateInterval 	= 60;	// in minutes, zero for disable
 $ignoreLabels 	= ['tv-sonarr', 'radarr'];	// list of labels to ignore
-$rutrackerCheckDebug = false;	// write diagnostic messages to the configured ruTorrent log
+// ??=, not =: every evaluator of this file -- the CLI entry points
+// (update.php, batch_check.php) and the web path (php/getplugins.php) --
+// runs it in global scope after conf/config.php has already been loaded,
+// so a plain assignment silently discards a value the administrator set
+// there. The default applies only when nothing else has set the variable.
+$rutrackerCheckDebug ??= false;	// write diagnostic messages to the configured ruTorrent log


### PR DESCRIPTION
**Problem.** The plugin conf is evaluated after `conf/config.php` in the same
global scope on every path that loads it — the CLI entry points (`update.php`,
`batch_check.php`) and the web path (`php/getplugins.php` → each plugin's
`init.php`). A plain `$rutrackerCheckDebug = false;` therefore silently discards
a value the administrator set globally. A per-user override
(`conf/users/<user>/plugins/rutracker_check/conf.php`) already works durably,
but there was no *global* override point.

**Fix.** `??=` — the plugin's default applies only when nothing has set the
variable. One line plus a comment. Deliberately scoped to this flag:
`$updateInterval` is declared by `scheduler` and `trafic` too, and plugin confs
share one global scope on the CLI paths, so `??=` there could inherit another
plugin's value.

**How to verify.** Set `$rutrackerCheckDebug = true;` in `conf/config.php`,
run `php plugins/rutracker_check/update.php <user>`: before — no debug lines;
after — the cycle logs. Requires PHP 7.4 (`??=`), which README already mandates.