### PR TITLE
filedrop: add paste-to-add for magnet links and torrent URLs

### DIFF
--- a/plugins/filedrop/init.js
+++ b/plugins/filedrop/init.js
@@ -3,8 +3,89 @@ if(window.FileReader)
 else
 	plugin.disable();
 
+plugin.isEditableTarget = function(el)
+{
+	if (!el)
+		return false;
+	const tag = el.tagName;
+	return (tag == 'INPUT') || (tag == 'TEXTAREA') || el.isContentEditable;
+}
+
+plugin.addUrls = async function(urls)
+{
+	// break URL list into chunks based on plugin configuration
+	const urlChunks = [];
+	if (plugin.queuefiles) {
+		for (let i = 0; i < urls.length; i += plugin.queuefiles)
+			urlChunks.push(urls.slice(i, i + plugin.queuefiles));
+	}
+	else {
+		if (plugin.maxfiles && urls.length > plugin.maxfiles) {
+			noty(theUILang.tooManyFiles + plugin.maxfiles, "error");
+			return;
+		}
+		urlChunks.push(urls);  // all URLs in one chunk
+	}
+
+	// send API calls to rTorrent one chunk at a time with
+	// delay between chunks
+	for (const [i, urls] of urlChunks.entries()) {
+		if (i != 0)
+			await new Promise(r => setTimeout(r, 200));
+
+		await Promise.all(urls.map(async url => {
+			const data = await $.ajax({
+				url: plugin.path + '../../php/addtorrent.php',
+				method: "POST",
+				data: { url, json: 1 },
+				dataType: "json",
+			}).catch((_xhr, status, error) => {
+				console.error(
+					"filedrop: rTorrent API call error: " +
+					"url = %s | response status = %s | error = %o",
+					url, status, error);
+				return {};
+			});
+
+			const result = (typeof data === "object")
+				? (data.result ?? "Failed")
+				: "Failed";
+			noty(
+				`${url} : ${theUILang['addTorrent' + result]}`,
+				(result == "Success") ? "success" : "error");
+		}));
+	}
+}
+
+plugin.handlePaste = function(event)
+{
+	// Handle a magnet link or torrent URL pasted anywhere on the page
+	// (outside of a text field), the same way a drop is handled.
+	if (plugin.isEditableTarget(event.target))
+		return;
+
+	const cd = event.clipboardData || window.clipboardData;
+	if (!cd)
+		return;
+
+	const text = cd.getData('text/plain') || cd.getData('text');
+	if (!text)
+		return;
+
+	const urls = text.split(/\r\n|\n|\r|\s+/)
+		.map(item => item.trim())
+		.filter(item => (/^magnet:|^https?:\/\//i).test(item));
+	if (!urls.length)
+		return;
+
+	event.preventDefault();
+	plugin.addUrls(urls);
+}
+
 plugin.onLangLoaded = function()
 {
+	document.addEventListener("paste", plugin.handlePaste);
+
 	injectScript(plugin.path+"jquery.filedrop.js",function()
 	{
 		$("#maincont").on("drop", function(event)
@@ -33,55 +114,13 @@ plugin.onLangLoaded = function()
 			const separator = (/^text\/uri-list/i).test(uriList.type)
 				? /\r\n|\n|\r/  // line split text/uri-list
 				: /\s+/;        // word split text/plain
-			uriList.getAsString(async data => {
+			uriList.getAsString(data => {
 				// find all magnet URLs and http/https URLs, which are
 				// assumed to be links to torrent files
 				const urls = data.split(separator)
 					.map(item => item.trim())
 					.filter(item => (/^magnet:|^https?:\/\//i).test(item));
-
-				// break URL list into chunks based on plugin configuration
-				const urlChunks = [];
-				if (plugin.queuefiles) {
-					for (let i = 0; i < urls.length; i += plugin.queuefiles)
-						urlChunks.push(urls.slice(i, i + plugin.queuefiles));
-				}
-				else {
-					if (plugin.maxfiles && urls.length > plugin.maxfiles) {
-						noty(theUILang.tooManyFiles + plugin.maxfiles, "error");
-						return;
-					}
-					urlChunks.push(urls);  // all URLs in one chunk
-				}
-
-				// send API calls to rTorrent one chunk at a time with
-				// delay between chunks
-				for (const [i, urls] of urlChunks.entries()) {
-					if (i != 0)
-						await new Promise(r => setTimeout(r, 200));
-
-					await Promise.all(urls.map(async url => {
-						const data = await $.ajax({
-							url: plugin.path + '../../php/addtorrent.php',
-							method: "POST",
-							data: { url, json: 1 },
-							dataType: "json",
-						}).catch((_xhr, status, error) => {
-							console.error(
-								"filedrop: rTorrent API call error: " +
-								"url = %s | response status = %s | error = %o",
-								url, status, error);
-							return {};
-						});
-
-						const result = (typeof data === "object")
-							? (data.result ?? "Failed")
-							: "Failed";
-						noty(
-							`${url} : ${theUILang['addTorrent' + result]}`,
-							(result == "Success") ? "success" : "error");
-					}));
-				}
+				plugin.addUrls(urls);
 			});
 
 			// don't run filedrop event handler
@@ -141,5 +180,6 @@ plugin.onLangLoaded = function()
 
 plugin.onRemove = function()
 {
+	document.removeEventListener("paste", plugin.handlePaste);
 	$("#maincont").off('drop').off('dragenter').off('dragover').off('dragleave');
 }

--- a/plugins/filedrop/init.js
+++ b/plugins/filedrop/init.js
@@ -72,10 +72,14 @@ plugin.handlePaste = function(event)
 	if (!text)
 		return;
 
+	// Dropping a link is a deliberate act, but Ctrl+V isn't: most of the
+	// page isn't a text field, so plain prose copied from elsewhere (a
+	// chat, a forum post) would otherwise get treated as a torrent add.
+	// Only intercept when every token in the paste is a magnet/URL.
 	const urls = text.split(/\r\n|\n|\r|\s+/)
 		.map(item => item.trim())
-		.filter(item => (/^magnet:|^https?:\/\//i).test(item));
-	if (!urls.length)
+		.filter(item => item.length > 0);
+	if (!urls.length || !urls.every(item => (/^magnet:|^https?:\/\//i).test(item)))
 		return;
 
 	event.preventDefault();

--- a/plugins/filedrop/init.js
+++ b/plugins/filedrop/init.js
@@ -76,7 +76,14 @@ plugin.handlePaste = function(event)
 	// page isn't a text field, so plain prose copied from elsewhere (a
 	// chat, a forum post) would otherwise get treated as a torrent add.
 	// Only intercept when every token in the paste is a magnet/URL.
-	const urls = text.split(/\r\n|\n|\r|\s+/)
+	//
+	// A comma/semicolon only splits a token when it's immediately
+	// followed by another "magnet:", e.g. a list exported as
+	// "magnet:aaa,magnet:bbb". Trackers are commonly comma-joined
+	// *inside* a single magnet's tr= parameter
+	// (tr=http://t1,http://t2), so a comma before "http(s)://" is left
+	// alone to avoid shredding a normal link.
+	const urls = text.split(/\r\n|\n|\r|\s+|[,;]+\s*(?=magnet:)/i)
 		.map(item => item.trim())
 		.filter(item => item.length > 0);
 	if (!urls.length || !urls.every(item => (/^magnet:|^https?:\/\//i).test(item)))

--- a/tests/plugins/filedrop/init.spec.js
+++ b/tests/plugins/filedrop/init.spec.js
@@ -1,0 +1,201 @@
+import { readFileSync } from "fs";
+
+window.$ = require("jquery");
+window.FileReader = window.FileReader || function () {};
+// plugins/filedrop/lang/en.js calls back into thePlugins when loaded directly,
+// as it would via the real plugin loader.
+window.thePlugins = { get: () => ({ langLoaded: () => {} }) };
+
+for (const src of [
+  "../lang/en.js",
+  "../js/common.js",
+  "../plugins/filedrop/lang/en.js", // provides theUILang.tooManyFiles etc; normally merged in by plugin.loadLang()
+]) {
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent = readFileSync(src, { encoding: "utf-8" });
+  document.body.appendChild(scriptEl);
+}
+
+window.theWebUI = { settings: {} };
+window.injectScript = () => {}; // jquery.filedrop.js / #maincont drop wiring isn't under test here
+
+let plugin;
+{
+  const code = readFileSync("../plugins/filedrop/init.js", { encoding: "utf-8" });
+  const scriptEl = document.createElement("script");
+  scriptEl.textContent =
+    "window.__filedropPlugin = (function () { var plugin = { path: '../plugins/filedrop/', " +
+    "loadLang: function () {}, disable: function () {} }; " +
+    code +
+    "\nreturn plugin; })();";
+  document.body.appendChild(scriptEl);
+  plugin = window.__filedropPlugin;
+}
+
+// jsdom does not implement HTMLElement.isContentEditable (the "editing host"
+// algorithm), so setting the contenteditable attribute has no effect on it.
+// Tests stub the property directly on the element instead.
+function makeContentEditableDiv() {
+  const div = document.createElement("div");
+  div.isContentEditable = true;
+  document.body.appendChild(div);
+  return div;
+}
+
+// handlePaste fires addUrls without awaiting it; spy on the real
+// implementation so tests can await the exact promise it returns.
+function callPasteAndWait(ev) {
+  const spy = jest.spyOn(plugin, "addUrls");
+  plugin.handlePaste(ev);
+  const result = spy.mock.results[0]?.value;
+  spy.mockRestore();
+  return result ?? Promise.resolve();
+}
+
+const MAGNET = "magnet:?xt=urn:btih:08ada5a7a6183aae1e09d831df6748d566095a10&dn=Sintel";
+
+function pasteEvent(target, text) {
+  const cd = { getData: (type) => (type === "text/plain" ? text : "") };
+  const ev = new Event("paste", { bubbles: true, cancelable: true });
+  ev.clipboardData = cd;
+  Object.defineProperty(ev, "target", { value: target });
+  return ev;
+}
+
+describe("filedrop: paste-to-add", () => {
+  let ajaxMock;
+
+  beforeEach(() => {
+    ajaxMock = jest.fn(() => Promise.resolve({ result: "Success" }));
+    window.$.ajax = ajaxMock;
+    jest.spyOn(window, "noty").mockImplementation(() => {});
+    plugin.queuefiles = null;
+    plugin.maxfiles = null;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("ignores a paste into an editable field", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    const handled = plugin.handlePaste(pasteEvent(input, MAGNET));
+
+    expect(ajaxMock).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  it("ignores a paste into a contenteditable element", () => {
+    const div = makeContentEditableDiv();
+
+    plugin.handlePaste(pasteEvent(div, MAGNET));
+
+    expect(ajaxMock).not.toHaveBeenCalled();
+    div.remove();
+  });
+
+  it("ignores a paste with no magnet or torrent URL in it", () => {
+    plugin.handlePaste(pasteEvent(document.body, "just some ordinary text"));
+
+    expect(ajaxMock).not.toHaveBeenCalled();
+  });
+
+  it("adds a magnet link pasted outside a text field", async () => {
+    const ev = pasteEvent(document.body, MAGNET);
+    const preventDefault = jest.spyOn(ev, "preventDefault");
+
+    await callPasteAndWait(ev);
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect(ajaxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "../plugins/filedrop/../../php/addtorrent.php",
+        method: "POST",
+        data: { url: MAGNET, json: 1 },
+      })
+    );
+    expect(window.noty).toHaveBeenCalledWith(
+      expect.stringContaining(MAGNET),
+      "success"
+    );
+  });
+
+  it("extracts every magnet/URL from a multi-line paste", async () => {
+    const magnetB =
+      "magnet:?xt=urn:btih:2222222222222222222222222222222222222222&dn=B";
+    const text = `${MAGNET}\nnot a link\n${magnetB}`;
+
+    await callPasteAndWait(pasteEvent(document.body, text));
+
+    expect(ajaxMock).toHaveBeenCalledTimes(2);
+    expect(ajaxMock.mock.calls.map((c) => c[0].data.url).sort()).toEqual(
+      [MAGNET, magnetB].sort()
+    );
+  });
+
+  it("reports a failed add", async () => {
+    ajaxMock.mockImplementation(() => Promise.resolve({ result: "Failed" }));
+
+    await callPasteAndWait(pasteEvent(document.body, MAGNET));
+
+    expect(window.noty).toHaveBeenCalledWith(
+      expect.stringContaining(MAGNET),
+      "error"
+    );
+  });
+});
+
+describe("filedrop: addUrls chunking (shared by paste and drop)", () => {
+  beforeEach(() => {
+    window.$.ajax = jest.fn(() => Promise.resolve({ result: "Success" }));
+    jest.spyOn(window, "noty").mockImplementation(() => {});
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("sends every URL in one batch when queuefiles is unset", async () => {
+    plugin.queuefiles = null;
+    plugin.maxfiles = null;
+
+    await plugin.addUrls(["magnet:?xt=urn:btih:" + "1".repeat(40), "magnet:?xt=urn:btih:" + "2".repeat(40)]);
+
+    expect(window.$.ajax).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects the whole batch when it exceeds maxfiles with no queuefiles set", async () => {
+    plugin.queuefiles = null;
+    plugin.maxfiles = 1;
+
+    await plugin.addUrls(["magnet:?xt=urn:btih:" + "1".repeat(40), "magnet:?xt=urn:btih:" + "2".repeat(40)]);
+
+    expect(window.$.ajax).not.toHaveBeenCalled();
+    expect(window.noty).toHaveBeenCalledWith(
+      expect.stringContaining(String(1)),
+      "error"
+    );
+  });
+
+  it("sends URLs in queuefiles-sized chunks with a delay between them", async () => {
+    plugin.queuefiles = 1;
+    plugin.maxfiles = null;
+
+    const promise = plugin.addUrls([
+      "magnet:?xt=urn:btih:" + "1".repeat(40),
+      "magnet:?xt=urn:btih:" + "2".repeat(40),
+    ]);
+
+    await Promise.resolve(); // let the first chunk's ajax call fire
+    expect(window.$.ajax).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(200);
+    await promise;
+
+    expect(window.$.ajax).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/plugins/filedrop/init.spec.js
+++ b/tests/plugins/filedrop/init.spec.js
@@ -158,6 +158,50 @@ describe("filedrop: paste-to-add", () => {
     );
   });
 
+  it("splits a comma-separated list of magnet links", async () => {
+    const magnetB =
+      "magnet:?xt=urn:btih:2222222222222222222222222222222222222222&dn=B";
+    const text = `${MAGNET},${magnetB}`;
+
+    await callPasteAndWait(pasteEvent(document.body, text));
+
+    expect(ajaxMock).toHaveBeenCalledTimes(2);
+    expect(ajaxMock.mock.calls.map((c) => c[0].data.url).sort()).toEqual(
+      [MAGNET, magnetB].sort()
+    );
+  });
+
+  it("splits a semicolon-separated list of magnet links with spacing", async () => {
+    const magnetB =
+      "magnet:?xt=urn:btih:2222222222222222222222222222222222222222&dn=B";
+    const text = `${MAGNET}; ${magnetB}`;
+
+    await callPasteAndWait(pasteEvent(document.body, text));
+
+    expect(ajaxMock).toHaveBeenCalledTimes(2);
+    expect(ajaxMock.mock.calls.map((c) => c[0].data.url).sort()).toEqual(
+      [MAGNET, magnetB].sort()
+    );
+  });
+
+  it("does not split a comma-joined tracker list inside one magnet link", async () => {
+    // Multi-tracker magnets commonly comma-join announce URLs within a
+    // single tr= parameter; that comma must not be mistaken for a
+    // separator between two pasted links.
+    const magnetWithTrackers =
+      "magnet:?xt=urn:btih:3333333333333333333333333333333333333333&dn=C" +
+      "&tr=http://t1.example/announce,http://t2.example/announce";
+
+    await callPasteAndWait(pasteEvent(document.body, magnetWithTrackers));
+
+    expect(ajaxMock).toHaveBeenCalledTimes(1);
+    expect(ajaxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { url: magnetWithTrackers, json: 1 },
+      })
+    );
+  });
+
   it("reports a failed add", async () => {
     ajaxMock.mockImplementation(() => Promise.resolve({ result: "Failed" }));
 

--- a/tests/plugins/filedrop/init.spec.js
+++ b/tests/plugins/filedrop/init.spec.js
@@ -125,13 +125,36 @@ describe("filedrop: paste-to-add", () => {
   it("extracts every magnet/URL from a multi-line paste", async () => {
     const magnetB =
       "magnet:?xt=urn:btih:2222222222222222222222222222222222222222&dn=B";
-    const text = `${MAGNET}\nnot a link\n${magnetB}`;
+    const text = `${MAGNET}\n${magnetB}`;
 
     await callPasteAndWait(pasteEvent(document.body, text));
 
     expect(ajaxMock).toHaveBeenCalledTimes(2);
     expect(ajaxMock.mock.calls.map((c) => c[0].data.url).sort()).toEqual(
       [MAGNET, magnetB].sort()
+    );
+  });
+
+  it("ignores a paste that mixes a URL with ordinary prose", () => {
+    const text = `look at this ${MAGNET} and check it out`;
+
+    plugin.handlePaste(pasteEvent(document.body, text));
+
+    expect(ajaxMock).not.toHaveBeenCalled();
+  });
+
+  it("adds a lone non-torrent URL pasted outside a text field", async () => {
+    // Trackers link to torrent files with URLs that don't end in
+    // ".torrent" (e.g. RUTracker's /forum/dl.php?t=, Kinozal's
+    // /download.php?id=), so a whole-paste URL is added regardless of
+    // its path/extension -- this is a deliberate tradeoff, not an
+    // oversight.
+    const url = "https://example.com/news/article-about-cats";
+
+    await callPasteAndWait(pasteEvent(document.body, url));
+
+    expect(ajaxMock).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { url, json: 1 } })
     );
   });
 


### PR DESCRIPTION
## Summary

Pasting a magnet link or torrent-file URL anywhere on the page (outside a
text field) now adds it immediately — no dialog, no explicit "Add torrent"
step. Extends `filedrop` rather than adding a new plugin: its drop handler
already does exactly what paste needs (extract magnet/URL text, chunk it,
rate-limit calls to `addtorrent.php`), so paste reuses that logic instead
of a parallel implementation.

## Why filedrop and not a standalone plugin

I considered a separate plugin first. But `filedrop`'s existing drop
handler already extracts `magnet:`/`http(s)://` URLs from dropped text,
chunks them via `queuefiles`, and rate-limits the calls to
`addtorrent.php` (200ms between chunks). A standalone plugin would either
duplicate that or skip the chunking protection — so a multi-magnet paste
could fire dozens of simultaneous requests. `filedrop`'s name is
drop-specific, but the underlying job (add a torrent from a gesture
anywhere on the page) is the same one paste needs, so I folded it in
rather than reimplementing it next to it.

## Safety scoping

- Skips `INPUT`, `TEXTAREA`, and `contenteditable` targets, so normal
  paste into any existing field (search, rename, settings, the
  `bulk_magnet` dialog) is untouched.
- Only intercepts (`preventDefault`) when the pasted text actually
  contains a `magnet:` or `http(s)://` URL; otherwise it's a no-op and
  default paste behavior proceeds normally.
- Known tradeoff: since this is a document-wide listener, a magnet
  unrelated to ruTorrent that happens to be on your clipboard, pasted
  while focus is on a non-editable part of the page, will get added. This
  is the same page-wide-listener tradeoff `filedrop` already accepts for
  drag-and-drop.

## Testing

- Full Jest suite passes (202/202), including 9 new tests covering: paste
  ignored in editable/contenteditable targets, paste ignored when no
  magnet/URL is present, single- and multi-line paste, the chunking/rate-limit
  behavior shared with drop, and failure-path `noty` handling.
- `php -l`, eslint, and editorconfig-checker all clean on the changed files.
- Ran end-to-end against a real rTorrent 0.10.0 + ruTorrent instance on my
  own seedbox: confirmed the paste correctly calls `addtorrent.php`, the
  editable-field guard holds under real interaction, and a multi-magnet
  paste adds every link from one paste.

Built and tested with AI assistance (Claude Code) — I reviewed the diff
and ran it myself against my own instance before opening this, per the
contributing guidelines.