### PR TITLE
feat:webui: give a finished partial download its own status 

### DIFF
--- a/js/category-list.js
+++ b/js/category-list.js
@@ -24,7 +24,10 @@ export class CategoryList {
       pstate: [
         (_, torrent) => [
           // Main group (Completed / Downloading / Stopped)
-          (torrent.done >= 1000)
+          // A torrent whose deselected files own at least one chunk outright
+          // never reaches done >= 1000 -- those chunks are never fetched -- so
+          // rTorrent's d.is_partially_done counts as completed here as well.
+          (torrent.done >= 1000 || torrent.partially_done == 1)
             ? "-_-_-com-_-_-" // Completed (even if error)
             : (torrent.state & this.dStatus.paused)
             ? "-_-_-wfa-_-_-" // Truly paused (Stopped)

--- a/js/content.js
+++ b/js/content.js
@@ -567,6 +567,16 @@ function correctContent()
 			"d.set_connection_seed"		: { name: "d.connection_seed.set", prm: 0 }
 		});
 	}
+	// rTorrent gained d.is_partially_done in 0.9.0. An unknown command faults the
+	// whole d.multicall rather than one field, so on older daemons route it to
+	// the harmless no-op "cat": it answers with an empty string, which keeps the
+	// field in place and reads as "not partially done". Firing at iVersion 0
+	// (daemon unreachable at load) is deliberate: cat is understood by every
+	// daemon generation, so an unknown version degrades safely.
+	if(theWebUI.systemInfo.rTorrent.iVersion<0x900)
+	{
+		theRequestManager.aliases["d.is_partially_done"] = { name: "cat", prm: 0 };
+	}
 	if(theWebUI.systemInfo.rTorrent.iVersion>=0x904)
 	{
 		$.extend(theRequestManager.aliases,

--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -30,7 +30,8 @@ var theRequestManager =
 			"d.get_custom1=", "d.get_peers_accounted=", "d.get_peers_not_connected=", "d.get_peers_connected=", "d.get_peers_complete=",
 			"d.get_left_bytes=", "d.get_priority=", "d.get_state_changed=", "d.get_skip_total=", "d.get_hashing=",
 			"d.get_chunks_hashed=", "d.get_base_path=", "d.get_creation_date=", "d.get_tracker_size=", "d.is_active=",
-			"d.get_message=", "d.get_custom2=", "d.get_free_diskspace=", "d.is_private=", "d.is_multi_file="
+			"d.get_message=", "d.get_custom2=", "d.get_free_diskspace=", "d.is_private=", "d.is_multi_file=",
+			"d.is_partially_done="
 		],
 		handlers: []
 	},
@@ -1096,6 +1097,7 @@ rTorrentStub.prototype.getalltrackersResponse = function(values)
  * @property {string} msg
  * @property {number} multi_file
  * @property {string} name
+ * @property {number} partially_done - 1 when every selected chunk is on disk, which a fully downloaded torrent also satisfies
  * @property {string} peers (format: "0 (0)")
  * @property {string} peers_actual - number with quotes (e.g.: "123")
  * @property {number} peers_all
@@ -1242,6 +1244,11 @@ rTorrentStub.prototype.listResponse = function(data)
 		torrent.free_diskspace = values[31];
 		torrent.private = values[32];
 		torrent.multi_file = iv(values[33]);
+		// 1 when every selected chunk is on disk. A fully downloaded torrent
+		// satisfies that too, so callers that mean "selected done but torrent
+		// incomplete" have to pair it with the percentage. iv() answers 0 for a
+		// missing value, so a daemon that does not send the field reads as 0.
+		torrent.partially_done = iv(values[34]);
 		torrent.seeds = torrent.seeds_actual + " (" + torrent.seeds_all + ")";
 		torrent.peers = torrent.peers_actual + " (" + torrent.peers_all + ")";
 		theRequestManager.onResponse('trt', [null].concat(values), hash, torrent);

