### PR TITLE
Add enabledByDefault flag to plugins.ini

### DIFF
--- a/conf/plugins.ini
+++ b/conf/plugins.ini
@@ -6,6 +6,8 @@
 ;;
 ;; [ratio]
 ;; enabled = yes			;; also may be "user-defined", in this case user can control plugin's state from UI
+;; enabledByDefault = yes		;; only meaningful when "enabled" is "user-defined": the state the
+;;  plugin has for a user who has never changed it from the UI
 ;; canChangeToolbar = yes
 ;; canChangeMenu = yes
 ;; canChangeOptions = no

--- a/php/getplugins.php
+++ b/php/getplugins.php
@@ -329,7 +329,7 @@ if($handle = opendir('../plugins'))
 			if($file != "." && $file != ".." && is_dir('../plugins/'.$file))
 			{
 				if(!array_key_exists($file,$userPermissions))
-					$userPermissions[$file] = true;
+					$userPermissions[$file] = (bool)getFlag($permissions,$file,"enabledByDefault");
 				$info = getPluginInfo( $file, $permissions );
 				if($info)
 				{

--- a/php/initplugins.php
+++ b/php/initplugins.php
@@ -155,7 +155,7 @@ if( $theSettings->linkExist && ($handle = opendir('../plugins')))
 		if($file != "." && $file != ".." && is_dir('../plugins/'.$file))
 		{
 			if(!array_key_exists($file,$userPermissions))
-				$userPermissions[$file] = true;
+				$userPermissions[$file] = (bool)getFlag($permissions,$file,"enabledByDefault");
 			$info = getPluginInfo( $file, $permissions );
 			if($info &&
 				$info["plugin.may_be_launched"] &&


### PR DESCRIPTION
This gives flexibility in providing user access to plugins, but not forcing them to load up as a result.