### PR TITLE
Give getScheduleCommand a deterministic start

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -381,18 +381,30 @@ class rTorrentSettings
 		$startAt = $interval+rand(0,$schedule_rand);
 		return( new rXMLRPCCommand("schedule", array( $name.User::getUser(), $startAt."", $interval."", $cmd )) );
 	}
-	public function getScheduleCommand($name,$interval,$cmd,&$startAt = null)	// $interval in minutes
+	public function getScheduleCommand($name,$interval,$cmd,&$startAt = null,$now = null)	// $interval in minutes
 	{
-		global $schedule_rand;
-		if(!isset($schedule_rand))
-			$schedule_rand = 10;
-		$tm = getdate();
-		$startAt = mktime($tm["hours"],
-			((int)($tm["minutes"]/$interval))*$interval+$interval,
-			0,$tm["mon"],$tm["mday"],$tm["year"])-$tm[0]+rand(0,$schedule_rand);
-		if($startAt<0)
-			$startAt = 0;
+		// The start has to be deterministic, not jittered with rand().
+		// php/getplugins.php re-runs every enabled plugin's init.php on each
+		// full load of the web interface, and rTorrent's scheduler replaces an
+		// entry that reuses a key, restarting its countdown at now+start
+		// (CommandScheduler::insert). With a random offset a reload landing in
+		// the jitter window -- after the wall-clock boundary but before the
+		// task actually fired -- recomputed to the *next* boundary, so a user
+		// who kept refreshing cost the task a whole interval each time.
+		// getAlignedStart spreads the tasks over that same window by the crc32
+		// of their key instead, so every re-registration of one task resolves
+		// to the same absolute instant; it counts in seconds, hence the
+		// conversion first. It also never returns 0, so a reload cannot fire
+		// the task at once, and $startAt stays the seconds-until-fire that
+		// callers such as plugins/rss report as the next update time.
+		//
+		// $now is the same clock seam getAlignedStart already carries, and it
+		// is here for the same reason: what this function has to promise is
+		// that two registrations made at *different* instants resolve to the
+		// same fire time, and a caller that can only read the clock samples a
+		// single instant. Production callers pass nothing and get time().
 		$interval = $interval*60;
+		$startAt = self::getAlignedStart($name,$interval,$now);
 		return( new rXMLRPCCommand("schedule", array( $name.User::getUser(), $startAt."", $interval."", $cmd )) );
 	}
 	static public function getAlignedStart($name,$interval,$now = null)	// $interval in seconds

--- a/tests/php/ScheduleTest.php
+++ b/tests/php/ScheduleTest.php
@@ -28,9 +28,43 @@ function scheduleFiresAt($name, $interval, $now)
     return $now + rTorrentSettings::getAlignedStart($name, $interval, $now);
 }
 
+// One registration of $name at $now, as both the caller (the &$startAt
+// out-parameter) and rTorrent (the serialized command) see it. Driving $now
+// rather than reading the clock is the whole point: the promise is that two
+// registrations made at *different* instants resolve to the same absolute fire
+// time, and the seconds where a broken implementation gives itself away are a
+// handful out of an interval, so sampling the real clock would only reach them
+// by luck.
+function scheduleCommandAt($name, $intervalMinutes, $now)
+{
+    $startAt = 0;
+    $command = rTorrentSettings::get()->getScheduleCommand(
+        $name, $intervalMinutes, 'print=noop', $startAt, $now
+    );
+    return array(
+        'now' => $now,
+        'startAt' => $startAt,
+        'firesAt' => $now + $startAt,
+        'key' => $command->params[0]->value,
+        'reported' => $command->params[1]->value,
+        'interval' => $command->params[2]->value,
+    );
+}
+
+// The second within an interval that $name's key claims for itself.
+function scheduleJitterOffset($name)
+{
+    global $schedule_rand;
+    return abs(crc32($name . User::getUser())) % ($schedule_rand + 1);
+}
+
 $hourly = 3600;
 $daily = 86400;
 $quarterMinute = 15;