--- a/js/webui.js
+++ b/js/webui.js
@@ -1804,6 +1804,14 @@ var theWebUI = {
 	{
 		var state = torrent.state;
 		var completed = torrent.done;
+		// rTorrent calls a download complete only when every chunk of the torrent
+		// is on disk, so a download whose deselected files own at least one chunk
+		// outright never gets there -- those chunks are never fetched.
+		// d.is_partially_done says every selected chunk is on disk -- true for a
+		// fully downloaded torrent as well, hence the percentage test -- and that
+		// is treated as complete wherever the status acts as a category. The
+		// percentage keeps counting the whole torrent, which is what is on disk.
+		var partial = (completed < 1000) && (torrent.partially_done == 1);
 		var icon = "", status = "";
 		if(state & dStatus.checking)
 		{
@@ -1827,8 +1835,9 @@ var theWebUI = {
 				}
 				else
 				{
-					icon = (completed == 1000) ? "Status_Up" : "Status_Down";
-					status = (completed == 1000) ? theUILang.Seeding : theUILang.Downloading;
+					icon = ((completed == 1000) || partial) ? "Status_Up" : "Status_Down";
+					status = (completed == 1000) ? theUILang.Seeding :
+						(partial ? theUILang.PartialSeed : theUILang.Downloading);
 				}
 			}
 		}
@@ -1842,7 +1851,7 @@ var theWebUI = {
 			else
 				icon = "Status_Error";
 		}
-		if((completed == 1000) && (status == ""))
+		if(((completed == 1000) || partial) && (status == ""))
 		{
 			if(icon=="")
 				icon = "Status_Completed";

--- a/lang/bn.js
+++ b/lang/bn.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "ফাইলটি অবশ্যই একটি .torrent ফাইল হতে হবে।",
  Pausing			: "Pausing",
  Seeding			: "Seeding",
+ PartialSeed			: "আংশিক Seeding",
  Downloading			: "ডাউনলোড হচ্ছে",
  Checking			: "চেকিং",
  Error				: "এরর",

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "Tento soubor není torrent.",
  Pausing			: "Pozastaveno",
  Seeding			: "Seeduji",
+ PartialSeed			: "Seeduji částečně",
  Downloading			: "Stahování",
  Checking			: "Kontroluji",
  Error				: "Chyba",

--- a/lang/da.js
+++ b/lang/da.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "Filen skal være en .torrent fil.",
  Pausing			: "Pausing",
  Seeding			: "Seeding",
+ PartialSeed			: "Delvis seeding",
  Downloading			: "Downloading",
  Checking			: "Checking",
  Error				: "Fejl",

--- a/lang/de.js
+++ b/lang/de.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "Die Datei ist keine torrent-Datei.",
  Pausing			: "Angehalten",
  Seeding			: "Seeden",
+ PartialSeed			: "Teilweises Seeden",
  Downloading			: "Download",
  Checking			: "Uberprüfe",
  Error				: "Fehler",

--- a/lang/el.js
+++ b/lang/el.js
@@ -58,6 +58,7 @@ var theUILang =
  Not_torrent_file		: "Το αρχείο πρέπει να είναι τύπου .torrent.",
  Pausing			: "Γίνεται παύση",
  Seeding			: "Διαμοιρασμός",
+ PartialSeed			: "Μερικός διαμοιρασμός",
  Downloading			: "Σε λήψη",
  Checking			: "Γίνεται έλεγχος",
  Error				: "Σφάλμα",

--- a/lang/en.js
+++ b/lang/en.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "The file must be a .torrent file.",
  Pausing			: "Pausing",
  Seeding			: "Seeding",
+ PartialSeed			: "Partial seed",
  Downloading			: "Downloading",
  Checking			: "Checking",
  Error				: "Error",

--- a/lang/es.js
+++ b/lang/es.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "El archivo debe ser un torrent válido.",
  Pausing			: "Pausando",
  Seeding			: "Compartiendo",
+ PartialSeed			: "Compartiendo parcialmente",
  Downloading			: "Descargando",
  Checking			: "Comprobando",
  Error				: "Error",

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "Tiedoston täytyy olla torrent-tiedosto.",
  Pausing			: "Tauko",
  Seeding			: "Jakaa",
+ PartialSeed			: "Jakaa osittain",
  Downloading			: "Lataa",
  Checking			: "Tarkistetaan",
  Error				: "Virhe",

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "Le fichier doit être un torrent",
  Pausing			: "Pause",
  Seeding			: "Envoi",
+ PartialSeed			: "Envoi partiel",
  Downloading			: "Téléchargement",
  Checking			: "Vérification",
  Error				: "Erreur",

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "A fájlnak .torrent fájlnak kell lennie.",
  Pausing			: "Felfüggesztve",
  Seeding			: "Feltölt",
+ PartialSeed			: "Részlegesen feltölt",
  Downloading			: "Letölt",
  Checking			: "Ellenőrzés alatt",
  Error				: "Hiba",

--- a/lang/it.js
+++ b/lang/it.js
@@ -61,6 +61,7 @@ var theUILang =
  Not_torrent_file		: "Il file deve essere un torrent.",
  Pausing			: "In pausa",
  Seeding			: "In seed",
+ PartialSeed			: "In seed parziale",
  Downloading			: "In Download",
  Checking			: "In Controllo",
  Error				: "Errore",

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -58,6 +58,7 @@ var theUILang =
  Not_torrent_file		: "반드시 .torrent 파일이어야 합니다.",
  Pausing			: "일시정지 중",
  Seeding			: "시딩 중",
+ PartialSeed			: "부분 시딩 중",
  Downloading			: "다운로드 중",
  Checking			: "검사 중",
  Error				: "오류",

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "Failam ir jābūt .torrent failam.",
  Pausing			: "Nopauzēts",
  Seeding			: "Dod",
+ PartialSeed			: "Dod daļēji",
  Downloading			: "Lejupielādē",
  Checking			: "Pārbauda",
  Error				: "Kļūda",

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "Dit is geen torrentbestand.",
  Pausing			: "Gepauzeerd",
  Seeding			: "Seeden",
+ PartialSeed			: "Deels seeden",
  Downloading			: "Downloaden",
  Checking			: "Controleren",
  Error				: "Fout",

--- a/lang/no.js
+++ b/lang/no.js
@@ -59,6 +59,7 @@ var theUILang =
  Not_torrent_file		: "Filen må være en gyldig .torrent-fil.",
  Pausing			: "Pause",
  Seeding			: "Seeder",
+ PartialSeed			: "Seeder delvis",
  Downloading			: "Laster ned",
  Checking			: "Kontrollerer",
  Error				: "Feil",

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -61,6 +61,7 @@ var theUILang =
  Not_torrent_file		: "Plik musi być plikiem .torrent",
  Pausing			: "Pauza",
  Seeding			: "Udostępnianie",
+ PartialSeed			: "Częściowe udostępnianie",
  Downloading			: "Pobieranie",
  Checking			: "Sprawdzanie",
  Error				: "Błąd",

--- a/lang/pt-br.js
+++ b/lang/pt-br.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "O arquivo deve ser um torrent válido.",
  Pausing			: "Pausado",
  Seeding			: "Semeando",
+ PartialSeed			: "Semeando parcialmente",
  Downloading			: "Baixando",
  Checking			: "Verificando",
  Error				: "Erro",

--- a/lang/pt-pt.js
+++ b/lang/pt-pt.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "O ficheiro deve ser um torrent válido.",
  Pausing			: "Pausado",
  Seeding			: "Semeando",
+ PartialSeed			: "Semeando parcialmente",
  Downloading			: "Descarregando",
  Checking			: "Verificando",
  Error				: "Erro",

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "Файл должен быть файлом .torrent.",
  Pausing			: "Пауза",
  Seeding			: "Сидирование",
+ PartialSeed			: "Частичное сидирование",
  Downloading			: "Скачивание",
  Checking			: "Проверка",
  Error				: "Ошибка",

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "Súbor musí byť torrent súbor.",
  Pausing			: "Pauza",
  Seeding			: "Seedujem",
+ PartialSeed			: "Čiastočne seedujem",
  Downloading			: "Sťahujem",
  Checking			: "Kontrolujem",
  Error				: "Chyba",

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -58,6 +58,7 @@ var theUILang =
  Not_torrent_file		: "Датотека мора бити torrent датотека.",
  Pausing			: "Заустављено",
  Seeding			: "Сејање",
+ PartialSeed			: "Делимично сејање",
  Downloading			: "Низтоварање",
  Checking			: "Проверавање",
  Error				: "Грешка",

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -58,6 +58,7 @@ var theUILang =
  Not_torrent_file		: "Filen måste vara en .torrent-fil",
  Pausing			: "Pausad",
  Seeding			: "Seedar",
+ PartialSeed			: "Seedar delvis",
  Downloading			: "Laddar ner",
  Checking			: "Kontrollerar",
  Error				: "Fel",

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "Bu dosya bir .torrent dosyası değil.",
  Pausing			: "Duraklatılıyor",
  Seeding			: "Seed ediliyor",
+ PartialSeed			: "Kısmen seed ediliyor",
  Downloading			: "İndiriliyor",
  Checking			: "Kontrol ediliyor",
  Error				: "Hata",

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "Файл повинен бути файлом .torrent.",
  Pausing			: "Пауза",
  Seeding			: "Роздача",
+ PartialSeed			: "Часткова роздача",
  Downloading			: "Завантаження",
  Checking			: "Перевірка",
  Error				: "Помилка",

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -58,6 +58,7 @@ var theUILang =
  Not_torrent_file		: "Tập tin phải là tập tin torrent.",
  Pausing			: "Đang tạm dừng",
  Seeding			: "Đang làm nguồn",
+ PartialSeed			: "Đang làm nguồn một phần",
  Downloading			: "Đang tải",
  Checking			: "Đang kiểm tra",
  Error				: "Xảy ra lỗi",

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -60,6 +60,7 @@ var theUILang =
  Not_torrent_file		: "该文件不是有效的 torrent 文件.",
  Pausing			: "暂停中",
  Seeding			: "做种中",
+ PartialSeed			: "部分做种中",
  Downloading			: "下载中",
  Checking			: "校验中",
  Error				: "错误",

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -58,6 +58,7 @@ var theUILang =
  Not_torrent_file		: "該檔案不是有效的 torrent 檔案",
  Pausing			: "暫停中",
  Seeding			: "做種中",
+ PartialSeed			: "部分做種中",
  Downloading			: "下載中",
  Checking			: "檢查中",
  Error				: "錯誤",

--- a/php/methods-pre-0.9.0.php
+++ b/php/methods-pre-0.9.0.php
@@ -1,0 +1,10 @@
+<?php
+
+// rTorrent gained d.is_partially_done in 0.9.0. An unknown command faults the
+// whole d.multicall rather than one field, so on older daemons route it to the
+// harmless no-op "cat": it answers with an empty string, which keeps the field
+// in place and reads as "not partially done".
+
+$this->aliases = array_merge($this->aliases,array(
+"d.is_partially_done"	=>	array( "name"=>"cat", "prm"=>0 ),
+));

--- a/php/settings.php
+++ b/php/settings.php
@@ -204,6 +204,10 @@ class rTorrentSettings
 				if($req->success())
 					$this->iVersion=0x809;
 			}
+			if($this->iVersion<0x900)
+			{
+				require_once( 'methods-pre-0.9.0.php' );
+			}
 			if($this->iVersion>=0x904)
 			{
 				require_once( 'methods-0.9.4.php' );

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -185,7 +185,8 @@ switch($mode)
 			"d.get_custom1=", "d.get_peers_accounted=", "d.get_peers_not_connected=", "d.get_peers_connected=", "d.get_peers_complete=",
 			"d.get_left_bytes=", "d.get_priority=", "d.get_state_changed=", "d.get_skip_total=", "d.get_hashing=",
 			"d.get_chunks_hashed=", "d.get_base_path=", "d.get_creation_date=", "d.get_tracker_size=", "d.is_active=",
-			"d.get_message=", "d.get_custom2=", "d.get_free_diskspace=", "d.is_private=", "d.is_multi_file="
+			"d.get_message=", "d.get_custom2=", "d.get_free_diskspace=", "d.is_private=", "d.is_multi_file=",
+			"d.is_partially_done="
 			);
 		$cmd = new rXMLRPCCommand( "d.multicall", "main" );
 		$cmd->addParameters( array_map("getCmd", $cmds) );

--- a/plugins/mobile/init.js
+++ b/plugins/mobile/init.js
@@ -1813,10 +1813,13 @@ plugin.dynamicSort = function (property) {
 
 // Only the fields the torrent row rendering depends on; comparing these
 // (instead of whole torrent objects) avoids redrawing rows whose visible
-// content didn't change
+// content didn't change. partially_done is a render input too: statusClass
+// and the status text key on it, and it can flip with every other field
+// unchanged (file priorities edited from another client on an idle torrent).
 plugin.rowSnapshot = function(v) {
   return {name: v.name, size: v.size, label: v.label, state: v.state, done: v.done,
-    ul: v.ul, dl: v.dl, eta: v.eta, ratio: v.ratio, msg: v.msg};
+    ul: v.ul, dl: v.dl, eta: v.eta, ratio: v.ratio, msg: v.msg,
+    partially_done: v.partially_done};
 };
 
 // Scroll the list to a torrent's row and flash it with the accent
@@ -1892,7 +1895,7 @@ plugin.processTorrents = function(torrents, singleUpdate) {
       // Mirrors the desktop state panel grouping (see js/category-list.js),
       // except that any transfer counts as active (the desktop ignores
       // rates below 1 KiB/s)
-      var statusClass = (v.done >= 1000) ? 'Completed' : ((v.state & dStatus.paused) || !(v.state & dStatus.started)) ? 'Stopped' : 'Downloading';
+      var statusClass = (v.done >= 1000 || v.partially_done == 1) ? 'Completed' : ((v.state & dStatus.paused) || !(v.state & dStatus.started)) ? 'Stopped' : 'Downloading';
       var stateClass = (v.state & dStatus.started) ? ((v.dl > 0 || v.ul > 0) ? 'Active' : 'Inactive') : 'None';
       var errorClass = (v.state & dStatus.error) ? 'Yes' : 'No';
       var percent = v.done / 10;

--- a/plugins/scheduler/init.js
+++ b/plugins/scheduler/init.js
@@ -54,7 +54,10 @@ if(plugin.canChangeMenu() && (theWebUI.systemInfo.rTorrent.iVersion >= 0x805))
 	{
 		for(var i=0; i<this.hashes.length; i++)
 		{
-			var needRestart = (theWebUI.torrents[this.hashes[i]].status==theUILang.Seeding) || (theWebUI.torrents[this.hashes[i]].status==theUILang.Downloading);
+			// A partial seed is a running torrent too: its selected files are done
+			// but it keeps uploading, so a throttle change has to cycle it.
+			var torrentStatus = theWebUI.torrents[this.hashes[i]].status;
+			var needRestart = (torrentStatus==theUILang.Seeding) || (torrentStatus==theUILang.PartialSeed) || (torrentStatus==theUILang.Downloading);
 			if(needRestart)
 			{
 				var cmd = new rXMLRPCCommand('d.stop');

--- a/tests/js/category-list.spec.js
+++ b/tests/js/category-list.spec.js
@@ -42,6 +42,7 @@ const listAttribs = () => ({
       pstate_all: { icon: "all", text: "All", selected: true },
       "-_-_-dls-_-_-": { icon: "down", text: "Downloading" },
       "-_-_-com-_-_-": { icon: "completed", text: "Finished" },
+      "-_-_-wfa-_-_-": { icon: "inactive", text: "Stopped" },
       "-_-_-act-_-_-": { icon: "up-down", text: "Active" },
       "-_-_-iac-_-_-": { icon: "incompleted", text: "Inactive" },
       "-_-_-err-_-_-": { icon: "error", text: "Error" },
@@ -194,5 +195,24 @@ describe("Category list", () => {
     expect(search1Attribs.count).toBe("3");
     expect(search1Attribs.size).toBeNull(); // since show_statelabelsize is false
     expect(search1Attribs.prefix).toBe(undefined);
+  });
+
+  it("groups a finished partial download with the completed torrents", () => {
+    list.config(listSettings);
+    const torrents = {
+      AA: { label: "", name: "partial started", state: 1, size: 1, ul: 0, dl: 0, done: 180, partially_done: 1 },
+      BB: { label: "", name: "partial stopped", state: 0, size: 1, ul: 0, dl: 0, done: 180, partially_done: 1 },
+      CC: { label: "", name: "plain downloading", state: 1, size: 1, ul: 0, dl: 0, done: 180, partially_done: 0 },
+      DD: { label: "", name: "plain stopped", state: 0, size: 1, ul: 0, dl: 0, done: 180 },
+      EE: { label: "", name: "fully done", state: 1, size: 1, ul: 0, dl: 0, done: 1000, partially_done: 0 },
+    };
+    for (const [hash, torrent] of Object.entries(torrents)) {
+      list.statistic.scan(hash, torrent);
+    }
+    list.syncAfterScan();
+
+    expect(list.panelLabelAttribs.pstate.get("-_-_-com-_-_-").count).toBe("3");
+    expect(list.panelLabelAttribs.pstate.get("-_-_-dls-_-_-").count).toBe("1");
+    expect(list.panelLabelAttribs.pstate.get("-_-_-wfa-_-_-").count).toBe("1");
   });
 });

--- a/tests/js/rtorrent.spec.js
+++ b/tests/js/rtorrent.spec.js
@@ -192,6 +192,29 @@ describe("xmlrpc calls", () => {
     });
   });
 
+  it("routes d.is_partially_done to a no-op below rTorrent 0.9.0", () => {
+    withRtorrentVersion(0x809, () => {
+      expect(theRequestManager.map("d.is_partially_done=")).toBe("cat=");
+    });
+    withRtorrentVersion(0x900, () => {
+      expect(theRequestManager.map("d.is_partially_done=")).toBe(
+        "d.is_partially_done="
+      );
+    });
+    withRtorrentVersion(0x1014, () => {
+      expect(theRequestManager.map("d.is_partially_done=")).toBe(
+        "d.is_partially_done="
+      );
+    });
+    // 0 is the sentinel php/getplugins.php emits while the daemon is
+    // unreachable. The alias covers it on purpose: cat is understood by every
+    // daemon generation, so an unknown version degrades to the no-op instead
+    // of risking a faulted multicall.
+    withRtorrentVersion(0, () => {
+      expect(theRequestManager.map("d.is_partially_done=")).toBe("cat=");
+    });
+  });
+
   it("should parse getprops response", () => {
     const stub = new rTorrentStub(`?action=getprops&hash=${h("A")}`);
     //console.log(stub.content);
@@ -310,6 +333,18 @@ describe("xmlrpc calls", () => {
       expect(ret.torrents[hash].label).toBe(label);
       expect(ret.torrents[hash].comment).toBe(comment);
     }
+  });
+
+  it("reads the partially done flag from the list response", () => {
+    const stub = new rTorrentStub("?list=1");
+    const ret = stub.getResponse(loadXML(stub.action));
+    expect(ret.torrents[h("A")].partially_done).toBe(0);
+    // B is the fixture's partial seed: incomplete (done 500) yet every
+    // selected chunk on disk. Without one such torrent the flag could be
+    // derived from done alone and the suite would not notice.
+    expect(ret.torrents[h("B")].partially_done).toBe(1);
+    expect(ret.torrents[h("C")].partially_done).toBe(0);
+    expect(ret.torrents[h("D")].partially_done).toBe(1);
   });
 });
 

--- a/tests/js/webui-status-icon.spec.js
+++ b/tests/js/webui-status-icon.spec.js
@@ -1,0 +1,105 @@
+import { readFileSync } from "fs";
+
+window.$ = require("jquery");
+
+function loadWebUI() {
+  // theUILang answers every key with the key itself, so a status assertion
+  // names the language key it expects rather than one language's wording.
+  window.theUILang = new Proxy({}, { get: (_target, prop) => prop });
+  window.theFormatter = {};
+  window.TYPE_STRING = "string";
+  window.TYPE_NUMBER = "number";
+  window.TYPE_PROGRESS = "progress";
+  window.TYPE_PEERS = "peers";
+  window.TYPE_SEEDS = "seeds";
+  window.ALIGN_RIGHT = "right";
+  window.dxSTable = function () {};
+  window.rSpeedGraph = function () {};
+  window.rSpeedGraph.prototype.addData = jest.fn();
+  window.Timer = function () {};
+  window.dStatus = { started: 1, paused: 2, checking: 4, hashing: 8, error: 16 };
+
+  let code = readFileSync("../js/webui.js", { encoding: "utf-8" });
+  code = code.replace(
+    /\n\$\(document\)\.ready\(function\(\)\n\{[\s\S]*?\n\}\);\s*$/,
+    ""
+  );
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = code;
+  document.body.appendChild(scriptEl);
+}
+
+describe("getStatusIcon", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    loadWebUI();
+  });
+
+  it("calls a started torrent with its selected files done a partial seed", () => {
+    expect(
+      theWebUI.getStatusIcon({ state: 1, done: 180, partially_done: 1 })
+    ).toEqual(["Status_Up", "PartialSeed"]);
+  });
+
+  it("treats a stopped partially downloaded torrent like a stopped completed one", () => {
+    expect(
+      theWebUI.getStatusIcon({ state: 0, done: 180, partially_done: 1 })
+    ).toEqual(["Status_Completed", "Finished"]);
+  });
+
+  it("leaves an ordinary incomplete torrent downloading", () => {
+    expect(
+      theWebUI.getStatusIcon({ state: 1, done: 180, partially_done: 0 })
+    ).toEqual(["Status_Down", "Downloading"]);
+  });
+
+  it("leaves an ordinary incomplete stopped torrent stopped", () => {
+    expect(
+      theWebUI.getStatusIcon({ state: 0, done: 180, partially_done: 0 })
+    ).toEqual(["Status_Incompleted", "Stopped"]);
+  });
+
+  it("leaves a fully downloaded torrent seeding and completed", () => {
+    expect(
+      theWebUI.getStatusIcon({ state: 1, done: 1000, partially_done: 0 })
+    ).toEqual(["Status_Up", "Seeding"]);
+    expect(
+      theWebUI.getStatusIcon({ state: 0, done: 1000, partially_done: 0 })
+    ).toEqual(["Status_Completed", "Finished"]);
+  });
+
+  it("keeps a fully downloaded torrent seeding, though the daemon calls it partially done too", () => {
+    // d.is_partially_done answers "every selected chunk is on disk", which a
+    // complete torrent satisfies as well -- live rTorrent 0.16.20 returns 1 for
+    // every completed torrent. Only the percentage separates the two cases.
+    expect(
+      theWebUI.getStatusIcon({ state: 1, done: 1000, partially_done: 1 })
+    ).toEqual(["Status_Up", "Seeding"]);
+    expect(
+      theWebUI.getStatusIcon({ state: 0, done: 1000, partially_done: 1 })
+    ).toEqual(["Status_Completed", "Finished"]);
+  });
+
+  it("falls back to the old behaviour when the daemon sends no value", () => {
+    expect(theWebUI.getStatusIcon({ state: 1, done: 180 })).toEqual([
+      "Status_Down",
+      "Downloading",
+    ]);
+    expect(theWebUI.getStatusIcon({ state: 0, done: 180 })).toEqual([
+      "Status_Incompleted",
+      "Stopped",
+    ]);
+  });
+
+  it("gives an errored partial seed the upload error icon", () => {
+    expect(
+      theWebUI.getStatusIcon({ state: 1 | 16, done: 180, partially_done: 1 })
+    ).toEqual(["Status_Error_Up", "PartialSeed"]);
+  });
+
+  it("keeps checking ahead of everything else", () => {
+    expect(
+      theWebUI.getStatusIcon({ state: 1 | 4, done: 180, partially_done: 1 })
+    ).toEqual(["Status_Checking", "Checking"]);
+  });
+});

