### PR TITLE
Harden the XMLRPC proxy's load parameter handling

### DIFF
--- a/php/xmlrpc_proxy.php
+++ b/php/xmlrpc_proxy.php
@@ -33,6 +33,18 @@ class XMLRPCProxy
 	}
 
 	/**
+	 * Make a client-supplied value safe to put in a log line: one line, and
+	 * short enough that it cannot push the rest of the entry out of view.
+	 */
+	private static function logValue($value)
+	{
+		$value = str_replace(array("\r", "\n", "\t"), ' ', (string)$value);
+		if(strlen($value) > 120)
+			$value = substr($value, 0, 120).'...';
+		return $value;
+	}
+
+	/**
 	 * Parse untrusted XMLRPC XML with entity loading disabled.
 	 *
 	 * PHP 8+ libxml2 defaults external-entity loading off; PHP 7.x does
@@ -56,7 +68,7 @@ class XMLRPCProxy
 	 * @param string $rawData     Raw XMLRPC XML from the client
 	 * @param string $mode        "off", "passthrough_unsafe", or "sanitize"
 	 * @param bool   $enableLog   Enable/disable logging
-	 * @param array  $safeParams  Whitelisted command prefixes for load.* params
+	 * @param array  $safeParams  Command names allowed as load.* params, matched exactly
 	 * @return string|null        SCGI response, or null on rejection
 	 */
 	public static function process($rawData, $mode = 'sanitize', $enableLog = true, $safeParams = array())
@@ -88,30 +100,82 @@ class XMLRPCProxy
 		if(in_array($methodName, self::$sanitizeMethods, true))
 		{
 			$rebuilt = self::rebuildLoadParams($xml, $methodName, $safeParams);
+
+			// Trusted only when every parameter was rebuilt from parts this
+			// side parsed. Anything carried over verbatim goes untrusted, so
+			// rtorrent still applies its own command restrictions to it.
+			$trusted = $rebuilt['rebuiltAll'];
+
+			$state = $trusted ? "trusted" : "untrusted (a parameter could not be rebuilt)";
 			if(count($rebuilt['stripped']) > 0)
-				self::log("sanitized: ".$methodName." (kept ".$rebuilt['kept']." params, stripped: ".implode(', ', $rebuilt['stripped']).")");
+			{
+				$stripped = array();
+				foreach($rebuilt['stripped'] as $value)
+					$stripped[] = self::logValue($value);
+				self::log($state.": ".$methodName." (kept ".$rebuilt['kept']." params, stripped: ".implode(', ', $stripped).")");
+			}
 			else
-				self::log("trusted: ".$methodName." (".$rebuilt['kept']." params)");
-			return rXMLRPCRequest::send($rebuilt['xml'], true);
+				self::log($state.": ".$methodName." (".$rebuilt['kept']." params)");
+
+			return rXMLRPCRequest::send($rebuilt['xml'], $trusted);
 		}
 
 		// Unknown method — pass through as untrusted.
 		// rtorrent's own whitelist will allow/reject.
-		self::log("untrusted: ".$methodName);
+		self::log("untrusted: ".self::logValue($methodName));
 		return rXMLRPCRequest::send($rawData, false);
 	}
 
 	/**
-	 * Check if a load.* command parameter matches the safe-prefix whitelist.
+	 * Rebuild one load.* command parameter, or return null to drop it.
+	 *
+	 * A parameter is not a single command: rtorrent ends a command at ';' or a
+	 * newline and calls a parenthesised (command,args) found in a value, so a
+	 * string that merely begins with an allowed command can carry others. The
+	 * command name is therefore compared for equality, and each argument is
+	 * quoted so that whatever it contains stays an argument.
+	 *
+	 * Arguments are split on ',' first, exactly as rtorrent would split them,
+	 * so a command that takes several keeps them, and each is trimmed as
+	 * rtorrent trims an unquoted argument.
+	 *
+	 * Values are taken literally: a client sends d.custom1.set=Movies, Inc,
+	 * not a pre-quoted d.custom1.set="Movies, Inc", since the quoting is added
+	 * here and a quote in the value is escaped rather than interpreted.
 	 */
