### PR TITLE
Share the plugins.ini flag lookup and pin what an unset flag means

### DIFF
--- a/php/getplugins.php
+++ b/php/getplugins.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once( 'which.php' );
+require_once( 'pluginflags.php' );
 require_once( "settings.php" );
 
 function pluginsSort($a, $b)
@@ -14,18 +15,6 @@ function pluginsSort($a, $b)
 	return( strcmp($a["name"],$b["name"]) );
 }
 
-function getFlag($permissions,$pname,$fname)
-{
-	$ret = true;
-	if(array_key_exists($pname,$permissions) &&
-		array_key_exists($fname,$permissions[$pname]))
-		$ret = $permissions[$pname][$fname];
-	else
-	if(array_key_exists("default",$permissions) &&
-		array_key_exists($fname,$permissions["default"]))
-		$ret = $permissions["default"][$fname];
-	return($ret);
-}
 
 function getPluginInfo( $name, $permissions )
 {

--- a/php/initplugins.php
+++ b/php/initplugins.php
@@ -27,18 +27,6 @@ function pluginsSort($a, $b)
 	return( strcmp($a["name"],$b["name"]) );
 }
 
-function getFlag($permissions,$pname,$fname)
-{
-	$ret = true;
-	if(array_key_exists($pname,$permissions) &&
-		array_key_exists($fname,$permissions[$pname]))
-		$ret = $permissions[$pname][$fname];
-	else
-	if(array_key_exists("default",$permissions) &&
-		array_key_exists($fname,$permissions["default"]))
-		$ret = $permissions["default"][$fname];
-	return($ret);
-}
 
 function getPluginInfo( $name, $permissions )
 {
@@ -122,6 +110,7 @@ if( count( $argv ) > 1 )
 	$_SERVER['REMOTE_USER'] = $argv[1];
 
 require_once( "which.php" );
+require_once( "pluginflags.php" );
 require_once( "settings.php" );
 
 // Check/init: $tempDirectory.

--- a/php/pluginflags.php
+++ b/php/pluginflags.php
@@ -1,0 +1,22 @@
+<?php
+
+// Resolve one flag for one plugin out of conf/plugins.ini: the plugin's own
+// section wins, a [default] section answers for the rest, and a flag nobody
+// set is true. That last rule is what keeps an upgrade quiet -- a plugins.ini
+// written before a flag existed must behave as it did before, which is why
+// enabledByDefault leaves a plugin enabled when it is absent.
+//
+// Shared because getplugins.php and initplugins.php both need it and neither
+// can include the other: each does work at the top level.
+function getFlag($permissions,$pname,$fname)
+{
+	$ret = true;
+	if(array_key_exists($pname,$permissions) &&
+		array_key_exists($fname,$permissions[$pname]))
+		$ret = $permissions[$pname][$fname];
+	else
+	if(array_key_exists("default",$permissions) &&
+		array_key_exists($fname,$permissions["default"]))
+		$ret = $permissions["default"][$fname];
+	return($ret);
+}

--- a/tests/php/PluginFlagsTest.php
+++ b/tests/php/PluginFlagsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/pluginflags.php');
+
+/**
+ * getFlag() answers every per-plugin question in conf/plugins.ini, and the two
+ * callers read its answer through a (bool) cast:
+ *
+ *     $userPermissions[$file] = (bool)getFlag($permissions,$file,"enabledByDefault");
+ *
+ * so what matters is the pair -- what parse_ini_file() makes of the written
+ * value, and what the cast then makes of that. "no" reaching the cast as the
+ * string 'no' would be true, the opposite of what the admin wrote, so these
+ * drive the real parser rather than hand-built arrays.
+ */
+class PluginFlagsTest extends TestCase
+{
+	private function parse($ini)
+	{
+		$file = tempnam(sys_get_temp_dir(), 'plgini');
+		file_put_contents($file, $ini);
+		$parsed = parse_ini_file($file, true);
+		unlink($file);
+		return $parsed;
+	}
+
+	/**
+	 * The compatibility rule: a plugins.ini written before a flag existed must
+	 * behave as it did before it existed. Every enabledByDefault upgrade rests
+	 * on this, since the shipped plugins.ini only mentions the flag in comments.
+	 */
+	public function testAFlagNobodySetIsTrue()
+	{
+		$p = $this->parse("[ratio]\ncanChangeToolbar = no\n");
+		$this->assertEquals(true, getFlag($p, 'ratio', 'enabledByDefault'),
+			'a flag missing from the plugin section is true');
+		$this->assertEquals(true, getFlag($p, 'nosuchplugin', 'enabledByDefault'),
+			'a plugin missing from the file entirely is true');
+		$this->assertEquals(true, (bool)getFlag($p, 'ratio', 'enabledByDefault'),
+			'and it survives the cast the callers apply');
+	}
+
+	public function testTheFalseSpellingsAllDisable()
+	{
+		foreach (array('no', 'off', 'false', '0') as $written) {
+			$p = $this->parse("[ratio]\nenabledByDefault = $written\n");
+			$this->assertEquals(false, (bool)getFlag($p, 'ratio', 'enabledByDefault'),
+				'"'.$written.'" disables the plugin for a user who has not chosen');
+		}
+	}
+
+	public function testTheTrueSpellingsAllEnable()
+	{
+		foreach (array('yes', 'on', 'true', '1') as $written) {
+			$p = $this->parse("[ratio]\nenabledByDefault = $written\n");
+			$this->assertEquals(true, (bool)getFlag($p, 'ratio', 'enabledByDefault'),
+				'"'.$written.'" leaves the plugin enabled');
+		}
+	}
+
+	public function testTheDefaultSectionAnswersForPluginsThatDoNotSayOtherwise()
+	{
+		$p = $this->parse("[default]\nenabledByDefault = no\n[ratio]\nenabledByDefault = yes\n[rss]\ncanChangeMenu = no\n");
+		$this->assertEquals(false, (bool)getFlag($p, 'rss', 'enabledByDefault'),
+			'a plugin with no opinion of its own takes the [default] one');
+		$this->assertEquals(false, (bool)getFlag($p, 'unlisted', 'enabledByDefault'),
+			'so does a plugin with no section at all');
+		$this->assertEquals(true, (bool)getFlag($p, 'ratio', 'enabledByDefault'),
+			'and a plugin that does have an opinion overrides [default]');
+	}
+}


### PR DESCRIPTION
Follow-up to #3197, which introduced enabledByDefault but could not be tested: getFlag() lives in getplugins.php and initplugins.php, both of which chdir, read $argv and require settings.php at top level, so neither can be included from a test. It was also duplicated verbatim between them — I diffed the copies and they were identical, so a change to one would have given page load and CLI init different behaviour.