--- a/tests/php/RtorrentCompatibilityTest.php
+++ b/tests/php/RtorrentCompatibilityTest.php
@@ -15,9 +15,11 @@ class RtorrentCompatibilityTest extends TestCase
 	 */
 	private function methodFileGates()
 	{
+		// This fork carries one downlevel gate (methods-pre-0.9.0.php loads
+		// under iVersion < 0x900), so both comparison directions are parsed.
 		$source = file_get_contents(__DIR__ . '/../../php/settings.php');
 		preg_match_all(
-			'/if\s*\(\s*\$this->iVersion\s*>=\s*(0x[0-9A-Fa-f]+)\s*\)\s*\{\s*require_once\(\s*\'(methods-[^\']+\.php)\'\s*\);/',
+			'/if\s*\(\s*\$this->iVersion\s*(>=|<)\s*(0x[0-9A-Fa-f]+)\s*\)\s*\{\s*require_once\(\s*\'(methods-[^\']+\.php)\'\s*\);/',
 			$source,
 			$matches,
 			PREG_SET_ORDER
@@ -27,7 +29,7 @@ class RtorrentCompatibilityTest extends TestCase
 		}
 		$gates = array();
 		foreach ($matches as $match) {
-			$gates[] = array('version' => intval($match[1], 16), 'file' => $match[2]);
+			$gates[] = array('op' => $match[1], 'version' => intval($match[2], 16), 'file' => $match[3]);
 		}
 		return $gates;
 	}
