### PR TITLE
harden: executing non-constant commands in env_check.php...

### DIFF
--- a/env_check.php
+++ b/env_check.php
@@ -127,17 +127,17 @@ foreach (array(
 }
 
 // ---- Recommended external programs ---------------------------------------
-if (fn_available('exec', $disabled)) {
-	foreach (array(
-		'php'  => 'runs plugin helper scripts scheduled by rtorrent (_task, autotools, ...)',
-		'curl' => 'used by some plugins',
-		'gzip' => 'response compression',
-	) as $prog => $why) {
-		$path = @exec('command -v ' . escapeshellarg($prog) . ' 2>/dev/null');
-		check('rec', !empty($path), "program: $prog", $path ? "found at $path" : $why);
+foreach (array(
+	'php'  => 'runs plugin helper scripts scheduled by rtorrent (_task, autotools, ...)',
+	'curl' => 'used by some plugins',
+	'gzip' => 'response compression',
+) as $prog => $why) {
+	$path = '';
+	foreach (explode(':', (string)getenv('PATH')) as $dir) {
+		$f = rtrim($dir, '/') . '/' . $prog;
+		if ($dir !== '' && @is_file($f) && @is_executable($f)) { $path = $f; break; }
 	}
-} else {
-	check('rec', false, 'external programs', 'exec() is disabled -- cannot check for php/curl/gzip; some plugins may not work');
+	check('rec', !empty($path), "program: $prog", $path ? "found at $path" : $why);
 }
 
 // ---- Load ruTorrent config (best effort) ---------------------------------


### PR DESCRIPTION
## Summary
Harden input handling in `env_check.php` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | php.lang.security.exec-use.exec-use |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `php.lang.security.exec-use.exec-use` |
| **File** | `env_check.php:136` |
| **Assessment** | Defensive hardening |

**Description**: Executing non-constant commands. This can lead to command injection.

## Changes
- `env_check.php`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
