### PR TITLE
loginmgr: match an account by the URL's host, and never below its scheme

### DIFF
--- a/plugins/loginmgr/accounts.php
+++ b/plugins/loginmgr/accounts.php
@@ -73,9 +73,57 @@ abstract class commonAccount
 	abstract protected function isOK($client);
 	abstract protected function login($client,$login,$password,&$url,&$method,&$content_type,&$body,&$is_result_fetched);
 
+	// Prefix-matching the URL string is not the same as matching the site.
+	// "https://tracker.example" is a prefix of "https://tracker.example@evil.test/"
+	// (the tracker name is userinfo, the host is the attacker's) and of
+	// "https://tracker.example.evil.test/" (the tracker name is one label of a
+	// longer domain). Either would have handed this account's cookies to
+	// whoever controls that host, and the URL does not have to come from the
+	// user -- plugins/rss follows links out of a feed.
 	public function test($url)
 	{
-		return( stripos($url,$this->url)===0 );
+		$site = @parse_url((string) $this->url);
+		if(!is_array($site) || empty($site["host"]) || empty($site["scheme"]))
+			return(false);
+		return(self::urlAddresses($url,array($site["host"]),$site["scheme"]));
+	}
+
+	// True when $url's host is one of $hosts, or a subdomain of one, and its
+	// scheme is $scheme when a scheme is named. Subclasses that accept several
+	// domains, or a whole domain's subdomains, say so here instead of matching
+	// the name anywhere in the URL string -- which also accepts
+	// "https://evil.test/path/tracker.example/x", whose host is the attacker's.
+	static protected function urlAddresses($url,$hosts,$scheme = null,$pathPrefix = null)
+	{
+		$parts = @parse_url((string) $url);
+		if(!is_array($parts) || empty($parts["host"]))
+			return(false);
+		// The URL may not weaken the site's scheme. An https site matched over
+		// http would have this account's cookies put on the wire in clear by
+		// the very first request, before any redirect could upgrade it, and a
+		// feed link is not written by the user. The other direction is allowed:
+		// an https URL to a site still configured http simply fails to
+		// connect, and costs nothing to permit.
+		if($scheme!==null)
+		{
+			$urlScheme = strtolower(isset($parts["scheme"]) ? $parts["scheme"] : '');
+			if(($urlScheme!==strtolower($scheme)) && ($urlScheme!=='https'))
+				return(false);
+		}
+		if($pathPrefix!==null)
+		{
+			$path = isset($parts["path"]) ? $parts["path"] : '/';
+			if(strncasecmp($path,$pathPrefix,strlen($pathPrefix))!==0)
+				return(false);
+		}
+		$host = strtolower($parts["host"]);
+		foreach($hosts as $candidate)
+		{
+			$candidate = strtolower($candidate);
+			if(($host===$candidate) || (substr($host,-strlen($candidate)-1)==='.'.$candidate))
+				return(true);
+		}
+		return(false);
 	}
 
 	protected function loadData( $client = null )

--- a/plugins/loginmgr/accounts/AniDUB.php
+++ b/plugins/loginmgr/accounts/AniDUB.php
@@ -2,7 +2,7 @@
 
 class AniDUBAccount extends commonAccount
 {
-    public $url = "http://tr.anidub.com";
+    public $url = "https://tr.anidub.com";
 
     protected function isOK($client)
     {
@@ -27,6 +27,6 @@ class AniDUBAccount extends commonAccount
     }
     public function test($url)
     {
-        return(preg_match( "/^http:\/\/tr\.anidub\.com\//si", $url ));
+        return(self::urlAddresses($url,array("tr.anidub.com"),"https"));
     }
 }

--- a/plugins/loginmgr/accounts/KinozalTV.php
+++ b/plugins/loginmgr/accounts/KinozalTV.php
@@ -33,8 +33,12 @@ class KinozalTVAccount extends commonAccount
 		}
 		return(false);
 	}
+	// Matched against the URL's host, not against the URL string: the pattern
+	// this replaced also accepted https://evil.test/path/kinozal.guru/x, whose
+	// host is the attacker's, and loginmgr would then have sent this account's
+	// cookies there.
 	public function test($url)
 	{
-		return(preg_match( "/(\.|\/)kinozal\.(tv|me|guru)\//si", $url ));
+		return(self::urlAddresses($url,array("kinozal.tv","kinozal.me","kinozal.guru")));
 	}
 }