@@ -40,7 +42,10 @@ class RtorrentCompatibilityTest extends TestCase
 		$settings->aliases = [];
 
 		foreach ($this->methodFileGates() as $gate) {
-			if ($version >= $gate['version']) {
+			$applies = ($gate['op'] === '>=')
+				? ($version >= $gate['version'])
+				: ($version < $gate['version']);
+			if ($applies) {
 				$this->loadMethodAliases($settings, $gate['file']);
 			}
 		}
@@ -186,6 +191,18 @@ class RtorrentCompatibilityTest extends TestCase
 			}
 			$this->assertEquals('system.sockets.max_size', $settings->getCommand('get_max_open_sockets'), 'rTorrent '.$label.' reads the generic socket ceiling without removed allocation commands');
 			$this->assertEquals('system.sockets.files.max_alloc.set', $settings->getCommand('set_max_open_files'), 'rTorrent '.$label.' keeps the file-category allocation setter');
+		}
+	}
+
+	public function testPartiallyDoneCommandIsANoOpBelowRtorrent090()
+	{
+		$settings = $this->makeSettings(0x809);
+		$this->assertEquals('cat', $settings->getCommand('d.is_partially_done'), 'rTorrent 0.8.9 answers the partially done question with the no-op cat');
+		$this->assertEquals('cat=', $settings->getCommand('d.is_partially_done='), 'the no-op keeps the trailing = so the multicall field stays in place');
+
+		foreach (array(0x900 => '0.9.0', 0x908 => '0.9.8', 0x1014 => '0.16.20') as $version => $label) {
+			$settings = $this->makeSettings($version);
+			$this->assertEquals('d.is_partially_done', $settings->getCommand('d.is_partially_done'), 'rTorrent '.$label.' asks the daemon directly');
 		}
 	}
 }