-	private static function isSafeLoadParam($paramValue, $safeParams)
+	private static function rebuildSafeLoadParam($paramValue, $safeParams)
 	{
-		foreach($safeParams as $prefix)
+		$separator = strpos($paramValue, '=');
+		if($separator === false)
+			return null;
+
+		$command = trim(substr($paramValue, 0, $separator));
+		if(!in_array($command, $safeParams, true))
+			return null;
+
+		$arguments = array();
+		foreach(explode(',', substr($paramValue, $separator + 1)) as $argument)
 		{
-			if(strpos($paramValue, $prefix) === 0)
-				return true;
+			// rtorrent trims an unquoted argument, so trim before anything else
+			// is decided about it — quoting a trimmed value must not turn a
+			// leading space into a leading '$'.
+			$argument = trim($argument);
+
+			// An argument whose first character is '$' is parsed and called as a
+			// command after quoting is undone, so quoting cannot make it safe.
+			if(isset($argument[0]) && $argument[0] === '$')
+				return null;
+
+			// A client that quoted the value itself gets dropped and logged
+			// rather than quietly mangled: the quoting is added here, and the
+			// split would fall inside the client's quotes.
+			if(isset($argument[0]) && $argument[0] === '"')
+				return null;
+
+			$arguments[] = '"'.str_replace(array('\\', '"'), array('\\\\', '\\"'), $argument).'"';
 		}
-		return false;
+
+		return $command.'='.implode(',', $arguments);
 	}
 
 	/**
@@ -120,7 +184,7 @@ class XMLRPCProxy
 	 * Handles both the typed form <value><string>foo</string></value> and
 	 * the implicit-string form <value>foo</value>. For non-string types
 	 * (<int>, <base64>) the raw text is returned; it simply won't match
-	 * any whitelist prefix and will be stripped — safe default.
+	 * any allowed command name and will be stripped — safe default.
 	 */
 	private static function extractParamValue($paramElement)
 	{
@@ -134,13 +198,16 @@ class XMLRPCProxy
 	 *
 	 *   Param 0: target           (always kept)
 	 *   Param 1: URL or raw data  (always kept)
-	 *   Param 2+: command strings (kept iff prefix-matches the whitelist,
-	 *                              otherwise stripped)
+	 *   Param 2+: command strings (kept iff the command name is in the
+	 *                              whitelist, otherwise stripped)
 	 *
 	 * Public for unit testing — production callers should go through
 	 * process().
 	 *
-	 * @return array ['xml' => string, 'kept' => int, 'stripped' => array]
+	 * @return array ['xml' => string, 'kept' => int, 'stripped' => array,
+	 *                'rebuiltAll' => bool] — rebuiltAll is false when any
+	 *               parameter had to be carried over verbatim, which means
+	 *               the call must not be sent as trusted.
 	 */
 	public static function rebuildLoadParams($xml, $methodName, $safeParams = array())
 	{
@@ -151,6 +218,8 @@ class XMLRPCProxy
 		$kept = 0;
 		$stripped = array();
 
+		$rebuiltAll = true;
+
 		if(isset($xml->params->param))
 		{
 			$index = 0;
@@ -158,16 +227,27 @@ class XMLRPCProxy
 			{
 				if($index < 2)
 				{
-					// Always keep target and URL/data
-					$cleanXml .= '<param>' . $param->value->asXML() . '</param>';
+					// Target and URL/data are values, never commands, but they
+					// are re-emitted rather than copied so that what was read
+					// and what is sent are the same bytes.
+					$payload = self::rebuildDataParam($param->value);
+					if($payload === null)
+					{
+						$payload = '<param>' . $param->value->asXML() . '</param>';
+						$rebuiltAll = false;
+					}
+					$cleanXml .= $payload;
 					$kept++;
 				}
 				else
 				{
 					$value = self::extractParamValue($param->value);
-					if(self::isSafeLoadParam($value, $safeParams))
+					$rebuiltParam = self::rebuildSafeLoadParam($value, $safeParams);
+					if($rebuiltParam !== null)
 					{
-						$cleanXml .= '<param>' . $param->value->asXML() . '</param>';
+						$cleanXml .= '<param><value><string>'
+							. htmlspecialchars($rebuiltParam, ENT_NOQUOTES, 'UTF-8')
+							. '</string></value></param>';
 						$kept++;
 					}
 					else
@@ -181,6 +261,33 @@ class XMLRPCProxy
 
 		$cleanXml .= '</params></methodCall>';
 
-		return array('xml' => $cleanXml, 'kept' => $kept, 'stripped' => $stripped);
+		return array('xml' => $cleanXml, 'kept' => $kept, 'stripped' => $stripped,
+			'rebuiltAll' => $rebuiltAll);
+	}
+
+	/**
+	 * Re-emit a target or URL/data parameter from its own content, keeping the
+	 * type the client used. Returns null for a type this side cannot rebuild,
+	 * which makes the whole request go untrusted.
+	 */
+	private static function rebuildDataParam($paramElement)
+	{
+		if(isset($paramElement->base64))
+		{
+			$decoded = base64_decode((string)$paramElement->base64, true);
+			if($decoded === false)
+				return null;
+			return '<param><value><base64>'.base64_encode($decoded).'</base64></value></param>';
+		}
+
+		if(isset($paramElement->string) || count($paramElement->children()) === 0)
+		{
+			$text = isset($paramElement->string) ? (string)$paramElement->string : (string)$paramElement;
+			return '<param><value><string>'
+				. htmlspecialchars($text, ENT_NOQUOTES, 'UTF-8')
+				. '</string></value></param>';
+		}
+
+		return null;
 	}
 }

--- a/plugins/httprpc/conf.php
+++ b/plugins/httprpc/conf.php
@@ -4,6 +4,9 @@
 // Options:
 //   "sanitize"           — (default) allow load.* with safe params only,
 //                          pass other methods as untrusted
+// Passing a method as untrusted only restricts it on rtorrent 0.16.10 and
+// later, which is where the UNTRUSTED_CONNECTION header is honoured. Older
+// versions ignore it and run those calls with full trust.
 //   "passthrough_unsafe" — send all raw XMLRPC as trusted (DANGEROUS)
 //   "off"                — reject all raw XMLRPC pass-through
 $XMLRPCProxy = "sanitize";
@@ -13,11 +16,13 @@ $XMLRPCProxy = "sanitize";
 // external client integration issues.
 $XMLRPCProxyLog = true;
 
-// Command prefixes allowed as load.* parameters in sanitize mode.
+// Command names allowed as load.* parameters in sanitize mode.
 // External clients (Prowlarr, Sonarr, Radarr, Transdroid) attach these
 // to load.start to set labels, directories, priorities, etc.
-// Any command param not matching these prefixes will be stripped.
-// Add entries here if your external client needs additional commands.
+// Entries are full command names and are matched exactly: 'd.custom' does
+// NOT cover 'd.custom1.set'. A param whose command name is not listed is
+// stripped and logged. Add entries here if your external client needs
+// additional commands.
 $XMLRPCProxySafeParams = array(
 	'd.custom1.set',            // label
 	'd.custom2.set',            // custom field

--- a/tests/php/XMLRPCProxyTest.php
+++ b/tests/php/XMLRPCProxyTest.php
@@ -95,7 +95,8 @@ class XMLRPCProxyTest extends TestCase
 		$result = XMLRPCProxy::rebuildLoadParams($xml, 'load.start', array('d.directory.set', 'd.custom1.set'));
 		$this->assertEquals(3, $result['kept'], 'should keep target + URL + safe param');
 		$this->assertEquals(0, count($result['stripped']), 'should strip nothing');
-		$this->assertTrue(strpos($result['xml'], 'd.directory.set=/srv/torrents') !== false, 'safe param survives');
+		$this->assertTrue(strpos($result['xml'], 'd.directory.set="/srv/torrents"') !== false,
+			'safe param survives, rebuilt as a quoted argument');
 	}
 
 	public function testSanitizeAlwaysKeepsFirstTwoParams()
@@ -144,5 +145,239 @@ class XMLRPCProxyTest extends TestCase
 		$this->assertTrue(!in_array('execute', $methods), 'execute NOT in sanitize list');
 		$this->assertTrue(!in_array('system.multicall', $methods), 'system.multicall NOT in sanitize list');
 		$this->assertTrue(!in_array('execute2', $methods), 'execute2 NOT in sanitize list');
+	}
+
+	// ---- A command parameter is not one command ----
+
+	private function sanitizeParam($param, $safeParams = array('d.custom1.set', 'd.custom2.set', 'd.custom.set'))
+	{
+		$this->resetMocks();
+		$xml = '<?xml version="1.0"?><methodCall><methodName>load.raw_start</methodName><params>'
+			. '<param><value><string></string></value></param>'
+			. '<param><value><string>http://example.test/x.torrent</string></value></param>'
+			. '<param><value><string>' . htmlspecialchars($param, ENT_NOQUOTES) . '</string></value></param>'
+			. '</params></methodCall>';
+		XMLRPCProxy::process($xml, 'sanitize', false, $safeParams);
+		return (string) rXMLRPCRequest::$lastPayload;
+	}
+
+	public function testChainedCommandIsNotForwarded()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set=A;d.custom2.set=(execute.capture,/bin/sh,-c,id)');
+		// The ';' and everything after it end up inside the first argument.
+		$this->assertTrue(strpos($sent, 'd.custom1.set="A;d.custom2.set=(execute.capture"') !== false,
+			'a chained command is forwarded as text inside an argument, not as a command');
+	}
+
+	public function testNestedCommandValueIsQuoted()
+	{
+		$sent = $this->sanitizeParam('d.custom2.set=(execute.capture,/bin/sh,-c,id)');
+		$this->assertTrue(strpos($sent, 'd.custom2.set="(execute.capture"') !== false,
+			'a parenthesised value must be forwarded quoted, as an argument');
+	}
+
+	public function testCommandNameMustMatchExactly()
+	{
+		$sent = $this->sanitizeParam('d.custom1.setEVIL=x;d.custom2.set=(execute.capture,/bin/sh,-c,"id")');
+		$this->assertTrue(strpos($sent, 'custom1.setEVIL') === false, 'a command that merely starts with an allowed name is dropped');
+		$this->assertTrue(strpos($sent, 'execute.capture') === false, 'and its payload goes with it');
+	}
+
+	public function testParameterWithoutSeparatorIsDropped()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set');
+		$this->assertTrue(strpos($sent, 'd.custom1.set') === false, 'a parameter with no = is dropped');
+	}
+
+	// ---- and the values clients legitimately send still arrive ----
+
+	public function testValueKeepsCharactersThatUsedToBreakIt()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set=Movies (2024)');
+		$this->assertTrue(strpos($sent, 'd.custom1.set="Movies (2024)"') !== false,
+			'parentheses and spaces survive as a quoted argument');
+	}
+
+	public function testQuotesAndBackslashesAreEscaped()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set=say "hi" \\ bye');
+		$this->assertTrue(strpos($sent, '\\"hi\\"') !== false, 'a quote in the value is escaped, not closing the argument');
+	}
+
+	public function testMultipleArgumentsArePreserved()
+	{
+		$sent = $this->sanitizeParam('d.custom.set=chk-state,7');
+		$this->assertTrue(strpos($sent, 'd.custom.set="chk-state","7"') !== false,
+			'a command taking two arguments still gets two');
+	}
+
+	// ---- trust ----
+
+	public function testRebuiltRequestIsTrusted()
+	{
+		$this->sanitizeParam('d.custom1.set=label');
+		$this->assertTrue(rXMLRPCRequest::$lastTrusted === true, 'a fully rebuilt request may be trusted');
+	}
+
+	public function testRequestIsUntrustedWhenAParamCannotBeRebuilt()
+	{
+		$this->resetMocks();
+		// An <int> target is a type this side does not rebuild.
+		$xml = '<?xml version="1.0"?><methodCall><methodName>load.raw_start</methodName><params>'
+			. '<param><value><int>1</int></value></param>'
+			. '<param><value><string>http://example.test/x.torrent</string></value></param>'
+			. '</params></methodCall>';
+		XMLRPCProxy::process($xml, 'sanitize', false, array('d.custom1.set'));
+		$this->assertTrue(rXMLRPCRequest::$lastTrusted === false,
+			'anything not rebuilt here is forwarded untrusted, for rtorrent to judge');
+	}
+
+	public function testDollarPrefixedArgumentIsDropped()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set=$execute.capture=/bin/hostname');
+		$this->assertTrue(strpos($sent, 'execute.capture') === false,
+			'an argument that would be re-parsed as a command is dropped, not quoted');
+	}
+
+	public function testDollarPrefixedSecondArgumentIsDropped()
+	{
+		$sent = $this->sanitizeParam('d.custom.set=key,$execute.capture=/bin/hostname');
+		$this->assertTrue(strpos($sent, 'execute.capture') === false,
+			'every argument is checked, not only the first');
+	}
+
+	public function testDollarInsideAValueIsKept()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set=cost 20$ or so');
+		$this->assertTrue(strpos($sent, 'd.custom1.set="cost 20$ or so"') !== false,
+			'only a leading $ is special, so ordinary values keep theirs');
+	}
+
+	// ---- what the log says ----
+
+	private function logText()
+	{
+		return implode("\n", FileUtil::$log);
+	}
+
+	public function testUntrustedRequestIsNeverLoggedAsTrusted()
+	{
+		$this->resetMocks();
+		// An <int> target is a type this side does not rebuild, so nothing is
+		// stripped but the call still cannot be trusted.
+		$xml = '<?xml version="1.0"?><methodCall><methodName>load.raw_start</methodName><params>'
+			. '<param><value><int>1</int></value></param>'
+			. '<param><value><string>http://example.test/x.torrent</string></value></param>'
+			. '</params></methodCall>';
+		XMLRPCProxy::process($xml, 'sanitize', true, array('d.custom1.set'));
+
+		$this->assertTrue(rXMLRPCRequest::$lastTrusted === false, 'the call is sent untrusted');
+		foreach(FileUtil::$log as $line)
+			$this->assertTrue(strpos($line, 'xmlrpc-proxy: trusted') !== 0,
+				'a request sent untrusted is never logged as trusted');
+		$this->assertTrue(strpos($this->logText(), 'untrusted') !== false, 'and it is logged as untrusted');
+	}
+
+	public function testStrippedValueCannotForgeALogLine()
+	{
+		$this->resetMocks();
+		$this->sanitizeParamLogged("execute=evil\nxmlrpc-proxy: trusted: load.raw_start (2 params)");
+		$this->assertTrue(strpos($this->logText(), "\nxmlrpc-proxy: trusted") === false,
+			'a newline in a stripped value cannot start a new log entry');
+	}
+
+	public function testLoggedValueIsLengthCapped()
+	{
+		$this->resetMocks();
+		$this->sanitizeParamLogged('execute=' . str_repeat('A', 500));
+		$this->assertTrue(strlen($this->logText()) < 400, 'a long stripped value is truncated');
+	}
+
+	private function sanitizeParamLogged($param)
+	{
+		$xml = '<?xml version="1.0"?><methodCall><methodName>load.raw_start</methodName><params>'
+			. '<param><value><string></string></value></param>'
+			. '<param><value><string>http://example.test/x.torrent</string></value></param>'
+			. '<param><value><string>' . htmlspecialchars($param, ENT_NOQUOTES) . '</string></value></param>'
+			. '</params></methodCall>';
+		XMLRPCProxy::process($xml, 'sanitize', true, array('d.custom1.set'));
+	}
+
+	// ---- shapes rtorrent itself accepts ----
+
+	public function testWhitespaceAroundTheCommandNameIsAccepted()
+	{
+		$this->assertTrue(strpos($this->sanitizeParam(' d.custom1.set=x'), 'd.custom1.set="x"') !== false,
+			'a leading space does not hide the command name');
+		$this->assertTrue(strpos($this->sanitizeParam('d.custom1.set =x'), 'd.custom1.set="x"') !== false,
+			'nor does a space before the =');
+	}
+
+	public function testArgumentsAreTrimmedAsRtorrentTrimsThem()
+	{
+		$this->assertTrue(strpos($this->sanitizeParam('d.custom.set=chk-state, 7'), 'd.custom.set="chk-state","7"') !== false,
+			'an unquoted argument is trimmed, matching what rtorrent stores');
+	}
+
+	public function testDollarIsCheckedAfterTrimming()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set= $execute.capture=/bin/hostname');
+		$this->assertTrue(strpos($sent, 'execute.capture') === false,
+			'trimming must not quote a leading space into a leading $');
+	}
+
+	// ---- parameter forms ----
+
+	public function testImplicitStringParamFormIsRead()
+	{
+		$this->resetMocks();
+		$xml = '<?xml version="1.0"?><methodCall><methodName>load.raw_start</methodName><params>'
+			. '<param><value><string></string></value></param>'
+			. '<param><value><string>http://example.test/x.torrent</string></value></param>'
+			. '<param><value>d.custom1.set=label</value></param>'
+			. '</params></methodCall>';
+		XMLRPCProxy::process($xml, 'sanitize', false, array('d.custom1.set'));
+		$this->assertTrue(strpos((string) rXMLRPCRequest::$lastPayload, 'd.custom1.set="label"') !== false,
+			'a value without an explicit <string> is read the same way');
+	}
+
+	public function testBase64DataParamIsRebuiltAndStillTrusted()
+	{
+		$this->resetMocks();
+		$data = str_repeat("torrent-bytes\x00\xc8", 20);
+		$xml = '<?xml version="1.0"?><methodCall><methodName>load.raw_start</methodName><params>'
+			. '<param><value><string></string></value></param>'
+			. '<param><value><base64>' . chunk_split(base64_encode($data), 76, "\n") . '</base64></value></param>'
+			. '<param><value><string>d.custom1.set=label</string></value></param>'
+			. '</params></methodCall>';
+		XMLRPCProxy::process($xml, 'sanitize', false, array('d.custom1.set'));
+		$sent = (string) rXMLRPCRequest::$lastPayload;
+
+		$this->assertTrue(preg_match('#<base64>(.*?)</base64>#s', $sent, $m) === 1, 'the data param is still base64');
+		$this->assertTrue(base64_decode($m[1], true) === $data, 'and it carries the same bytes, wrapping removed');
+		$this->assertTrue(rXMLRPCRequest::$lastTrusted === true, 'a rebuilt base64 param does not force the call untrusted');
+	}
+
+	public function testPreQuotedValueIsDroppedNotMangled()
+	{
+		$this->resetMocks();
+		$this->sanitizeParamLogged('d.custom1.set="Movies, Inc"');
+		$this->assertTrue(strpos((string) rXMLRPCRequest::$lastPayload, 'd.custom1.set') === false,
+			'a value the client quoted itself is dropped, not split inside its quotes');
+		$this->assertTrue(strpos($this->logText(), 'stripped') !== false,
+			'and the drop is visible in the log');
+	}
+
+	public function testUnknownMethodNameCannotForgeALogLine()
+	{
+		$this->resetMocks();
+		$name = "system.foo\nxmlrpc-proxy: trusted: forged";
+		$xml = '<?xml version="1.0"?><methodCall><methodName>' . htmlspecialchars($name)
+			. '</methodName><params></params></methodCall>';
+		XMLRPCProxy::process($xml, 'sanitize', true, array());
+
+		$this->assertTrue(rXMLRPCRequest::$lastTrusted === false, 'an unknown method is sent untrusted');
+		$this->assertTrue(strpos($this->logText(), "\nxmlrpc-proxy: trusted") === false,
+			'a method name cannot start a log line of its own');
 	}
 }


### PR DESCRIPTION
Command parameters are rebuilt from the parsed command name and quoted arguments rather than prefix-matched and copied through, the command name is compared for equality against the configured list, and the request is forwarded on a trusted connection only when every parameter was rebuilt here. An argument whose first character is '$' is dropped rather than quoted, since rtorrent re-parses and calls such a string after quoting is undone.

The command name and each argument are trimmed, matching what rtorrent does with an unquoted argument, so the shapes it accepts still work. An argument the client quoted itself is dropped and logged rather than re-quoted, since the split would fall inside the client's quotes; clients send values raw.

Values clients could not send before now arrive intact: a label with spaces and parentheses, or one containing a quote, used to be dropped.

Client-supplied text reaching the log is flattened to one line and capped, so a stripped parameter or an unknown method name cannot write a log line of its own. conf.php notes that passing a method as untrusted only restricts it on rtorrent 0.16.10 and later.

Note for anyone who edited $XMLRPCProxySafeParams: entries are now matched as whole command names, so an entry written as a prefix ('d.custom' meant to cover d.custom1.set and friends) no longer matches and those parameters are stripped, with a line in the log. List the command names in full. The shipped defaults are already full names and are unaffected.