### PR TITLE
Separate the XMLRPC proxy decision from the sending of it

### DIFF
--- a/php/xmlrpc_proxy.php
+++ b/php/xmlrpc_proxy.php
@@ -9,10 +9,15 @@
  *                          payload as trusted; pass unknown methods as
  *                          untrusted (rtorrent whitelist decides)
  *
- * Dependencies (loaded by the production caller before non-"off" modes):
+ * process() applies the policy and sends the result; decide() applies it and
+ * returns the result, for a caller that owns its own connection to rtorrent.
+ *
+ * Dependencies of process() (loaded by the production caller before non-"off"
+ * modes):
  *   php/util.php    — FileUtil::toLog
  *   php/xmlrpc.php  — rXMLRPCRequest::send
  * (Both are required by plugins/httprpc/action.php, the production caller.)
+ * decide() has none.
  */
 
 class XMLRPCProxy
@@ -75,25 +80,45 @@ class XMLRPCProxy
 	{
 		self::$log = $enableLog;
 
-		if($mode === 'off')
-		{
-			self::log("rejected (proxy disabled)");
+		$decision = self::decide($rawData, $mode, $safeParams);
+
+		foreach($decision['log'] as $line)
+			self::log($line);
+
+		if($decision['action'] !== 'send')
 			return null;
-		}
+
+		return rXMLRPCRequest::send($decision['payload'], $decision['trusted']);
+	}
+
+	/**
+	 * Decide what to do with a raw XMLRPC payload, without acting on it.
+	 *
+	 * Same policy as process(), separated from the sending and the logging so
+	 * that a caller holding its own connection to rtorrent can apply it —
+	 * ruTorrent's SCGI plumbing needs the settings bootstrap, and an endpoint
+	 * whose whole job is to filter one request should not have to carry that.
+	 *
+	 * @param string $rawData     Raw XMLRPC XML from the client
+	 * @param string $mode        "off", "passthrough_unsafe", or "sanitize"
+	 * @param array  $safeParams  Command names allowed as load.* params, matched exactly
+	 * @return array  'action'  => "send" or "reject"
+	 *                'payload' => the bytes to send, empty when rejecting
+	 *                'trusted' => whether the connection carrying them may be trusted
+	 *                'log'     => what happened, in the order it happened
+	 */
+	public static function decide($rawData, $mode = 'sanitize', $safeParams = array())
+	{
+		if($mode === 'off')
+			return self::reject("rejected (proxy disabled)");
 
 		if($mode === 'passthrough_unsafe')
-		{
-			self::log("passthrough (UNSAFE mode)");
-			return rXMLRPCRequest::send($rawData, true);
-		}
+			return self::forward($rawData, true, "passthrough (UNSAFE mode)");
 
 		// sanitize mode
 		$xml = self::parseXml($rawData);
 		if($xml === false || !isset($xml->methodName))
-		{
-			self::log("untrusted (invalid XML)");
-			return rXMLRPCRequest::send($rawData, false);
-		}
+			return self::forward($rawData, false, "untrusted (invalid XML)");
 
 		$methodName = (string)$xml->methodName;
 
@@ -112,18 +137,29 @@ class XMLRPCProxy
 				$stripped = array();
 				foreach($rebuilt['stripped'] as $value)
 					$stripped[] = self::logValue($value);
-				self::log($state.": ".$methodName." (kept ".$rebuilt['kept']." params, stripped: ".implode(', ', $stripped).")");
+				$line = $state.": ".$methodName." (kept ".$rebuilt['kept']." params, stripped: ".implode(', ', $stripped).")";
 			}
 			else
-				self::log($state.": ".$methodName." (".$rebuilt['kept']." params)");
+				$line = $state.": ".$methodName." (".$rebuilt['kept']." params)";
 
-			return rXMLRPCRequest::send($rebuilt['xml'], $trusted);
+			return self::forward($rebuilt['xml'], $trusted, $line);
 		}
 
 		// Unknown method — pass through as untrusted.
 		// rtorrent's own whitelist will allow/reject.