+
+// conf/config.php's default, pinned here so the offsets the tests compute are
+// the ones the code computes.
+$schedule_rand = 10;
 
 $tests = array(
     'reloads do not move the fire time' => function () use ($hourly) {
@@ -121,6 +155,130 @@ $tests = array(
             );
         }
         scheduleAssertTrue(count(array_unique($offsets)) > 1, 'Every task landed on the same second');
+    },
+    'a reload inside the jitter window does not move a getScheduleCommand fire time' => function () {
+        global $schedule_rand;
+
+        // The window this case exists to walk runs from the interval boundary
+        // up to the key's own second within the jitter spread, so it needs a
+        // key whose offset is not 0 or there is nothing between the two to
+        // walk. getScheduleCommand's own callers cannot supply one -- 'trafic'
+        // and 'rss' both happen to hash to 0 -- so 'ratio' is borrowed here for
+        // its offset of 9; the alignment is a pure function of the key, so any
+        // key exercises the same code.
+        $name = 'ratio';
+        $offset = scheduleJitterOffset($name);
+        scheduleAssertTrue($offset > 0, "{$name} hashes to offset 0, so this test walks an empty window");
+
+        $intervalMinutes = 60;
+        $interval = $intervalMinutes * 60;
+        $boundary = 1755198000;                 // a multiple of $interval, so the slot is $boundary+$offset
+        scheduleAssertSame(0, $boundary % $interval, 'The chosen instant is not an interval boundary');
+        $slot = $boundary + $offset;
+
+        // Every second from just before the boundary to the far end of the
+        // jitter spread. Up to the slot the answer must be the slot; from the
+        // slot on it must be the next one, one whole interval later and not a
+        // fresh countdown. An implementation that jumps to the *next* boundary
+        // as soon as this one passes -- the behaviour the deterministic
+        // alignment replaced -- reports slot+$interval for the seconds in
+        // between.
+        for ($now = $boundary - 1; $now <= $boundary + $schedule_rand; $now++) {
+            $sample = scheduleCommandAt($name, $intervalMinutes, $now);
+            $expected = ($now < $slot) ? $slot : $slot + $interval;
+            scheduleAssertSame(
+                $expected,
+                $sample['firesAt'],
+                'A reload at boundary' . sprintf('%+d', $now - $boundary)
+                . 's fires at boundary' . sprintf('%+d', $sample['firesAt'] - $boundary)
+                . 's instead of boundary' . sprintf('%+d', $expected - $boundary) . 's'
+            );
+            scheduleAssertSame(
+                (string) $sample['startAt'],
+                $sample['reported'],
+                'A reload at boundary' . sprintf('%+d', $now - $boundary)
+                . 's told rTorrent a start the caller was never given'
+            );
+            scheduleAssertSame((string) $interval, $sample['interval'], 'The interval reached rTorrent in minutes');
+            scheduleAssertTrue(
+                $sample['startAt'] >= 1 && $sample['startAt'] <= $interval,
+                "Start {$sample['startAt']} is outside 1..{$interval}, so a reload could fire the task at once"
+            );
+        }
+    },
+    'a getScheduleCommand fire time holds for a whole interval of reloads' => function () {
+        $name = 'ratio';
+        $intervalMinutes = 60;
+        $interval = $intervalMinutes * 60;
+        $slot = 1755198000 + scheduleJitterOffset($name);
+
+        // The slot is reached from anywhere in the interval that precedes it,
+        // one second at a time; the second the slot itself arrives belongs to
+        // the following one.
+        for ($now = $slot - $interval; $now < $slot; $now++) {
+            scheduleAssertSame(
+                $slot,
+                scheduleCommandAt($name, $intervalMinutes, $now)['firesAt'],
+                'A reload ' . ($slot - $now) . 's before the slot moved it'
+            );
+        }
+        scheduleAssertSame(
+            $slot + $interval,
+            scheduleCommandAt($name, $intervalMinutes, $slot)['firesAt'],
+            'The slot after a fire is not one interval later'
+        );
+    },
+    'each scheduled task gets its own getScheduleCommand slot' => function () {
+        global $schedule_rand;
+
+        $intervalMinutes = 5;
+        $interval = $intervalMinutes * 60;
+        $now = 1755198000;
+        $offsets = array();
+        foreach (array('trafic', 'rss', 'ratio', 'loginmgr', 'scheduler') as $name) {
+            $sample = scheduleCommandAt($name, $intervalMinutes, $now);
+            $offsets[$name] = $sample['firesAt'] % $interval;
+
+            scheduleAssertSame(
+                scheduleJitterOffset($name),
+                $offsets[$name],
+                "{$name} did not land on the slot its name picks out"
+            );
+            scheduleAssertSame(
+                $offsets[$name],
+                scheduleCommandAt($name, $intervalMinutes, $now + 137)['firesAt'] % $interval,
+                "{$name} did not keep its slot across a reload"
+            );
+            scheduleAssertSame($name . User::getUser(), $sample['key'], "{$name} registered under the wrong key");
+        }
+        scheduleAssertTrue(count(array_unique($offsets)) > 1, 'Every task landed on the same second');
+        scheduleAssertTrue(max($offsets) <= $schedule_rand, 'A task landed outside the jitter window');
+    },
+    'the clock seam is optional' => function () {
+        // Production callers -- plugins/trafic/init.php and
+        // plugins/rss/rss.php -- pass four arguments and get time(). Retried
+        // until the second holds still across the call, since a tick
+        // underneath it would move the answer for an honest reason.
+        for ($attempt = 0; $attempt < 20; $attempt++) {
+            $startAt = 0;
+            $now = time();
+            $command = rTorrentSettings::get()->getScheduleCommand('ratio', 60, 'print=noop', $startAt);
+            if (time() !== $now) {
+                continue;
+            }
+            scheduleAssertSame(
+                (string) $startAt,
+                $command->params[1]->value,
+                'The out-parameter and the command disagree'
+            );
+            scheduleAssertSame(
+                scheduleCommandAt('ratio', 60, $now)['firesAt'],
+                $now + $startAt,
+                'Reading the clock and being handed the same instant give different answers'
+            );
+            return;
+        }
+        throw new RuntimeException('The clock ticked through every attempt at a stable call');
     },
 );
 


