### PR TITLE
Escape the download directory in the load command string

### DIFF
--- a/php/rtorrent.php
+++ b/php/rtorrent.php
@@ -236,9 +236,11 @@ class rTorrent
 	 */
 	static public function quoteCommandArg($value)
 	{
-		// One str_replace() pass, not two: escaping the quote first and the
-		// backslash afterwards would double the backslash the quote escaping
-		// just added, leaving a live quote behind it.
+		// The order of the pairs is what makes this correct, and it must not be
+		// changed: str_replace() works through the arrays left to right and can
+		// revisit a value an earlier pair inserted. Escaping the quote first
+		// would double the backslash that escaping just added, leaving a live
+		// quote behind it -- so the backslash pair has to come first.
 		return('"'.str_replace(array('\\', '"'), array('\\\\', '\\"'), $value).'"');
 	}
 

--- a/php/rtorrent.php
+++ b/php/rtorrent.php
@@ -72,7 +72,7 @@ class rTorrent
 				if(!rTorrentSettings::get()->correctDirectory($directory))
 					return(false);
 				$req->addCommand( new rXMLRPCCommand( 'execute', array('mkdir','-p',$directory) ) );
-				$cmd->addParameter( ($isAddPath ? getCmd("d.set_directory=")."\"" : getCmd("d.set_directory_base=")."\"").$directory."\"" );
+				$cmd->addParameter( getCmd($isAddPath ? "d.set_directory=" : "d.set_directory_base=").self::quoteCommandArg($directory) );
 			}
 			$comment = $torrent->comment();
 			if($comment)
@@ -124,7 +124,7 @@ class rTorrent
 				{
 					if(!rTorrentSettings::get()->correctDirectory($directory))
 						return(false);
-					$cmd->addParameter( ($isAddPath ? getCmd("d.set_directory=")."\"" : getCmd("d.set_directory_base=")."\"").$directory."\"" );
+					$cmd->addParameter( getCmd($isAddPath ? "d.set_directory=" : "d.set_directory_base=").self::quoteCommandArg($directory) );
 					$req->addCommand( new rXMLRPCCommand( 'execute', array('mkdir','-p',$directory) ) );
 				}
 				if($label && (strlen($label)>0))
@@ -219,6 +219,27 @@ class rTorrent
 			return($torrent);
 		}
 		return(false);
+	}
+
+	/**
+	 * Quote a value for use inside an rtorrent command string.
+	 *
+	 * The commands handed to load/load_raw are not typed parameters: rtorrent
+	 * parses them itself (src/rpc/parse.cc), ending a quoted argument at the
+	 * first unescaped '"' and reading '\' as an escape. A value wrapped in
+	 * quotes without escaping therefore ends the argument early -- a download
+	 * directory holding a quote silently loses everything from that quote on,
+	 * and the command around it stops parsing.
+	 *
+	 * Mirrors the escaping XMLRPCProxy::rebuildSafeLoadParam() applies to the
+	 * command strings it rebuilds.
+	 */
+	static public function quoteCommandArg($value)
+	{
+		// One str_replace() pass, not two: escaping the quote first and the
+		// backslash afterwards would double the backslash the quote escaping
+		// just added, leaving a live quote behind it.
+		return('"'.str_replace(array('\\', '"'), array('\\\\', '\\"'), $value).'"');
 	}
 
 	static protected function parseDirectory($directory, $isAddPath)

--- a/plugins/datadir/util_rt.php
+++ b/plugins/datadir/util_rt.php
@@ -2,6 +2,7 @@
 
 require_once( "../../php/xmlrpc.php" );
 require_once( "../../php/Torrent.php" );
+require_once( "../../php/rtorrent.php" );
 
 //------------------------------------------------------------------------------
 // Debug stub
@@ -389,7 +390,7 @@ function rtAddTorrent( $fname, $isStart, $directory, $label, $dbg = false )
 
 	if( $directory && strlen( $directory ) > 0 )
 	{
-		$directory = rtMakeStrParam( "d.set_directory=\"".$directory."\"" );
+		$directory = rtMakeStrParam( "d.set_directory=".rTorrent::quoteCommandArg( $directory ) );
 	}
 	else $directory = "";
 