--- a/plugins/loginmgr/accounts/LostFilm.php
+++ b/plugins/loginmgr/accounts/LostFilm.php
@@ -2,7 +2,11 @@
 
 class LostFilmAccount extends commonAccount
 {
-	public $url = "http://lostfilm.tv";
+	// https, because login() below posts the account's password to
+	// $url."/useri.php". A redirect to https afterwards does not protect a
+	// POST that has already gone out in the clear -- and the site issues
+	// exactly such a redirect, so http here bought nothing but the exposure.
+	public $url = "https://lostfilm.tv";
 
 	protected function isOK($client)
 	{
@@ -38,6 +42,6 @@ class LostFilmAccount extends commonAccount
 	}
 	public function test($url)
 	{
-		return( stripos( $url, $this->url."/download.php" )===0 );
+		return(self::urlAddresses($url,array("lostfilm.tv"),"https","/download.php"));
 	}
 }

--- a/plugins/loginmgr/accounts/NovaFilm.php
+++ b/plugins/loginmgr/accounts/NovaFilm.php
@@ -2,7 +2,7 @@
 
 class NovaFilmAccount extends commonAccount
 {
-	public $url = "http://novafilm.tv";
+	public $url = "https://novafilm.tv";
 
 	protected function isOK($client)
 	{
@@ -22,6 +22,6 @@ class NovaFilmAccount extends commonAccount
 	}
 	public function test($url)
 	{
-		return( stripos( $url, $this->url."/download/" )===0 );
+		return(self::urlAddresses($url,array("novafilm.tv"),"https","/download/"));
 	}
 }

--- a/plugins/loginmgr/accounts/RUTracker.php
+++ b/plugins/loginmgr/accounts/RUTracker.php
@@ -58,8 +58,13 @@ class ruTrackerAccount extends commonAccount
 		}
 		return(false);
 	}
+	// Matched against the URL's host, not against the URL string: the pattern
+	// this replaced also accepted https://evil.test/path/rutracker.org/forum/x, whose
+	// host is the attacker's, and loginmgr would then have sent this account's
+	// cookies there.
 	public function test($url)
 	{
-		return(preg_match( "/(\.|\/)rutracker\.(org|cr|net|nl)\/forum\//si", $url ));
+		return(self::urlAddresses($url,
+			array("rutracker.org","rutracker.cr","rutracker.net","rutracker.nl"),null,"/forum/"));
 	}
 }

--- a/plugins/loginmgr/accounts/TapochekNet.php
+++ b/plugins/loginmgr/accounts/TapochekNet.php
@@ -24,8 +24,12 @@ class TapochekNetAccount extends commonAccount
 		}
 		return(false);
 	}
+	// Matched against the URL's host, not against the URL string: the pattern
+	// this replaced also accepted https://evil.test/path/tapochek.net/x, whose
+	// host is the attacker's, and loginmgr would then have sent this account's
+	// cookies there.
 	public function test($url)
 	{
-		return(preg_match( "/(\.|\/)tapochek\.net\//si", $url ));
+		return(self::urlAddresses($url,array("tapochek.net")));
 	}
 }

--- a/plugins/loginmgr/accounts/Tfile.php
+++ b/plugins/loginmgr/accounts/Tfile.php
@@ -2,7 +2,7 @@
 
 class TfileAccount extends commonAccount
 {
-	public $url = "http://megatfile.cc";
+	public $url = "https://megatfile.cc";
 
 	protected function isOK($client)
 	{
@@ -24,8 +24,12 @@ class TfileAccount extends commonAccount
 		}
 		return(false);
 	}
+	// Matched against the URL's host, not against the URL string: the pattern
+	// this replaced also accepted https://evil.test/path/megatfile.cc/forum/x, whose
+	// host is the attacker's, and loginmgr would then have sent this account's
+	// cookies there.
 	public function test($url)
 	{
-		return(preg_match( "/(\.|\/)megatfile\.cc\/forum\//si", $url ));
+		return(self::urlAddresses($url,array("megatfile.cc"),"https","/forum/"));
 	}
 }

--- a/plugins/loginmgr/accounts/Toloka.php
+++ b/plugins/loginmgr/accounts/Toloka.php
@@ -21,8 +21,12 @@ class tolokaAccount extends commonAccount
 		}
 		return(false);
 	}
