### PR TITLE
kinozal: stop reporting live topics as deleted when the session has expired

### DIFF
--- a/plugins/loginmgr/accounts/KinozalTV.php
+++ b/plugins/loginmgr/accounts/KinozalTV.php
@@ -6,7 +6,16 @@ class KinozalTVAccount extends commonAccount
 
 	protected function isOK($client)
 	{
-		return(strpos($client->results, 'type="password" name="password"')===false);
+		// Two independent markers of a guest answer, because Kinozal has two
+		// kinds of them. The login form is matched on the password field alone
+		// (like RUTracker/TapochekNet do): the previous two-attribute probe
+		// stopped matching once the markup became <input type=password size=35
+		// id="password" name="password">. But get_srv_details.php answers a
+		// guest with a plain "not authorized" line and no form at all, so the
+		// registration link -- which every guest answer carries and no
+		// authenticated one does -- is what catches that second shape.
+		return(strpos($client->results, ' name="password"')===false &&
+			strpos($client->results, '/signup.php')===false);
 	}
 	protected function login($client,$login,$password,&$url,&$method,&$content_type,&$body,&$is_result_fetched)
 	{

--- a/plugins/rutracker_check/trackers/kinozal.php
+++ b/plugins/rutracker_check/trackers/kinozal.php
@@ -17,6 +17,27 @@ class KinozalCheckImpl
     // never masquerade as a removed release.
     const MISSING_MARKER = 'Торрент файл не найден';
 
+    // Per-process latch. Production runs one PHP process per cycle (update.php,
+    // batch_check.php), so process lifetime IS cycle lifetime and the latch
+    // cannot outlive the run. A locked-out loginmgr account is a property of
+    // the whole run rather than of one topic: without this, every Kinozal
+    // torrent spent a request proving the same thing over again -- 130 of
+    // them per cycle on the live fleet -- and buried the log under 130
+    // identical lines. The latch dies with the process, so the next cycle
+    // retries from scratch and a restored session heals itself.
+    static private $sessionDead = false;
+
+    // How many guest answers in a row mean the session is really gone rather
+    // than blinking. Measured on the live fleet: one cycle got a guest answer
+    // and the next, three seconds later, was authorised again with the very
+    // same stored cookies. Latching on that single answer cost every remaining
+    // Kinozal torrent an hour of waiting, so one is forgiven and the second
+    // in a row is believed -- two wasted requests instead of a hundred and
+    // thirty, and a blink no longer skips the cycle.
+    const GUEST_TOLERANCE = 2;
+
+    static private $guestAnswers = 0;
+
     // get_srv_details.php is served as UTF-8 while the rest of the site is
     // windows-1251, so a needle is looked up in both encodings rather than
     // pinned to whichever charset that endpoint happens to use today.
@@ -58,10 +79,27 @@ class KinozalCheckImpl
         return ruTrackerChecker::STE_CANT_REACH_TRACKER;
     }
 
+    // Same verdict as cantReach(), plus the running count of guest answers.
+    // Once they stop being isolated the session is declared gone for the whole
+    // run: it is one session, so what the tracker just refused it will refuse
+    // for every remaining topic too.
+    static private function guestAnswer($log)
+    {
+        if (++self::$guestAnswers < self::GUEST_TOLERANCE)
+            return self::cantReach($log);
+        self::$sessionDead = true;
+        return self::cantReach($log . ', the rest of this cycle is skipped');
+    }
+
     static public function download_torrent($url, $hash, $old_torrent)
     {
         if (!preg_match('`^https?://kinozal\.(tv|me|guru)/details\.php\?id=(?P<id>\d+)$`', $url, $matches))
             return ruTrackerChecker::STE_NOT_NEED;
+
+        // Checked after the URL match, so a topic this handler does not own
+        // still falls through to STE_NOT_NEED exactly as before.
+        if (self::$sessionDead)
+            return ruTrackerChecker::STE_CANT_REACH_TRACKER;
 
         $id = $matches["id"];
         $client = ruTrackerChecker::makeClient("https://kinozal.guru/get_srv_details.php?action=2&id=".$id);
@@ -70,7 +108,12 @@ class KinozalCheckImpl
 
         $details = (string) $client->results;
         if (self::isGuestAnswer($details))
-            return self::cantReach("get_srv_details answered a guest page, check the loginmgr account: id=".$id);
+            return self::guestAnswer("get_srv_details answered a guest page, check the loginmgr account: id=".$id);
+        // An authenticated answer clears the count: only guest answers that
+        // run together mean a lost session, and isolated ones must not add up
+        // across an otherwise healthy cycle.
+        self::$guestAnswers = 0;
+
         if (self::bodyHas($details, self::MISSING_MARKER))
             return ruTrackerChecker::STE_DELETED;
 
@@ -97,7 +140,7 @@ class KinozalCheckImpl
         if (self::isMetainfo($payload))
             return ruTrackerChecker::createTorrent($payload, $hash);
         if (self::isGuestAnswer($payload))
-            return self::cantReach("download.php answered a guest page, check the loginmgr account: id=".$id);
+            return self::guestAnswer("download.php answered a guest page, check the loginmgr account: id=".$id);
         return self::cantReach("download.php returned no metainfo: id=".$id." bytes=".strlen($payload));
     }
 }