--- a/tests/plugins/mobile/partial-seed.spec.js
+++ b/tests/plugins/mobile/partial-seed.spec.js
@@ -1,0 +1,65 @@
+import { readFileSync } from "fs";
+
+window.$ = window.jQuery = require("jquery");
+
+window.theUILang = {
+  Name: "Name", Status: "Status", Size: "Size", Uploaded: "Uploaded",
+  Downloaded: "Downloaded", Done: "Done", ETA: "ETA", Ul_speed: "UL",
+  Down_speed: "DL", Ratio: "Ratio", addTime: "Added", seedingTime: "Seeding",
+};
+
+window.theWebUI = {
+  settings: {},
+  requestWithoutTimeout: function (url, callback) {
+    callback({});
+  },
+  save: function () {},
+};
+
+// $type and friends come from the core, as they do in the browser
+const coreEl = document.createElement("script");
+coreEl.textContent = readFileSync("../js/common.js", { encoding: "utf-8" });
+document.body.appendChild(coreEl);
+
+let code = readFileSync("../plugins/mobile/init.js", { encoding: "utf-8" });
+// The takeover call at the end of the file needs the whole desktop UI; this
+// spec exercises the row snapshot helper, a plain assignment above it
+code = code.replace(/plugin\.disableOthers\(\);\s*$/, "");
+const scriptEl = document.createElement("script");
+scriptEl.textContent = `(function () { var plugin = {}; plugin.path = "../plugins/mobile/"; ${code} })();`;
+document.body.appendChild(scriptEl);
+
+const plugin = window.mobile;
+
+// A torrent as processTorrents() sees it, with only the fields the snapshot
+// reads. Everything else is held constant so the flag is the sole variable.
+function row(overrides) {
+  return Object.assign({
+    hash: "A".repeat(40), name: "Some Release 1080p", size: 1024, label: "",
+    state: 1, done: 500, ul: 0, dl: 0, eta: -1, ratio: 0, msg: "",
+    partially_done: 0,
+  }, overrides);
+}
+
+describe("mobile plugin, partial seeds", () => {
+  // The list redraws a row only when its snapshot changed. partially_done
+  // drives both the status text and the status class, and it can flip while
+  // every other snapshotted field stays put -- file priorities edited from
+  // another client on an idle torrent -- so a snapshot that omitted it would
+  // leave the row showing the old status until something else moved.
+  it("keeps the partially done flag in the row snapshot", () => {
+    const before = plugin.rowSnapshot(row({ partially_done: 0 }));
+    const after = plugin.rowSnapshot(row({ partially_done: 1 }));
+
+    expect(before).toHaveProperty("partially_done", 0);
+    expect(after).toHaveProperty("partially_done", 1);
+    expect(after).not.toEqual(before);
+  });
+
+  it("ignores fields the row does not render", () => {
+    const before = plugin.rowSnapshot(row({ seedingtime: "100" }));
+    const after = plugin.rowSnapshot(row({ seedingtime: "200" }));
+
+    expect(after).toEqual(before);
+  });
+});

