### PR TITLE
loginmgr: distinguish unavailable responses from expired sessions

### DIFF
--- a/plugins/loginmgr/accounts.php
+++ b/plugins/loginmgr/accounts.php
@@ -136,26 +136,112 @@ abstract class commonAccount
 		return(true);
 	}
 
+	// Three answers, not two. They call for three different repairs, and this
+	// class used to make only two of them:
+	//
+	//   ANSWER_LIVE   the tracker answered from behind the login wall.
+	//   ANSWER_GUEST  the tracker answered, and answered as a guest. The
+	//                 session is dead and logging in again is the repair.
+	//   ANSWER_NONE   nothing usable arrived. This says NOTHING about the
+	//                 session, so logging in again is not a repair: it spends
+	//                 a credential POST on a tracker that is already failing
+	//                 and then throws away cookies never shown to be stale.
+	//
+	// Every isOK() under accounts/ tells the first two apart by looking for a
+	// guest marker -- a login form, a registration link, a "you must log in"
+	// line -- and none of them can answer the third, because a page that never
+	// arrived carries no marker either. That is why all three used to collapse
+	// into "the session is live", and why a 5xx error page went back to the
+	// caller as the page or the torrent it had asked for.
+	const ANSWER_NONE = 0;
+	const ANSWER_GUEST = 1;
+	const ANSWER_LIVE = 2;
+
+	// What the client is holding after a fetch of the caller's own URL.
+	protected function classifyAnswer($client)
+	{
+		if(!is_object($client))
+			return(self::ANSWER_NONE);
+		$status = (int) $client->status;
+		// A conditional request the server honoured. It answered, it answered
+		// the authenticated request, and it sent no body on purpose: the
+		// caller asked for that (plugins/rss sends If-None-Match and reads
+		// $client->status itself). Judging it by its absent body would turn
+		// every unchanged poll of an authenticated feed into a fresh login.
+		if($status===304)
+			return(self::ANSWER_LIVE);
+		// Only 2xx carries a body meant for the caller. A 3xx reaching here is
+		// a redirect Snoopy did not follow -- a followed chain ends at the
+		// status of its last hop -- and the boilerplate body a server puts on
+		// one carries no guest marker either, so it would read as a live
+		// session for want of evidence.
+		if(($status<200) || ($status>=300))
+			return(self::ANSWER_NONE);
+		if(!$this->hasReadableBody($client))
+			return(self::ANSWER_NONE);
+		return($this->isOK($client) ? self::ANSWER_LIVE : self::ANSWER_GUEST);
+	}
+
+	// True when $client->results is something a strpos() marker test can read.
+	// Snoopy does not always leave a string there: when a gzipped body arrives
+	// on a build without gzinflate() it shells out to gzip, and if the
+	// decompressed file is missing the body is lost. strpos() on a non-string
+	// is fatal in PHP 8, and every marker test under accounts/ is a strpos().
+	protected function hasReadableBody($client)
+	{
+		return(is_object($client) && is_string($client->results) && ($client->results!==''));
+	}
+
+	// The login answer is a narrower question than the caller's answer: a
+	// login endpoint may legitimately answer with no body at all -- a 30x to
+	// the landing page, or a 200 whose whole content is Set-Cookie -- and it
+	// is the fetch that follows which proves whether the session took. So the
+	// marker test is applied only when there is a body to apply it to, and the
+	// status range stays the one this class has always used here.
+	protected function loginWasNotRefused($client)
+	{
+		if(!is_object($client))
+			return(false);
+		$status = (int) $client->status;
+		if(($status<200) || ($status>=400))
+			return(false);
+		return(!$this->hasReadableBody($client) || $this->isOK($client));
+	}
+
 	protected function isOKPostFetch($client,$url,$method,$content_type,$body)
 	{
-		return($this->isOK($client));
+		return($this->classifyAnswer($client)===self::ANSWER_LIVE);
 	}
 
 	public function fetch( $client, $url, $login, $password, $method, $content_type, $body )
 	{
-	        $is_result_fetched = false;
+		$is_result_fetched = false;
 		$data = $this->loadData($client);
-		$ret = ( ($data->loaded &&
-				$this->updateCached($client,$url,$method,$content_type,$body) &&
-				$client->fetch($url,$method,$content_type,$body) &&
-				$this->isOKPostFetch($client,$url,$method,$content_type,$body)) ||
-			($this->login($client,$login,$password,$url,$method,$content_type,$body,$is_result_fetched) &&
-				$client->status>=200 &&
-				$client->status<400 &&
-				$this->isOK($client) &&
-                                ($is_result_fetched || $client->fetch($url,$method,$content_type,$body)) &&
-				$this->isOKPostFetch($client,$url,$method,$content_type,$body) &&
-				$data->store($client)) );
+		if($data->loaded &&
+			$this->updateCached($client,$url,$method,$content_type,$body))
+		{
+			if(!$client->fetch($url,$method,$content_type,$body))
+				return(false);
+			// Taken before isOKPostFetch(), because an override may fetch
+			// further pages onto this client and the question here is about
+			// the answer to the caller's own URL.
+			$answer = $this->classifyAnswer($client);
+			if($this->isOKPostFetch($client,$url,$method,$content_type,$body))
+				return(true);
+			// Only a guest answer is evidence that the session died. Anything
+			// else leaves that unproven, so report the failure and keep the
+			// cookies rather than log in again against a tracker that is not
+			// answering: one outage would otherwise cost a credential POST per
+			// call for every caller looping over a torrent list, which is how
+			// an account gets locked out.
+			if($answer!==self::ANSWER_GUEST)
+				return(false);
+		}
+		$ret = ( $this->login($client,$login,$password,$url,$method,$content_type,$body,$is_result_fetched) &&
+			$this->loginWasNotRefused($client) &&
+			($is_result_fetched || $client->fetch($url,$method,$content_type,$body)) &&
+			$this->isOKPostFetch($client,$url,$method,$content_type,$body) &&
+			$data->store($client) );
 		if(!$ret)
 			$data->remove();
 		return($ret);
@@ -166,14 +252,24 @@ abstract class commonAccount
 		$modified = privateData::getModified($this->getName());
 		if( ($modified===false) || ((time()-$modified)>=$auto))
 		{
+			// login() takes these by reference and several accounts read them
+			// before writing: undeclared, they arrived as null, and an account
+			// whose login() starts by fetching $url could never authenticate
+			// from here at all.
+			$url = $this->url;
+			$method = "GET";
+			$content_type = "";
+			$body = "";
+			$is_result_fetched = false;
 			$data = $this->loadData();
 			if($this->login($client,$login,$password,$url,$method,$content_type,$body,$is_result_fetched) &&
-				$client->status>=200 &&
-				$client->status<400 &&
-				$this->isOK($client))
+				$this->loginWasNotRefused($client))
 				$data->store($client);
-			else
-				$data->remove();
+			// A login that did not come back is not evidence that the stored
+			// session is stale, and this job exists to REFRESH a session:
+			// deleting one it merely failed to renew leaves the user worse off
+			// than not running at all. A session that really has died is
+			// discovered, and replaced, by the next fetch().
 		}
 	}
 }

