### PR TITLE
history: stop logging rTorrent's magnet placeholder as a user event

### DIFF
--- a/plugins/history/history.php
+++ b/plugins/history/history.php
@@ -98,6 +98,22 @@ class rHistoryData
 		return(true);
 	}
 
+	// True for the placeholder rTorrent gives a magnet that has no metadata
+	// yet: it names such a download <INFOHASH>.meta and replaces it with the
+	// real one the moment the metainfo arrives. rTorrent::sendMagnet() hands
+	// the magnet straight to load/load_start, so this is what every magnet
+	// added through ruTorrent looks like for as long as the fetch takes --
+	// one magnet, an arrival and a removal of a torrent named after its own
+	// hash, neither of which the user did.
+	//
+	// The name is the whole test on purpose. An entry whose name merely ends
+	// in .meta, or a hash-named file with any other extension, is a real
+	// download and stays in the log.
+	static public function isMagnetPlaceholder( $name )
+	{
+		return(preg_match('/^[0-9A-Fa-f]{40}\.meta$/', (string) $name) === 1);
+	}
+
 	public function add( $e, $limit )
 	{
 		$e["action_time"] = time();

--- a/plugins/history/update.php
+++ b/plugins/history/update.php
@@ -32,12 +32,19 @@
 			"tracker"=>$tracker,
 			"label"=>rawurldecode($argv[11]),
 		);
-		if($mgr->log[$actions[$action]])
+		// A magnet placeholder is not the user's own event: neither record it
+		// nor notify about it. The notification is skipped for the same reason
+		// the row is -- a push about a torrent named after its own hash tells
+		// the user nothing they did.
+		if(!rHistoryData::isMagnetPlaceholder($data["name"]))
 		{
-			$hst->add( $data, $mgr->log["limit"] );
-		}
-		if($mgr->log['pushbullet_enabled'] && $mgr->log['pushbullet_'.$actions[$action]] && !$argv[12])
-		{
-			$mgr->pushBulletNotify( $data );
+			if($mgr->log[$actions[$action]])
+			{
+				$hst->add( $data, $mgr->log["limit"] );
+			}
+			if($mgr->log['pushbullet_enabled'] && $mgr->log['pushbullet_'.$actions[$action]] && !$argv[12])
+			{
+				$mgr->pushBulletNotify( $data );
+			}
 		}
 	}

--- a/tests/plugins/history/HistoryDataTest.php
+++ b/tests/plugins/history/HistoryDataTest.php
@@ -137,6 +137,34 @@ $tests = array(
         historyAssertSame('new', array_keys($ours->data)[0], 'the newest row is kept');
     },
 
+    // rTorrent names a magnet that has no metadata yet <INFOHASH>.meta and
+    // replaces that placeholder with the real download the moment metadata
+    // arrives, so every magnet the user adds logs an arrival and a removal
+    // nobody asked for. The hash is hex, so the pattern is case-insensitive on
+    // the letters and anchored on both ends: only a name that IS a placeholder
+    // qualifies, never one that merely looks related.
+    'magnet placeholders are recognised, real downloads are not' => function () {
+        $placeholders = array(
+            'an uppercase placeholder' => str_repeat('A', 40) . '.meta',
+            'a lowercase placeholder' => str_repeat('b', 40) . '.meta',
+            'a mixed-case placeholder' => str_repeat('cD', 20) . '.meta',
+        );
+        foreach ($placeholders as $label => $name)
+            historyAssertSame(true, rHistoryData::isMagnetPlaceholder($name), $label . ' must be recognised');
+
+        $real = array(
+            'a normal download' => 'Some Release 1080p',
+            'a name that merely ends in .meta' => 'metadata.meta',
+            'a hash-named file with another extension' => str_repeat('A', 40) . '.mkv',
+            'a hash-named directory with no extension' => str_repeat('A', 40),
+            'a placeholder name with something appended' => str_repeat('A', 40) . '.meta.part',
+            'a name one character short of a hash' => str_repeat('A', 39) . '.meta',
+            'a name with a non-hex character' => str_repeat('A', 39) . 'Z.meta',
+        );
+        foreach ($real as $label => $name)
+            historyAssertSame(false, rHistoryData::isMagnetPlaceholder($name), $label . ' must be kept');
+    },
+
     'the stored format carries nothing but what it always carried' => function () {
         $ours = historyLoaded(array('a' => historyRecord('a', 100)));
         historyRecordAddition($ours, historyRecord('b', 101), 500);


### PR DESCRIPTION
history: stop logging rTorrent's magnet placeholder as a user event

**Problem.** A magnet has no metainfo when it is added, so rTorrent names the
download `<INFOHASH>.meta` and swaps that placeholder for the real one once the
metadata arrives. `php/rtorrent.php::sendMagnet()` hands the magnet straight to
`load`/`load_start`, so this is what every magnet added through ruTorrent looks
like for as long as the fetch takes.

The history plugin hooks `on_insert`, `on_finished` and `on_erase` and passes
`d.get_name` to `update.php`, so it logs both halves of that swap. One magnet
writes an arrival *and* a removal of a torrent named after its own hash, and
fires a pushbullet notification for each. The removal is the misleading one:
nothing was deleted, the placeholder became the torrent. Each magnet costs
exactly two of these rows against the one real entry it produces.

**Fix.** `rHistoryData::isMagnetPlaceholder()` recognises the name, and
`update.php` skips the record and the notification together — a push about a
torrent named after its own hash is noise for the same reason the row is. The
name is the whole test: a name that merely ends in `.meta`, a hash-named file
with another extension, and a name one character short of a hash are all still
logged.

**How to verify.** Enable History with "added" and "deleted" logging, then add
any magnet link.
*Before:* three rows — `<40 hex chars>.meta` added, the same name deleted, then
the real torrent.
*After:* only the real torrent.

`HistoryDataTest` pins 3 placeholder shapes (upper, lower, mixed case) and 7
names that must survive, including `metadata.meta`, a hash with a `.mkv`
extension, and a name with a non-hex character.