### PR TITLE
Up/small UI

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -263,13 +263,21 @@ function getClickableTrackerStatus(text)
 {
 	if (!text) return '';
 	var sanitized = escapeHTML(text);
-	return sanitized.replace(/https?:\/\/[^\s<>"']+/gi, function(match) {
+	var linked = sanitized.replace(/https?:\/\/[^\s<>"']+/gi, function(match) {
 		var entityMatch = match.match(/&(?:quot|#039|#39|lt|gt);/i);
 		var truncated = entityMatch ? match.substring(0, entityMatch.index) : match;
 		var cleanUrl = truncated.replace(/[.,)!?:;\\\]}]+$/g, '');
 		var trailing = match.substring(cleanUrl.length);
 		return '<a href="' + cleanUrl + '" target="_blank" rel="noopener noreferrer">' + cleanUrl + '</a>' + trailing;
 	});
+	// d.message belongs to the whole download, and rTorrent JOINS the message
+	// of every failing tracker row into it with ' /// ' between them -- e.g.
+	// "Tracker: [Could not connect to server /// Could not resolve hostname]"
+	// from two different rows. Run together on one line that reads as a single
+	// garbled sentence, so each row's answer gets its own line. Done AFTER the
+	// linkification: a URL cannot contain a space, so this separator can never
+	// fall inside one of the links just built.
+	return linked.replace(/ \/\/\/ /g, '<br>');
 }
 
 

--- a/js/stable.js
+++ b/js/stable.js
@@ -981,6 +981,17 @@ dxSTable.prototype.createRow = function(cols, sId, icon, attr) {
 			td.append(
 				$("<div>").text(celldata || " "),
 			);
+			// The table is table-layout:fixed with white-space:nowrap and
+			// overflow:hidden, so a value wider than its column is cut off at
+			// the edge with no ellipsis and no other sign that anything is
+			// missing. Wrapping instead is not an option: the body is
+			// virtualized and derives every row's height from the first one
+			// (TR_HEIGHT), so one taller row desynchronizes the scroll for the
+			// whole list. A column that opts in therefore carries the full
+			// value as the cell's own tooltip.
+			// Only when there is something to show: an empty title="" on the
+			// cell would shadow the row's tooltip, which carries the name.
+			if (cdat.titled && celldata) td.attr("title", celldata);
 		}
 		row.append(td);
 	}
@@ -1385,6 +1396,13 @@ dxSTable.prototype.syncDOM = function()
 						textEl = td.firstChild;
 					}
 					$(textEl).text(fmtVal);
+					// The rows are built once and updated in place from here
+					// on, so a tooltip set only in createRow would freeze at
+					// whatever the message was when the row first appeared.
+					if (this.colsdata[c].titled) {
+						if (fmtVal) td.setAttribute("title", fmtVal);
+						else td.removeAttribute("title");
+					}
 				}
 			}
 			// update icon

--- a/js/webui.js
+++ b/js/webui.js
@@ -25,7 +25,9 @@ var theWebUI = {
 				{ text: theUILang.Priority, 		width: "80px", 	id: "priority",		type: TYPE_NUMBER },
 				{ text: theUILang.Created_on,		width: "110px", id: "created",		type: TYPE_NUMBER },
 				{ text: theUILang.Remaining, 		width: "90px", 	id: "remaining",	type: TYPE_NUMBER },
-				{ text: theUILang.Save_path,		width: "200px", id: "save_path",	type: TYPE_STRING }
+				// titled: a save path is routinely wider than the column, and it
+				// is the value a user most often needs to read in full.
+				{ text: theUILang.Save_path,		width: "200px", id: "save_path",	type: TYPE_STRING, titled: true }
 			],
 			container:	"List",
 			format:		theFormatter.torrents,