+	// Matched against the URL's host, not against the URL string: the pattern
+	// this replaced also accepted https://evil.test/path/toloka.to/x, whose
+	// host is the attacker's, and loginmgr would then have sent this account's
+	// cookies there.
 	public function test($url)
 	{
-		return(preg_match( "/(\.|\/)toloka.to\//si", $url ));
+		return(self::urlAddresses($url,array("toloka.to")));
 	}
 }

--- a/plugins/loginmgr/accounts/Torrentech.php
+++ b/plugins/loginmgr/accounts/Torrentech.php
@@ -2,7 +2,7 @@
 
 class TorrentechAccount extends commonAccount
 {
-	public $url = "http://www.torrentech.org";
+	public $url = "https://www.torrentech.org";
 
 	protected function isOK($client)
 	{

--- a/plugins/loginmgr/accounts/YggTorrent.php
+++ b/plugins/loginmgr/accounts/YggTorrent.php
@@ -11,9 +11,22 @@ class YggTorrentAccount extends commonAccount
         );
     }
 
+    // The tracker changes domain often, so the host is matched by shape rather
+    // than by name -- but against the host, not against the whole URL. The
+    // pattern this replaced also accepted
+    // https://evil.test/x/ygg.example/engine/download_torrent?id=1, whose host
+    // is the attacker's and which would have been sent this account's cookies.
     public function test($url)
     {
-    	return( preg_match( '/https:\/\/(.*\.)?ygg.*\..*\/engine\/download_torrent\?id=/', $url ) === 1 );
+        $parts = @parse_url((string) $url);
+        if(!is_array($parts) || empty($parts["host"]) ||
+            (strtolower(isset($parts["scheme"]) ? $parts["scheme"] : '')!=='https'))
+            return(false);
+        if(!preg_match('/(^|\.)ygg[^.]*\.[^.]+$/i',$parts["host"]))
+            return(false);
+        if(strcasecmp(isset($parts["path"]) ? $parts["path"] : '','/engine/download_torrent')!==0)
+            return(false);
+        return(preg_match('/(^|&)id=/',isset($parts["query"]) ? $parts["query"] : '')===1);
     }
 
     protected function login($client, $login, $password, &$url, &$method, &$content_type, &$body, &$is_result_fetched)

--- a/plugins/loginmgr/accounts/ZamundaNet.php
+++ b/plugins/loginmgr/accounts/ZamundaNet.php
@@ -23,8 +23,12 @@ class ZamundaNetAccount extends commonAccount
 		}
 		return(false);
 	}
+	// Matched against the URL's host, not against the URL string: the pattern
+	// this replaced also accepted https://evil.test/path/zamunda.net/x, whose
+	// host is the attacker's, and loginmgr would then have sent this account's
+	// cookies there.
 	public function test($url)
 	{
-		return(preg_match( "/(\.|\/)zamunda\.(net|ch)\//si", $url ));
+		return(self::urlAddresses($url,array("zamunda.net","zamunda.ch")));
 	}
 }

