### PR TITLE
httprpc: keep client-quoted load.* arguments instead of dropping them

### DIFF
--- a/php/xmlrpc_proxy.php
+++ b/php/xmlrpc_proxy.php
@@ -592,6 +592,77 @@ class XMLRPCProxy
 	}
 
 	/**
+	 * Split command arguments the way rtorrent does: commas separate them, and
+	 * a double-quoted string is one argument even when it contains commas.
+	 * Unquoted arguments are trimmed; quoted ones are not. An unclosed quote,
+	 * or text after a quoted argument that is not a comma, is malformed and
+	 * returns null so the whole parameter is dropped.
+	 *
+	 * Clients such as cross-seed quote every value (d.custom1.set="cross-seed").
+	 * Splitting on ',' first would cut inside those quotes; dropping them left
+	 * torrents unlabeled and in the default directory. Unquoting here, then
+	 * re-quoting in rebuildSafeLoadParam, keeps the value as one argument.
+	 */
+	private static function splitLoadArguments($value)
+	{
+		$arguments = array();
+		$len = strlen($value);
+		$i = 0;
+		while($i < $len)
+		{
+			while($i < $len && ($value[$i] === ' ' || $value[$i] === "\t"))
+				$i++;
+			if($i >= $len)
+				break;
+
+			if($value[$i] === '"')
+			{
+				$i++;
+				$argument = '';
+				$closed = false;
+				while($i < $len)
+				{
+					$c = $value[$i];
+					if($c === '\\' && $i + 1 < $len)
+					{
+						$argument .= $value[$i + 1];
+						$i += 2;
+						continue;
+					}
+					if($c === '"')
+					{
+						$closed = true;
+						$i++;
+						break;
+					}
+					$argument .= $c;
+					$i++;
+				}
+				if(!$closed)
+					return null;
+				$arguments[] = $argument;
+			}
+			else
+			{
+				$start = $i;
+				while($i < $len && $value[$i] !== ',')
+					$i++;
+				$arguments[] = trim(substr($value, $start, $i - $start));
+			}
+
+			while($i < $len && ($value[$i] === ' ' || $value[$i] === "\t"))
+				$i++;
+			if($i < $len)
+			{
+				if($value[$i] !== ',')
+					return null;
+				$i++;
+			}
+		}
+		return $arguments;
+	}
+
+	/**
 	 * Rebuild one command parameter, or return null to drop it.
 	 *
 	 * A parameter is not a single command: rtorrent ends a command at ';' or a
@@ -600,13 +671,11 @@ class XMLRPCProxy
 	 * command name is therefore compared for equality, and each argument is
 	 * quoted so that whatever it contains stays an argument.
 	 *
-	 * Arguments are split on ',' first, exactly as rtorrent would split them,
-	 * so a command that takes several keeps them, and each is trimmed as
-	 * rtorrent trims an unquoted argument.
-	 *
-	 * Values are taken literally: a client sends d.custom1.set=Movies, Inc,
-	 * not a pre-quoted d.custom1.set="Movies, Inc", since the quoting is added
-	 * here and a quote in the value is escaped rather than interpreted.
+	 * Arguments are split the way rtorrent splits them (commas, with quoted
+	 * strings kept whole), so a command that takes several keeps them, and
+	 * each unquoted argument is trimmed as rtorrent trims one. A value the
+	 * client already quoted is unquoted here, then re-quoted, rather than
+	 * dropped: cross-seed and others send d.custom1.set="label".
 	 */
 	private static function rebuildSafeLoadParam($paramValue, $safeParams, $directory = null)
 	{
@@ -618,31 +687,29 @@ class XMLRPCProxy
 		if(!in_array($command, $safeParams, true))
 			return null;
 
+		$parts = self::splitLoadArguments(substr($paramValue, $separator + 1));
+		if($parts === null)
+			return null;
+
 		// A caller that states no boundary is not policed here, which is the
 		// behaviour every caller had before this existed. rpc2.php always states
 		// one and refuses to start without it; the httprpc plugin does not, and
 		// its door needs a ruTorrent session rather than a machine credential.
-		if(($directory !== null) && in_array($command, self::$directoryCommands, true) &&
-			!self::directoryIsAllowed(trim(substr($paramValue, $separator + 1)), $directory))
-			return null;
+		if(($directory !== null) && in_array($command, self::$directoryCommands, true))
+		{
+			$path = isset($parts[0]) ? $parts[0] : '';
+			if(!self::directoryIsAllowed($path, $directory))
+				return null;
+		}
 
 		$arguments = array();
-		foreach(explode(',', substr($paramValue, $separator + 1)) as $argument)
+		foreach($parts as $argument)
 		{
-			// rtorrent trims an unquoted argument, so trim before anything else
-			// is decided about it — quoting a trimmed value must not turn a
-			// leading space into a leading '$'.
-			$argument = trim($argument);
-
 			// An argument whose first character is '$' is parsed and called as a
 			// command after quoting is undone, so quoting cannot make it safe.
+			// Unquoted values are already trimmed by the split; trimming again
+			// here would not turn a leading space into a leading '$'.
 			if(isset($argument[0]) && $argument[0] === '$')
-				return null;
-
-			// A client that quoted the value itself gets dropped and logged
-			// rather than quietly mangled: the quoting is added here, and the
-			// split would fall inside the client's quotes.
-			if(isset($argument[0]) && $argument[0] === '"')
 				return null;
 
 			$arguments[] = '"'.str_replace(array('\\', '"'), array('\\\\', '\\"'), $argument).'"';

--- a/plugins/httprpc/conf.php
+++ b/plugins/httprpc/conf.php
@@ -32,8 +32,9 @@ $XMLRPCProxyLog = true;
 $XMLRPCProxyAllowLocalPaths = false;
 
 // Command names allowed as load.* parameters in sanitize mode.
-// External clients (Prowlarr, Sonarr, Radarr, Transdroid) attach these
-// to load.start to set labels, directories, priorities, etc.
+// External clients (Prowlarr, Sonarr, Radarr, Transdroid, cross-seed)
+// attach these to load.start / load.raw_start to set labels, directories,
+// priorities, etc. Quoted values (d.custom1.set="cross-seed") are accepted.
 // Entries are full command names and are matched exactly: 'd.custom' does
 // NOT cover 'd.custom1.set'. A param whose command name is not listed is
 // stripped and logged. Add entries here if your external client needs

--- a/tests/php/XMLRPCProxyContractFixture.php
+++ b/tests/php/XMLRPCProxyContractFixture.php
@@ -315,7 +315,7 @@ return array(
 			"xmlrpc-proxy: trusted: load.start (kept 2 params, stripped: d.custom1.set=\$execute.capture=/bin/hostname)",
 		),
 	),
-	"a value the client quoted itself is dropped" => array(
+	"a value the client quoted itself is kept as one argument" => array(
 		"request" => "<?xml version=\"1.0\"?><methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=&quot;Movies, Inc&quot;</string></value></param></params></methodCall>",
 		"mode" => "sanitize",
 		"enableLog" => true,
@@ -328,9 +328,9 @@ return array(
 		"returned" => "SCGI-REPLY",
 		"sends" => 1,
 		"trusted" => true,
-		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param></params></methodCall>",
+		"payload" => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<methodCall><methodName>load.start</methodName><params><param><value><string></string></value></param><param><value><string>http://example.test/x.torrent</string></value></param><param><value><string>d.custom1.set=\"Movies, Inc\"</string></value></param></params></methodCall>",
 		"log" => array(
-			"xmlrpc-proxy: trusted: load.start (kept 2 params, stripped: d.custom1.set=\"Movies, Inc\")",
+			"xmlrpc-proxy: trusted: load.start (3 params)",
 		),
 	),
 	"a long stripped value is truncated in the log" => array(

--- a/tests/php/XMLRPCProxyTest.php
+++ b/tests/php/XMLRPCProxyTest.php
@@ -361,12 +361,43 @@ class XMLRPCProxyTest extends TestCase
 		$this->assertTrue(rXMLRPCRequest::$lastTrusted === true, 'a rebuilt base64 param does not force the call untrusted');
 	}
 
-	public function testPreQuotedValueIsDroppedNotMangled()
+	public function testPreQuotedValueIsKeptAsOneArgument()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set="Movies, Inc"');
+		$this->assertTrue(strpos($sent, 'd.custom1.set="Movies, Inc"') !== false,
+			'a value the client quoted itself is unquoted and re-quoted as one argument');
+		$this->assertTrue(strpos($sent, 'd.custom1.set="Movies","Inc"') === false,
+			'and the comma inside the quotes does not split it');
+	}
+
+	public function testCrossSeedQuotedLoadParamsAreKept()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set="cross-seed"',
+			array('d.custom1.set', 'd.directory_base.set', 'd.custom.set'));
+		$this->assertTrue(strpos($sent, 'd.custom1.set="cross-seed"') !== false,
+			'cross-seed quotes the label; that must still set custom1');
+
+		$sent = $this->sanitizeParam(
+			'd.directory_base.set="/data/Media/torrent/download/cross-seed/PassThePopcorn"',
+			array('d.custom1.set', 'd.directory_base.set', 'd.custom.set'));
+		$this->assertTrue(strpos($sent,
+			'd.directory_base.set="/data/Media/torrent/download/cross-seed/PassThePopcorn"') !== false,
+			'and the quoted save path must still set directory_base');
+	}
+
+	public function testQuotedDollarPrefixedArgumentIsDropped()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set="$execute.capture=/bin/hostname"');
+		$this->assertTrue(strpos($sent, 'execute.capture') === false,
+			'quoting does not hide a leading $; the argument is still dropped');
+	}
+
+	public function testUnclosedQuoteIsDropped()
 	{
 		$this->resetMocks();
-		$this->sanitizeParamLogged('d.custom1.set="Movies, Inc"');
+		$this->sanitizeParamLogged('d.custom1.set="Movies, Inc');
 		$this->assertTrue(strpos((string) rXMLRPCRequest::$lastPayload, 'd.custom1.set') === false,
-			'a value the client quoted itself is dropped, not split inside its quotes');
+			'an unclosed quote is malformed and dropped, not split inside it');
 		$this->assertTrue(strpos($this->logText(), 'stripped') !== false,
 			'and the drop is visible in the log');
 	}