--- a/js/webui.js
+++ b/js/webui.js
@@ -906,6 +906,12 @@ var theWebUI = {
 
 	addPeers: function(data, hash)
 	{
+		// A getpeers answer can arrive after its torrent stopped being shown,
+		// or after it disappeared from the list entirely. Ignore a hash we no
+		// longer know: caching it would leak, because the cleanup loop below
+		// only walks the torrents that are still there.
+		if (!Object.prototype.hasOwnProperty.call(this.torrents, hash))
+			return;
 		const table = this.getTable("prs");
 		for (const peer of Object.values(data))
 		{
@@ -918,10 +924,12 @@ var theWebUI = {
 			};
 		}
 		this.peers[hash] = data;
+		// Only the shown torrent may touch the peer table. Clearing it here
+		// would wipe the rows of whatever torrent is actually open; the paths
+		// that own that decision -- getPeers() on a fresh open, and
+		// clearDetails() when the details block closes -- clear it themselves.
 		if (this.dID == hash)
 			table.updateRows(this.peers[hash]);
-		else
-			table.clearRows();
 	},
 
 	prsSelect: function(e, id)

--- a/plugins/trackerstatus/init.js
+++ b/plugins/trackerstatus/init.js
@@ -5,7 +5,7 @@ if(plugin.canChangeColumns())
 	plugin.config = theWebUI.config;
 	theWebUI.config = function()
 	{
-		this.tables.trt.columns.push({text: 'Tracker Status', width: '200px', id: 'msg', type: TYPE_STRING});
+		this.tables.trt.columns.push({text: 'Tracker Status', width: '200px', id: 'msg', type: TYPE_STRING, titled: true});
 		plugin.config.call(this);
 		plugin.trtRenameColumn();
 	}

--- a/tests/js/stable-cell-tooltip.spec.js
+++ b/tests/js/stable-cell-tooltip.spec.js
@@ -1,0 +1,114 @@
+import { readFileSync } from "fs";
+
+window.$ = require("jquery");
+
+// stable.js is the real thing here: the point of this file is the cell DOM it
+// builds, so a stub would test nothing. Only the module-level constants it
+// expects from webui.js are supplied.
+window.TYPE_STRING = "string";
+window.TYPE_NUMBER = "number";
+window.TYPE_PROGRESS = "progress";
+window.TYPE_STRING_LABEL = "label";
+window.theWebUI = { resource: {} };
+
+// common.js first: stable.js reaches for its $$() helper when it refreshes a
+// row in place.
+for (const src of ["../lang/en.js", "../js/common.js", "../js/stable.js"]) {
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = readFileSync(src, { encoding: "utf-8" });
+  document.body.appendChild(scriptEl);
+}
+
+// A real dxSTable, minus create(). Most of what the widget reads is a GETTER
+// over the DOM under dCont (cols, tHeadCols, tBodyCols, tBody are all defined
+// that way at the bottom of stable.js), so the harness builds that markup
+// rather than stubbing the getters -- which is also what keeps this test
+// honest: createRow and syncDOM run as themselves.
+function fakeTable(columns, fmtdata) {
+  const dCont = window.$(
+    "<div id='trt' class='stable'>" +
+      "<table><colgroup></colgroup><thead><tr></tr></thead><tbody></tbody></table>" +
+    "</div>"
+  );
+  for (const _ of columns) {
+    dCont.find("colgroup").append(window.$("<col>"));
+    dCont.find("thead tr").append(window.$("<td>").css("text-align", "left"));
+  }
+  document.body.appendChild(dCont[0]);
+
+  const table = Object.create(window.dxSTable.prototype);
+  table.created = true;
+  table.dCont = dCont;
+  table.colOrder = columns.map((_, i) => i);
+  table.colsdata = columns;
+  table.ids = columns.map((c) => c.id);
+  table.rowdata = { ROW1: { fmtdata } };
+  table.createIcon = () => window.$("<span>");
+  return table;
+}
+
+// The message column is 200px in a table-layout:fixed, white-space:nowrap,
+// overflow:hidden table (css/stable.css), so anything longer is cut off at the
+// edge with no ellipsis and no other sign that there is more. rTorrent's
+// d.message is routinely longer than that, because it JOINS the message of
+// every failing tracker row into one string with ' /// '.
+const LONG = "Tracker: [Could not connect to server /// Could not resolve hostname]";
+
+describe("dxSTable cell tooltips", () => {
+  it("gives a column that asks for it the untruncated value as the cell tooltip", () => {
+    const columns = [
+      { text: "Name", width: 200, id: "name", type: window.TYPE_STRING, enabled: true },
+      { text: "Tracker Status", width: 200, id: "msg", type: window.TYPE_STRING, enabled: true, titled: true },
+    ];
+    const table = fakeTable(columns, { 0: "Some.Release.2026", 1: LONG });
+
+    const tr = window.dxSTable.prototype.createRow.call(table, ["Some.Release.2026", LONG], "ROW1", null);
+
+    expect(tr.cells[1].getAttribute("title")).toBe(LONG);
+    // The row's own tooltip carries the torrent name; a column that did not
+    // ask for a tooltip must not shadow it with one of its own.
+    expect(tr.cells[0].hasAttribute("title")).toBe(false);
+    expect(tr.getAttribute("title")).toBe("Some.Release.2026");
+  });
+
+  it("does not put an empty tooltip on a cell with nothing in it", () => {
+    // title="" on the cell would suppress the row tooltip for that cell while
+    // showing nothing in its place, which is worse than no tooltip at all.
+    const columns = [
+      { text: "Name", width: 200, id: "name", type: window.TYPE_STRING, enabled: true },
+      { text: "Tracker Status", width: 200, id: "msg", type: window.TYPE_STRING, enabled: true, titled: true },
+    ];
+    const table = fakeTable(columns, { 0: "Some.Release.2026", 1: "" });
+
+    const tr = window.dxSTable.prototype.createRow.call(table, ["Some.Release.2026", ""], "ROW1", null);
+
+    expect(tr.cells[1].hasAttribute("title")).toBe(false);
+  });
+
+  it("keeps the tooltip current when the row is updated in place", () => {
+    // Rows are built once and refreshed from syncDOM on every poll, so a
+    // tooltip written only by createRow would freeze at whatever the message
+    // was when the torrent first appeared in the list.
+    const columns = [
+      { text: "Name", width: 200, id: "name", type: window.TYPE_STRING, enabled: true },
+      { text: "Tracker Status", width: 200, id: "msg", type: window.TYPE_STRING, enabled: true, titled: true },
+    ];
+    const table = fakeTable(columns, { 0: "Some.Release.2026", 1: "Tracker: [Timed out]" });
+    const tr = window.dxSTable.prototype.createRow.call(table, ["Some.Release.2026", "Tracker: [Timed out]"], "ROW1", null);
+    table.dCont.find("tbody").append(tr);
+    expect(tr.cells[1].getAttribute("title")).toBe("Tracker: [Timed out]");
+
+    table.rowdata.ROW1.fmtdata[1] = LONG;
+    table.rowdata.ROW1.data = { 1: LONG };
+    table.pendingSync = { dirty: { ROW1: { col: { 1: true } } } };
+    window.dxSTable.prototype.syncDOM.call(table);
+    expect(tr.cells[1].getAttribute("title")).toBe(LONG);
+
+    // And it is taken away again when the message clears, rather than being
+    // left behind as a tooltip for a state the torrent is no longer in.
+    table.rowdata.ROW1.fmtdata[1] = "";
+    table.pendingSync = { dirty: { ROW1: { col: { 1: true } } } };
+    window.dxSTable.prototype.syncDOM.call(table);
+    expect(tr.cells[1].hasAttribute("title")).toBe(false);
+  });
+});

--- a/tests/js/trackerstatus.spec.js
+++ b/tests/js/trackerstatus.spec.js
@@ -45,6 +45,28 @@ describe("getClickableTrackerStatus", () => {
     expect(window.getClickableTrackerStatus(input)).toBe(expected);
   });
 
+  // rTorrent's d.message belongs to the download, not to one tracker row: it
+  // joins the message of every failing row with ' /// '. Live sample from a
+  // 400-torrent fleet, 2026-08-21:
+  //   Tracker: [Could not connect to server /// Could not resolve hostname]
+  // on a torrent whose failing rows were a retracker and an IPv6 mirror.
+  it("puts each joined tracker row's message on its own line", () => {
+    const input = "Tracker: [Could not connect to server /// Could not resolve hostname]";
+    expect(window.getClickableTrackerStatus(input)).toBe(
+      "Tracker: [Could not connect to server<br>Could not resolve hostname]");
+  });
+
+  it("splits the join without touching a URL that contains slashes", () => {
+    const input = "Tracker: [Failure reason /// see https://tracker.foo/a///b for details]";
+    const expected = 'Tracker: [Failure reason<br>see <a href="https://tracker.foo/a///b" target="_blank" '
+      + 'rel="noopener noreferrer">https://tracker.foo/a///b</a> for details]';
+    expect(window.getClickableTrackerStatus(input)).toBe(expected);
+  });
+
+  it("leaves a bare /// with no surrounding spaces alone", () => {
+    expect(window.getClickableTrackerStatus("a///b")).toBe("a///b");
+  });
+
   it("handles torrent failure status with PtP style links and escaped quotes", () => {
     const input = 'https://torrent.site/page?id1=224822&id2=1534647\\"]';
     const expected = '<a href="https://torrent.site/page?id1=224822&amp;id2=1534647" target="_blank" rel="noopener noreferrer">https://torrent.site/page?id1=224822&amp;id2=1534647</a>\\&quot;]';

--- a/tests/js/webui-stale-details.spec.js
+++ b/tests/js/webui-stale-details.spec.js
@@ -118,4 +118,92 @@ describe("webui stale details", () => {
     expect(theWebUI.peers[oldHash]).toBeUndefined();
     expect(theWebUI.trackers[oldHash]).toBeUndefined();
   });
+
+  it("discards peer response and preserves clean cache when torrent is not in torrents list", () => {
+    const oldHash = h("A");
+    const currentHash = h("B");
+    const table = {
+      updateRows: jest.fn(),
+      clearRows: jest.fn(),
+    };
+
+    Object.assign(theWebUI, {
+      torrents: {
+        [currentHash]: { name: "current" },
+      },
+      dID: currentHash,
+      peers: {},
+      getTable: jest.fn(() => table),
+    });
+
+    theWebUI.addPeers(
+      {
+        p1: { name: "1.2.3.4", port: 80, ip: "1.2.3.4", attr: {} },
+      },
+      oldHash
+    );
+
+    expect(theWebUI.peers[oldHash]).toBeUndefined();
+    expect(table.clearRows).not.toHaveBeenCalled();
+    expect(table.updateRows).not.toHaveBeenCalled();
+  });
+
+  it("updates cache and table when peer response is for currently selected active torrent", () => {
+    const currentHash = h("B");
+    const table = {
+      updateRows: jest.fn(),
+      clearRows: jest.fn(),
+    };
+
+    Object.assign(theWebUI, {
+      torrents: {
+        [currentHash]: { name: "current" },
+      },
+      dID: currentHash,
+      peers: {},
+      getTable: jest.fn(() => table),
+    });
+
+    theWebUI.addPeers(
+      {
+        p1: { name: "1.2.3.4", port: 80, ip: "1.2.3.4", attr: {} },
+      },
+      currentHash
+    );
+
+    expect(theWebUI.peers[currentHash]).toBeDefined();
+    expect(theWebUI.peers[currentHash].p1.name).toBe("1.2.3.4:80");
+    expect(table.updateRows).toHaveBeenCalledWith(theWebUI.peers[currentHash]);
+  });
+
+  it("updates cache but not table when peer response is for active unselected torrent", () => {
+    const currentHash = h("B");
+    const unselectedHash = h("C");
+    const table = {
+      updateRows: jest.fn(),
+      clearRows: jest.fn(),
+    };
+
+    Object.assign(theWebUI, {
+      torrents: {
+        [currentHash]: { name: "current" },
+        [unselectedHash]: { name: "unselected" },
+      },
+      dID: currentHash,
+      peers: {},
+      getTable: jest.fn(() => table),
+    });
+
+    theWebUI.addPeers(
+      {
+        p1: { name: "5.6.7.8", port: 51413, ip: "5.6.7.8", attr: {} },
+      },
+      unselectedHash
+    );
+
+    expect(theWebUI.peers[unselectedHash]).toBeDefined();
+    expect(theWebUI.peers[unselectedHash].p1.name).toBe("5.6.7.8:51413");
+    expect(table.updateRows).not.toHaveBeenCalled();
+    expect(table.clearRows).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Three unrelated fixes in the torrent list and the details pane, kept as three separate commits so any subset can be taken on its own. They touch different regions of different functions — the two `js/webui.js` hunks sit ~880 lines apart — so cherry-picking one without the others applies cleanly.

## 1. Keep the peer table when a peer response is for another torrent

`addPeers()` ended with `if (this.dID == hash) table.updateRows(...) else table.clearRows()`, so a `getpeers` answer that is **not** for the torrent whose details are open blanked the peer table that *is* open. Open details on torrent A, switch to B, and A's in-flight response arrives after B's rows were drawn: B's peer list goes empty until the next poll paints it again.

Clearing is not this function's decision to make. `getPeers()` already clears the table before a fresh open, and `clearDetails()` clears it when the details block closes or the selected torrent disappears — so dropping the `else` branch leaves every path that *should* empty the table still doing so.

The same function also wrote `this.peers[hash]` for any hash at all, while the poll's cleanup loop only walks `this.torrents`. A response for a torrent that was removed mid-poll therefore parked its peer list in the cache with nothing left to release it, for the life of the page. It now returns early for a hash that is no longer in the list.

## 2. Give each joined tracker message its own line

`d.message` belongs to the download, not to one tracker row. When more than one tracker row is failing, rTorrent joins their messages into that single string with `" /// "` between them, so the General tab renders

```
Tracker: [Could not connect to server /// Could not resolve hostname]
```

on one line, which reads as one garbled sentence rather than one answer per tracker. This is observed behaviour rather than a citation into rTorrent's source, but it is not a one-off: on a live 400-torrent instance, sampled repeatedly, **every** non-empty `d.message` was such a join — between 36 and 122 torrents at a time depending on where the announce cycle stood, always exactly two parts, and never once a message without the separator. The two distinct texts seen were `Tracker: [Could not resolve hostname /// Could not resolve hostname]` and `Tracker: [Could not connect to server /// Could not resolve hostname]`.

`getClickableTrackerStatus()` now replaces that separator with `<br>` **after** the links have been built. Both the order and the surrounding spaces matter:

- a URL cannot contain a space, so `" /// "` can never fall inside a link that was just built;
- a path such as `https://tracker.example/a///b` is left whole;
- a bare `a///b` with nothing around it is not a join, and is left alone too.

## 3. Let a column show its untruncated value as a cell tooltip

The torrent table is `table-layout:fixed` with `white-space:nowrap` and `overflow:hidden`, so a value wider than its column is cut at the column edge with no ellipsis and no other sign that there is more to read. A save path longer than the 200px Save-path column is simply gone, and hovering the cell shows the *row* tooltip — the torrent's name — rather than the path.

Wrapping is not available here: the table body is virtualized and derives every row's height from the first one (`TR_HEIGHT`), so a single taller row desynchronizes the scroll for the whole list. A tooltip is what is left.

A column definition can now carry `titled: true`:

- `createRow()` sets the cell's own `title`;
- `syncDOM()` keeps it current — rows are built once and refreshed in place on every poll, so a title written only at creation would freeze at whatever the value was when the row first appeared;
- the title is written only when there is something to show, and removed when the value goes empty, because `title=""` on a cell shadows the row tooltip while displaying nothing in its place.

Two columns opt in: **Save path**, whose values are unbounded, and the **tracker status** column of the `trackerstatus` plugin, where `d.message` is routinely far longer than its 200px — on the instance above every one of those messages ran 60–69 characters, roughly two and a half times what a 200px column shows. Every other column is untouched.

## How to verify

Each commit carries its own cases, driving the real functions against jsdom rather than asserting on a reimplementation:

- `tests/js/webui-stale-details.spec.js` — a response for an unknown hash touches neither the cache nor the table; one for the shown torrent updates both; one for a known but unselected torrent updates the cache and leaves the table alone.
- `tests/js/trackerstatus.spec.js` — the join is split, a URL containing slashes survives, a bare `///` is left alone.
- `tests/js/stable-cell-tooltip.spec.js` (new) — drives the real `createRow()` and `syncDOM()` and is column-agnostic: an opted-in column gets the full value as its cell title, a column that did not opt in keeps no title of its own and the row tooltip still shows through, an update moves the title with the value, and a value going empty removes the attribute rather than leaving `title=""`.

```
cd tests && npx jest
```

**193 tests in 19 suites** on this branch, against **184 in 18** on `master` — the 9 added cases above, no existing case changed.
