### PR TITLE
rutracker_check: a missing ratio view must not break the replacement load

### DIFF
--- a/plugins/rutracker_check/check.php
+++ b/plugins/rutracker_check/check.php
@@ -271,11 +271,39 @@ class ruTrackerChecker
 		}
 	}
 
-	static private function buildReplacementAddition($connectionSeed, $throttle, $ratioViews, $state, $marker)
+	// The views rTorrent currently has, keyed by name; null when the list
+	// itself could not be read. Views are runtime state: rTorrent recreates
+	// none of the rat_N ones on restart -- ruTorrent's ratio plugin does, on
+	// its next start (plugins/ratio/ratio.php, flush()).
+	static private function existingViews()
+	{
+		// Only php/methods-0.9.4.php aliases "view_list" to view.list, but
+		// php/settings.php layers the method tables cumulatively, so that
+		// mapping is loaded for every daemon >= 0.9.4; on anything older the
+		// name passes through unchanged and is the native command.
+		$req = new rXMLRPCRequest( new rXMLRPCCommand(getCmd("view_list")) );
+		$req->important = false;
+		if(!$req->success())
+			return(null);
+		$views = array();
+		foreach($req->val as $view)
+			if(is_string($view))
+				$views[$view] = true;
+		return($views);
+	}
+
+	// $existingViews is existingViews()' answer, read by createTorrent()
+	// while the old torrent was still running; null means unreadable.
+	static private function buildReplacementAddition($connectionSeed, $throttle, $ratioViews, $existingViews, $state, $marker)
 	{
 		$now = time();
 		$addition = array(
 			getCmd("d.set_custom")."=".self::REPLACEMENT_MARKER_KEY.",".$marker,
+			// d.set_connection_seed= resolves to d.connection_seed.set, which
+			// rTorrent registers PRIVATE: it works here only because a load
+			// command list is executed internally, not through the XMLRPC
+			// entry point. Moving it into a post-load system.multicall would
+			// silently fault.
 			getCmd("d.set_connection_seed=").$connectionSeed,
 			getCmd("d.set_custom")."=chk-state,".$state,
 			getCmd("d.set_custom")."=chk-time,".$now,
@@ -283,8 +311,52 @@ class ruTrackerChecker
 		);
 		if(!empty($throttle))
 			$addition[] = getCmd("d.set_throttle_name=").$throttle;
+
+		// DownloadFactory runs this whole list inside one try block: the first
+		// torrent::input_error aborts every command after it, plus the
+		// d.state.set and the event.download.inserted_new that rTorrent itself
+		// appends. view.set_visible throws exactly that error for a view that
+		// does not exist. The abort is not fatal to the load -- the marker is
+		// the first command, so waitForLoad() still confirms ownership, and
+		// for a previously-started source activateReplacement()'s d.start
+		// makes the download visible in the started view, whose view event
+		// sets d.state=1. What it silently costs is every load command after
+		// the failing one, the inserted_new side effects (history logging,
+		// the ratio plugin's default-group hook), and -- since that d.start
+		// rescue only reaches sources activateReplacement() starts -- a
+		// previously-stopped source staying closed at state 0.
+		//
+		// So memberships are forwarded in two tiers. A view confirmed against
+		// the live view list gets view.set_visible, which also records the
+		// membership in the d.views attribute (rat_N views are persistent,
+		// and a persistent view's event_added runs d.views.push_back_unique).
+		// An unconfirmed one gets d.views.push_back_unique directly: it never
+		// throws and records the attribute only. Dropping it instead would be
+		// worse than a lost group -- a replacement with an empty d.views is
+		// re-homed by the ratio plugin's default-group insert hook (a branch
+		// over d.views.has, ratio.php flush()) into the DEFAULT ratio group,
+		// whose action can be erase-data. The attribute keeps that hook a
+		// no-op, and the ratio plugin's correct() pass turns it back into
+		// visible membership once the views exist again.
+		$attributeOnly = array();
 		foreach($ratioViews as $ratioView)
-			$addition[] = getCmd("view.set_visible=").$ratioView;
+		{
+			if($existingViews !== null && isset($existingViews[$ratioView]))
+				$addition[] = getCmd("view.set_visible=").$ratioView;
+			else
+			{
+				$addition[] = getCmd("d.views.push_back_unique=").$ratioView;
+				$attributeOnly[] = $ratioView;
+			}
+		}
+		if(count($attributeOnly))
+			self::logDebug("buildReplacementAddition: forwarded ".implode(',', $attributeOnly)
+				." as the d.views attribute only (".($existingViews === null
+					? "the view list could not be read"
+					: "no such view in rTorrent")
+				."): view.set_visible would throw input_error and abort the rest of"
+				." the load command list; the ratio plugin restores the visible"
+				." membership once the views exist again");
 		return($addition);
 	}
 