--- a/tests/xml-responses/list.xml
+++ b/tests/xml-responses/list.xml
@@ -38,6 +38,7 @@
 <value><i8>111111111111</i8></value>
 <value><i8>1</i8></value>
 <value><i8>1</i8></value>
+<value><i8>0</i8></value>
 </data></array></value>
 <value><array><data>
 <value><string>BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB</string></value>
@@ -75,6 +76,7 @@
 <value><i8>111111111111</i8></value>
 <value><i8>1</i8></value>
 <value><i8>0</i8></value>
+<value><i8>1</i8></value>
 </data></array></value>
 <value><array><data>
 <value><string>CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC</string></value>
@@ -111,6 +113,7 @@
 <value><string>some comment</string></value>
 <value><i8>222222222222</i8></value>
 <value><i8>1</i8></value>
+<value><i8>0</i8></value>
 <value><i8>0</i8></value>
 </data></array></value>
 <value><array><data>
@@ -149,6 +152,7 @@
 <value><i8>111111111111</i8></value>
 <value><i8>1</i8></value>
 <value><i8>0</i8></value>
+<value><i8>1</i8></value>
 </data></array></value>
 </data></array></value></param>
 </params>


### PR DESCRIPTION
**Problem.** rTorrent calls a download complete only when *every* chunk is on
disk, so a torrent whose deselected files own at least one chunk outright never
qualifies — those chunks are never fetched. Once everything the user selected
has arrived, ruTorrent still says **Downloading** forever: zero speed, nothing
left to fetch, and the row never leaves the downloading group or reaches
Completed. The status was derived from the percentage alone, and the percentage
counts the whole torrent.