--- a/plugins/loginmgr/accounts/mTeam.php
+++ b/plugins/loginmgr/accounts/mTeam.php
@@ -2,7 +2,7 @@
 
 class mTeamAccount extends commonAccount
 {
-	public $url = "http://mteam.fr";
+	public $url = "https://mteam.fr";
 
 	protected function isOK($client)
 	{

--- a/tests/plugins/loginmgr/AccountSelectionTest.php
+++ b/tests/plugins/loginmgr/AccountSelectionTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * accountManager picks an account for a URL by asking each enabled account
+ * test($url). Getting that wrong is not a cosmetic bug: the account it picks
+ * is the one whose cookies Snoopy then sends to whatever host the URL really
+ * names, and the URL does not have to come from the user -- plugins/rss
+ * follows links out of a feed, and plugins/extsearch out of a search result.
+ */
+
+require_once(__DIR__ . '/../../../plugins/loginmgr/accounts.php');
+foreach (glob(__DIR__ . '/../../../plugins/loginmgr/accounts/*.php') as $accountFile) {
+    require_once($accountFile);
+}
+
+// A site still configured http, to pin the direction the rule allows.
+class ProbeHttpSiteAccount extends commonAccount
+{
+    public $url = 'http://http-only.example';
+    protected function isOK($client) { return true; }
+    protected function login($c, $l, $p, &$u, &$m, &$ct, &$b, &$f) { return false; }
+}
+
+function selAssertSame($expected, $actual, $message)
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException(
+            $message . '; expected ' . var_export($expected, true)
+            . ', got ' . var_export($actual, true)
+        );
+    }
+}
+
+$tests = array(
+    'an account is chosen by the url host, not by a substring of the url' => function () {
+        // A prefix match accepts https://tracker.example@evil.test/ (the name
+        // is userinfo) and https://tracker.example.evil.test/ (the name is one
+        // label of a longer domain); matching the name anywhere accepts
+        // https://evil.test/path/tracker.example/x. All three would have sent
+        // the account's cookies to a host the attacker controls, and the url
+        // need not come from the user -- plugins/rss follows feed links.
+        $cases = array(
+            array('ABTorrentsAccount', 'https://abtorrents.me/x', true),
+            array('ABTorrentsAccount', 'https://abtorrents.me@evil.test/', false),
+            array('ABTorrentsAccount', 'https://abtorrents.me.evil.test/', false),
+            array('ABTorrentsAccount', 'https://evil.test/abtorrents.me/', false),
+            array('KinozalTVAccount', 'https://kinozal.guru/details.php?id=1', true),
+            array('KinozalTVAccount', 'https://dl.kinozal.guru/download.php?id=1', true),
+            array('KinozalTVAccount', 'https://evil.test/path/kinozal.guru/feed', false),
+            array('ruTrackerAccount', 'https://rutracker.org/forum/dl.php?t=1', true),
+            array('ruTrackerAccount', 'https://rutracker.org/other/', false),
+            array('ruTrackerAccount', 'https://evil.test/x/rutracker.org/forum/', false),
+            array('TapochekNetAccount', 'https://tapochek.net/x', true),
+            array('TapochekNetAccount', 'https://tapochek.net.evil.test/x', false),
+            array('YggTorrentAccount', 'https://www.ygg.re/engine/download_torrent?id=1', true),
+            array('YggTorrentAccount', 'https://evil.test/x/ygg.re/engine/download_torrent?id=1', false),
+            array('LostFilmAccount', 'https://lostfilm.tv/download.php?id=7&', true),
+            array('LostFilmAccount', 'https://lostfilm.tv.evil.test/download.php?id=7&', false),
+        );
+        foreach ($cases as $case) {
+            list($class, $url, $expected) = $case;
+            $account = new $class();
+            selAssertSame($expected, (bool) $account->test($url), $class . ' vs ' . $url);
+        }
+    },
+
+    'a url may not weaken the scheme its site is configured with' => function () {
+        // Matched over http, an https site would have this account's cookies
+        // put on the wire in clear by the very first request, before any
+        // redirect could upgrade it -- and the url can arrive from a feed.
+        foreach (array(
+            array('LostFilmAccount', 'http://lostfilm.tv/download.php?id=7&'),
+            array('TfileAccount', 'http://megatfile.cc/forum/index.php'),
+            array('AniDUBAccount', 'http://tr.anidub.com/'),
+            array('ABTorrentsAccount', 'http://abtorrents.me/x'),
+        ) as $case) {
+            list($class, $url) = $case;
+            $account = new $class();
+            selAssertSame(false, (bool) $account->test($url),
+                $class . ' must not claim the http form of an https site');
+        }
+    },
+
+    'an https url still reaches a site whose own scheme is http' => function () {
+        // The other direction costs nothing to allow: an https url to a site
+        // that really is http-only simply fails to connect.
+        $account = new ProbeHttpSiteAccount();
+        selAssertSame(true, (bool) $account->test('https://http-only.example/x'), 'https is accepted');
+        selAssertSame(true, (bool) $account->test('http://http-only.example/x'), 'so is its own scheme');
+    },
+
+    'a url with no host at all matches nothing' => function () {
+        foreach (get_declared_classes() as $class) {
+            if (!is_subclass_of($class, 'commonAccount') || $class === 'ProbeHttpSiteAccount') {
+                continue;
+            }
+            $account = new $class();
+            foreach (array('', 'not a url', '/relative/path', 'javascript:alert(1)') as $url) {
+                selAssertSame(false, (bool) $account->test($url),
+                    $class . ' must not claim ' . var_export($url, true));
+            }
+        }
+    },
+);
+
+$failures = 0;
+foreach ($tests as $name => $callback) {
+    try {
+        $callback();
+        echo "ok - {$name}\n";
+    } catch (Throwable $error) {
+        $failures++;
+        echo "not ok - {$name}\n";
+        echo '  ' . get_class($error) . ': ' . $error->getMessage() . "\n";
+    }
+}
+echo count($tests) . ' tests, ' . $failures . " failures\n";
+exit($failures === 0 ? 0 : 1);