--- a/tests/php/RtorrentCommandArgTest.php
+++ b/tests/php/RtorrentCommandArgTest.php
@@ -1,0 +1,96 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/rtorrent.php');
+
+/**
+ * rtorrent does not receive the directory as a typed XMLRPC parameter. It
+ * receives a command string -- d.directory.set="<path>" -- that its own parser
+ * (src/rpc/parse.cc) takes apart, so the path is quoted by us and unquoted by
+ * rtorrent.
+ *
+ * That parser ends a quoted argument at the first unescaped '"' and treats '\'
+ * as an escape, so a path carrying either character has to be escaped before
+ * it is wrapped, exactly as XMLRPCProxy::rebuildSafeLoadParam() already does
+ * for the command strings it rebuilds.
+ */
+class RtorrentCommandArgTest extends TestCase
+{
+	public function testPlainPathIsWrappedInQuotes()
+	{
+		$this->assertEquals(
+			'"/home/user/downloads"',
+			rTorrent::quoteCommandArg('/home/user/downloads'),
+			'a path with nothing to escape is just quoted');
+	}
+
+	/**
+	 * The reported bug: adding a torrent into a path with a double quote left
+	 * the download with no directory, because
+	 * d.directory.set="/x/Richard "Popcorn" Wylie" ends the argument at the
+	 * quote before "Popcorn".
+	 */
+	public function testDoubleQuoteIsEscapedSoItDoesNotEndTheArgument()
+	{
+		$this->assertEquals(
+			'"/x/Richard \"Popcorn\" Wylie"',
+			rTorrent::quoteCommandArg('/x/Richard "Popcorn" Wylie'),
+			'a quote in the path is escaped, not left to close the argument');
+	}
+
+	public function testBackslashIsEscaped()
+	{
+		$this->assertEquals(
+			'"/x/a\\\\b"',
+			rTorrent::quoteCommandArg('/x/a\b'),
+			'a backslash is doubled, so rtorrent unescapes it back to one');
+	}
+
+	/**
+	 * The ordering trap: escaping the quote first and the backslash afterwards
+	 * would re-escape the backslash that the quote escaping just introduced,
+	 * turning \" into \\" -- an escaped backslash followed by a live quote,
+	 * which ends the argument again. A single str_replace() pass avoids it.
+	 */
+	public function testBackslashBeforeQuoteIsEscapedInOnePass()
+	{
+		$this->assertEquals(
+			'"/x/a\\\\\"b"',
+			rTorrent::quoteCommandArg('/x/a\"b'),
+			'a backslash followed by a quote survives as an escaped pair');
+	}
+
+	/**
+	 * rtorrent splits a command's arguments on ',' before it unquotes them, so
+	 * a comma is only safe while it sits inside the quotes we add.
+	 */
+	public function testCommaStaysInsideTheArgument()
+	{
+		$this->assertEquals(
+			'"/x/Earth, Wind & Fire"',
+			rTorrent::quoteCommandArg('/x/Earth, Wind & Fire'),
+			'a comma is carried inside the quotes rather than splitting the argument');
+	}
+
+	public function testEmptyValueIsStillAQuotedArgument()
+	{
+		$this->assertEquals(
+			'""',
+			rTorrent::quoteCommandArg(''),
+			'an empty value quotes to an empty argument');
+	}
+
+	/**
+	 * Guard against the fix being undone at either call site: sendTorrent()
+	 * and sendMagnet() both used to concatenate the raw path between two
+	 * literal quotes, which is the defect these tests exist for.
+	 */
+	public function testNoCallSiteConcatenatesTheRawDirectory()
+	{
+		$source = file_get_contents(__DIR__ . '/../../php/rtorrent.php');
+		$this->assertEquals(
+			0,
+			preg_match('/"\s*\.\s*\$directory\s*\.\s*"/', $source),
+			'no call site wraps $directory in quotes without escaping it');
+	}
+}

