### PR TITLE
Do not cache a settings object whose probe failed

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -159,6 +159,14 @@ class rTorrentSettings
 
 	public function store()
 	{
+		// Only obtain() sets linkExist, and only getplugins.php and
+		// initplugins.php call it. Every other entry point reads this cache
+		// and takes it at its word, so caching an object whose probe failed
+		// makes one unanswered request speak for the install: the alias map is
+		// empty, and getCommand() then hands back the pre-0.9 spelling of every
+		// renamed command until something probes again.
+		if(!$this->linkExist)
+			return(false);
 		$cache = new rCache();
 		return($cache->set($this));
 	}

--- a/tests/php/SettingsCacheTest.php
+++ b/tests/php/SettingsCacheTest.php
@@ -1,0 +1,142 @@
+<?php
+
+$_ENV['RU_PROFILE_PATH'] = sys_get_temp_dir() . '/rutorrent-settings-cache-test-' . getmypid();
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/settings.php');
+
+/**
+ * rTorrentSettings caches itself into share/settings/rtorrent.dat, and
+ * php/xmlrpc.php builds its singleton from that file on the first
+ * rXMLRPCCommand of every later request. Only obtain() can set linkExist, and
+ * only getplugins.php / initplugins.php call obtain(); every other entry point
+ * takes the cache at its word. A stored object whose probe failed therefore
+ * speaks for the whole install until something probes again -- with an empty
+ * alias map, so getCommand() hands back the 0.9.x spelling of every renamed
+ * command.
+ */
+class SettingsCacheTest extends TestCase
+{
+	private $profilePath;
+
+	public function setUp()
+	{
+		$this->profilePath = $_ENV['RU_PROFILE_PATH'];
+		if (is_dir($this->profilePath)) {
+			$this->removeDir($this->profilePath);
+		}
+		FileUtil::makeDirectory(FileUtil::getSettingsPath());
+	}
+
+	public function tearDown()
+	{
+		if (is_dir($this->profilePath)) {
+			$this->removeDir($this->profilePath);
+		}
+	}
+
+	private function removeDir($dir)
+	{
+		foreach (array_diff(scandir($dir), ['.', '..']) as $entry) {
+			$path = $dir . '/' . $entry;
+			if (is_dir($path) && !is_link($path)) {
+				$this->removeDir($path);
+			} else {
+				unlink($path);
+			}
+		}
+		rmdir($dir);
+	}
+
+	// The constructor is private and get() is a per-process singleton, so build
+	// instances the way RtorrentCompatibilityTest does.
+	private function makeSettings($linkExist)
+	{
+		$reflection = new ReflectionClass('rTorrentSettings');
+		$settings = $reflection->newInstanceWithoutConstructor();
+		$settings->linkExist = $linkExist;
+		if ($linkExist) {
+			$settings->version = '0.16.20';
+			$settings->iVersion = 0x1014;
+			$settings->aliases = array(
+				'set_download_rate' => array('name' => 'throttle.global_down.max_rate.set', 'prm' => 1),
+			);
+		}
+		return $settings;
+	}
+
+	private function cacheFile()
+	{
+		return FileUtil::getSettingsPath() . '/rtorrent.dat';
+	}
+
+	private function readCached()
+	{
+		$cached = new ReflectionClass('rTorrentSettings');
+		$cached = $cached->newInstanceWithoutConstructor();
+		(new rCache())->get($cached);
+		return $cached;
+	}
+
+	public function testFailedProbeIsNotCached()
+	{
+		$this->makeSettings(false)->store();
+		$this->assertTrue(
+			!is_file($this->cacheFile()),
+			'A settings object whose probe failed must not be written to the cache'
+		);
+	}
+
+	public function testFailedProbeReportsThatItStoredNothing()
+	{
+		$this->assertEquals(
+			false,
+			$this->makeSettings(false)->store(),
+			'store() reports false when it declines to cache a failed probe'
+		);
+	}
+
+	public function testSuccessfulProbeIsCached()
+	{
+		$this->assertTrue(
+			$this->makeSettings(true)->store() !== false,
+			'store() reports success for a settings object with a live link'
+		);
+		$this->assertTrue(
+			is_file($this->cacheFile()),
+			'A settings object with a live link is written to the cache'
+		);
+		$cached = $this->readCached();
+		$this->assertTrue($cached->linkExist, 'The cached object carries linkExist');
+		$this->assertEquals('0.16.20', $cached->version, 'The cached object carries the probed version');
+	}
+
+	// The defect: an outage window, or doneplugins.php finding no cache file at
+	// all, replaces a good cache with a failed one, and every request after it
+	// inherits the verdict.
+	public function testFailedProbeDoesNotOverwriteAGoodCache()
+	{
+		$this->makeSettings(true)->store();
+		$this->makeSettings(false)->store();
+
+		$cached = $this->readCached();
+		$this->assertTrue($cached->linkExist, 'A failed probe leaves an existing good cache alone');
+		$this->assertEquals(
+			'throttle.global_down.max_rate.set',
+			$cached->getCommand('set_download_rate'),
+			'The cached alias map survives a failed probe, so renamed commands keep resolving'
+		);
+	}
+
+	// What the tenant meets when the map is lost: the status bar's rate control
+	// sends a name rtorrent has not answered to since 0.9.x, and the daemon
+	// faults instead of throttling.
+	public function testAnEmptyAliasMapSendsLegacyCommandNames()
+	{
+		$this->assertEquals(
+			'set_download_rate',
+			$this->makeSettings(false)->getCommand('set_download_rate'),
+			'With no alias map getCommand() falls back to the legacy spelling'
+		);
+	}
+}


### PR DESCRIPTION
rTorrentSettings caches itself into share/settings/rtorrent.dat, and php/xmlrpc.php builds its singleton from that file on the first rXMLRPCCommand of every later request. Only obtain() sets linkExist, and only getplugins.php and initplugins.php call obtain(), so every other entry point takes the cached verdict at its word.

store() wrote the object unconditionally. A page load that lands in a window where rTorrent is not answering therefore replaced a good cache with a failed one. doneplugins.php reached the same state with no outage at all: it builds the object through rTorrentSettings::get(), which on a missing cache file returns a pristine instance with linkExist false and an empty alias map, and then stores it while rTorrent is healthy.

Either way the stored object speaks for the install until something probes again. With no aliases, getCommand() falls back to the pre-0.9 spelling of every renamed command, so the status bar's rate control sends set_download_rate and the daemon answers "Method 'set_download_rate' not defined"; the torrent list request faults on "invalid parameters: invalid target"; and the UI reports the engine as unknown while it is running.

Guard store() rather than its callers. There is more than one originator, so guarding one of them only moves the poisoning to the next request. Every caller discards store()'s return value, so declining to write is inert beyond not writing.