### PR DESCRIPTION

A URL that merely *contains* a tracker's name selects that tracker's account, and the account's stored session cookies are then sent to whatever host the URL really names. A link like

```
https://evil.test/x/rutracker.org/forum/dl.php?t=1
```

hands the reader's RuTracker session to `evil.test`. No password is involved, and the link need not come from the user: `php/addtorrent.php` downloads a torrent by URL, and `plugins/rss` takes that URL out of a feed.

### Why nothing else stops it

The chain is short and has no other guard in it:

```php
// php/Snoopy.class.inc, fetchComplex()
$acc = $am->getAccount($URI);
if($acc) return($am->fetch( $acc, $this, $URI, $method, $content_type, $body ));

// plugins/loginmgr/accounts.php, privateData::load()
$client->cookies = $rt->cookies;

// php/Snoopy.class.inc, _httprequest() -- no host binding at all
$cookie_str = 'Cookie: ';
foreach( $this->cookies as $cookieKey => $cookieVal )
    $cookie_str .= $cookieKey."=".$cookieVal."; ";
```

Everything rests on `test()`, and `test()` was comparing strings.

### The two shapes of it

`commonAccount::test()`, which fifteen accounts use unchanged:

```php
return( stripos($url,$this->url)===0 );
```

For a site `https://tracker.example` that also accepts

```
https://tracker.example@evil.test/     the tracker name is userinfo; the host is the attacker's
https://tracker.example.evil.test/     the tracker name is one label of a longer domain
```

Seven other accounts match their domain *anywhere* in the URL with a regex —

```php
return(preg_match( "/(\.|\/)rutracker\.(org|cr|net|nl)\/forum\//si", $url ));
```

— which is the case in the opening example. `YggTorrent`'s is the loosest, matching any host with `ygg` somewhere in the string.

### What changes

All of them now parse the URL and compare against its **host**: the base class against its own site's host, the seven against the domain list each already had, keeping the path requirement each already had. Subdomains still match — that is what those regexes meant by their leading `(\.|/)`, and what mirrors such as `dl.kinozal.guru` need.

The scheme is checked too, and asymmetrically: **a URL may not be weaker than the site it claims.** An https site matched over http would have the account's cookies put on the wire in clear by the very first request, before any redirect could upgrade it. The other direction is allowed — an https URL to a site still configured http simply fails to connect, and costs nothing to permit.

That rule has a companion. Six accounts named an http site while posting the account's **password** to it, and a later redirect to https does not protect a POST that has already gone out in the clear. None was moved on assumption:

| account | evidence |
|---|---|
| `lostfilm.tv` | https 200, valid cert, and http `301`s to it |
| `www.torrentech.org` | https 200, valid cert, and http `301`s to it |
| `mteam.fr` | https 200, valid cert, http `301`s to it, and the login endpoint answers over it |
| `tr.anidub.com` | https 200, valid cert, serves the site (137 KB) |
| `megatfile.cc` | https 200, valid cert, body byte-identical to the http one |
| `novafilm.tv` | TLS terminates with a valid cert, but the origin is down (Cloudflare `522`) over http and https alike, so only the edge could be verified |



### What this does not do

Snoopy still keeps one flat cookie jar and does not scope cookies by host. This fixes *which account a URL may spend*, not how a session is stored — that is a larger change.

### One user-visible effect

An account whose site moved to https no longer claims an `http://` URL, so a stored http link to one of those six has to be updated once. For the three that redirect, their own pages hand out https links anyway. That is the intended direction: a login manager should fail closed rather than put its cookies on the wire in clear.

### How to verify

`tests/plugins/loginmgr/AccountSelectionTest.php` pins each shape against the account it would have been mismatched to, that an http URL no longer reaches an https site while an https URL still reaches an http one, and that no account claims a URL with no host at all. Restore either old form of `test()`, or either half of the scheme rule, and it is the only suite that fails.

```sh
cd tests && bash php-test.sh
```