@@ -426,6 +498,15 @@ class ruTrackerChecker
 				$ratioViews[$view] = true;
 		$ratioViews = array_keys($ratioViews);
 
+		// Confirm the memberships against the live view list now, while the
+		// old torrent is still running: the round trip must not lengthen the
+		// window between the stop/close below and the replacement load. It is
+		// still a check-to-load TOCTOU either way -- the hoist leaves that gap
+		// at the same order of magnitude, buildReplacementAddition() just
+		// degrades an unconfirmed membership instead of trusting it. Skipped
+		// entirely when the torrent belongs to no ratio group.
+		$existingViews = empty($ratioViews) ? null : self::existingViews();
+
 		// Snapshot the logical state and stop/close it in the same multicall so a
 		// scheduler action cannot slip between the read and the mutation.
 		$req = new rXMLRPCRequest( array(
@@ -453,7 +534,7 @@ class ruTrackerChecker
 		$wasStarted = ($req->val[4] != 0);
 		$wasOpen = ($req->val[5] != 0);
 		$addition = self::buildReplacementAddition(
-			$connectionSeed, $throttle, $ratioViews, self::STE_UPDATED, $marker
+			$connectionSeed, $throttle, $ratioViews, $existingViews, self::STE_UPDATED, $marker
 		);
 
 		// Stage stopped: a failed pre-commit replacement cannot write shared data.

--- a/tests/plugins/rutracker_check/CheckerTest.php
+++ b/tests/plugins/rutracker_check/CheckerTest.php
@@ -174,10 +174,19 @@ class CheckerTest
 		rTorrent::$sendResult = 'NEW';
 	}
 
-	private function queueViews($views = null)
+	// $views is what the OLD torrent belongs to (d.views); $existing is what
+	// rTorrent currently has (view.list, aliased "view_list"). They are two
+	// different reads: views are runtime state, so a rat_N the old torrent
+	// belonged to before a restart can be missing from the live list, and a
+	// view.set_visible for it would throw input_error inside the load command
+	// list. By default every view the old torrent belongs to still exists.
+	private function queueViews($views = null, $existing = null)
 	{
-		rXMLRPCRequest::queue('d.views', true, false,
-			$views === null ? array('main', 'rat_2', 'rat_7', 'rat_9', 'rat_bad', 'rat_2_extra') : $views);
+		$views = $views === null ? array('main', 'rat_2', 'rat_7', 'rat_9', 'rat_bad', 'rat_2_extra') : $views;
+		rXMLRPCRequest::queue('d.views', true, false, $views);
+		if($existing !== false)
+			rXMLRPCRequest::queue('view_list', true, false,
+				$existing === null ? array_merge(array('main', 'default', 'seeding'), $views) : $existing);
 	}
 
 	private function queueSnapshot($baseDir, $state = 1, $open = 1)
@@ -247,6 +256,34 @@ class CheckerTest
 		strictInvoke('ruTrackerChecker', 'cleanupObsoleteFiles', array($oldTorrent, $newTorrent, $baseDir));
 	}
 
