### PR TITLE
httprpc: report a refused XMLRPC call as a refusal, not an outage

### DIFF
--- a/php/xmlrpc_proxy.php
+++ b/php/xmlrpc_proxy.php
@@ -242,7 +242,7 @@ class XMLRPCProxy
 
 		if(self::isDenied($methodName, $deny))
 			return self::reject("rejected (not allowed on this connection): ".
-				self::logValue($methodName));
+				self::logValue($methodName), $methodName);
 
 		$directory = isset($options['directory']) ? $options['directory'] : null;
 
@@ -253,7 +253,7 @@ class XMLRPCProxy
 				$uri = self::loadUri($xml);
 				if(($uri !== null) && !preg_match(self::$networkUri, $uri))
 					return self::reject("rejected (load from a local path): ".
-						$methodName." ".self::logValue($uri));
+						$methodName." ".self::logValue($uri), $methodName);
 			}
 
 			$rebuilt = self::rebuildLoadParams($xml, $methodName, $safeParams, $directory);
@@ -291,7 +291,7 @@ class XMLRPCProxy
 					$command = self::commandName($value);
 					if(($command !== null) && self::isDenied($command, $deny))
 						return self::reject("rejected (not allowed on this connection): ".
-							$methodName." carrying ".self::logValue($command));
+							$methodName." carrying ".self::logValue($command), $command);
 				}
 
 				return self::forward($rawData, false, "untrusted: ".$methodName." (".
@@ -323,7 +323,7 @@ class XMLRPCProxy
 			foreach(self::multicallMemberNames($xml) as $member)
 				if(self::isDenied($member, $deny))
 					return self::reject("rejected (not allowed on this connection): ".
-						"system.multicall carrying ".self::logValue($member));
+						"system.multicall carrying ".self::logValue($member), $member);
 		}
 
 		// Unknown method — pass through as untrusted.
@@ -560,13 +560,35 @@ class XMLRPCProxy
 	private static function forward($payload, $trusted, $line)
 	{
 		return array('action' => 'send', 'payload' => $payload,
-			'trusted' => $trusted, 'log' => array($line));
+			'trusted' => $trusted, 'method' => null, 'log' => array($line));
 	}
 
