### PR TITLE
Keep an escaped comma inside a load argument

### DIFF
--- a/php/xmlrpc_proxy.php
+++ b/php/xmlrpc_proxy.php
@@ -644,10 +644,39 @@ class XMLRPCProxy
 			}
 			else
 			{
-				$start = $i;
-				while($i < $len && $value[$i] !== ',')
+				// Only one escape changes where an argument ends: rtorrent reads
+				// '\\,' as a comma inside the value rather than a separator
+				// (parse_string, src/rpc/parse.cc), so splitting on every comma
+				// cut such a value in two and delivered a second argument the
+				// client never sent.
+				//
+				// Its other escapes are deliberately left alone. rtorrent would
+				// read '\\' as an escape everywhere, which turns C:\\downloads
+				// into C:downloads -- but this side re-quotes the value, so the
+				// backslash reaches rtorrent intact, and clients have been
+				// sending paths and labels through here on that basis. Matching
+				// rtorrent exactly would eat those backslashes.
+				$argument = '';
+				$keep = 0;
+				while($i < $len)
+				{
+					$c = $value[$i];
+					if($c === ',')
+						break;
+					if(($c === '\\') && ($i + 1 < $len) && ($value[$i + 1] === ','))
+					{
+						$argument .= ',';
+						$i += 2;
+						$keep = strlen($argument);
+						continue;
+					}
+					$argument .= $c;
 					$i++;
-				$arguments[] = trim(substr($value, $start, $i - $start));
+					// Trailing whitespace is trimmed as rtorrent trims it.
+					if(($c !== ' ') && ($c !== "\t"))
+						$keep = strlen($argument);
+				}
+				$arguments[] = substr($argument, 0, $keep);
 			}
 
 			while($i < $len && ($value[$i] === ' ' || $value[$i] === "\t"))

--- a/tests/php/XMLRPCProxyTest.php
+++ b/tests/php/XMLRPCProxyTest.php
@@ -878,4 +878,47 @@ class XMLRPCProxyTest extends TestCase
 		$this->assertTrue(rXMLRPCRequest::$lastPayload === $xml, 'forwarded byte for byte');
 		$this->assertTrue(rXMLRPCRequest::$lastTrusted === false, 'and untrusted');
 	}
+
+	// ---- an escaped comma is part of the value, not a separator ----
+
+	public function testAnEscapedCommaDoesNotSeparateArguments()
+	{
+		$sent = $this->sanitizeParam('d.custom.set=a\,b', array('d.custom.set'));
+		$this->assertTrue(strpos($sent, 'd.custom.set="a,b"') !== false,
+			'rtorrent reads a\,b as the one argument a,b; splitting on it invented a second');
+	}
+
+	public function testAnEscapedCommaAtTheEndOfAValueIsKept()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set=a\,', array('d.custom1.set'));
+		$this->assertTrue(strpos($sent, 'd.custom1.set="a,"') !== false,
+			'the comma is value content, so it survives to the end');
+	}
+
+	public function testAnUnescapedCommaStillSeparates()
+	{
+		$sent = $this->sanitizeParam('d.custom.set=chk-state,7', array('d.custom.set'));
+		$this->assertTrue(strpos($sent, 'd.custom.set="chk-state","7"') !== false,
+			'a bare comma keeps separating arguments');
+	}
+
+	/**
+	 * Every other backslash is left where it is. rtorrent would read it as an
+	 * escape and turn C:\downloads into C:downloads, but this side re-quotes
+	 * the value, so the backslash reaches rtorrent whole -- and clients have
+	 * been sending paths and labels through here on that basis.
+	 */
+	public function testABackslashThatIsNotBeforeACommaIsKept()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set=C:\downloads\tv', array('d.custom1.set'));
+		$this->assertTrue(strpos($sent, 'd.custom1.set="C:\\\\downloads\\\\tv"') !== false,
+			'a windows-style path survives, re-escaped on the way out');
+	}
+
+	public function testATrailingBackslashIsStillJustAValue()
+	{
+		$sent = $this->sanitizeParam('d.custom1.set=abc\\', array('d.custom1.set'));
+		$this->assertTrue(strpos($sent, 'd.custom1.set="abc\\\\"') !== false,
+			'a value ending in a backslash is quoted, not dropped');
+	}
 }


### PR DESCRIPTION
rtorrent reads d.custom.set=a\,b as the one argument a,b; splitting on every comma delivered a second argument the client never sent.