--- a/plugins/rutracker_check/trackers/kinozal.php
+++ b/plugins/rutracker_check/trackers/kinozal.php
@@ -2,22 +2,103 @@
 
 class KinozalCheckImpl
 {
+    // Kinozal serves no torrent data to guests: get_srv_details.php answers
+    // with a plain "not authorized" line and dl.kinozal.guru redirects to
+    // login.php. Both of those answers -- and the login page itself -- offer
+    // registration; no authenticated answer does (measured 2026-08-07 against
+    // the live site, authorized and anonymous, on both endpoints). So this one
+    // link is what tells "we are locked out" apart from "the tracker replied".
+    const GUEST_MARKER = '/signup.php';
+
+    // The tracker's own verdict for an id it no longer serves: HTTP 200 with
+    // this body, in an authenticated session. It is the only authoritative
+    // deletion signal this handler has; everything it merely fails to check
+    // stays retryable, so a login wall, a dead socket or a layout change can
+    // never masquerade as a removed release.
+    const MISSING_MARKER = 'Торрент файл не найден';
+
+    // get_srv_details.php is served as UTF-8 while the rest of the site is
+    // windows-1251, so a needle is looked up in both encodings rather than
+    // pinned to whichever charset that endpoint happens to use today.
+    static private function bodyHas($body, $needle)
+    {
+        if (!is_string($body) || $body === '') return false;
+        if (strpos($body, $needle) !== false) return true;
+        if (function_exists('iconv')) {
+            $legacy = @iconv('UTF-8', 'CP1251//IGNORE', $needle);
+            if (is_string($legacy) && $legacy !== '' && strpos($body, $legacy) !== false) return true;
+        }
+        return false;
+    }
+
+    static private function isGuestAnswer($body)
+    {
+        return self::bodyHas($body, self::GUEST_MARKER);
+    }
+
+    // createTorrent() treats an unparseable payload as proof that the topic is
+    // gone (check.php's legacy contract), so nothing reaches it before it is
+    // known to be metainfo -- the same order rutracker.php's metadata harvest
+    // validates in.
+    static private function isMetainfo($payload)
+    {
+        if (!is_string($payload) || $payload === '') return false;
+        // PHP 7.4 warns when Torrent probes binary metainfo as a filename.
+        $torrent = @new Torrent($payload);
+        return !$torrent->errors() && strlen((string) $torrent->hash_info()) === 40;
+    }
+
+    // The state constant carries the whole user-facing verdict: init.js renders
+    // it through theUILang.chkResults, which every lang/ file translates. The
+    // detail below stays in the debug log, which is developer-facing and
+    // gated by $rutrackerCheckDebug -- no untranslated text reaches the UI.
+    static private function cantReach($log)
+    {
+        ruTrackerChecker::logDebug($log);
+        return ruTrackerChecker::STE_CANT_REACH_TRACKER;
+    }
+
     static public function download_torrent($url, $hash, $old_torrent)
     {
-        if (preg_match('`^https?://kinozal\.(tv|me|guru)/details\.php\?id=(?P<id>\d+)$`', $url, $matches)) {
-            $client = ruTrackerChecker::makeClient("https://kinozal.guru/get_srv_details.php?action=2&id=".$matches["id"]);
-            if ($client->status != 200) return ruTrackerChecker::STE_CANT_REACH_TRACKER;
-            if (preg_match('`<li>.*(?P<hash>[0-9A-Fa-f]{40})</li>`', $client->results, $matches1)) {
-                if (strtoupper($matches1["hash"])==$hash) {
-                    return  ruTrackerChecker::STE_UPTODATE;
-                }
-            }
-            $client->setcookies();
-            $client->fetchComplex("https://dl.kinozal.guru/download.php?id=".$matches["id"]);
-            if ($client->status != 200) return (($client->status < 0) ? ruTrackerChecker::STE_CANT_REACH_TRACKER : ruTrackerChecker::STE_DELETED);
-            return ruTrackerChecker::createTorrent($client->results, $hash);
-        }
-        return ruTrackerChecker::STE_NOT_NEED;
+        if (!preg_match('`^https?://kinozal\.(tv|me|guru)/details\.php\?id=(?P<id>\d+)$`', $url, $matches))
+            return ruTrackerChecker::STE_NOT_NEED;
+
+        $id = $matches["id"];
+        $client = ruTrackerChecker::makeClient("https://kinozal.guru/get_srv_details.php?action=2&id=".$id);
+        if ($client->status != 200)
+            return self::cantReach("get_srv_details failed: status=".$client->status." id=".$id);
+
+        $details = (string) $client->results;
+        if (self::isGuestAnswer($details))
+            return self::cantReach("get_srv_details answered a guest page, check the loginmgr account: id=".$id);
+        if (self::bodyHas($details, self::MISSING_MARKER))
+            return ruTrackerChecker::STE_DELETED;
+
+        // Strict comparison: loose == reads a hex hash shaped like scientific
+        // notation as a number -- '1E' followed by 38 zeros == '00...01'
+        // (both are numerically 1) -- so two different 40-char hashes could
+        // pass as equal.
+        if (preg_match('`<li>.*(?P<hash>[0-9A-Fa-f]{40})</li>`', $details, $matches1)
+            && strtoupper($matches1["hash"]) === strtoupper((string) $hash))
+            return ruTrackerChecker::STE_UPTODATE;
+
+        $client->setcookies();
+        $client->fetchComplex("https://dl.kinozal.guru/download.php?id=".$id);
+        // A guest download is a redirect to login.php. Whether Snoopy follows
+        // it to the 200 login page (the guest marker below catches that) or
+        // stops on a 3xx, the answer is treated as a login wall either way:
+        // a non-200 status is "could not fetch", never "deleted".
+        if ($client->status != 200)
+            return self::cantReach("download.php failed: status=".$client->status." id=".$id);
+
+        // Metainfo first: bytes that parse ARE the torrent, whatever text they
+        // happen to contain, so a torrent is never mistaken for a login wall.
+        $payload = (string) $client->results;
+        if (self::isMetainfo($payload))
+            return ruTrackerChecker::createTorrent($payload, $hash);
+        if (self::isGuestAnswer($payload))
+            return self::cantReach("download.php answered a guest page, check the loginmgr account: id=".$id);
+        return self::cantReach("download.php returned no metainfo: id=".$id." bytes=".strlen($payload));
     }
 }
 