-	private static function reject($line)
+	private static function reject($line, $method = null)
 	{
 		return array('action' => 'reject', 'payload' => '',
-			'trusted' => false, 'log' => array($line));
+			'trusted' => false, 'method' => $method, 'log' => array($line));
+	}
+
+	/**
+	 * The XMLRPC fault a door returns when this filter refuses a call: -501
+	 * and a string that names the command, matching the fault rpc2.php
+	 * answers for the same refusals so both doors report a refusal the same
+	 * way. rtorrent never saw the call, so the string says this server
+	 * refused it rather than blaming rtorrent for an outage that did not
+	 * happen.
+	 */
+	public static function rejectionFault($method)
+	{
+		$faultString = (($method !== null) && ($method !== ''))
+			? "The command '".$method."' was rejected by this server."
+			: "This XMLRPC call was rejected by this server.";
+		return '<?xml version="1.0" encoding="UTF-8"?>'."\n"
+			.'<methodResponse><fault><value><struct>'
+			.'<member><name>faultCode</name><value><i4>-501</i4></value></member>'
+			.'<member><name>faultString</name><value><string>'
+			.htmlspecialchars($faultString, ENT_NOQUOTES, 'UTF-8')
+			.'</string></value></member>'
+			.'</struct></value></fault></methodResponse>';
 	}
 
 	/**

--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -707,7 +707,31 @@ switch($mode)
 					? $topDirectory : '/',
 				'resolve' => 'httprpcResolvePath',
 			));
-			$result = XMLRPCProxy::process($HTTP_RAW_POST_DATA, $proxyMode, $proxyLog, $proxySafeParams, $proxyLocalPaths, $proxyOptions);
+			// decide() here, not process(): this endpoint owns its own
+			// connection to rtorrent, and process()'s null return cannot tell a
+			// call this filter refused from one rtorrent could not answer. That
+			// is what rpc2.php does with the same policy.
+			$decision = XMLRPCProxy::decide($HTTP_RAW_POST_DATA, $proxyMode, $proxySafeParams, $proxyLocalPaths, $proxyOptions);
+			if($proxyLog)
+				foreach($decision['log'] as $line)
+					FileUtil::toLog("xmlrpc-proxy: ".$line);
+			if($decision['action'] !== 'send')
+			{
+				// This filter refused the call; rtorrent never saw it. Name the
+				// command and say this server refused it, the 403/-501 rpc2.php
+				// answers for the same refusals -- not "is rtorrent running",
+				// which sends the client to restart a client that is up.
+				header("HTTP/1.0 403 Forbidden");
+				CachedEcho::send(XMLRPCProxy::rejectionFault($decision['method']), "text/xml");
+			}
+			$result = rXMLRPCRequest::send($decision['payload'], $decision['trusted']);
+			if($result === false)
+			{
+				// The call passed the filter but the SCGI connection failed --
+				// this one really is an outage.
+				header("HTTP/1.0 500 Server Error");
+				CachedEcho::send("Could not reach rTorrent over XMLRPC. Is rTorrent running?", "text/html");
+			}
 			if(!empty($result))
 			{
 				$pos = strpos($result, "\r\n\r\n");

--- a/tests/php/XMLRPCProxyRejectionTest.php
+++ b/tests/php/XMLRPCProxyRejectionTest.php
@@ -1,0 +1,134 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/xmlrpc_proxy.php');
+
+/**
+ * A call this filter refuses must be reported as a refusal that names the
+ * command, not as "could not reach rtorrent" -- rtorrent never sees a refused
+ * call, and reporting a refusal as an outage sends the customer to restart a
+ * client that is up and answering.
+ *
+ * decide() already separates a refusal (action 'reject') from a call it
+ * forwards (action 'send'); the door acts on that. These tests pin two things
+ * the door needs from it: that a refusal carries the name of the command it
+ * refused, and that the fault the door renders from it is the -501 rpc2.php
+ * answers for the same refusals, naming the command and blaming this server.
+ */
+class XMLRPCProxyRejectionTest extends TestCase
+{
+	private $safe = array('d.custom1.set', 'd.directory.set');
+	private $opts;
+
+	public function setUp()
+	{
+		// The directory boundary action.php passes; irrelevant to these
+		// refusals but present so decide() runs the same code path it does live.
+		$this->opts = array('directory' => array('root' => '/', 'resolve' => null));
+	}
+
+	private function call($method, $params = array())
+	{
+		$xml = '<?xml version="1.0"?><methodCall><methodName>' . $method
+			. '</methodName><params>';
+		foreach($params as $p)
+			$xml .= '<param><value><string>' . htmlspecialchars($p, ENT_NOQUOTES)
+				. '</string></value></param>';
+		$xml .= '</params></methodCall>';
+		return XMLRPCProxy::decide($xml, 'sanitize', $this->safe, false, $this->opts);
+	}
+
+	// --- a refusal carries the name of the command it refused ---
+
+	public function testADeniedMethodIsRejectedAndNamed()
+	{
+		$d = $this->call('execute.capture', array('', '/bin/id'));
+		$this->assertTrue($d['action'] === 'reject',
+			'execute.capture is refused');
+		$this->assertTrue(isset($d['method']) && $d['method'] === 'execute.capture',
+			'the refusal names execute.capture');
+	}
+
+	public function testSystemShutdownIsRejectedAndNamed()
+	{
+		$d = $this->call('system.shutdown');
+		$this->assertTrue($d['action'] === 'reject',
+			'system.shutdown is refused');
+		$this->assertTrue(isset($d['method']) && $d['method'] === 'system.shutdown',
+			'the refusal names system.shutdown');
+	}
+
+	public function testAMulticallCarryingADeniedCommandNamesThatCommand()
+	{
+		// The command the multicall smuggles is what the caller must be told
+		// about, not the multicall wrapper.
+		$d = $this->call('d.multicall2', array('', 'main', 'execute.capture=/bin/id'));
+		$this->assertTrue($d['action'] === 'reject',
+			'a multicall carrying execute.capture is refused');
+		$this->assertTrue(isset($d['method']) && $d['method'] === 'execute.capture',
+			'the refusal names the carried command, execute.capture');
+	}
+
+	public function testSystemMulticallCarryingADeniedMemberNamesIt()
+	{
+		$xml = '<?xml version="1.0"?><methodCall><methodName>system.multicall</methodName>'
+			. '<params><param><value><array><data><value><struct>'
+			. '<member><name>methodName</name><value><string>system.shutdown</string></value></member>'
+			. '<member><name>params</name><value><array><data></data></array></value></member>'
+			. '</struct></value></data></array></value></param></params></methodCall>';
+		$d = XMLRPCProxy::decide($xml, 'sanitize', $this->safe, false, $this->opts);
+		$this->assertTrue($d['action'] === 'reject',
+			'a system.multicall carrying system.shutdown is refused');
+		$this->assertTrue(isset($d['method']) && $d['method'] === 'system.shutdown',
+			'the refusal names the carried member, system.shutdown');
+	}
+
+	// --- the split the door relies on: a forwardable call is sent, so a real
+	//     outage on that call is still reported as an outage ---
+
+	public function testAForwardableCallIsSentNotRefused()
+	{
+		$d = $this->call('system.client_version');
+		$this->assertTrue($d['action'] === 'send',
+			'system.client_version is forwarded, so a genuine connection '
+			. 'failure on it is still an outage');
+		$this->assertTrue(!isset($d['method']) || $d['method'] === null,
+			'a forwarded call names no refused command');
+	}
+
+	// --- the fault the door renders names the command and blames this server ---
+
+	public function testRejectionFaultNamesTheCommandAndBlamesThisServer()
+	{
+		$this->assertTrue(method_exists('XMLRPCProxy', 'rejectionFault'),
+			'the proxy renders a refusal fault the door can return');
+		if(!method_exists('XMLRPCProxy', 'rejectionFault'))
+			return;
+
+		$fault = XMLRPCProxy::rejectionFault('execute.capture');
+		$this->assertTrue(strpos($fault, '<i4>-501</i4>') !== false,
+			'the fault carries faultCode -501, as rpc2.php does');
+		$this->assertTrue(
+			strpos($fault, "The command 'execute.capture' was rejected by this server.") !== false,
+			'the fault names the command and says this server refused it');
+		$this->assertTrue(strpos($fault, 'Is rTorrent running') === false,
+			'the fault does not blame rtorrent for an outage that did not happen');
+	}
+
+	public function testRejectionFaultWithoutACommandStillBlamesThisServer()
+	{
+		if(!method_exists('XMLRPCProxy', 'rejectionFault'))
+		{
+			$this->assertTrue(false, 'the proxy renders a refusal fault');
+			return;
+		}
+		$fault = XMLRPCProxy::rejectionFault(null);
+		$this->assertTrue(strpos($fault, '<i4>-501</i4>') !== false,
+			'the generic refusal fault still carries -501');
+		$this->assertTrue(
+			strpos($fault, 'This XMLRPC call was rejected by this server.') !== false,
+			'the generic refusal still says this server refused it');
+		$this->assertTrue(strpos($fault, 'Is rTorrent running') === false,
+			'and still does not blame rtorrent');
+	}
+}


### PR DESCRIPTION
plugins/httprpc/action.php refused a call by returning XMLRPCProxy's null, which is also what a failed connection returns, so action.php reported every refusal as HTTP 500 "Is rTorrent running?" with rtorrent up and answering. It now calls decide() and send() directly, the way rpc2.php does: a refusal returns 403 with faultCode -501 naming the command, and only a genuine connection failure still says rtorrent is unreachable.