@@ -752,6 +783,13 @@ class XMLRPCProxyTest extends TestCase
 			'd.directory_base.set sets the root directly, so it is the blunter of the two');
 		$this->assertTrue($this->loadInto('/torrents1/downloads/x', $policy, 'd.directory_base.set'),
 			'and still works inside the boundary');
+	}
+
+	public function testQuotedDirectoryInsideTheBoundaryIsKept()
+	{
+		$policy = array('root' => '/torrents1/downloads');
+		$this->assertTrue($this->loadInto('"/torrents1/downloads/cross-seed"', $policy, 'd.directory_base.set'),
+			'a client-quoted path is unquoted before the boundary check');
 	}
 
 	public function testPathTricksDoNotEscape()


### PR DESCRIPTION
## Summary

The XMLRPC proxy sanitizer (#3181) rebuilds `load.*` command parameters and dropped any argument that started with `"`, on the assumption that clients send values raw and this side quotes them.

That does not match what rtorrent clients actually send. **cross-seed** injects with:

```
load.raw_start
  d.directory_base.set="/data/.../cross-seed/PassThePopcorn"
  d.custom1.set="cross-seed"
  d.custom.set=addtime,<timestamp>
```

Those quoted setters were stripped. The torrent was still added (`load.raw_start`), but into the default download directory with no label. Hardlinked files were already in the cross-seed path, so the client sat in **Pausing** at 0%. Unquoted clients (Sonarr/Radarr `d.custom1.set=tv/sonarr`) were unaffected.

This change unquotes a client-quoted argument (commas inside quotes stay one argument), then re-quotes it the same way as an unquoted value. A leading `$` is still dropped after unquoting, so `d.custom1.set="$execute.capture=..."` cannot sneak through.

## Test plan

- [x] `tests/php-test.sh` (full PHP suite)
- [ ] Inject a cross-seed match through httprpc: torrent should get label `cross-seed` and `directory_base` under the link dir, then start/seed
- [ ] Confirm a Sonarr/Radarr add with an unquoted label still sets the label
- [ ] Confirm `d.custom1.set="$execute.capture=/bin/hostname"` is still stripped


Made with [Cursor](https://cursor.com)