### PR TITLE
s-table: fix the delayed draw, and stop it dropping row changes

### DIFF
--- a/js/stable.js
+++ b/js/stable.js
@@ -601,7 +601,7 @@ dxSTable.prototype.assignEvents = function()
 				if (
 					self.isScrolling ||
 					(!self.noDelayingDraw &&
-						Math.abs(self.scrollDiff) > this.TR_HEIGHT*3 &&
+						Math.abs(self.scrollDiff) > self.TR_HEIGHT*3 &&
 						(self.viewRows > maxRows))
 				) {
 					self.isScrolling = true;
@@ -1332,6 +1332,12 @@ dxSTable.prototype.markSelectionDirty = function()
 dxSTable.prototype.syncDOM = function()
 {
 	if (!this.created || !this.dCont.length)
+		return;
+	// refreshRows() draws nothing while the table is scrolling, and this
+	// consumes what it is handed, so rows added or removed mid-scroll would be
+	// dropped with nothing left to ask for them again. Leave them queued: the
+	// scroll timeout syncs once more when it clears isScrolling.
+	if (this.isScrolling && this.pendingSync.prows)
 		return;
 	const p = this.pendingSync;
 	this.pendingSync = {};

--- a/tests/js/stable-scroll.spec.js
+++ b/tests/js/stable-scroll.spec.js
@@ -1,0 +1,92 @@
+import { readFileSync } from "fs";
+
+window.$ = require("jquery");
+
+function loadStable() {
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = readFileSync("../js/stable.js", { encoding: "utf-8" });
+  document.body.appendChild(scriptEl);
+}
+
+// dBody, tBody and TR_HEIGHT are getters over dCont, so the table needs a real
+// container; everything else is stripped to what the scroll handler and syncDOM
+// touch.
+function makeTable(props) {
+  const cont = $(
+    '<div class="stable">' +
+      '<div class="stable-body"><table>' +
+        "<colgroup><col></colgroup>" +
+        "<thead><tr><td></td></tr></thead>" +
+        '<tbody class="stable-virtpad"><tr></tr></tbody>' +
+        "<tbody><tr><td></td></tr></tbody>" +
+        '<tbody class="stable-virtpad"><tr></tr></tbody>' +
+      "</table></div>" +
+      '<div class="stable-scrollpos"></div>' +
+    "</div>"
+  );
+  $(document.body).append(cont);
+  return Object.assign(Object.create(window.dxSTable.prototype), {
+    created: true,
+    dCont: cont,
+    pendingSync: {},
+    viewRows: 500,
+    noDelayingDraw: 0,
+    getMaxRows: () => 20,
+    getColById: () => -1,
+    syncDOMAsync: jest.fn(),
+    refreshRows: jest.fn(),
+    refreshSelection: jest.fn(),
+    noSort: true,
+    sortId: "",
+    sortId2: "",
+    rowdata: {},
+    ...props,
+  });
+}
+
+describe("s-table scrolling", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    loadStable();
+  });
+
+  it("delays drawing once a scroll passes a few rows", () => {
+    const table = makeTable();
+    dxSTable.prototype.assignEvents.call(table);
+    expect(table.isScrolling).toBe(false);
+
+    table.dBody.scrollTop = table.TR_HEIGHT * 10;
+    $(table.dBody).trigger("scroll");
+
+    expect(table.isScrolling).toBe(true);
+  });
+
+  it("keeps drawing immediately when the option is on", () => {
+    const table = makeTable({ noDelayingDraw: 1 });
+    dxSTable.prototype.assignEvents.call(table);
+
+    table.dBody.scrollTop = table.TR_HEIGHT * 10;
+    $(table.dBody).trigger("scroll");
+
+    expect(table.isScrolling).toBe(false);
+  });
+
+  it("leaves rows added or removed mid-scroll queued for the scroll to end", () => {
+    const table = makeTable({ isScrolling: true, pendingSync: { prows: { A: 0 } } });
+
+    dxSTable.prototype.syncDOM.call(table);
+
+    expect(table.refreshRows).not.toHaveBeenCalled();
+    expect(table.pendingSync.prows).toEqual({ A: 0 });
+  });
+
+  it("draws those rows as soon as the scroll ends", () => {
+    const table = makeTable({ isScrolling: true, pendingSync: { prows: { A: 0 } } });
+    dxSTable.prototype.syncDOM.call(table);
+
+    table.isScrolling = false;
+    dxSTable.prototype.syncDOM.call(table);
+
+    expect(table.refreshRows).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Two defects, one dependent on the other.

The scroll handler is a function() bound on this.dBody, so this is the DOM node being scrolled. Every other line in it reaches the table through self, but the row-height comparison reads this.TR_HEIGHT, and TR_HEIGHT became a getter on the dxSTable prototype in 2b6435fc, where the reference was rewritten from the global it used to be. Math.abs(self.scrollDiff) > undefined * 3 is always false, so isScrolling never became true: with Show table content while scrolling off, the table still redrew on every scroll event.

Reading it through self makes the option work again -- and exposes the second defect. refreshRows() draws nothing while isScrolling is set, but syncDOM() empties pendingSync before calling it, so a row added or removed mid-scroll was dropped with nothing left to ask for it again. The sync at the end of the scroll reacts only to the scroll and returns early when the visible window has not moved, so scrolling away and back left an erased torrent on screen until the page was reloaded: gone from the table model, still in the DOM. Leaving the work in pendingSync until the scroll ends is enough -- the timeout that clears isScrolling syncs once more and draws it.

tests/js/stable-scroll.spec.js covers both: the handler now sets isScrolling for a scroll of more than three rows (and still does not when the option is on), and syncDOM keeps queued rows through a scroll and draws them once it ends.