### PR TITLE
ratio: delete the data of downloads a ratio group erases

### DIFF
--- a/plugins/erasedata/erase.php
+++ b/plugins/erasedata/erase.php
@@ -1,0 +1,34 @@
+<?php
+
+// CLI entry point for "erase this download and delete its data", for callers
+// that run inside rtorrent and have no PHP context of their own -- the ratio
+// group commands built in plugins/ratio/ratio.php.
+//
+// Usage: php erase.php <hash> [force] [user]
+//   force: 1 = delete the download's own files (default), 2 = delete the whole
+//          base path, honoured only when $enableForceDeletion is on.
+//   user:  the ruTorrent user, on multi-user installs. Trails the other
+//          arguments because it is empty on a single-user install.
+//
+// The file list is read over RPC and recorded for the garbage collector before
+// the download is erased, which is the sequence the web UI's "Remove and delete
+// data" takes as well.
+
+$hash = isset($argv[1]) ? $argv[1] : "";
+$force = (isset($argv[2]) && ($argv[2] !== "")) ? $argv[2] : "1";
+$user = isset($argv[3]) ? $argv[3] : "";
+
+if(!preg_match('/^[0-9A-Fa-f]{40}$/', $hash))
+	exit(1);
+if($user !== "")
+	$_SERVER['REMOTE_USER'] = $user;
+
+require_once( dirname(__FILE__)."/../../php/xmlrpc.php" );
+require_once( dirname(__FILE__)."/removewithdata.php" );
+
+// A ratio group command runs on every check until the download is gone, so a
+// hash already recorded is left to the garbage collector.
+if(is_file(FileUtil::getSettingsPath()."/erasedata/".$hash.".list"))
+	exit(0);
+
+exit((erasedataRemoveWithData(array($hash), $force) === false) ? 1 : 0);

--- a/plugins/ratio/ratio.php
+++ b/plugins/ratio/ratio.php
@@ -135,6 +135,21 @@ class rRatio
 			($no<count($this->rat)) &&
 		        ($this->rat[$no]["name"]!=""));
 	}
+	// A download's data is deleted by the erasedata plugin, which needs the file
+	// list read over RPC while the download still exists. Hand the erase to that
+	// plugin's helper instead of erasing here, so a ratio group deletes the same
+	// way the web UI's "Remove and delete data" does. Backgrounded: a foreground
+	// execute would block rtorrent while the helper waits for rtorrent to answer.
+	public function getEraseWithDataCommand($force)
+	{
+		$prefix = getCmd("d.stop=")."; ".getCmd("d.close=")."; ";
+		$helper = dirname(dirname(__FILE__))."/erasedata/erase.php";
+		if(!is_file($helper))
+			return($prefix.getCmd("d.set_custom5=").$force."; ".getCmd("d.erase="));
+		return($prefix.'execute.nothrow.bg={'.Utility::getPHP().','.$helper.
+			',$'.getCmd("d.get_hash").'=,'.$force.','.User::getUser().'}');
+	}
+
 	public function correct()
 	{
 		$cmd = new rXMLRPCCommand("d.multicall",array("default",getCmd("d.get_hash=")));
@@ -214,13 +229,13 @@ class rRatio
 						case RAT_ERASEDATA:
 						{
 							$req->addCommand(new rXMLRPCCommand("system.method.set", array("group.rat_".$i.".ratio.command",
-								getCmd("d.stop=")."; ".getCmd("d.close=")."; ".getCmd("d.set_custom5=")."1; ".getCmd("d.erase="))));
+								$this->getEraseWithDataCommand("1"))));
 							break;
 						}
 						case RAT_ERASEDATAALL:
 						{
 							$req->addCommand(new rXMLRPCCommand("system.method.set", array("group.rat_".$i.".ratio.command",
-								getCmd("d.stop=")."; ".getCmd("d.close=")."; ".getCmd("d.set_custom5=")."2; ".getCmd("d.erase="))));
+								$this->getEraseWithDataCommand("2"))));
 							break;
 						}
 						default:

--- a/tests/plugins/ratio/EraseWithDataCommandTest.php
+++ b/tests/plugins/ratio/EraseWithDataCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+require_once(__DIR__ . '/../../php/TestCase.php');
+require_once(__DIR__ . '/../../../plugins/ratio/ratio.php');
+
+class EraseWithDataCommandTest extends TestCase
+{
+	private function command($force)
+	{
+		$rat = new rRatio();
+		return($rat->getEraseWithDataCommand($force));
+	}
+
+	public function testStopsAndClosesBeforeDeleting()
+	{
+		$this->assertEquals(0, strpos($this->command("1"), "d.stop=; d.close=; "),
+			'the download is stopped and closed first');
+	}
+
+	public function testHandsTheEraseToTheErasedataHelper()
+	{
+		$cmd = $this->command("1");
+		$this->assertTrue(strpos($cmd, "/erasedata/erase.php") !== false,
+			'the erase runs through the erasedata helper, which records the file list first');
+		$this->assertTrue(strpos($cmd, "d.erase") === false,
+			'the group command no longer erases by itself, or the data would be gone with the download');
+	}
+
+	public function testHelperIsShipped()
+	{
+		$this->assertTrue(is_file(__DIR__ . '/../../../plugins/erasedata/erase.php'),
+			'the helper the command points at is part of the tree');
+	}
+
+	public function testRunsInTheBackground()
+	{
+		$this->assertTrue(strpos($this->command("1"), "execute.nothrow.bg={") !== false,
+			'a foreground execute would block rtorrent while the helper waits for rtorrent');
+	}
+
+	public function testPassesTheHashOfTheDownloadItRunsOn()
+	{
+		$this->assertTrue(strpos($this->command("1"), ',$' . getCmd("d.get_hash") . '=,') !== false,
+			'the hash is substituted by rtorrent when the group command fires');
+	}
+
+	public function testForceFlagDistinguishesTheTwoActions()
+	{
+		$hash = '$' . getCmd("d.get_hash") . '=';
+		$this->assertTrue(strpos($this->command("1"), $hash . ',1,') !== false,
+			'Remove data asks for the download\'s own files');
+		$this->assertTrue(strpos($this->command("2"), $hash . ',2,') !== false,
+			'Remove data (All) asks for the whole base path');
+	}
+}


### PR DESCRIPTION
The Remove data actions marked the download with d.custom5 and erased it. That marker was read by erasedata event.download.erased handlers, which 54165cb5 dropped because file.append needs method.use_deprecated. The RPC capture that replaced them runs only on the web UI path, so ratio groups have been erasing downloads without deleting their data since.

Hand the erase to erasedata instead: the group command runs that plugin new CLI helper in the background, which records the file list over RPC -- the same call Remove and delete data makes -- and erases the download once it is recorded. Falls back to the previous command when the plugin is not installed.