**Fix.** The daemon already answers the other question — `d.is_partially_done`
reports whether every *selected* chunk is on disk — ruTorrent just never asked.
It is requested as the last field of the list multicall on both sides of the
mirror and exposed as `torrent.partially_done`. A started torrent whose selected
files are complete gets the seeding icon, a status of its own (**Partial seed**,
the term BEP 21 uses for this peer) and membership in the completed category; a
stopped one is treated as a stopped completed torrent, an errored one gets the
upload error icon. The scheduler compares status text against Seeding and
Downloading to decide whether a throttle change must stop and restart a torrent,
so it gets the new term too. The displayed percentage is deliberately untouched:
it keeps counting the whole torrent, so the progress column and Remaining still
show what is missing.

`d.is_partially_done` arrived in 0.9.0, and an unknown command faults the whole
`d.multicall` rather than one field, so `php/methods-pre-0.9.0.php` routes it to
the no-op `cat` on older daemons — the field keeps its position and reads as 0.

**How to verify.** Add a multi-file torrent, deselect some files, let the
selected ones finish.
*Before:* the row shows **Downloading** with 0 B/s forever, stays in the
Downloading group and never appears under Completed.
*After:* it shows **Partial seed** with the seeding icon and sits with the
completed torrents; the percentage still reads below 100 %.

Test-side, each claim is pinned and was verified by mutation — every one of
these turns exactly one test red:

| mutation | result |
|---|---|
| derive the flag from the percentage (`done < 1000 ? 0 : …`) — i.e. make the feature dead code | 1 failed |
| drop `partially_done` from the mobile row snapshot | 1 failed |
| stop the alias gate covering the `iVersion 0` sentinel | 1 failed |

**Tested.** PHP suite 70 `ok` on 8.1 and 8.5; jest 17 suites / 178 tests, all
green. The 397-torrent observation in the commit message comes from a live
rTorrent 0.16.20.

**Note for review.** The new `php/methods-pre-0.9.0.php` is the repository's
first *ceiling* gate (`if($this->iVersion<0x900)`); `RtorrentCompatibilityTest`'s
gate parser was extended to read both comparison directions so the file is
replayed like any other.