--- a/tests/plugins/loginmgr/KinozalAccountTest.php
+++ b/tests/plugins/loginmgr/KinozalAccountTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Unit test for KinozalTVAccount::isOK() -- loginmgr's "are we still logged
+ * in?" detector for Kinozal.
+ *
+ * accounts.php is deliberately NOT loaded: it evals the plugin config, pulls
+ * in cache.php/Snoopy.class.inc and, through them, the real rXMLRPC* classes,
+ * none of which isOK() touches. The account file itself has no requires, so a
+ * minimal commonAccount base is all it needs to load -- the code under test is
+ * the real one, straight from plugins/loginmgr/accounts/KinozalTV.php.
+ */
+
+require_once(__DIR__ . '/../rutracker_check/TestLib.php');
+
+abstract class commonAccount
+{
+    public $url = 'http://abstract.com';
+
+    abstract protected function isOK($client);
+    abstract protected function login($client, $login, $password, &$url, &$method, &$content_type, &$body, &$is_result_fetched);
+}
+
+require_once(testFindRepoRoot() . '/plugins/loginmgr/accounts/KinozalTV.php');
+
+// isOK() reads exactly one field off the Snoopy client.
+class KinozalFakeClient
+{
+    public $results = '';
+
+    public function __construct($results)
+    {
+        $this->results = $results;
+    }
+}
+
+function kinozalIsOK($body)
+{
+    $account = new KinozalTVAccount();
+    $method = new ReflectionMethod('KinozalTVAccount', 'isOK');
+    if (PHP_VERSION_ID < 80100) {
+        $method->setAccessible(true);
+    }
+    return $method->invoke($account, new KinozalFakeClient($body));
+}
+
+// Captured from https://kinozal.guru/login.php on 2026-08-07: type= carries no
+// quotes and size=/id= sit between it and name=, so the old two-attribute
+// probe ('type="password" name="password"') finds nothing here.
+function kinozalLoginPage()
+{
+    return '<div class=pad0x0x5x0><ul class=lis><li class=mn><a href="/login.php">Вход</a></li>'
+        . '<li><a href="/signup.php">Регистрация в Кинозал.GURU</a></li></ul></div>'
+        . '<form method=post action="/takelogin.php" name=upt">'
+        . '<input type=text size=35 id="username" name="username" value="">'
+        . '<input type=password size=35 id="password" name="password" value="">'
+        . '<input class=buttonS type=submit value=" Войти "></form>';
+}
+
+// The markup the original detector was written against.
+function kinozalLegacyLoginPage()
+{
+    return '<form method=post action="/takelogin.php">'
+        . '<input type="text" name="username" value="">'
+        . '<input type="password" name="password" value=""></form>';
+}
+
+// Captured from get_srv_details.php without a session (HTTP 200, UTF-8).
+function kinozalUnauthorizedAnswer()
+{
+    return 'Вы не зарегистрированный пользователь или не авторизированы, чтобы '
+        . 'зарегистрироваться пройдите <a href=\'/signup.php\' class=\'sba\'>сюда</a>.';
+}
+
+$suite = new StrictTestSuite();
+
+$suite->test('today\'s login form is recognised as a dead session', function () {
+    strictAssertSame(false, kinozalIsOK(kinozalLoginPage()),
+        'the unquoted type= / reordered attribute form must not read as logged in');
+});
+
+$suite->test('the older quoted login form is still recognised', function () {
+    strictAssertSame(false, kinozalIsOK(kinozalLegacyLoginPage()),
+        'the markup the original detector targeted must keep failing the check');
+});
+
+$suite->test('the not-authorized answer of get_srv_details is a dead session', function () {
+    // This one never renders a login form, so the password-field marker alone
+    // cannot see it -- yet it is the answer the checker actually receives, and
+    // loginmgr must re-login on it rather than pass the text upstream.
+    strictAssertSame(false, kinozalIsOK(kinozalUnauthorizedAnswer()),
+        'the guest answer of get_srv_details.php must not read as logged in');
+});
+
+$suite->test('a logged-in page reads as a live session', function () {
+    $page = '<div class="mn"><a href="/userdetails.php?id=20244841">fessfess</a>'
+        . '<a href="/logout.php">Выход</a></div>'
+        . '<form action="/browse.php" method="get" id="srchform">'
+        . '<input type="text" class="inp" id="s" name="s" size="15" value=""></form>';
+    strictAssertSame(true, kinozalIsOK($page), 'a page behind the login wall is fine');
+});
+
+$suite->test('authorized tracker answers read as a live session', function () {
+    strictAssertSame(
+        true,
+        kinozalIsOK('<ul><li>Инфо хеш: ' . str_repeat('A', 40) . '</li><li>Размер части торрента: 2 МБ</li></ul>'),
+        'the details answer must not be mistaken for a login wall'
+    );
+    strictAssertSame(true, kinozalIsOK('Торрент файл не найден.'),
+        'a removed topic is an answer from the tracker, not a dead session');
+});
+
+$suite->test('torrent bytes read as a live session', function () {
+    $raw = 'd8:announce31:http://tr2.torrent4me.com/ann?uk=X4:infod6:lengthi1e'
+        . '4:name9:movie.mkv12:piece lengthi16384e6:pieces20:' . str_repeat("\0", 20) . 'ee';
+    strictAssertSame(true, kinozalIsOK($raw),
+        'a downloaded torrent must never be mistaken for a login wall');
+});
+
+exit($suite->run());