-		self::log("untrusted: ".self::logValue($methodName));
-		return rXMLRPCRequest::send($rawData, false);
+		return self::forward($rawData, false, "untrusted: ".self::logValue($methodName));
+	}
+
+	private static function forward($payload, $trusted, $line)
+	{
+		return array('action' => 'send', 'payload' => $payload,
+			'trusted' => $trusted, 'log' => array($line));
+	}
+
+	private static function reject($line)
+	{
+		return array('action' => 'reject', 'payload' => '',
+			'trusted' => false, 'log' => array($line));
 	}
 
 	/**

--- a/tests/php/XMLRPCProxyContractFixture.php
+++ b/tests/php/XMLRPCProxyContractFixture.php
@@ -1,0 +1,412 @@
+<?php
+
+// The observable result of XMLRPCProxy::process() for every branch it has:
+// what it returned, what it sent, on what trust, and what it logged.
+//
+// Generated from the implementation, then frozen. It is not a description of
+// what the proxy should do — the suite next to it covers that — it is a record
+// of what it does, so that a change to how the decision is reached shows up
+// here if it changes the decision.
+
+return array(
+	"off mode rejects and sends nothing" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"mode" => "off",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => null,
+		"sends" => 0,
+		"trusted" => null,
+		"payload" => null,
+		"log" => array(
+			"xmlrpc-proxy: rejected (proxy disabled)",
+		),
+	),
+	"off mode rejects a body that is not XML" => array(
+		"request" => "not xml at all",
+		"mode" => "off",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => null,
+		"sends" => 0,
+		"trusted" => null,
+		"payload" => null,
+		"log" => array(
+			"xmlrpc-proxy: rejected (proxy disabled)",
+		),
+	),
+	"passthrough_unsafe forwards the body verbatim, trusted" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>execute</methodName><params><param><value><string>id</string></value></param></params></methodCall>",
+		"mode" => "passthrough_unsafe",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\"?><methodCall><methodName>execute</methodName><params><param><value><string>id</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: passthrough (UNSAFE mode)",
+		),
+	),
+	"a body that is not XML is forwarded untrusted" => array(
+		"request" => "not xml at all",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => false,
+		"payload" => "not xml at all",
+		"log" => array(
+			"xmlrpc-proxy: untrusted (invalid XML)",
+		),
+	),
+	"a methodCall with no methodName is forwarded untrusted" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><params></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => false,
+		"payload" => "<?xml version=\"1.0\"?><methodCall><params></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: untrusted (invalid XML)",
+		),
+	),
+	"an unknown method is forwarded untrusted" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>system.client_version</methodName><params></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => false,
+		"payload" => "<?xml version=\"1.0\"?><methodCall><methodName>system.client_version</methodName><params></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: untrusted: system.client_version",
+		),
+	),
+	"a newline in an unknown method name cannot forge a log line" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>system.foo\nxmlrpc-proxy: trusted: forged</methodName><params></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => false,
+		"payload" => "<?xml version=\"1.0\"?><methodCall><methodName>system.foo\nxmlrpc-proxy: trusted: forged</methodName><params></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: untrusted: system.foo xmlrpc-proxy: trusted: forged",
+		),
+	),
+	"load.start with an allowed command param is rebuilt and trusted" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=label</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=\"label\"</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (3 params)",
+		),
+	),
+	"load.start strips a command param that is not allowed" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>execute=evil</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (kept 2 params, stripped: execute=evil)",
+		),
+	),
+	"every stripped param is named in one log line" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>execute=evil</string></value></param><param><value><string>d.peers_max.set=1</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (kept 2 params, stripped: execute=evil, d.peers_max.set=1)",
+		),
+	),
+	"a param this side cannot rebuild forces the call untrusted" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.raw_start</methodName><params><param><value><int>1</int></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => false,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.raw_start</methodName><params><param><value><int>1</int></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: untrusted (a parameter could not be rebuilt): load.raw_start (2 params)",
+		),
+	),
+	"a base64 data param is re-emitted without its line wrapping" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.raw_start</methodName><params><param><value><string></string></value></param><param><value><base64>Ynl0ZXMAyGJ5dGVzAMhieXRlcwDIYnl0ZXMAyGJ5dGVzAMhieXRlcwDIYnl0ZXMAyGJ5dGVzAMg=\n</base64></value></param><param><value><string>d.custom1.set=label</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.raw_start</methodName><params><param><value><string></string></value></param><param><value><base64>Ynl0ZXMAyGJ5dGVzAMhieXRlcwDIYnl0ZXMAyGJ5dGVzAMhieXRlcwDIYnl0ZXMAyGJ5dGVzAMg=</base64></value></param><param><value><string>d.custom1.set=\"label\"</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.raw_start (3 params)",
+		),
+	),
+	"a value with no explicit string element is read the same way" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value>d.custom1.set=label</value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=\"label\"</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (3 params)",
+		),
+	),
+	"the 0.9.x method names take the same parameter positions" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load_start</methodName><params><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=label</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load_start</methodName><params><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=label</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load_start (2 params)",
+		),
+	),
+	"a command taking two arguments keeps both, each trimmed" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom.set=chk-state, 7</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom.set=\"chk-state\",\"7\"</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (3 params)",
+		),
+	),
+	"quotes and backslashes in a value are escaped, not dropped" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=say &quot;hi&quot; \\ bye</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=\"say \\\"hi\\\" \\\\ bye\"</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (3 params)",
+		),
+	),
+	"an argument starting with \$ is dropped rather than quoted" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=\$execute.capture=/bin/hostname</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (kept 2 params, stripped: d.custom1.set=\$execute.capture=/bin/hostname)",
+		),
+	),
+	"a value the client quoted itself is dropped" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=&quot;Movies, Inc&quot;</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (kept 2 params, stripped: d.custom1.set=\"Movies, Inc\")",
+		),
+	),
+	"a long stripped value is truncated in the log" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>execute=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (kept 2 params, stripped: execute=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...)",
+		),
+	),
+	"a newline in a stripped value cannot forge a log line" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>execute=evil\nxmlrpc-proxy: trusted: forged</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (kept 2 params, stripped: execute=evil xmlrpc-proxy: trusted: forged)",
+		),
+	),
+	"an empty allowlist strips every command param" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=label</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (kept 2 params, stripped: d.custom1.set=label)",
+		),
+	),
+	"a load call with no params at all is still rebuilt" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => true,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params></params></methodCall>",
+		"log" => array(
+			"xmlrpc-proxy: trusted: load.start (0 params)",
+		),
+	),
+	"logging off changes what is logged and nothing else" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>execute=evil</string></value></param></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => false,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => true,
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"log" => array(),
+	),
+	"logging off on the unknown-method path too" => array(
+		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>system.client_version</methodName><params></params></methodCall>",
+		"mode" => "sanitize",
+		"enableLog" => false,
+		"safeParams" => array(
+			"d.custom1.set",
+			"d.custom.set",
+			"d.directory.set",
+		),
+		"returned" => "SCGI-REPLY",
+		"sends" => 1,
+		"trusted" => false,
+		"payload" => "<?xml version=\"1.0\"?><methodCall><methodName>system.client_version</methodName><params></params></methodCall>",
+		"log" => array(),
+	),
+);

--- a/tests/php/XMLRPCProxyContractTest.php
+++ b/tests/php/XMLRPCProxyContractTest.php
@@ -1,0 +1,212 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+
+// The mocks stand in for what plugins/httprpc/action.php loads before calling
+// the proxy. The reply is a marker so the fixture can pin what process()
+// returns, not merely that it returned something.
+if(!class_exists('FileUtil'))
+{
+	class FileUtil
+	{
+		public static $log = array();
+		public static function toLog($msg) { self::$log[] = $msg; }
+	}
+}
+if(!class_exists('rXMLRPCRequest'))
+{
+	class rXMLRPCRequest
+	{
+		public static $lastPayload = null;
+		public static $lastTrusted = null;
+		public static $sent = 0;
+		public static function send($data, $trusted)
+		{
+			self::$lastPayload = $data;
+			self::$lastTrusted = $trusted;
+			self::$sent++;
+			return 'SCGI-REPLY';
+		}
+	}
+}
+
+require_once(__DIR__ . '/../../php/xmlrpc_proxy.php');
+
+/**
+ * process() is decide() plus a send. These tests exist to keep that a refactor:
+ * the fixture records what process() did before decide() was split out of it,
+ * and nothing here describes what the proxy ought to do — XMLRPCProxyTest
+ * covers that. If a change alters a decision, it shows up as a diff to the
+ * fixture, which is the point.
+ *
+ * Comparisons are identity, not equality: '' == null and 0 == false, and this
+ * suite is about bytes.
+ */
+class XMLRPCProxyContractTest extends TestCase
+{
+	private $cases = array();
+
+	public function setUp()
+	{
+		$this->cases = require(__DIR__ . '/XMLRPCProxyContractFixture.php');
+	}
+
+	private function callProcess($case)
+	{
+		FileUtil::$log = array();
+		rXMLRPCRequest::$lastPayload = null;
+		rXMLRPCRequest::$lastTrusted = null;
+		rXMLRPCRequest::$sent = 0;
+
+		$returned = XMLRPCProxy::process($case['request'], $case['mode'],
+			$case['enableLog'], $case['safeParams']);
+
+		return array(
+			'returned' => $returned,
+			'sends'    => rXMLRPCRequest::$sent,
+			'trusted'  => rXMLRPCRequest::$lastTrusted,
+			'payload'  => rXMLRPCRequest::$lastPayload,
+			'log'      => FileUtil::$log,
+		);
+	}
+
+	public function testFixtureCoversEveryBranch()
+	{
+		$this->assertTrue(count($this->cases) > 0, 'the contract fixture loaded');
+
+		$seen = array();
+		foreach($this->cases as $case)
+		{
+			if($case['sends'] === 0)
+				$seen['reject'] = true;
+			else if($case['trusted'] === true)
+				$seen['trusted'] = true;
+			else
+				$seen['untrusted'] = true;
+		}
+		$this->assertTrue(isset($seen['reject']), 'a rejected request is covered');
+		$this->assertTrue(isset($seen['trusted']), 'a trusted forward is covered');
+		$this->assertTrue(isset($seen['untrusted']), 'an untrusted forward is covered');
+	}
+
+	public function testProcessDoesExactlyWhatItDidBefore()
+	{
+		foreach($this->cases as $name => $case)
+		{
+			$actual = $this->callProcess($case);
+
+			$this->assertTrue($actual['returned'] === $case['returned'],
+				$name.' — returns the same thing');
+			$this->assertTrue($actual['sends'] === $case['sends'],
+				$name.' — sends the same number of times');
+			$this->assertTrue($actual['trusted'] === $case['trusted'],
+				$name.' — sends on the same trust');
+			$this->assertTrue($actual['payload'] === $case['payload'],
+				$name.' — sends the same bytes');
+			$this->assertTrue($actual['log'] === $case['log'],
+				$name.' — logs the same lines, in the same order');
+		}
+	}
+
+	public function testDecideReachesTheSameDecisionProcessActsOn()
+	{
+		foreach($this->cases as $name => $case)
+		{
+			$decision = XMLRPCProxy::decide($case['request'], $case['mode'],
+				$case['safeParams']);
+
+			$this->assertTrue($decision['action'] === (($case['sends'] === 1) ? 'send' : 'reject'),
+				$name.' — decides to send exactly when process() sent');
+
+			if($case['sends'] === 1)
+			{
+				$this->assertTrue($decision['payload'] === $case['payload'],
+					$name.' — decides on the same bytes');
+				$this->assertTrue($decision['trusted'] === $case['trusted'],
+					$name.' — decides on the same trust');
+			}
+			else
+			{
+				$this->assertTrue($decision['payload'] === '',
+					$name.' — a rejection carries no payload');
+				$this->assertTrue($decision['trusted'] === false,
+					$name.' — a rejection is never trusted');
+			}
+		}
+	}
+
+	public function testDecideSendsNothingItself()
+	{
+		foreach($this->cases as $name => $case)
+		{
+			rXMLRPCRequest::$sent = 0;
+			FileUtil::$log = array();
+
+			XMLRPCProxy::decide($case['request'], $case['mode'], $case['safeParams']);
+
+			$this->assertTrue(rXMLRPCRequest::$sent === 0,
+				$name.' — decide() reaches no socket');
+			$this->assertTrue(FileUtil::$log === array(),
+				$name.' — decide() writes no log of its own');
+		}
+	}
+
+	public function testDecideReportsItsReasoningWhateverLoggingIsSetTo()
+	{
+		foreach($this->cases as $name => $case)
+		{
+			$decision = XMLRPCProxy::decide($case['request'], $case['mode'],
+				$case['safeParams']);
+
+			// One line per decision, whether or not the caller wants it logged.
+			// The switch belongs to the caller, which is why the fixture has
+			// cases with logging off that still send identical bytes.
+			$this->assertTrue(count($decision['log']) === 1,
+				$name.' — reports exactly one line');
+
+			if($case['enableLog'])
+			{
+				$expected = array();
+				foreach($case['log'] as $line)
+					$expected[] = substr($line, strlen('xmlrpc-proxy: '));
+				$this->assertTrue($decision['log'] === $expected,
+					$name.' — reports what process() logged, without the prefix');
+			}
+		}
+	}
+
+	/**
+	 * The reason for the split: an endpoint that only needs to filter a request
+	 * should not have to load ruTorrent to do it. Checked in a fresh process,
+	 * because in this one the mocks above are already defined and would hide a
+	 * dependency rather than reveal it.
+	 */
+	public function testDecideRunsWithNothingElseLoaded()
+	{
+		if(!function_exists('exec') || (PHP_BINARY === ''))
+		{
+			// A host that forbids starting a process cannot answer this; say so
+			// rather than report a dependency that was never looked for.
+			$this->assertTrue(true, 'no second process available, dependency check not run');
+			return;
+		}
+
+		$proxy = realpath(__DIR__ . '/../../php/xmlrpc_proxy.php');
+		$this->assertTrue($proxy !== false, 'the proxy file is where the test expects it');
+
+		$script = 'require ' . var_export($proxy, true) . ';'
+			. '$d = XMLRPCProxy::decide("not xml at all", "sanitize", array());'
+			. 'echo $d["action"], "|", $d["trusted"] ? "trusted" : "untrusted", "|", $d["payload"];';
+
+		$output = array();
+		$status = 1;
+		@exec(escapeshellarg(PHP_BINARY) . ' -d error_reporting=E_ALL -d display_errors=1 -r '
+			. escapeshellarg($script) . ' 2>&1', $output, $status);
+
+		$this->assertTrue($status === 0,
+			'decide() runs with neither FileUtil nor rXMLRPCRequest defined: '
+			. implode(' / ', $output));
+		$this->assertTrue(implode("\n", $output) === 'send|untrusted|not xml at all',
+			'and reaches the same decision there');
+	}
+}


### PR DESCRIPTION
XMLRPCProxy::process() parses a request, decides what may be forwarded and on what trust, sends it and logs the outcome. Only the sending needs rXMLRPCRequest, and only the logging needs FileUtil, so the sanitizing is reachable only by a caller that can bring the whole settings bootstrap with it. Anything else fronting rtorrent has to reimplement the policy.

decide() now returns the payload, the trust to send it with, and one line describing why; process() is that plus the send and the log, so the plugin path is unchanged.

No behaviour changes. XMLRPCProxyContractFixture.php is generated from the implementation as it stood before the split and records, for every branch, what process() returned, what it sent, on what trust and what it logged; regenerating it from the code afterwards produces the same file. The suite compares by identity rather than equality, and a check in a second process proves decide() needs neither dependency loaded.