### PR TITLE
httprpc: tell the client when the list answer is a full one

### DIFF
--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -1161,6 +1161,13 @@ rTorrentStub.prototype.listResponse = function(data)
 	/** @type {ListResponseType} */
 	var ret = { labels: {}, labels_size: {}, torrents: {} };
 	theRequestManager.cid = data.cid;
+	// A full answer lists every torrent there is, so anything held that it does
+	// not mention is gone. Deletions are reported against a previous state the
+	// server no longer has, and would otherwise never arrive.
+	if(data.full)
+		for( var hash in theRequestManager.torrents )
+			if(!(hash in data.t))
+				delete theRequestManager.torrents[hash];
 	if(data.d)
 		$.each( data.d, function( ndx, hash )
 		{

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -236,8 +236,14 @@ switch($mode)
 					$torrents[$current_index][] = $value;
 			}
 
-			$theCache->calcDifference( $cid, $torrents, $dTorrents );
+			// Without a previous state there is nothing to diff against, so the
+			// answer is the whole list and carries no deletions -- say so, or a
+			// client that has been running since before the state was lost keeps
+			// torrents rtorrent no longer has, with only a reload to clear them.
+			$hasPrevious = $theCache->calcDifference( $cid, $torrents, $dTorrents );
 			$result = array( "t"=>$torrents, "cid"=>$cid );
+			if(!$hasPrevious)
+				$result["full"] = 1;
 			if(count($dTorrents))
 				$result["d"] = $dTorrents;
 		}

--- a/tests/js/rtorrent.spec.js
+++ b/tests/js/rtorrent.spec.js
@@ -335,6 +335,37 @@ describe("xmlrpc calls", () => {
     }
   });
 
+  // The server diffs against a cached copy of the previous answer. When it has
+  // none -- first poll, or the cache was evicted or could not be written -- it
+  // sends the whole list and no deletions, and says so with "full".
+  function seedListState() {
+    const stub = new rTorrentStub("?list=1");
+    stub.getResponse(loadXML(stub.action));
+    return stub;
+  }
+
+  it("drops torrents a full list does not mention", () => {
+    const stub = seedListState();
+    expect(Object.keys(theRequestManager.torrents)).toHaveLength(4);
+
+    const kept = { [h("A")]: theRequestManager.torrents[h("A")] };
+    const ret = stub.listResponse({ t: kept, cid: 7, full: 1 });
+
+    expect(Object.keys(theRequestManager.torrents)).toEqual([h("A")]);
+    expect(Object.keys(ret.torrents)).toEqual([h("A")]);
+  });
+
+  it("keeps torrents a partial list does not mention", () => {
+    const stub = seedListState();
+    const changed = { [h("A")]: theRequestManager.torrents[h("A")] };
+
+    stub.listResponse({ t: changed, cid: 8 });
+
+    expect(Object.keys(theRequestManager.torrents).sort()).toEqual(
+      [h("A"), h("B"), h("C"), h("D")].sort()
+    );
+  });
+
   it("reads the partially done flag from the list response", () => {
     const stub = new rTorrentStub("?list=1");
     const ret = stub.getResponse(loadXML(stub.action));

--- a/tests/plugins/httprpc/RpcCacheTest.php
+++ b/tests/plugins/httprpc/RpcCacheTest.php
@@ -1,0 +1,85 @@
+<?php
+
+require_once(__DIR__ . '/../../php/TestCase.php');
+require_once(__DIR__ . '/../../../plugins/httprpc/rpccache.php');
+
+// The cache keeps its state files in a directory taken from the profile path.
+// Point it at a scratch directory instead, and let a test take that directory
+// away to stand in for an evicted or unwritable cache.
+class TestRpcCache extends rpcCache
+{
+	public function useDirectory($dir)
+	{
+		$this->dir = $dir;
+		@mkdir($dir, 0777, true);
+	}
+}
+
+class RpcCacheTest extends TestCase
+{
+	private $dir;
+	private $cache;
+
+	public function setUp()
+	{
+		$this->dir = sys_get_temp_dir().'/rpccache-test-'.getmypid();
+		$this->cache = new TestRpcCache();
+		$this->cache->useDirectory($this->dir);
+	}
+
+	public function tearDown()
+	{
+		foreach(glob($this->dir.'/*') as $f)
+			@unlink($f);
+		@rmdir($this->dir);
+	}
+
+	private function torrents($hashes)
+	{
+		$ret = array();
+		foreach($hashes as $hash)
+			$ret[$hash] = array("1", "name of ".$hash, "0");
+		return($ret);
+	}
+
+	private function difference($cid, $hashes)
+	{
+		$torrents = $this->torrents($hashes);
+		$deleted = array();
+		$hadPrevious = $this->cache->calcDifference($cid, $torrents, $deleted);
+		return(array("cid"=>$cid, "changed"=>$torrents, "deleted"=>$deleted, "hadPrevious"=>$hadPrevious));
+	}
+
+	public function testFirstAnswerIsFullAndSaysSo()
+	{
+		$first = $this->difference(0, array("A", "B"));
+		$this->assertTrue(!$first["hadPrevious"], 'nothing to diff against on the first request');
+		$this->assertEquals(array("A","B"), array_keys($first["changed"]), 'the whole list is answered');
+		$this->assertEquals(array(), $first["deleted"], 'and it carries no deletions');
+	}
+
+	public function testDeletionIsReportedAgainstThePreviousState()
+	{
+		$first = $this->difference(0, array("A", "B"));
+		$second = $this->difference($first["cid"], array("A"));
+		$this->assertTrue($second["hadPrevious"], 'the previous state was found');
+		$this->assertEquals(array("B"), $second["deleted"], 'B is reported as deleted');
+	}
+
+	// The state files are a ring of ten, so a client that polls slowly while
+	// another one polls fast can come back with a cid that is gone -- as can any
+	// client if the directory cannot be written at all.
+	public function testALostStateIsAnnouncedAsFullRatherThanLosingTheDeletion()
+	{
+		$first = $this->difference(0, array("A", "B"));
+		foreach(glob($this->dir.'/*') as $f)
+			@unlink($f);
+
+		$second = $this->difference($first["cid"], array("A"));
+
+		$this->assertTrue(!$second["hadPrevious"], 'the state the client named is gone');
+		$this->assertEquals(array(), $second["deleted"], 'so no deletion can be derived');
+		$this->assertEquals(array("A"), array_keys($second["changed"]),
+			'and the answer is the whole list, which is what lets the client drop B itself');
+	}
+}


### PR DESCRIPTION
The list endpoint answers with what changed since the state the client names by cid, plus the hashes that went away. Both come from a copy of the previous answer kept in share/settings/httprpc, a ring of ten files. When that copy is not there -- the ring rotated past it while another client polled, the directory is not writable by the web server, the profile was moved -- the diff is taken against nothing: everything reads as changed and nothing reads as deleted.

The values keep flowing, so the list looks alive while it quietly stops losing torrents: one that rtorrent has erased stays on screen, and the deletion can never arrive later, because every following answer diffs against a state that already lacks it. Only a reload clears it. calcDifference() already reports whether it had a previous state; the endpoint discarded that answer.

Pass it on as "full", and let listResponse drop what a full answer does not mention. A lost state then costs one full list instead of a list that is wrong until the page is reloaded.