### PR DESCRIPTION
## The problem

`php/getplugins.php` re-runs every enabled plugin's `init.php` on each full load of the web interface, so a plugin re-registers its scheduled task on **every page reload**. rTorrent's `CommandScheduler::insert` replaces an entry that reuses a key and restarts its countdown at `now + start` — which means the start this function computes decides the fire time afresh each time.

`getScheduleCommand` aligned that start to the next wall-clock boundary, then added `rand(0, $schedule_rand)` on top:

```php
$startAt = mktime($tm["hours"],
    ((int)($tm["minutes"]/$interval))*$interval+$interval,
    0,$tm["mon"],$tm["mday"],$tm["year"])-$tm[0]+rand(0,$schedule_rand);
```

Between the boundary and the task's own jittered instant the alignment has already rolled over. So a reload landing in that window recomputes to the *following* boundary and pushes the task out by a whole interval. Refresh again inside the next window and it moves again.

Both callers are affected — `plugins/trafic` and `plugins/rss` — and `rss` reports the recomputed value back to the user as the next update time.

## The fix

Use `getAlignedStart()`, which this class **already has** and which `getAlignedScheduleCommand()` **already uses**:

- it spreads tasks over the same jitter window by the `crc32` of their key rather than at random, so every re-registration of one task resolves to the same absolute instant;
- it never returns `0`, so a reload cannot fire the task immediately;
- it removes the duplicated boundary arithmetic.

The optional `$now` argument is the clock seam `getAlignedStart()` already carries. The property under test is that two registrations made at *different* instants agree — which a caller that can only read the clock cannot express.

## Two things worth noting

- The window the old behaviour misbehaves in is `$schedule_rand` seconds (**10** by default) per interval, not the whole interval.
- Alignment moves from a local-time boundary to a multiple of the interval in epoch seconds. In a timezone whose UTC offset is not a whole number of hours, an hourly task now fires at `:30` or `:45` local time rather than `:00`.

## How to verify

`tests/php/ScheduleTest.php` gains cases that drive `$now` across the whole jitter window — `boundary-1` through `boundary+$schedule_rand` — and assert the absolute fire instant is identical for every one of them. The name used has a non-zero `crc32` offset, so the window is not empty.

```
cd tests && bash php-test.sh
```