--- a/tests/plugins/rutracker_check/KinozalHandlerTest.php
+++ b/tests/plugins/rutracker_check/KinozalHandlerTest.php
@@ -1,0 +1,264 @@
+<?php
+
+/**
+ * Kinozal handler: every answer that only proves "could not check" must stay
+ * retryable, and only the tracker's own "no such torrent" may end as a
+ * deletion. Fixtures are the bodies the live site returned on 2026-08-07.
+ */
+
+define('TESTLIB_HANDLER_STUBS', 1);
+require_once(__DIR__ . '/TestLib.php');
+require_once(testFindRepoRoot() . '/plugins/rutracker_check/trackers/kinozal.php');
+
+function kinozalReset()
+{
+    ruTrackerChecker::reset();
+}
+
+function kinozalTopicUrl($id)
+{
+    return 'https://kinozal.me/details.php?id=' . $id;
+}
+
+function kinozalDetailsUrl($id)
+{
+    return 'https://kinozal.guru/get_srv_details.php?action=2&id=' . $id;
+}
+
+function kinozalDownloadUrl($id)
+{
+    return 'https://dl.kinozal.guru/download.php?id=' . $id;
+}
+
+// get_srv_details.php answers in UTF-8 (Content-Type: text/html; charset=UTF-8)
+// even though the rest of the site is windows-1251.
+function kinozalDetailsBody($hash)
+{
+    return '<ul><li>Инфо хеш: ' . $hash . '</li><li>Размер части торрента: 2 МБ</li>'
+        . '<li><div class=\'b ing\'>movie.mkv <i>26.75 ГБ (28721509590)</i></div></li></ul>';
+}
+
+function kinozalUnauthorizedBody()
+{
+    return 'Вы не зарегистрированный пользователь или не авторизированы, чтобы '
+        . 'зарегистрироваться пройдите <a href=\'/signup.php\' class=\'sba\'>сюда</a>.';
+}
+
+function kinozalMissingBody()
+{
+    return 'Торрент файл не найден.';
+}
+
+function kinozalLoginPage()
+{
+    return '<ul class=lis><li class=mn><a href="/login.php">Вход</a></li>'
+        . '<li><a href="/signup.php">Регистрация в Кинозал.GURU</a></li></ul>'
+        . '<form method=post action="/takelogin.php">'
+        . '<input type=password size=35 id="password" name="password" value=""></form>';
+}
+
+// Builds a parseable Kinozal torrent plus its hash and topic URL.
+function kinozalTorrent($name, $id)
+{
+    $raw = strictTorrentRaw($name, 'http://tr2.torrent4me.com/ann?uk=K0I5ZrJ6If1', kinozalTopicUrl($id));
+    $torrent = @new Torrent($raw);
+    strictAssertTrue(!$torrent->errors(), 'torrent fixture must parse');
+    return array($raw, (string) $torrent->hash_info(), $torrent);
+}
+
+$suite = new StrictTestSuite();
+
+$suite->test('a guest answer from the details endpoint is a reachability error', function () {
+    kinozalReset();
+    list($raw, $hash, $torrent) = kinozalTorrent('current.mkv', 2148020);
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalUnauthorizedBody());
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $hash, $torrent);
+
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER, $result,
+        'a login wall proves nothing about the topic');
+    strictAssertSame(
+        array(array('fetchComplex', kinozalDetailsUrl(2148020))),
+        Snoopy::$requests,
+        'the chain stops at the details request'
+    );
+    strictAssertSame(0, ruTrackerChecker::$createCalls, 'the replacement path is never entered');
+});
+
+$suite->test('the login page served with status 200 is a reachability error', function () {
+    kinozalReset();
+    list($raw, $hash, $torrent) = kinozalTorrent('current.mkv', 2148020);
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalLoginPage());
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $hash, $torrent);
+
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER, $result,
+        'a followed redirect that lands on login.php is not a verdict');
+    strictAssertSame(1, count(Snoopy::$requests), 'the chain stops at the details request');
+});
+
+$suite->test('the tracker\'s own "no such torrent" is a deletion', function () {
+    kinozalReset();
+    list($raw, $hash, $torrent) = kinozalTorrent('gone.mkv', 2148020);
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalMissingBody());
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $hash, $torrent);
+
+    strictAssertSame(ruTrackerChecker::STE_DELETED, $result,
+        'an authenticated "not found" is the only authoritative deletion signal');
+    strictAssertSame(1, count(Snoopy::$requests), 'a deleted topic needs no download attempt');
+});
+
+$suite->test('a windows-1251 "no such torrent" answer is recognised too', function () {
+    kinozalReset();
+    list($raw, $hash, $torrent) = kinozalTorrent('gone-cp1251.mkv', 2148020);
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, strictCp1251(kinozalMissingBody()));
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $hash, $torrent);
+
+    strictAssertSame(ruTrackerChecker::STE_DELETED, $result,
+        'the site\'s own legacy charset must not hide the deletion signal');
+});
+
+$suite->test('a matching info hash is up to date without a download', function () {
+    kinozalReset();
+    list($raw, $hash, $torrent) = kinozalTorrent('current.mkv', 2148020);
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalDetailsBody($hash));
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $hash, $torrent);
+
+    strictAssertSame(ruTrackerChecker::STE_UPTODATE, $result, 'the tracker still lists our hash');
+    strictAssertSame(
+        array(array('fetchComplex', kinozalDetailsUrl(2148020))),
+        Snoopy::$requests,
+        'an up-to-date topic is never downloaded'
+    );
+});
+
+$suite->test('a changed info hash hands valid metainfo to the replacement', function () {
+    kinozalReset();
+    list($oldRaw, $oldHash, $oldTorrent) = kinozalTorrent('old.mkv', 2148020);
+    list($newRaw, $newHash, $newTorrent) = kinozalTorrent('new.mkv', 2148020);
+    strictAssertTrue($oldHash !== $newHash, 'the fixtures must represent an update');
+
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalDetailsBody($newHash));
+    Snoopy::queue(kinozalDownloadUrl(2148020), 200, $newRaw);
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $oldHash, $oldTorrent);
+
+    strictAssertSame(null, $result, 'a successful replacement propagates createTorrent\'s result');
+    strictAssertSame(1, ruTrackerChecker::$createCalls, 'the new torrent is handed over once');
+    strictAssertSame($newRaw, ruTrackerChecker::$created[0]['payload'], 'the downloaded bytes are passed through');
+    strictAssertSame($oldHash, ruTrackerChecker::$created[0]['old_hash'], 'the replacement targets the old hash');
+});
+
+$suite->test('a download redirected to the login page is a reachability error', function () {
+    kinozalReset();
+    list($oldRaw, $oldHash, $oldTorrent) = kinozalTorrent('old.mkv', 2148020);
+    list($newRaw, $newHash, $newTorrent) = kinozalTorrent('new.mkv', 2148020);
+
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalDetailsBody($newHash));
+    // What dl.kinozal.guru answers without a session, as seen when the
+    // redirect chain does not end in a 200: the 302 itself, with the
+    // login.php Location it carries on the live site.
+    Snoopy::queue(kinozalDownloadUrl(2148020), 302, '',
+        array('Location: //kinozal.guru/login.php?to=%2Fdownload.php%3Fid%3D2148020'));
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $oldHash, $oldTorrent);
+
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER, $result,
+        'a redirect to the login wall is not proof of deletion');
+    strictAssertSame(0, ruTrackerChecker::$createCalls, 'createTorrent is never reached');
+});
+
+$suite->test('a login page instead of a torrent is a reachability error', function () {
+    kinozalReset();
+    list($oldRaw, $oldHash, $oldTorrent) = kinozalTorrent('old.mkv', 2148020);
+    list($newRaw, $newHash, $newTorrent) = kinozalTorrent('new.mkv', 2148020);
+
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalDetailsBody($newHash));
+    Snoopy::queue(kinozalDownloadUrl(2148020), 200, kinozalLoginPage());
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $oldHash, $oldTorrent);
+
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER, $result,
+        'HTML where metainfo was expected is not proof of deletion');
+    strictAssertSame(0, ruTrackerChecker::$createCalls,
+        'createTorrent\'s "unparseable means deleted" contract is never invoked');
+});
+
+$suite->test('an unparseable download body is a reachability error', function () {
+    kinozalReset();
+    list($oldRaw, $oldHash, $oldTorrent) = kinozalTorrent('old.mkv', 2148020);
+    list($newRaw, $newHash, $newTorrent) = kinozalTorrent('new.mkv', 2148020);
+
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalDetailsBody($newHash));
+    Snoopy::queue(kinozalDownloadUrl(2148020), 200, 'not a torrent at all');
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $oldHash, $oldTorrent);
+
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER, $result,
+        'bytes that are not metainfo are validated before the replacement');
+    strictAssertSame(0, ruTrackerChecker::$createCalls, 'nothing is handed over');
+});
+
+$suite->test('an empty download body is a reachability error', function () {
+    kinozalReset();
+    list($oldRaw, $oldHash, $oldTorrent) = kinozalTorrent('old.mkv', 2148020);
+    list($newRaw, $newHash, $newTorrent) = kinozalTorrent('new.mkv', 2148020);
+
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalDetailsBody($newHash));
+    Snoopy::queue(kinozalDownloadUrl(2148020), 200, '');
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $oldHash, $oldTorrent);
+
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER, $result, 'an empty body carries no verdict');
+    strictAssertSame(0, ruTrackerChecker::$createCalls, 'nothing is handed over');
+});
+
+$suite->test('a transport failure is a reachability error', function () {
+    kinozalReset();
+    list($raw, $hash, $torrent) = kinozalTorrent('current.mkv', 2148020);
+    // The https path stores curl's exit code (6 = DNS failure) as the status.
+    Snoopy::queue(kinozalDetailsUrl(2148020), 6, '');
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $hash, $torrent);
+
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER, $result, 'a dead socket is retryable');
+});
+
+$suite->test('a server error on the details endpoint is a reachability error', function () {
+    kinozalReset();
+    list($raw, $hash, $torrent) = kinozalTorrent('current.mkv', 2148020);
+    Snoopy::queue(kinozalDetailsUrl(2148020), 503, '<html>maintenance</html>');
+
+    $result = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $hash, $torrent);
+
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER, $result,
+        'an HTTP error is never a deletion');
+});
+
+$suite->test('every Kinozal mirror in the comment is handled', function () {
+    foreach (array('kinozal.tv', 'kinozal.me', 'kinozal.guru') as $host) {
+        kinozalReset();
+        list($raw, $hash, $torrent) = kinozalTorrent('current.mkv', 2148020);
+        $url = 'https://' . $host . '/details.php?id=2148020';
+        Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalDetailsBody($hash));
+
+        $result = KinozalCheckImpl::download_torrent($url, $hash, $torrent);
+
+        strictAssertSame(ruTrackerChecker::STE_UPTODATE, $result, $host . ' must be recognised');
+    }
+});
+
+$suite->test('a URL this handler does not own triggers no request', function () {
+    kinozalReset();
+    list($raw, $hash, $torrent) = kinozalTorrent('current.mkv', 2148020);
+
+    $result = KinozalCheckImpl::download_torrent('http://tr2.torrent4me.com/ann?uk=K0I5ZrJ6If1', $hash, $torrent);
+
+    strictAssertSame(ruTrackerChecker::STE_NOT_NEED, $result, 'an announce URL carries no topic id');
+    strictAssertSame(0, count(Snoopy::$requests), 'no request is made');
+});
+
+exit($suite->run());