--- a/tests/php/RtorrentCommandArgTest.php
+++ b/tests/php/RtorrentCommandArgTest.php
@@ -4,6 +4,37 @@ require_once(__DIR__ . '/TestCase.php');
 require_once(__DIR__ . '/../../php/rtorrent.php');
 
 /**
+ * Thrown by the settings stub once it has seen the commands, so the request
+ * stops before it opens a socket.
+ */
+class RtorrentCommandArgCaptured extends Exception
+{
+}
+
+/**
+ * rXMLRPCRequest::run() hands its commands to
+ * rTorrentSettings::get()->patchDeprecatedRequest() before it sends anything,
+ * which is the seam these tests capture at: replacing the settings singleton
+ * with this subclass yields the parameters sendTorrent() actually emitted,
+ * without a daemon and without reading the source.
+ */
+class RtorrentCommandArgSettings extends rTorrentSettings
+{
+	public $captured = array();
+
+	public function correctDirectory(&$dir, $resolve_links = false)
+	{
+		return true;
+	}
+
+	public function patchDeprecatedRequest($commands)
+	{
+		$this->captured = $commands;
+		throw new RtorrentCommandArgCaptured();
+	}
+}
+
+/**
  * rtorrent does not receive the directory as a typed XMLRPC parameter. It
  * receives a command string -- d.directory.set="<path>" -- that its own parser
  * (src/rpc/parse.cc) takes apart, so the path is quoted by us and unquoted by
@@ -16,6 +47,121 @@ require_once(__DIR__ . '/../../php/rtorrent.php');
  */
 class RtorrentCommandArgTest extends TestCase
 {
+	private $settings;
+	private $previousSettings;
+	private $torrentFile;
+
+	public function setUp()
+	{
+		// newInstanceWithoutConstructor() because rTorrentSettings' constructor
+		// reaches for a live daemon; the two fields the load path reads are set
+		// by hand instead.
+		$stub = new ReflectionClass('RtorrentCommandArgSettings');
+		$this->settings = $stub->newInstanceWithoutConstructor();
+		$this->settings->iVersion = 0x904;
+		$this->settings->aliases = array();
+
+		$reflection = new ReflectionClass('rTorrentSettings');
+		$property = $reflection->getProperty('theSettings');
+		$property->setAccessible(true);
+		$this->previousSettings = $property->getValue();
+		$property->setValue(null, $this->settings);
+
+		$this->torrentFile = tempnam(sys_get_temp_dir(), 'rtca') . '.torrent';
+		file_put_contents($this->torrentFile, $this->minimalTorrent());
+	}
+
+	public function tearDown()
+	{
+		$reflection = new ReflectionClass('rTorrentSettings');
+		$property = $reflection->getProperty('theSettings');
+		$property->setAccessible(true);
+		$property->setValue(null, $this->previousSettings);
+
+		if ($this->torrentFile && file_exists($this->torrentFile)) {
+			@unlink($this->torrentFile);
+		}
+	}
+
+	private function minimalTorrent()
+	{
+		$info = 'd6:lengthi1e4:name9:test.data12:piece lengthi16384e6:pieces20:'
+			. str_repeat("\x01", 20) . 'e';
+		return 'd8:announce28:http://example.test/announce4:info' . $info . 'e';
+	}
+
+	/**
+	 * Run a load through sendTorrent() and return the command parameters it
+	 * put on the wire, as plain strings.
+	 */
+	private function loadInto($directory, $addPath = true)
+	{
+		try {
+			rTorrent::sendTorrent($this->torrentFile, true, $addPath, $directory,
+				null, true, false);
+		} catch (RtorrentCommandArgCaptured $stop) {
+			// expected: the request was stopped at the seam
+		}
+
+		$parameters = array();
+		foreach ($this->settings->captured as $command) {
+			foreach ($command->params as $param) {
+				$parameters[] = (string)$param->value;
+			}
+		}
+		return $parameters;
+	}
+
+	// ---- what sendTorrent() actually emits -------------------------------
+
+	/**
+	 * The reported bug: adding a torrent into a path with a double quote left
+	 * the download with no directory, because
+	 * d.directory.set="/x/Richard "Popcorn" Wylie" ends the argument at the
+	 * quote before "Popcorn".
+	 */
+	public function testSendTorrentEscapesAQuoteInTheDirectory()
+	{
+		$parameters = $this->loadInto('/x/Richard "Popcorn" Wylie');
+		$this->assertTrue(
+			in_array('d.set_directory="/x/Richard \"Popcorn\" Wylie"', $parameters, true),
+			'sendTorrent() emits the directory with the quote escaped');
+	}
+
+	public function testSendTorrentEscapesABackslashInTheDirectory()
+	{
+		$parameters = $this->loadInto('/x/a\b');
+		$this->assertTrue(
+			in_array('d.set_directory="/x/a\\\\b"', $parameters, true),
+			'sendTorrent() emits the directory with the backslash doubled');
+	}
+
+	/**
+	 * Without add-path the same value goes to d.set_directory_base, so the
+	 * escaping has to hold on that branch too.
+	 */
+	public function testSendTorrentEscapesTheBaseDirectoryToo()
+	{
+		$parameters = $this->loadInto('/x/Richard "Popcorn" Wylie', false);
+		$this->assertTrue(
+			in_array('d.set_directory_base="/x/Richard \"Popcorn\" Wylie"', $parameters, true),
+			'the directory_base branch escapes the quote as well');
+	}
+
+	/**
+	 * The directory rtorrent is told to create is a typed parameter of its own,
+	 * never part of a command string, so it must stay unquoted and unescaped.
+	 */
+	public function testTheMkdirArgumentIsNotQuoted()
+	{
+		$parameters = $this->loadInto('/x/Richard "Popcorn" Wylie');
+		$this->assertTrue(
+			in_array('/x/Richard "Popcorn" Wylie', $parameters, true),
+			'mkdir receives the path verbatim as its own parameter');
+	}
+
+	// ---- the quoting itself ----------------------------------------------
+
 	public function testPlainPathIsWrappedInQuotes()
 	{
 		$this->assertEquals(
@@ -24,12 +170,6 @@ class RtorrentCommandArgTest extends TestCase
 			'a path with nothing to escape is just quoted');
 	}
 
-	/**
-	 * The reported bug: adding a torrent into a path with a double quote left
-	 * the download with no directory, because
-	 * d.directory.set="/x/Richard "Popcorn" Wylie" ends the argument at the
-	 * quote before "Popcorn".
-	 */
 	public function testDoubleQuoteIsEscapedSoItDoesNotEndTheArgument()
 	{
 		$this->assertEquals(
@@ -47,12 +187,13 @@ class RtorrentCommandArgTest extends TestCase
 	}
 
 	/**
-	 * The ordering trap: escaping the quote first and the backslash afterwards
-	 * would re-escape the backslash that the quote escaping just introduced,
-	 * turning \" into \\" -- an escaped backslash followed by a live quote,
-	 * which ends the argument again. A single str_replace() pass avoids it.
+	 * str_replace() works through the arrays left to right and can revisit a
+	 * value an earlier pair inserted, so the pairs are ordered backslash first,
+	 * quote second. Reversed, the backslash added while escaping the quote gets
+	 * doubled in turn, yielding \\" -- an escaped backslash and a live quote,
+	 * which ends the argument again.
 	 */
-	public function testBackslashBeforeQuoteIsEscapedInOnePass()
+	public function testBackslashBeforeQuoteSurvivesTheReplacementOrder()
 	{
 		$this->assertEquals(
 			'"/x/a\\\\\"b"',
@@ -78,19 +219,5 @@ class RtorrentCommandArgTest extends TestCase
 			'""',
 			rTorrent::quoteCommandArg(''),
 			'an empty value quotes to an empty argument');
-	}
-
-	/**
-	 * Guard against the fix being undone at either call site: sendTorrent()
-	 * and sendMagnet() both used to concatenate the raw path between two
-	 * literal quotes, which is the defect these tests exist for.
-	 */
-	public function testNoCallSiteConcatenatesTheRawDirectory()
-	{
-		$source = file_get_contents(__DIR__ . '/../../php/rtorrent.php');
-		$this->assertEquals(
-			0,
-			preg_match('/"\s*\.\s*\$directory\s*\.\s*"/', $source),
-			'no call site wraps $directory in quotes without escaping it');
 	}
 }


### PR DESCRIPTION
Fixes #3194.

`sendTorrent()` and `sendMagnet()` embed the download directory in a
command string that rtorrent parses itself, wrapping the raw path in
literal quotes without escaping it. A path containing `"` therefore ends
the argument early and the directory is never applied — the torrent is
added with an empty save path and fails to save its data. A path
containing `\` fails the same way. The issue has the full analysis with
permalinks.

The escaping already exists in this codebase:
`XMLRPCProxy::rebuildSafeLoadParam()` escapes `\` and `"` before quoting
a command argument, pinned by the contract fixture entry "quotes and
backslashes in a value are escaped, not dropped". This adds
`rTorrent::quoteCommandArg()` doing the same, and routes both call sites
through it, which also removes the duplicated construction between the
two.

The replacement is a single `str_replace()` pass rather than two
sequential ones: escaping the quote first and the backslash afterwards
would double the backslash the quote escaping just introduced, leaving a
live quote behind it and reopening the same defect.

`tests/php/RtorrentCommandArgTest.php` covers the quote, the backslash,
that ordering trap, a comma staying inside the argument, and guards both
call sites against the raw concatenation returning. Full PHP suite:
1402 passed, 0 failed.

Not fixed here: `rtAddTorrent()` in `plugins/datadir/util_rt.php` carries
the same concatenation, but it has no callers anywhere in the
repository, so it seemed out of scope.