--- a/plugins/loginmgr/accounts/KinozalTV.php
+++ b/plugins/loginmgr/accounts/KinozalTV.php
@@ -6,6 +6,14 @@ class KinozalTVAccount extends commonAccount
 
 	protected function isOK($client)
 	{
+		// A downloaded torrent is payload, not a page. It may carry any bytes
+		// at all -- a /signup.php URL in its comment field included -- and the
+		// registration-link marker below would then read a perfectly good
+		// torrent as a login wall, costing a re-login and the cached session
+		// on every download of it. Nothing that opens a bencoded dictionary
+		// came from the web front end.
+		if((strncmp($client->results,'d',1)===0) && (strpos($client->results,'4:info')!==false))
+			return(true);
 		// Two independent markers of a guest answer, because Kinozal has two
 		// kinds of them. The login form is matched on the password field alone
 		// (like RUTracker/TapochekNet do): the previous two-attribute probe
@@ -19,12 +27,12 @@ class KinozalTVAccount extends commonAccount
 	}
 	protected function login($client,$login,$password,&$url,&$method,&$content_type,&$body,&$is_result_fetched)
 	{
-	        $is_result_fetched = false;
+		$is_result_fetched = false;
 		if($client->fetch( $this->url ))
 		{
-                        $client->setcookies();
+			$client->setcookies();
 			$client->referer = $this->url;
-        		if($client->fetch( $this->url."/takelogin.php","POST","application/x-www-form-urlencoded",
+			if($client->fetch( $this->url."/takelogin.php","POST","application/x-www-form-urlencoded",
 				"username=".rawurlencode($login)."&password=".rawurlencode($password) ))
 			{
 				$client->setcookies();

--- a/plugins/loginmgr/accounts/LostFilm.php
+++ b/plugins/loginmgr/accounts/LostFilm.php
@@ -14,15 +14,32 @@ class LostFilmAccount extends commonAccount
 	}
 	protected function isOKPostFetch($client,$url,$method,$content_type,$body)
 	{
+		// Taken first: the recovery below fetches details.php onto this same
+		// client, and after that $client->results is that page rather than the
+		// answer the caller asked for. Judging the fallthrough on it would be
+		// judging the wrong response.
+		$answered = $this->classifyAnswer($client);
 		if(	preg_match("`/download\.php\?id=(\d+)&`si", $url, $matches) &&
-			preg_match("`/browse.php\?cat=`si", $client->lastredirectaddr) &&
+			preg_match("`/browse.php\?cat=`si", (string) $client->lastredirectaddr) &&
 			$client->fetch($this->url."/details.php?id=".$matches[1]) &&
 			preg_match("`/download\.php\?id=".$matches[1]."&\S+\s*\sonMouseOver=\"setCookie\('dlt','([^']*)'`si", $client->results, $md5))
 		{
 			$client->cookies["dlt_2"] = $md5[1];
-			return($client->fetch($url,$method,$content_type,$body) && ($client->get_filename()!==false));
+			// The retry is an answer like any other. get_filename() reads only
+			// the Content-Disposition header -- never the status, never the
+			// body -- so on its own it accepts a 500 page and a body Snoopy
+			// failed to decompress, which are the shapes the base class exists
+			// to refuse.
+			return($client->fetch($url,$method,$content_type,$body) &&
+				($this->classifyAnswer($client)===commonAccount::ANSWER_LIVE) &&
+				($client->get_filename()!==false));
 		}
-		return(true);
+		// The "nothing special to do here" branch. It has to hand the question
+		// back rather than answer true on its own: this is the only override
+		// of isOKPostFetch() in accounts/, so answering here was the one way
+		// to skip the base class's verdict -- and on the cached path it
+		// skipped isOK() with it, leaving this account checking nothing.
+		return($answered===commonAccount::ANSWER_LIVE);
 	}
 	protected function login($client,$login,$password,&$url,&$method,&$content_type,&$body,&$is_result_fetched)
 	{

--- a/tests/plugins/loginmgr/CommonAccountTest.php
+++ b/tests/plugins/loginmgr/CommonAccountTest.php
@@ -1,0 +1,424 @@
+<?php
+
+/**
+ * commonAccount -- how loginmgr decides whether a stored session is still good,
+ * and what it does when it is not.
+ *
+ * The subject is the orchestration, not one predicate: the interesting claims
+ * are about which of fetch()'s two branches runs, whether a credential POST is
+ * spent, and whether the cookie cache survives. So most of this drives the real
+ * public fetch() and check() with a scripted client and a recording cache,
+ * rather than reaching into isOK() through reflection.
+ *
+ * The real plugins/loginmgr/accounts.php is loaded, so the base class under
+ * test is the shipped one. That rules out tests/plugins/rutracker_check/
+ * TestLib.php, whose rTorrentSettings/rXMLRPCRequest doubles collide with the
+ * classes accounts.php reaches through php/cache.php -- the same reason
+ * tests/plugins/history/HistoryDataTest.php carries its own small runner.
+ */
+
+require_once(__DIR__ . '/../../../plugins/loginmgr/accounts.php');
+foreach (glob(__DIR__ . '/../../../plugins/loginmgr/accounts/*.php') as $accountFile) {
+    require_once($accountFile);
+}
+
+function caAssertSame($expected, $actual, $message)
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException(
+            $message . '; expected ' . var_export($expected, true)
+            . ', got ' . var_export($actual, true)
+        );
+    }
+}
+
+// Every concrete account, in a stable order so a failure names the same class
+// twice running.
+function caAccountClasses()
+{
+    $classes = array();
+    foreach (get_declared_classes() as $class) {
+        if (is_subclass_of($class, 'commonAccount') && $class !== 'ProbeAccount') {
+            $classes[] = $class;
+        }
+    }
+    sort($classes);
+    return $classes;
+}
+
+/**
+ * A Snoopy stand-in. fetch() returns the scripted transport result whatever the
+ * status, because the real one does: php/Snoopy.class.inc returns the transport
+ * result and answers true for a 500 as readily as for a 200. That is the premise
+ * of the whole guard, so a double that returned false for 4xx/5xx would let a
+ * reverted fix pass.
+ */
+class CAClient
+{
+    public $status = 200;
+    public $results = '';
+    public $lastredirectaddr = '';
+    public $referer = '';
+    public $cookies = array();
+    public $fetches = 0;
+    public $filename = 'movie.torrent';
+    private $queue;
+
+    public function __construct($queue = array())
+    {
+        $this->queue = $queue;
+    }
+
+    public function fetch($url, $method = 'GET', $contentType = '', $body = '')
+    {
+        $this->fetches++;
+        if ($this->queue) {
+            $answer = array_shift($this->queue);
+            $this->apply($answer);
+            return isset($answer[2]) ? $answer[2] : true;
+        }
+        return true;
+    }
+
+    public function queueAnswers($queue)
+    {
+        $this->queue = $queue;
+    }
+
+    public function apply($answer)
+    {
+        $this->status = $answer[0];
+        $this->results = $answer[1];
+    }
+
+    public function setcookies()
+    {
+        $this->cookies['sid'] = 'abc';
+    }
+
+    public function get_filename()
+    {
+        return $this->filename;
+    }
+}
+
+// A privateData that counts what was asked of it instead of touching rCache.
+class CARecordingData extends privateData
+{
+    public $stored = 0;
+    public $removed = 0;
+
+    public function store($client)
+    {
+        $this->stored++;
+        return true;
+    }
+
+    public function remove()
+    {
+        $this->removed++;
+    }
+}
+
+// A minimal account: one guest marker, and a login() whose answer the test
+// scripts. Everything else is the real base class.
+class ProbeAccount extends commonAccount
+{
+    public $url = 'https://tracker.example';
+    public $data;
+    public $logins = 0;
+    public $loginAnswer = null;     // array(status, body), or null for "login failed"
+    public $urlSeenByLogin = 'unset';
+
+    public function __construct()
+    {
+        $this->data = new CARecordingData('Probe');
+    }
+
+    protected function loadData($client = null)
+    {
+        return $this->data;
+    }
+
+    protected function isOK($client)
+    {
+        return strpos($client->results, 'name="password"') === false;
+    }
+
+    protected function login($client, $login, $password, &$url, &$method, &$content_type, &$body, &$is_result_fetched)
+    {
+        $this->logins++;
+        $this->urlSeenByLogin = $url;
+        $is_result_fetched = false;
+        if ($this->loginAnswer === null) {
+            return false;
+        }
+        $client->apply($this->loginAnswer);
+        $client->setcookies();
+        return true;
+    }
+}
+
+// A page carrying none of the guest markers any account looks for, so every
+// isOK() under accounts/ reads it as authenticated. It is the control: the
+// refusals below differ from it in the answer's status or body alone.
+function caLivePage()
+{
+    return '<html><body><a href="/logout.php">Log out</a></body></html>';
+}
+
+function caGuestPage()
+{
+    return '<html><form action="/login.php"><input type="password" name="password"></form></html>';
+}
+
+// A cached session that has already been loaded from disk.
+function caWarmProbe($queue)
+{
+    $account = new ProbeAccount();
+    $account->data->loaded = true;
+    return array($account, new CAClient($queue));
+}
+
+function caFetch($account, $client)
+{
+    return $account->fetch($client, 'https://tracker.example/dl.php?id=1', 'user', 'pass', 'GET', '', '');
+}
+
+// A client already holding an answer, for the paths that do not fetch first.
+function caHolding($status, $body, $lastRedirect = '')
+{
+    $client = new CAClient();
+    $client->status = $status;
+    $client->results = $body;
+    $client->lastredirectaddr = $lastRedirect;
+    return $client;
+}
+
+function caPostFetch($class, $client, $url = 'https://tracker.example/page.php')
+{
+    $method = new ReflectionMethod($class, 'isOKPostFetch');
+    if (PHP_VERSION_ID < 80100) {
+        $method->setAccessible(true);
+    }
+    return $method->invoke(new $class(), $client, $url, 'GET', '', '');
+}
+
+$tests = array(
+
+    // ---- what fetch() does with each kind of answer -------------------------
+
+    'a live page on the cached path is used, and costs no login' => function () {
+        list($account, $client) = caWarmProbe(array(array(200, caLivePage())));
+        caAssertSame(true, caFetch($account, $client), 'the cached session serves the page');
+        caAssertSame(0, $account->logins, 'no credential POST is spent on a working session');
+        caAssertSame(0, $account->data->removed, 'the cookies are kept');
+        caAssertSame(1, $client->fetches, 'exactly one request leaves the box');
+    },
+
+    'a guest page is the one answer that re-logs in' => function () {
+        // The only evidence that the session died: the tracker answered, and
+        // answered as a guest.
+        list($account, $client) = caWarmProbe(array(array(200, caGuestPage()), array(200, caLivePage())));
+        $account->loginAnswer = array(200, caLivePage());
+        caAssertSame(true, caFetch($account, $client), 'the re-login recovers the fetch');
+        caAssertSame(1, $account->logins, 'exactly one login');
+        caAssertSame(1, $account->data->stored, 'the new session is cached');
+        caAssertSame(0, $account->data->removed, 'and not thrown away again');
+    },
+
+    'a server error costs no login and keeps the session' => function () {
+        // A 5xx says nothing about whether the session is alive, so logging in
+        // again is not a repair -- it spends a credential POST on a tracker
+        // that is already failing. Callers that loop over a torrent list would
+        // otherwise turn one outage into a login per torrent.
+        list($account, $client) = caWarmProbe(array(array(503, '<html>bad gateway</html>')));
+        caAssertSame(false, caFetch($account, $client), 'the failure is reported');
+        caAssertSame(0, $account->logins, 'no credential POST is spent on an outage');
+        caAssertSame(0, $account->data->removed, 'cookies never shown to be stale are kept');
+        caAssertSame(1, $client->fetches, 'and no second request is made');
+    },
+
+    'a cached request that cannot reach the tracker keeps its session' => function () {
+        // A false Snoopy::fetch() means no response arrived at all. It cannot
+        // establish that the cached cookies are stale, so this attempt must
+        // stop before the Kinozal credential POST and leave that session alone.
+        list($account, $client) = caWarmProbe(array(array(0, '', false)));
+        $client->cookies = array('sid' => 'cached');
+        caAssertSame(false, caFetch($account, $client), 'a transport failure is reported');
+        caAssertSame(0, $account->logins, 'no credential POST is spent without an answer');
+        caAssertSame(0, $account->data->removed, 'the cached session is not deleted');
+        caAssertSame(array('sid' => 'cached'), $client->cookies, 'the cached cookies stay in place');
+        caAssertSame(1, $client->fetches, 'the failed request is not retried through login');
+    },
+
+    'an unchanged conditional answer is a live session' => function () {
+        // plugins/rss sends If-None-Match and reads $client->status itself. A
+        // 304 is empty on purpose; judging it by its absent body would turn
+        // every unchanged poll of an authenticated feed into a fresh login.
+        list($account, $client) = caWarmProbe(array(array(304, '')));
+        caAssertSame(true, caFetch($account, $client), '304 is an answer, and an authenticated one');
+        caAssertSame(0, $account->logins, 'an unchanged feed costs no login');
+        caAssertSame(0, $account->data->removed, 'and does not drop the session');
+    },
+
+    'a redirect that was not followed is neither live nor dead' => function () {
+        // A followed chain ends at the status of its last hop, so a 3xx here
+        // means Snoopy stopped following. The boilerplate body a server puts on
+        // one carries no guest marker, so it used to read as a live session.
+        foreach (array('', '<html><head><title>302 Found</title></head><body>moved</body></html>') as $stub) {
+            list($account, $client) = caWarmProbe(array(array(302, $stub)));
+            caAssertSame(false, caFetch($account, $client), 'a 302 is not a page to hand to the caller');
+            caAssertSame(0, $account->logins, 'and not evidence that the session died');
+            caAssertSame(0, $account->data->removed, 'so the cookies stay');
+        }
+    },
+
+    'an empty body is not a live session' => function () {
+        list($account, $client) = caWarmProbe(array(array(200, '')));
+        caAssertSame(false, caFetch($account, $client), 'nothing arrived, so nothing is served');
+        caAssertSame(0, $account->logins, 'and no login is spent guessing why');
+    },
+
+    'a body the transport could not decompress is refused, not fatal' => function () {
+        // php/Snoopy.class.inc shells out to gzip when it has no gzinflate();
+        // a failed decompression used to leave exec()'s output array in
+        // ->results, and every marker test under accounts/ is a strpos(),
+        // which is fatal on an array in PHP 8.
+        list($account, $client) = caWarmProbe(array(array(200, array('gzip: stdin: not in gzip format'))));
+        caAssertSame(false, caFetch($account, $client), 'a non-string body is refused');
+        caAssertSame(0, $account->logins, 'and is not read as a dead session either');
+    },
+
+    // ---- what fetch() does on the login path --------------------------------
+
+    'a login answered with cookies and no body still authenticates' => function () {
+        // A login endpoint may answer 204, or a 30x to the landing page, and do
+        // all its work in Set-Cookie. It is the fetch that follows which proves
+        // whether the session took, so the marker test cannot be applied to a
+        // body that is not there.
+        $account = new ProbeAccount();
+        $account->loginAnswer = array(302, '');
+        $client = new CAClient(array(array(200, caLivePage())));
+        caAssertSame(true, caFetch($account, $client), 'a bodyless login answer is not a refusal');
+        caAssertSame(1, $account->data->stored, 'the session it produced is cached');
+    },
+
+    'a login answered with the guest form is a refusal' => function () {
+        $account = new ProbeAccount();
+        $account->loginAnswer = array(200, caGuestPage());
+        $client = new CAClient();
+        caAssertSame(false, caFetch($account, $client), 'wrong credentials do not authenticate');
+        caAssertSame(1, $account->data->removed, 'and the stale cache is dropped');
+    },
+
+    // ---- check(), the auto-relogin cron -------------------------------------
+
+    'check() hands login() a usable url' => function () {
+        // These are by-reference parameters, and several accounts read them
+        // before writing. Undeclared, they arrived as null, and an account
+        // whose login() begins by fetching $url could never authenticate here.
+        $account = new ProbeAccount();
+        $account->loginAnswer = array(200, caLivePage());
+        $account->check(new CAClient(), 'user', 'pass', 0);
+        caAssertSame('https://tracker.example', $account->urlSeenByLogin, 'login() is given the account url');
+        caAssertSame(1, $account->data->stored, 'a renewed session is cached');
+    },
+
+    'check() never deletes a session it merely failed to renew' => function () {
+        // The job exists to REFRESH a session. Deleting one because this run
+        // could not reach the tracker leaves the user worse off than not
+        // running it at all; a session that really died is found by fetch().
+        $account = new ProbeAccount();
+        $account->loginAnswer = null;
+        $account->check(new CAClient(), 'user', 'pass', 0);
+        caAssertSame(0, $account->data->removed, 'the stored session survives a failed renewal');
+        caAssertSame(0, $account->data->stored, 'and nothing bogus is stored either');
+    },
+
+    // ---- the family, and its one override -----------------------------------
+
+    'every account still accepts a page from behind the login wall' => function () {
+        $classes = caAccountClasses();
+        caAssertSame(true, count($classes) > 0, 'the account files were found at all');
+        foreach ($classes as $class) {
+            caAssertSame(true, caPostFetch($class, caHolding(200, caLivePage())),
+                $class . ' must accept an answer that did arrive');
+        }
+    },
+
+    'no account reads an answer that never arrived as a live session' => function () {
+        foreach (caAccountClasses() as $class) {
+            foreach (array(array(200, ''), array(503, caLivePage()), array(302, caLivePage()),
+                array(200, array('gzip: not in gzip format'))) as $answer) {
+                caAssertSame(false, caPostFetch($class, caHolding($answer[0], $answer[1])),
+                    $class . ' on status ' . $answer[0]);
+            }
+        }
+    },
+
+    'the one override of isOKPostFetch hands the fallthrough back' => function () {
+        // LostFilm is the only override in accounts/, and its fallthrough used
+        // to answer true on its own -- the one way to skip the base verdict,
+        // which on the cached path skipped isOK() with it.
+        caAssertSame(false, caPostFetch('LostFilmAccount', caHolding(200, '')),
+            'LostFilm is not exempt from the guard its siblings get');
+        caAssertSame(false, caPostFetch('LostFilmAccount', caHolding(503, caLivePage())),
+            'nor from the status half of it');
+    },
+
+    'the override judges the answer the caller asked for' => function () {
+        // Its recovery branch fetches details.php onto the same client. Once it
+        // has, ->results is that page and no longer the answer to $url, so the
+        // fallthrough verdict has to be taken before the branch runs.
+        // The dlt marker is absent from details.php, so the branch falls
+        // through -- but only after replacing ->results with a page that would
+        // pass on its own.
+        $client = caHolding(200, caGuestPage(), '/browse.php?cat=1');
+        $client->queueAnswers(array(array(200, caLivePage())));
+        caAssertSame(false,
+            caPostFetch('LostFilmAccount', $client, 'https://lostfilm.tv/download.php?id=7&x'),
+            'the guest answer to the download url decides, not details.php');
+    },
+
+    'the override does not accept a download by its headers alone' => function () {
+        // get_filename() reads Content-Disposition and never the status or the
+        // body, so on its own it accepts a 500 page and a body Snoopy could not
+        // decompress -- the shapes the base class exists to refuse.
+        $client = caHolding(200, '<html>ok</html>', '/browse.php?cat=1');
+        $client->queueAnswers(array(
+            // details.php, carrying the dlt token in the shape the regex wants
+            array(200, '<a href="/download.php?id=7&yyy" onMouseOver="setCookie(\'dlt\',\'deadbeef\'"></a>'),
+            // the retried download: a filename header, but an error page
+            array(500, '<html>error</html>'),
+        ));
+        caAssertSame(false,
+            caPostFetch('LostFilmAccount', $client, 'https://lostfilm.tv/download.php?id=7&x'),
+            'a 500 carrying a filename header is not a torrent');
+    },
+
+    // ---- one tracker-specific claim worth pinning ---------------------------
+
+    'a downloaded torrent is not mistaken for a login wall' => function () {
+        // Kinozal reads a guest answer off the registration link, which a
+        // torrent may legitimately carry in its comment field.
+        $torrent = 'd8:announce31:http://tr.kinozal.guru/ann?uk=X7:comment28:see /signup.php to register'
+            . '4:infod6:lengthi1e4:name9:movie.mkv12:piece lengthi16384eee';
+        caAssertSame(true, caPostFetch('KinozalTVAccount', caHolding(200, $torrent)),
+            'a torrent whose comment names /signup.php is still a torrent');
+    },
+);
+
+$failures = 0;
+foreach ($tests as $name => $callback) {
+    try {
+        $callback();
+        echo "ok - {$name}\n";
+    } catch (Throwable $error) {
+        $failures++;
+        echo "not ok - {$name}\n";
+        echo '  ' . get_class($error) . ': ' . $error->getMessage() . "\n";
+    }
+}
+echo count($tests) . ' tests, ' . $failures . " failures\n";
+exit($failures === 0 ? 0 : 1);

--- a/tests/plugins/loginmgr/KinozalAccountTest.php
+++ b/tests/plugins/loginmgr/KinozalAccountTest.php
@@ -23,25 +23,69 @@ abstract class commonAccount
 
 require_once(testFindRepoRoot() . '/plugins/loginmgr/accounts/KinozalTV.php');
 
-// isOK() reads exactly one field off the Snoopy client.
+// isOK() and login() test double.
 class KinozalFakeClient
 {
+    public $status = 200;
     public $results = '';
+    public $referer = '';
+    public $cookies = array();
+    public $responses = array();
+    public $unreachable = null;
 
-    public function __construct($results)
+    public function __construct($results = '', $status = 200)
     {
         $this->results = $results;
+        $this->status = $status;
+    }
+
+    public function fetch($url, $method = 'GET', $contentType = '', $body = '')
+    {
+        if ($this->unreachable !== null && $url === $this->unreachable) {
+            return false;
+        }
+        if (isset($this->responses[$url])) {
+            $resp = $this->responses[$url];
+            $this->status = $resp['status'] ?? 200;
+            $this->results = $resp['results'] ?? '';
+        }
+        // Snoopy::fetch() returns the transport result, not a verdict on the
+        // status: it answers true for a 500 as readily as for a 200. A double
+        // that refused 4xx/5xx here would do the rejecting that the code under
+        // test is supposed to do, and a reverted fix would still pass.
+        return true;
+    }
+
+    public function setcookies()
+    {
+        $this->cookies['uid'] = '12345';
+        $this->cookies['pass'] = 'abcde';
     }
 }
 
-function kinozalIsOK($body)
+function kinozalIsOK($body, $status = 200)
 {
     $account = new KinozalTVAccount();
     $method = new ReflectionMethod('KinozalTVAccount', 'isOK');
     if (PHP_VERSION_ID < 80100) {
         $method->setAccessible(true);
     }
-    return $method->invoke($account, new KinozalFakeClient($body));
+    return $method->invoke($account, new KinozalFakeClient($body, $status));
+}
+
+function kinozalLogin($client, $user = 'user', $pass = 'pass')
+{
+    $account = new KinozalTVAccount();
+    $method = new ReflectionMethod('KinozalTVAccount', 'login');
+    if (PHP_VERSION_ID < 80100) {
+        $method->setAccessible(true);
+    }
+    $url = '';
+    $httpMethod = 'GET';
+    $contentType = '';
+    $body = '';
+    $isFetched = false;
+    return $method->invokeArgs($account, array($client, $user, $pass, &$url, &$httpMethod, &$contentType, &$body, &$isFetched));
 }
 
 // Captured from https://kinozal.guru/login.php on 2026-08-07: type= carries no
@@ -115,6 +159,42 @@ $suite->test('torrent bytes read as a live session', function () {
         . '4:name9:movie.mkv12:piece lengthi16384e6:pieces20:' . str_repeat("\0", 20) . 'ee';
     strictAssertSame(true, kinozalIsOK($raw),
         'a downloaded torrent must never be mistaken for a login wall');
+});
+
+$suite->test('a torrent whose comment names the signup page is still a torrent', function () {
+    // The registration link is a marker of a guest PAGE. A torrent is payload
+    // and may carry any bytes at all, so reading the marker out of one would
+    // cost a re-login, and the cached session, on every download of it.
+    $torrent = 'd8:announce31:http://tr.kinozal.guru/ann?uk=X7:comment28:see /signup.php to register'
+        . '4:infod6:lengthi1e4:name9:movie.mkv12:piece lengthi16384eee';
+    strictAssertSame(true, kinozalIsOK($torrent),
+        'a torrent must not be read as a login wall because of its comment');
+});
+
+$suite->test('login reports whether the exchange happened, not whether it was accepted', function () {
+    // The verdict belongs to commonAccount::fetch()/check(), which apply it to
+    // this same answer the moment login() returns; the other twenty-four
+    // accounts report the exchange and nothing more, and a login() that judged
+    // for itself would make "false" mean both "the tracker did not answer" and
+    // "the credentials were refused", which the caller cannot tell apart.
+    $client = new KinozalFakeClient();
+    $client->responses = array(
+        'https://kinozal.guru' => array('status' => 200, 'results' => '<html>main page</html>'),
+        'https://kinozal.guru/takelogin.php' => array('status' => 200, 'results' => kinozalLoginPage()),
+    );
+    strictAssertSame(true, kinozalLogin($client, 'baduser', 'badpass'),
+        'both requests went through, which is all login() is asked');
+    strictAssertSame(false, kinozalIsOK($client->results),
+        'and the guest form it came back with is what the caller then refuses');
+    strictAssertSame(true, isset($client->cookies['uid']), 'cookies are captured either way');
+});
+
+$suite->test('login fails when the tracker cannot be reached at all', function () {
+    $client = new KinozalFakeClient();
+    $client->responses = array('https://kinozal.guru' => array('status' => 200, 'results' => ''));
+    $client->unreachable = 'https://kinozal.guru/takelogin.php';
+    strictAssertSame(false, kinozalLogin($client, 'user', 'pass'),
+        'a request that did not go through is a failed login');
 });
 
 exit($suite->run());


### PR DESCRIPTION
`KinozalTVAccount::isOK()` decides a session is still alive by *failing* to find
the guest markers in `$client->results`: no ` name="password"` and no
`/signup.php`. An HTTP 5xx page, a redirect Snoopy did not follow, and an empty
body contain neither marker either — so all three were read as a live,
authenticated session.

`isOK()` is also what `commonAccount::isOKPostFetch()` applies to a fetched
result, so the same blind spot accepted a failed download as a successful one:
loginmgr handed the empty body back to the caller as the downloaded page or
torrent and kept the cached cookies, so it never re-authenticated and every
following fetch failed the same way.

This requires a 200 and a non-empty string body before looking for the markers.

Two consequences worth naming up front:

* `status !== 200` is stricter than the `200..399` the framework applies around
  this call, so a 30x that Snoopy did not follow now forces a re-login for this
  tracker rather than being accepted as a live page. That is the intent, but it
  is a behaviour change on Kinozal.
* `login()` now returns `$this->isOK($client)` instead of a bare `true`. This
  changes no outcome — `commonAccount::fetch()` and `::check()` already apply
  `status >= 200 && status < 400` together with `isOK()` to that same response —
  it only makes `login()` honest about the result it reports. The surrounding
  indentation in `login()` is normalised to tabs while the return is changed.

### How to verify

`tests/plugins/loginmgr/KinozalAccountTest.php` covers the three answers that
used to pass (500, 302, empty body) and pins `login()`'s verdict on both a
`takelogin.php` reply that comes back as the guest form and one that comes back
authenticated.

    cd tests && bash php-test.sh