+	// Both spellings a ratio membership can take in the load command list:
+	// view.set_visible for a confirmed view, d.views.push_back_unique for an
+	// attribute-only forward of an unconfirmed one.
+	private function membershipCommands($addition)
+	{
+		return array_values(array_filter($addition, function($command) {
+			return strpos($command, 'view.set_visible=') === 0
+				|| strpos($command, 'd.views.push_back_unique=') === 0;
+		}));
+	}
+
+	private function withDebugLog($body)
+	{
+		$savedDebug = isset($GLOBALS['rutrackerCheckDebug']) ? $GLOBALS['rutrackerCheckDebug'] : null;
+		$GLOBALS['rutrackerCheckDebug'] = true;
+		try
+		{
+			$body();
+		}
+		finally
+		{
+			if($savedDebug === null)
+				unset($GLOBALS['rutrackerCheckDebug']);
+			else
+				$GLOBALS['rutrackerCheckDebug'] = $savedDebug;
+		}
+	}
+
 	public function testStartedReplacementSucceeds()
 	{
 		$this->resetFakes();
@@ -262,13 +299,10 @@ class CheckerTest
 		strictAssertTrue(strpos($addition[0], 'd.set_custom=chk-replacement,') === 0, 'the ownership marker must be the first load command');
 		strictAssertTrue(in_array('d.set_connection_seed=seed-value', $addition, true), 'the connection seed must be forwarded');
 		strictAssertTrue(in_array('d.set_throttle_name=slow', $addition, true), 'the throttle must be forwarded');
-		$views = array_values(array_filter($addition, function($command) {
-			return strpos($command, 'view.set_visible=') === 0;
-		}));
 		strictAssertSame(
 			array('view.set_visible=rat_2', 'view.set_visible=rat_7', 'view.set_visible=rat_9'),
-			$views,
-			'exactly the rat_N view memberships must be forwarded'
+			$this->membershipCommands($addition),
+			'exactly the rat_N view memberships must be forwarded, all visible when all are confirmed'
 		);
 
 		$waits = $this->requestIndexes('d.get_custom');
@@ -280,6 +314,112 @@ class CheckerTest
 		$clears = rXMLRPCRequest::requestsFor('d.set_custom');
 		strictAssertSame(1, count($clears), 'the replacement marker must be cleared exactly once');
 		strictAssertSame(array('NEW', 'chk-replacement', ''), $clears[0]['commands'][0]->params, 'the marker clear must target the new hash');
+	}
+
+	// rTorrent runs a load command list inside ONE try block: the first
+	// input_error aborts every command after it, plus rTorrent's own
+	// d.state.set and event.download.inserted_new. view.set_visible throws
+	// that error for a view that does not exist, and views are runtime state:
+	// every rat_N is gone after a restart until ruTorrent's ratio plugin
+	// recreates it. An unconfirmed membership must therefore ride along as
+	// d.views.push_back_unique -- the attribute write never throws -- both to
+	// keep the list abort-free and because an empty d.views would let the
+	// ratio plugin's default-group insert hook re-home the replacement into
+	// the default ratio group, whose action can be erase-data.
+	public function testMissingRatioViewIsForwardedAsAttributeOnly()
+	{
+		$this->resetFakes();
+		$this->withDebugLog(function() {
+			$this->stageTorrents();
+			rXMLRPCRequest::queue('d.hash', true, true, array());
+			$this->queueViews(
+				array('main', 'rat_2', 'rat_7', 'rat_9'),
+				array('main', 'default', 'seeding', 'rat_2', 'rat_9')  // rat_7 did not survive the restart
+			);
+			$this->queueSnapshot(sys_get_temp_dir(), 1, 1);
+			$this->queueLoadConfirmed();
+			rXMLRPCRequest::queue('d.erase', true, false, array(0));
+			rXMLRPCRequest::queue('d.set_custom', true, false, array());
+			rXMLRPCRequest::queue('d.start', true, false, array(0));
+			rXMLRPCRequest::queue(array('d.get_state', 'd.is_open'), true, false, array(1, 1));
+
+			strictAssertSame(null, ruTrackerChecker::createTorrent('new-torrent', 'OLD'),
+				'a missing view must cost nothing but the visible membership');
+			strictAssertSame(
+				array(
+					'view.set_visible=rat_2',
+					'd.views.push_back_unique=rat_7',
+					'view.set_visible=rat_9',
+				),
+				$this->membershipCommands(rTorrent::$lastSend['addition']),
+				'a confirmed membership stays visible; the missing one becomes the d.views attribute only'
+			);
+			$viewList = $this->requestIndexes('view_list');
+			$snapshots = $this->requestIndexes(self::SNAPSHOT_KEY);
+			strictAssertSame(1, count($viewList),
+				'the live view list is read exactly once per replacement');
+			strictAssertTrue(count($snapshots) === 1 && $viewList[0] < $snapshots[0],
+				'the view list must be read while the old torrent still runs, before the stop/close');
+			$line = strictAssertOneLogMatching(FileUtil::$log, 'rat_7',
+				'an attribute-only membership is never silent');
+			strictAssertEnglish($line, 'the attribute-only line');
+		});
+	}
+
+	public function testUnreadableViewListForwardsEveryRatioViewAsAttributeOnly()
+	{
+		$this->resetFakes();
+		$this->withDebugLog(function() {
+			$this->stageTorrents();
+			rXMLRPCRequest::queue('d.hash', true, true, array());
+			$this->queueViews(array('main', 'rat_2', 'rat_9'), false); // nothing queued: view.list faults
+			$this->queueSnapshot(sys_get_temp_dir(), 1, 1);
+			$this->queueLoadConfirmed();
+			rXMLRPCRequest::queue('d.erase', true, false, array(0));
+			rXMLRPCRequest::queue('d.set_custom', true, false, array());
+			rXMLRPCRequest::queue('d.start', true, false, array(0));
+			rXMLRPCRequest::queue(array('d.get_state', 'd.is_open'), true, false, array(1, 1));
+
+			strictAssertSame(null, ruTrackerChecker::createTorrent('new-torrent', 'OLD'),
+				'an unreadable view list must not abort the replacement');
+			strictAssertSame(
+				array('d.views.push_back_unique=rat_2', 'd.views.push_back_unique=rat_9'),
+				$this->membershipCommands(rTorrent::$lastSend['addition']),
+				'every unconfirmed membership becomes the d.views attribute, none stays view.set_visible'
+			);
+			$line = strictAssertOneLogMatching(FileUtil::$log, 'rat_2,rat_9',
+				'the attribute-only memberships are named');
+			strictAssertEnglish($line, 'the unreadable-view-list line');
+		});
+	}
+
+	// Most replacements belong to no ratio group at all: d.views comes back
+	// with nothing matching rat_\d+, so there is no membership to confirm and
+	// the view.list round trip would buy nothing. createTorrent() skips it --
+	// a lookup whose answer nothing uses is a round trip wasted between the
+	// tracker check and the load.
+	public function testNoRatioViewsSkipsTheViewListLookup()
+	{
+		$this->resetFakes();
+		$this->stageTorrents();
+		rXMLRPCRequest::queue('d.hash', true, true, array());
+		// rat_bad and rat_2_extra do not match rat_\d+. view_list is NOT
+		// queued, so asking for it anyway would surface as a fault.
+		$this->queueViews(array('main', 'rat_bad', 'rat_2_extra'), false);
+		$this->queueSnapshot(sys_get_temp_dir(), 1, 1);
+		$this->queueLoadConfirmed();
+		rXMLRPCRequest::queue('d.erase', true, false, array(0));
+		rXMLRPCRequest::queue('d.set_custom', true, false, array());
+		rXMLRPCRequest::queue('d.start', true, false, array(0));
+		rXMLRPCRequest::queue(array('d.get_state', 'd.is_open'), true, false, array(1, 1));
+
+		strictAssertSame(null, ruTrackerChecker::createTorrent('new-torrent', 'OLD'),
+			'a replacement without ratio groups must succeed without a view list read');
+		$keys = array_map(function($request) { return $request['key']; }, rXMLRPCRequest::$requests);
+		strictAssertTrue(!in_array('view_list', $keys, true),
+			'no ratio views were collected, so view.list must never be asked for: saw ' . implode(',', $keys));
+		strictAssertSame(array(), $this->membershipCommands(rTorrent::$lastSend['addition']),
+			'and no membership command can be emitted either');
 	}
 
 	public function testStoppedOpenReplacementUsesOpen()