--- a/tests/plugins/rutracker_check/KinozalHandlerTest.php
+++ b/tests/plugins/rutracker_check/KinozalHandlerTest.php
@@ -13,6 +13,11 @@ require_once(testFindRepoRoot() . '/plugins/rutracker_check/trackers/kinozal.php
 function kinozalReset()
 {
     ruTrackerChecker::reset();
+    // The latch is per-process, and one test process stands in for many
+    // production cycles, so it is cleared between them the same way the
+    // other private statics in this suite are.
+    strictSetPrivateStatic('KinozalCheckImpl', 'sessionDead', false);
+    strictSetPrivateStatic('KinozalCheckImpl', 'guestAnswers', 0);
 }
 
 function kinozalTopicUrl($id)
@@ -83,6 +88,84 @@ $suite->test('a guest answer from the details endpoint is a reachability error',
         'the chain stops at the details request'
     );
     strictAssertSame(0, ruTrackerChecker::$createCalls, 'the replacement path is never entered');
+});
+
+$suite->test('two guest answers in a row stop the rest of the cycle from asking again', function () {
+    kinozalReset();
+    list($rawA, $hashA, $torrentA) = kinozalTorrent('first.mkv', 2148020);
+    list($rawB, $hashB, $torrentB) = kinozalTorrent('second.mkv', 2144802);
+    list($rawC, $hashC, $torrentC) = kinozalTorrent('third.mkv', 2144913);
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalUnauthorizedBody());
+    Snoopy::queue(kinozalDetailsUrl(2144802), 200, kinozalUnauthorizedBody());
+
+    $first = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $hashA, $torrentA);
+    $second = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2144802), $hashB, $torrentB);
+    $third = KinozalCheckImpl::download_torrent(kinozalTopicUrl(2144913), $hashC, $torrentC);
+
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER, $first, 'a login wall proves nothing');
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER, $second, 'and neither does the second one');
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER, $third,
+        'a skipped topic keeps the same retryable verdict it would have got the hard way');
+    strictAssertSame(
+        array(
+            array('fetchComplex', kinozalDetailsUrl(2148020)),
+            array('fetchComplex', kinozalDetailsUrl(2144802)),
+        ),
+        Snoopy::$requests,
+        'the third topic costs no request: the session is by then known to be gone'
+    );
+});
+
+$suite->test('a single guest answer is a blink and does not cost the cycle', function () {
+    kinozalReset();
+    list($rawA, $hashA, $torrentA) = kinozalTorrent('blinked.mkv', 2148020);
+    list($rawB, $hashB, $torrentB) = kinozalTorrent('healthy.mkv', 2144802);
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalUnauthorizedBody());
+    Snoopy::queue(kinozalDetailsUrl(2144802), 200, kinozalDetailsBody($hashB));
+
+    strictAssertSame(ruTrackerChecker::STE_CANT_REACH_TRACKER,
+        KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $hashA, $torrentA),
+        'the blink itself is still unproven, so it stays retryable');
+    strictAssertSame(ruTrackerChecker::STE_UPTODATE,
+        KinozalCheckImpl::download_torrent(kinozalTopicUrl(2144802), $hashB, $torrentB),
+        'the next topic is checked for real: one answer is not proof of a lost session');
+    strictAssertSame(2, count(Snoopy::$requests), 'both topics were asked about');
+});
+
+$suite->test('an authenticated answer between two guest ones clears the count', function () {
+    kinozalReset();
+    list($rawA, $hashA, $torrentA) = kinozalTorrent('first.mkv', 2148020);
+    list($rawB, $hashB, $torrentB) = kinozalTorrent('healthy.mkv', 2144802);
+    list($rawC, $hashC, $torrentC) = kinozalTorrent('third.mkv', 2144913);
+    list($rawD, $hashD, $torrentD) = kinozalTorrent('fourth.mkv', 2130523);
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalUnauthorizedBody());
+    Snoopy::queue(kinozalDetailsUrl(2144802), 200, kinozalDetailsBody($hashB));
+    Snoopy::queue(kinozalDetailsUrl(2144913), 200, kinozalUnauthorizedBody());
+    Snoopy::queue(kinozalDetailsUrl(2130523), 200, kinozalDetailsBody($hashD));
+
+    KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $hashA, $torrentA);
+    KinozalCheckImpl::download_torrent(kinozalTopicUrl(2144802), $hashB, $torrentB);
+    KinozalCheckImpl::download_torrent(kinozalTopicUrl(2144913), $hashC, $torrentC);
+
+    strictAssertSame(ruTrackerChecker::STE_UPTODATE,
+        KinozalCheckImpl::download_torrent(kinozalTopicUrl(2130523), $hashD, $torrentD),
+        'two guest answers separated by a healthy one are two blinks, not a lost session');
+    strictAssertSame(4, count(Snoopy::$requests), 'every topic was asked about on its own merits');
+});
+
+$suite->test('a live session checks every topic on its own merits', function () {
+    kinozalReset();
+    list($rawA, $hashA, $torrentA) = kinozalTorrent('first.mkv', 2148020);
+    list($rawB, $hashB, $torrentB) = kinozalTorrent('second.mkv', 2144802);
+    Snoopy::queue(kinozalDetailsUrl(2148020), 200, kinozalDetailsBody($hashA));
+    Snoopy::queue(kinozalDetailsUrl(2144802), 200, kinozalDetailsBody($hashB));
+
+    strictAssertSame(ruTrackerChecker::STE_UPTODATE,
+        KinozalCheckImpl::download_torrent(kinozalTopicUrl(2148020), $hashA, $torrentA), 'first topic');
+    strictAssertSame(ruTrackerChecker::STE_UPTODATE,
+        KinozalCheckImpl::download_torrent(kinozalTopicUrl(2144802), $hashB, $torrentB),
+        'the latch must not trip on an authenticated answer');
+    strictAssertSame(2, count(Snoopy::$requests), 'both topics were asked about');
 });
 
 $suite->test('the login page served with status 200 is a reachability error', function () {

--- a/tests/plugins/rutracker_check/TestLib.php
+++ b/tests/plugins/rutracker_check/TestLib.php
@@ -286,6 +286,7 @@ if (defined('TESTLIB_HANDLER_STUBS')) {
 
         public $status = -1;
         public $results = '';
+        public $headers = array();
         public $read_timeout = 0;
         public $_fp_timeout = 0;
         public $agent = '';
@@ -296,12 +297,12 @@ if (defined('TESTLIB_HANDLER_STUBS')) {
             self::$requests = array();
         }
 
-        public static function queue($url, $status, $results)
+        public static function queue($url, $status, $results, $headers = array())
         {
             if (!isset(self::$responses[$url])) {
                 self::$responses[$url] = array();
             }
-            self::$responses[$url][] = array($status, $results);
+            self::$responses[$url][] = array($status, $results, $headers);
         }
 
         private function respond($method, $url)
@@ -310,7 +311,7 @@ if (defined('TESTLIB_HANDLER_STUBS')) {
             if (!isset(self::$responses[$url]) || count(self::$responses[$url]) === 0) {
                 throw new RuntimeException("Unexpected {$method} request: {$url}");
             }
-            list($this->status, $this->results) = array_shift(self::$responses[$url]);
+            list($this->status, $this->results, $this->headers) = array_shift(self::$responses[$url]);
             return true;
         }
 
@@ -345,6 +346,9 @@ if (defined('TESTLIB_HANDLER_STUBS')) {
             . "Chrome/120.0.0.0 Safari/537.36";
 
         public static $created = array();
+        // $created only records payloads that parsed, so a handler that must
+        // not reach createTorrent() at all is asserted against this counter.
+        public static $createCalls = 0;
         public static $logs = array();
         public static $registrations = array();
         public static $createResult = null;
@@ -352,6 +356,7 @@ if (defined('TESTLIB_HANDLER_STUBS')) {
         public static function reset()
         {
             self::$created = array();
+            self::$createCalls = 0;
             self::$logs = array();
             self::$registrations = array();
             self::$createResult = null;
@@ -373,6 +378,7 @@ if (defined('TESTLIB_HANDLER_STUBS')) {
 
         public static function createTorrent($payload, $oldHash)
         {
+            self::$createCalls++;
             $parsed = @new Torrent($payload);
             if ($parsed->errors() || strlen((string) $parsed->hash_info()) !== 40) {
                 return self::STE_ERROR;


### PR DESCRIPTION
**Problem.** Two defects combined. loginmgr's session probe searched for the
literal `type="password" name="password"`, which Kinozal's current markup no
longer contains — so a dead session read as healthy and was never re-logged-in.
The checker then received guest answers, and the handler's legacy contract
turned every non-200 `download.php` answer into "probably deleted". Live
torrents were reported deleted.

**Fix.** 
Commit 1: the probe matches the password field alone plus the
`/signup.php` registration link (present in every guest answer of both checker
endpoints, absent from authenticated ones — measured against the live site on
both, authorized and anonymous); guest answers, login redirects and
non-metainfo bodies become the retryable `STE_CANT_REACH_TRACKER`, and the
payload is validated as metainfo before `createTorrent()`. The tracker's own
"Торрент файл не найден" (in an authenticated session) remains the only
deletion signal. 
Commit 2: a per-process latch — production runs one PHP
process per cycle, so process lifetime is cycle lifetime — stops re-asking
after two consecutive guest answers (measured live: 130 requests and 130 log
lines per cycle became 2), while a single guest answer is forgiven as a blink
(the live fleet was observed re-authorising three seconds later on the same
cookies).

**How to verify.** New `KinozalAccountTest` (6) + `KinozalHandlerTest` (18).
Against the pre-fix handler: 2 of 6 account tests fail (both current guest
shapes read as logged in), and all 18 handler tests fail.

**Tested.** Full suite clean on 8.1 and 8.5; the request-storm numbers come
from a live fleet running the equivalent fork code since 2026-08-08.