--- a/tests/plugins/rutracker_check/TestLib.php
+++ b/tests/plugins/rutracker_check/TestLib.php
@@ -72,6 +72,37 @@ function strictAssertSame($expected, $actual, $message)
     }
 }
 
+// Every log line this plugin writes must be English. The UI text moved into
+// plugins/rutracker_check/lang/*.js (the plugin writes a chk-msg token and the
+// browser renders it), so what is left in PHP is log lines only, and the log is
+// read by whoever maintains the plugin rather than by the torrent's owner.
+// Plain printable ASCII is the check: it rejects Cyrillic prose without
+// pretending to judge grammar.
+function strictAssertEnglish($text, $message)
+{
+    strictAssertTrue(is_string($text) && $text !== '', $message . '; not a non-empty string');
+    strictAssertTrue(preg_match('/^[\x09\x20-\x7E]+$/', $text) === 1,
+        $message . '; log line is not plain-ASCII English: ' . $text);
+}
+
+// The recorded log lines containing $needle. Log assertions name the line they
+// mean rather than its index, so adding a diagnostic elsewhere in the same
+// flow cannot silently retarget an existing assertion.
+function strictLogsMatching($logs, $needle)
+{
+    return array_values(array_filter((array) $logs, function ($line) use ($needle) {
+        return strpos((string) $line, $needle) !== false;
+    }));
+}
+
+function strictAssertOneLogMatching($logs, $needle, $message)
+{
+    $matched = strictLogsMatching($logs, $needle);
+    strictAssertSame(1, count($matched), $message . '; expected exactly one line containing "'
+        . $needle . '", saw ' . var_export($logs, true));
+    return $matched[0];
+}
+
 function strictRemoveTree($path)
 {
     if (is_link($path) || is_file($path)) {


### PR DESCRIPTION

**Problem.** `buildReplacementAddition()` ends the load command list with
`view.set_visible=rat_N` for every ratio view the replaced torrent belonged
to. rTorrent's DownloadFactory executes that list in one try block, so the
first `torrent::input_error` — which `view.set_visible` throws for a view that
does not exist — silently skips every later load command plus rTorrent's own
`d.state.set` and `event.download.inserted_new`. And `rat_N` views are runtime
state: gone after any rTorrent restart until the ratio plugin recreates them.
A previously-started source is later rescued by `d.start`; a previously-stopped
one stays closed at state 0, and the `inserted_new` side effects (history
logging, the ratio plugin's hooks) are lost either way.

**Fix.** Memberships are forwarded in two tiers: a view confirmed against
`view.list` gets `view.set_visible` as before; an unconfirmed one gets
`d.views.push_back_unique` — it never throws, records the membership in the
`d.views` attribute so the ratio plugin's default-group insert hook (a branch
over `d.views.has`) does not re-home the replacement into the default group,
and the plugin's `correct()` pass restores visible membership once the views
exist again. The `view.list` read runs before the old torrent is stopped, so
the stopped-and-closed window does not grow; when the torrent belongs to no
ratio group there is no `view.list` round trip at all.

**How to verify.** Three CheckerTest cases pin the three shapes (confirmed /
mixed / unreadable list); against the pre-fix code, two of them fail.

**Tested.** Full suite clean on 8.1 and 8.5. The abort mechanics were verified
against rtorrent v0.16.19 sources (`download_factory.cc`, `command_ui.cc`,
`command_download.cc`) and `plugins/ratio/ratio.php`.
