### PR TITLE
Test what the scripts that rewrite a torrent do to it

### DIFF
--- a/tests/php/TorrentAddPathSequenceTest.php
+++ b/tests/php/TorrentAddPathSequenceTest.php
@@ -1,0 +1,373 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/TorrentSequenceFixtures.php');
+require_once(__DIR__ . '/../../php/rtorrent.php');
+
+/**
+ * rTorrent::fastResume() asks the settings singleton whether the download
+ * directory is inside the configured tree, which on a live install is answered
+ * out of a cache written by a running daemon. Here it is answered yes, so the
+ * fixture directory this test made can be used.
+ */
+class AddPathSequenceSettings extends rTorrentSettings
+{
+	public function correctDirectory(&$dir, $resolve_links = false)
+	{
+		return true;
+	}
+}
+
+/**
+ * What the add path does to a torrent: php/addtorrent.php line 120 onwards,
+ * and the two places in php/rtorrent.php it hands the torrent to.
+ *
+ * php/rtorrent.php is declarations only -- three require_once and then the
+ * classes -- so rTorrent::fastResume() is the real function here, driven
+ * directly. It is the caller that matters most: it builds
+ * libtorrent_resume['files'][$i]['mtime'] one array offset at a time, into a
+ * key the torrent may not have at all, and if that write does not reach the
+ * torrent every fast-resume load silently loses its resume data and rehashes.
+ *
+ * addtorrent.php and rTorrent::sendTorrent() cannot be included -- one reads
+ * $_REQUEST at the top level, the other talks SCGI -- so their sequences are
+ * transcribed. That pins the transcription, not the script; the subject is
+ * Torrent, and the bencoded bytes are asserted whole.
+ */
+class TorrentAddPathSequenceTest extends TestCase
+{
+	use TorrentSequenceFixtures;
+
+	private $base;
+	private $previousSettings;
+
+	/** The mtimes the fixture files are given, so the expected bytes are fixed. */
+	private $mtimes = array(
+		'test.data'            => 1500000001,
+		'payload/one.data'     => 1500000002,
+		'payload/sub/two.data' => 1500000003,
+	);
+
+	public function setUp()
+	{
+		$this->base = sys_get_temp_dir() . '/rutorrent-addpath-seq-' . getmypid();
+		$this->makeFile('test.data', 1024);
+		$this->makeFile('payload/one.data', 600);
+		$this->makeFile('payload/sub/two.data', 400);
+
+		// rTorrentSettings' constructor reaches for a live daemon, so the
+		// singleton is replaced with an instance built without it.
+		$stub = new ReflectionClass('AddPathSequenceSettings');
+		$settings = $stub->newInstanceWithoutConstructor();
+		$settings->directory = $this->base;
+		$settings->iVersion = 0x904;
+		$settings->aliases = array();
+
+		$property = new ReflectionProperty('rTorrentSettings', 'theSettings');
+		$property->setAccessible(true);
+		$this->previousSettings = $property->getValue();
+		$property->setValue(null, $settings);
+	}
+
+	public function tearDown()
+	{
+		$property = new ReflectionProperty('rTorrentSettings', 'theSettings');
+		$property->setAccessible(true);
+		$property->setValue(null, $this->previousSettings);
+
+		foreach (array_keys($this->mtimes) as $relative) {
+			@unlink($this->base . '/' . $relative);
+		}
+		@rmdir($this->base . '/payload/sub');
+		@rmdir($this->base . '/payload');
+		@rmdir($this->base);
+	}
+
+	private function makeFile($relative, $size)
+	{
+		$path = $this->base . '/' . $relative;
+		$dir = dirname($path);
+		if (!is_dir($dir)) {
+			mkdir($dir, 0777, true);
+		}
+		file_put_contents($path, str_repeat("\x00", $size));
+		touch($path, $this->mtimes[$relative]);
+		clearstatcache(true, $path);
+	}
+
+	/** A libtorrent_resume dictionary as fastResume() builds one. */
+	private function expectedResume($chunks, $files)
+	{
+		$entries = array();
+		foreach ($files as $relative) {
+			$entries[] = $this->bdict(array(
+				'mtime'    => $this->bint($this->mtimes[$relative]),
+				'priority' => $this->bint(2),
+			));
+		}
+		return $this->bdict(array(
+			'bitfield' => $this->bint($chunks),
+			'files'    => $this->blist($entries),
+		));
+	}
+
+	// ---- rTorrent::fastResume() ------------------------------------------
+
+	/**
+	 * A single file torrent that has never been loaded: the key is not there
+	 * at all and fastResume() has to create it, offset by offset.
+	 */
+	public function testFastResumeBuildsResumeDataOnATorrentThatHasNone()
+	{
+		$torrent = new Torrent($this->announceOnlyTorrent());
+		$this->assertTrue(!isset($torrent->libtorrent_resume), 'the fixture has no resume data');
+
+		$resumed = rTorrent::fastResume($torrent, $this->base, true);
+		$this->assertTrue($resumed === $torrent, 'fastResume() hands back the torrent it was given');
+
+		$expected = $this->bdict(array(
+			'announce'          => $this->bstr('http://one.test/announce'),
+			'created by'        => $this->bstr('uTorrent/3.5.5'),
+			'creation date'     => $this->bint(1234567890),
+			'info'              => $this->singleFileInfo(),
+			'libtorrent_resume' => $this->expectedResume(1, array('test.data')),
+		));
+		$this->assertTrue((string)$torrent === $expected,
+			'the resume data is written and nothing else moved -- fastResume() is not a setter, '
+				. 'so the creation date the file came with is still there');
+
+		$reread = new Torrent((string)$torrent);
+		$resume = $reread->libtorrent_resume;
+		$this->assertTrue($resume['bitfield'] == 1, 'the bitfield reached the written torrent');
+		$this->assertTrue(count($resume['files']) === 1, 'one file entry was written');
+		$this->assertTrue($resume['files'][0]['priority'] == 2 &&
+				$resume['files'][0]['mtime'] == $this->mtimes['test.data'],
+			'with the priority and the mtime of the file on disk');
+	}
+
+	/**
+	 * A multi file torrent, added with its own directory: every path is
+	 * prefixed with the torrent name, and one entry is written per file in
+	 * the order info/files carries them.
+	 */
+	public function testFastResumeWritesOneEntryPerFileWithTheAddPathPrefix()
+	{
+		$torrent = new Torrent($this->privateMultiFileTorrent());
+		rTorrent::fastResume($torrent, $this->base, true);
+
+		$expected = $this->bdict(array(
+			'announce'          => $this->bstr('http://one.test/announce'),
+			'comment'           => $this->bstr('from the tracker'),
+			'created by'        => $this->bstr('uTorrent/3.5.5'),
+			'creation date'     => $this->bint(1234567890),
+			'encoding'          => $this->bstr('UTF-8'),
+			'info'              => $this->multiFileInfo(true),
+			'libtorrent_resume' => $this->expectedResume(1,
+				array('payload/one.data', 'payload/sub/two.data')),
+		));
+		$this->assertTrue((string)$torrent === $expected,
+			'both files are stat-ed under the torrent name and written in order');
+	}
+
+	/**
+	 * Without add-path the files are looked for directly under the base
+	 * directory, so a torrent whose files are not there gets no resume data
+	 * at all -- fastResume() returns false and the caller loads the torrent
+	 * unchanged rather than telling rtorrent the data is complete.
+	 */
+	public function testFastResumeRefusesWhenAFileIsNotWhereItWouldBe()
+	{
+		$torrent = new Torrent($this->privateMultiFileTorrent());
+		$fixture = (string)$torrent;
+
+		$resumed = rTorrent::fastResume($torrent, $this->base, false);
+		$this->assertTrue($resumed === false, 'a missing file is refused');
+
+		$reread = new Torrent((string)$torrent);
+		$this->assertTrue($reread->info['name'] === 'payload', 'the torrent still parses');
+		$this->assertTrue(strpos((string)$torrent, $this->bstr('info')) !== false,
+			'and it still carries its info dictionary');
+		$this->assertTrue((string)$torrent !== $fixture,
+			'the half-built resume key is left behind, which is why the caller drops the result');
+	}
+
+	/**
+	 * The torrent rtorrent saved already carries resume data. fastResume()
+	 * overwrites the entry for every file it stats and leaves the dictionary
+	 * otherwise as it found it.
+	 */
+	public function testFastResumeOverwritesTheResumeDataASessionTorrentCameWith()
+	{
+		$torrent = new Torrent($this->sessionTorrent());
+		$this->assertTrue($torrent->libtorrent_resume['files'][0]['mtime'] == 1234567891,
+			'the fixture carries an mtime of its own');
+
+		rTorrent::fastResume($torrent, $this->base, true);
+
+		$expected = $this->bdict(array(
+			'announce'          => $this->bstr('http://one.test/announce'),
+			'announce-list'     => $this->bannounceList(array(
+				array('http://one.test/announce'),
+				array('udp://two.test/announce'),
+			)),
+			'created by'        => $this->bstr('uTorrent/3.5.5'),
+			'creation date'     => $this->bint(1234567890),
+			'info'              => $this->singleFileInfo(),
+			'libtorrent_resume' => $this->expectedResume(1, array('test.data')),
+			'rtorrent'          => $this->rtorrentDictionary(),
+		));
+		$this->assertTrue((string)$torrent === $expected,
+			'the entry is replaced with the mtime on disk and the rest of the torrent is untouched');
+	}
+
+	// ---- php/addtorrent.php ---------------------------------------------
+
+	/**
+	 * addtorrent.php line 129: the "randomize hash" box writes a key into the
+	 * info dictionary, which is the point -- the info hash has to come out
+	 * different, and everything else has to come out the same.
+	 */
+	public function testRandomizeHashWritesIntoInfoAndMovesTheInfoHash()
+	{
+		$torrent = new Torrent($this->announceOnlyTorrent());
+		$was = $torrent->hash_info();
+
+		$torrent->info['unique'] = 'rutorrent-fixed';
+
+		$info = $this->bdict(array(
+			'length'       => $this->bint(1024),
+			'name'         => $this->bstr('test.data'),
+			'piece length' => $this->bint(16384),
+			'pieces'       => $this->bstr($this->pieces()),
+			'unique'       => $this->bstr('rutorrent-fixed'),
+		));
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'created by'    => $this->bstr('uTorrent/3.5.5'),
+			'creation date' => $this->bint(1234567890),
+			'info'          => $info,
+		));
+		$this->assertTrue((string)$torrent === $expected, 'info/unique is written into the info dictionary');
+		$this->assertTrue($torrent->hash_info() === strtoupper(sha1($info)), 'the info hash follows it');
+		$this->assertTrue($torrent->hash_info() !== $was, 'and it is not the hash it had');
+
+		$reread = new Torrent((string)$torrent);
+		$this->assertTrue($reread->info['unique'] === 'rutorrent-fixed', 'it survives a write and a read');
+		$this->assertTrue($reread->info['name'] === 'test.data', 'the rest of info is as it was');
+	}
+
+	/**
+	 * The whole add path, in order: a torrent picked up from disk, randomized,
+	 * and fast-resumed before it goes to rtorrent.
+	 */
+	public function testTheAddPathRandomizesThenFastResumes()
+	{
+		$torrent = new Torrent($this->announceOnlyTorrent());
+		$torrent->info['unique'] = 'rutorrent-fixed';
+		$resumed = rTorrent::fastResume($torrent, $this->base, true);
+		$this->assertTrue($resumed === $torrent, 'the torrent was fast-resumed');
+
+		$info = $this->bdict(array(
+			'length'       => $this->bint(1024),
+			'name'         => $this->bstr('test.data'),
+			'piece length' => $this->bint(16384),
+			'pieces'       => $this->bstr($this->pieces()),
+			'unique'       => $this->bstr('rutorrent-fixed'),
+		));
+		$expected = $this->bdict(array(
+			'announce'          => $this->bstr('http://one.test/announce'),
+			'created by'        => $this->bstr('uTorrent/3.5.5'),
+			'creation date'     => $this->bint(1234567890),
+			'info'              => $info,
+			'libtorrent_resume' => $this->expectedResume(1, array('test.data')),
+		));
+		$this->assertTrue((string)$torrent === $expected, 'both writes are in the bytes handed to rtorrent');
+	}
+
+	// ---- rTorrent::sendTorrent() and rTorrent::getSource() ---------------
+
+	/**
+	 * sendTorrent() lines 26-35: a torrent being loaded as a new one has the
+	 * two keys rtorrent left on it dropped, so that rtorrent does not take the
+	 * old session state with it.
+	 */
+	public function testSendTorrentDropsBothOfRtorrentsKeysForANewTorrent()
+	{
+		$torrent = new Torrent($this->sessionTorrent());
+
+		$isNew = true;
+		$mustSave = false;
+		if ($isNew && isset($torrent->{'libtorrent_resume'})) {
+			unset($torrent->{'libtorrent_resume'});
+			$mustSave = true;
+		}
+		if ($isNew && isset($torrent->{'rtorrent'})) {
+			unset($torrent->{'rtorrent'});
+			$mustSave = true;
+		}
+
+		$this->assertTrue($mustSave === true, 'the torrent was changed, so it has to be saved');
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'announce-list' => $this->bannounceList(array(
+				array('http://one.test/announce'),
+				array('udp://two.test/announce'),
+			)),
+			'created by'    => $this->bstr('uTorrent/3.5.5'),
+			'creation date' => $this->bint(1234567890),
+			'info'          => $this->singleFileInfo(),
+		));
+		$this->assertTrue((string)$torrent === $expected,
+			'both keys are gone and the rest of the torrent is byte for byte as it was');
+	}
+
+	/**
+	 * The same two keys, on a torrent that has neither: the isset() guards
+	 * must not add them.
+	 */
+	public function testSendTorrentLeavesATorrentWithNeitherKeyAlone()
+	{
+		$fixture = $this->announceOnlyTorrent();
+		$torrent = new Torrent($fixture);
+
+		if (isset($torrent->{'libtorrent_resume'})) {
+			unset($torrent->{'libtorrent_resume'});
+		}
+		if (isset($torrent->{'rtorrent'})) {
+			unset($torrent->{'rtorrent'});
+		}
+		$this->assertTrue((string)$torrent === $fixture, 'the torrent is untouched');
+	}
+
+	/**
+	 * rTorrent::getSource() lines 164-171, which is what plugins/source hands
+	 * the user: the torrent as it was, with everything rtorrent added taken
+	 * back off it.
+	 */
+	public function testGetSourceStripsWhatRtorrentAdded()
+	{
+		$torrent = new Torrent($this->sessionTorrent());
+		$this->assertTrue($torrent->errors() === false, 'the session torrent parses');
+		if (isset($torrent->{'libtorrent_resume'})) {
+			unset($torrent->{'libtorrent_resume'});
+		}
+		if (isset($torrent->{'rtorrent'})) {
+			unset($torrent->{'rtorrent'});
+		}
+
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'announce-list' => $this->bannounceList(array(
+				array('http://one.test/announce'),
+				array('udp://two.test/announce'),
+			)),
+			'created by'    => $this->bstr('uTorrent/3.5.5'),
+			'creation date' => $this->bint(1234567890),
+			'info'          => $this->singleFileInfo(),
+		));
+		$this->assertTrue((string)$torrent === $expected, 'what is offered for download is the original torrent');
+
+		// plugins/source/action.php line 54 names the file in the zip after it.
+		$this->assertTrue($torrent->info['name'] === 'test.data', 'and its name is readable for the zip entry');
+	}
+}

--- a/tests/php/TorrentCreatePathSequenceTest.php
+++ b/tests/php/TorrentCreatePathSequenceTest.php
@@ -1,0 +1,265 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/TorrentSequenceFixtures.php');
+
+/**
+ * What the create path does to a torrent: plugins/create/createtorrent.php
+ * lines 70-93, plugins/create/correct.php lines 53-76, and the re-read at
+ * plugins/create/action.php line 233 that hands the result to the browser.
+ *
+ * The create path is the one that writes the three keys a torrent carries
+ * which are not PHP identifiers -- 'created by', 'creation date' and
+ * 'announce-list'. A torrent is built here from real files, saved, and read
+ * back, so that both halves of that -- what is written and what comes back --
+ * are asserted against bytes this test built by hand.
+ *
+ * All three scripts are top level scripts that read $argv or $_REQUEST, so
+ * their sequences are transcribed rather than executed. That pins the
+ * transcription, not the script; the subject is Torrent.
+ */
+class TorrentCreatePathSequenceTest extends TestCase
+{
+	use TorrentSequenceFixtures;
+
+	private $root;
+	private $source;
+	private $saved;
+
+	/** The contents of the files the torrent is built from. */
+	private $files = array(
+		'a.data'     => 'the first file',
+		'sub/b.data' => 'the second file, in a subdirectory',
+	);
+
+	public function setUp()
+	{
+		$this->root = sys_get_temp_dir() . '/rutorrent-create-seq-' . getmypid();
+		$this->source = $this->root . '/created-payload';
+		$this->saved = $this->root . '/result.torrent';
+		foreach ($this->files as $relative => $contents) {
+			$path = $this->source . '/' . $relative;
+			if (!is_dir(dirname($path))) {
+				mkdir(dirname($path), 0777, true);
+			}
+			file_put_contents($path, $contents);
+		}
+	}
+
+	public function tearDown()
+	{
+		foreach (array_keys($this->files) as $relative) {
+			@unlink($this->source . '/' . $relative);
+		}
+		@unlink($this->saved);
+		@rmdir($this->source . '/sub');
+		@rmdir($this->source);
+		@rmdir($this->root);
+	}
+
+	/**
+	 * The info dictionary the class builds out of those files.
+	 *
+	 * Torrent::files() sorts deepest path first and then by name, hashes the
+	 * files in that order as one stream, and records each one's length and its
+	 * path relative to the folder. The pieces are computed here from the same
+	 * contents, in that order, so nothing in the expected bytes comes from the
+	 * class.
+	 */
+	private function createdInfo($extra = array())
+	{
+		$order = array('sub/b.data', 'a.data');
+		$stream = '';
+		$entries = array();
+		foreach ($order as $relative) {
+			$stream .= $this->files[$relative];
+			$components = array();
+			foreach (explode('/', $relative) as $component) {
+				$components[] = $this->bstr($component);
+			}
+			$entries[] = $this->bdict(array(
+				'length' => $this->bint(strlen($this->files[$relative])),
+				'path'   => $this->blist($components),
+			));
+		}
+		$pairs = array(
+			'files'        => $this->blist($entries),
+			'name'         => $this->bstr('created-payload'),
+			'piece length' => $this->bint(16 * 1024),
+			'pieces'       => $this->bstr(sha1($stream, true)),
+		);
+		foreach ($extra as $key => $value) {
+			$pairs[$key] = $value;
+		}
+		ksort($pairs, SORT_STRING);
+		return $this->bdict($pairs);
+	}
+
+	// ---- plugins/create/createtorrent.php --------------------------------
+
+	/**
+	 * The create form with several trackers, a comment, a source tag and the
+	 * private box ticked: everything the plugin can put on a new torrent.
+	 */
+	public function testCreatingATorrentWritesEveryKeyTheFormCanSet()
+	{
+		$before = time();
+		$announce_list = array(
+			array('http://one.test/announce', 'http://one.test/announce2'),
+			array('udp://two.test/announce'),
+		);
+		$trackersCount = 3;
+
+		// createtorrent.php lines 70-93.
+		$torrent = new Torrent($this->source, $announce_list[0][0], 16, null, null);
+		if ($trackersCount > 1) {
+			$torrent->announce_list($announce_list);
+		}
+		$torrent->source('XIRVIK');
+		$torrent->comment('made here');
+		$torrent->is_private(true);
+
+		$this->assertTrue($torrent->errors() === false, 'the torrent was built without errors');
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'announce-list' => $this->bannounceList($announce_list),
+			'comment'       => $this->bstr('made here'),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->createdInfo(array(
+				'private' => $this->bint(1),
+				'source'  => $this->bstr('XIRVIK'),
+			)),
+		));
+		$this->assertTrue($written === $expected, 'the built torrent is byte for byte what it should be');
+		$this->assertTrue($torrent->hash_info() === strtoupper(sha1($this->createdInfo(array(
+				'private' => $this->bint(1),
+				'source'  => $this->bstr('XIRVIK'),
+			)))),
+			'and its info hash is the hash of the info dictionary that was written');
+	}
+
+	/** One tracker: announce is set by the constructor and no announce-list is added. */
+	public function testCreatingATorrentWithOneTrackerWritesNoAnnounceList()
+	{
+		$before = time();
+		$torrent = new Torrent($this->source, 'http://only.test/announce', 16, null, null);
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://only.test/announce'),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->createdInfo(),
+		));
+		$this->assertTrue($written === $expected, 'the torrent carries announce and nothing else');
+	}
+
+	/** No tracker at all is a valid create, and the two stamped keys are still written. */
+	public function testCreatingATorrentWithNoTrackerStillStampsTheCreator()
+	{
+		$before = time();
+		$torrent = new Torrent($this->source, array(), 16, null, null);
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->createdInfo(),
+		));
+		$this->assertTrue($written === $expected, 'a trackerless torrent is built and stamped');
+	}
+
+	// ---- save, then plugins/create/action.php line 233 --------------------
+
+	/**
+	 * The plugin saves the result and a later request reads it back to hand it
+	 * to the browser. The three keys that are not identifiers have to survive
+	 * that round trip, because they are the ones a new storage could quietly
+	 * drop.
+	 */
+	public function testASavedTorrentReadsBackByteForByte()
+	{
+		$before = time();
+		$torrent = new Torrent($this->source, 'http://one.test/announce', 16, null, null);
+		$torrent->announce_list(array(
+			array('http://one.test/announce'),
+			array('udp://two.test/announce'),
+		));
+		$torrent->comment('made here');
+
+		$written = (string)$torrent;
+		$this->assertTrue($torrent->save($this->saved) !== false, 'the torrent was saved');
+		$this->assertTrue(file_get_contents($this->saved) === $written,
+			'what is on disk is what the object encodes to');
+		$this->assertTrue($torrent->getFileName() === $this->saved, 'and the object knows where it went');
+
+		// plugins/create/action.php line 233.
+		$reread = new Torrent($this->saved);
+		$this->assertTrue($reread->errors() === false, 'the saved torrent parses');
+		$this->assertTrue((string)$reread === $written, 'and re-encodes to the same bytes');
+
+		$stamped = $this->stampedDate($written, $before);
+		$this->assertTrue(strpos($written, $this->bstr('created by') . $this->bstr($this->ourCreator())) !== false,
+			"'created by' is written with our creator");
+		$this->assertTrue(strpos($written, $this->bstr('creation date') . $this->bint($stamped)) !== false,
+			"'creation date' is written with the time of the build");
+		$this->assertTrue($reread->announce_list() === array(
+				array('http://one.test/announce'), array('udp://two.test/announce')),
+			"'announce-list' reads back through a save and a load");
+		$this->assertTrue($reread->comment() === 'made here', 'and so does the comment');
+	}
+
+	// ---- plugins/create/correct.php --------------------------------------
+
+	/**
+	 * correct.php opens the torrent an external creator wrote and puts the
+	 * form's values on it. Its first move is clear_announce() with no
+	 * clear_announce_list(), so a torrent that arrives with an announce-list
+	 * and is corrected to a single tracker keeps the list it came with -- and
+	 * that has to stay exactly as it is, list and all.
+	 */
+	public function testCorrectingAnExternallyBuiltTorrentSetsTheFormsValues()
+	{
+		$before = time();
+		$torrent = new Torrent($this->announceListTorrent());
+
+		// correct.php lines 53-76, with one tracker on the form.
+		$announce_list = array(array('http://corrected.test/announce'));
+		$trackersCount = 1;
+		$torrent->clear_announce();
+		if (count($announce_list) > 0) {
+			$torrent->announce($announce_list[0][0]);
+			if ($trackersCount > 1) {
+				$torrent->announce_list($announce_list);
+			}
+		}
+		$torrent->comment('corrected');
+		$torrent->is_private(true);
+		$torrent->source('XIRVIK');
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://corrected.test/announce'),
+			'announce-list' => $this->bannounceList(array(
+				array('http://one.test/announce'),
+				array('udp://two.test/announce', 'udp://two.test/announce2'),
+			)),
+			'comment'       => $this->bstr('corrected'),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->bdict(array(
+				'length'       => $this->bint(1024),
+				'name'         => $this->bstr('test.data'),
+				'piece length' => $this->bint(16384),
+				'pieces'       => $this->bstr($this->pieces()),
+				'private'      => $this->bint(1),
+				'source'       => $this->bstr('XIRVIK'),
+			)),
+		));
+		$this->assertTrue($written === $expected,
+			'the form values are written and the announce-list it came with is left alone');
+	}
+}

--- a/tests/php/TorrentSequenceFixtures.php
+++ b/tests/php/TorrentSequenceFixtures.php
@@ -1,0 +1,237 @@
+<?php
+
+require_once(dirname(__FILE__) . '/TestCase.php');
+require_once(dirname(__FILE__) . '/../../php/Torrent.php');
+
+/**
+ * Bencode fixtures for the tests that replay a script's call sequence against
+ * Torrent.
+ *
+ * A fixture is built here, by hand, so that it is its own expected output: the
+ * class under test must never be the thing that produced the bytes a test
+ * compares against. Dictionary keys are written in the order a bencoded
+ * dictionary carries them -- ksort(SORT_STRING), i.e. plain byte order -- and
+ * bdict() refuses an unsorted one rather than let a mis-ordered fixture pass
+ * for a mis-ordered encoder.
+ *
+ * This is a trait and not a base class on purpose: the test runner only
+ * instantiates classes whose immediate parent is TestCase, so a shared base
+ * class would silently stop every test in this directory from running.
+ */
+trait TorrentSequenceFixtures
+{
+	// ---- bencode ---------------------------------------------------------
+
+	protected function bstr($string)
+	{
+		return strlen($string) . ':' . $string;
+	}
+
+	protected function bint($integer)
+	{
+		return 'i' . $integer . 'e';
+	}
+
+	protected function blist($items)
+	{
+		return 'l' . implode('', $items) . 'e';
+	}
+
+	/** A bencoded dictionary. $pairs maps key => already encoded value, and
+	 * must be given in byte order. */
+	protected function bdict($pairs)
+	{
+		$previous = null;
+		$encoded = 'd';
+		foreach ($pairs as $key => $value) {
+			$key = strval($key);
+			if (!is_null($previous) && strcmp($previous, $key) >= 0) {
+				throw new Exception("Fixture keys out of order: '{$previous}' before '{$key}'");
+			}
+			$previous = $key;
+			$encoded .= $this->bstr($key) . $value;
+		}
+		return $encoded . 'e';
+	}
+
+	/** A bencoded list of bencoded lists of strings, i.e. an announce-list. */
+	protected function bannounceList($groups)
+	{
+		$encoded = array();
+		foreach ($groups as $group) {
+			$strings = array();
+			foreach ($group as $tracker) {
+				$strings[] = $this->bstr($tracker);
+			}
+			$encoded[] = $this->blist($strings);
+		}
+		return $this->blist($encoded);
+	}
+
+	// ---- pieces of a torrent ---------------------------------------------
+
+	protected function pieces()
+	{
+		return str_repeat("\x01", 20);
+	}
+
+	/** The info dictionary of a single file torrent. */
+	protected function singleFileInfo($private = null)
+	{
+		$pairs = array(
+			'length'       => $this->bint(1024),
+			'name'         => $this->bstr('test.data'),
+			'piece length' => $this->bint(16384),
+			'pieces'       => $this->bstr($this->pieces()),
+		);
+		if (!is_null($private)) {
+			$pairs['private'] = $this->bint($private ? 1 : 0);
+		}
+		return $this->bdict($pairs);
+	}
+
+	/** The info dictionary of a two file torrent. */
+	protected function multiFileInfo($private = null)
+	{
+		$pairs = array(
+			'files' => $this->blist(array(
+				$this->bdict(array(
+					'length' => $this->bint(600),
+					'path'   => $this->blist(array($this->bstr('one.data'))),
+				)),
+				$this->bdict(array(
+					'length' => $this->bint(400),
+					'path'   => $this->blist(array($this->bstr('sub'), $this->bstr('two.data'))),
+				)),
+			)),
+			'name'         => $this->bstr('payload'),
+			'piece length' => $this->bint(16384),
+			'pieces'       => $this->bstr($this->pieces()),
+		);
+		if (!is_null($private)) {
+			$pairs['private'] = $this->bint($private ? 1 : 0);
+		}
+		return $this->bdict($pairs);
+	}
+
+	protected function resumeDictionary()
+	{
+		return $this->bdict(array(
+			'bitfield' => $this->bint(1),
+			'files'    => $this->blist(array(
+				$this->bdict(array(
+					'mtime'    => $this->bint(1234567891),
+					'priority' => $this->bint(2),
+				)),
+			)),
+		));
+	}
+
+	protected function rtorrentDictionary()
+	{
+		return $this->bdict(array(
+			'directory' => $this->bstr('/downloads/test.data'),
+			'tied_to_file' => $this->bstr('/session/AAAA.torrent'),
+		));
+	}
+
+	// ---- whole torrents --------------------------------------------------
+
+	/** A plain public torrent with a single tracker and no announce-list. */
+	protected function announceOnlyTorrent()
+	{
+		return $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'created by'    => $this->bstr('uTorrent/3.5.5'),
+			'creation date' => $this->bint(1234567890),
+			'info'          => $this->singleFileInfo(),
+		));
+	}
+
+	/** A torrent with no tracker at all -- retrackers has a branch for it. */
+	protected function trackerlessTorrent()
+	{
+		return $this->bdict(array(
+			'created by'    => $this->bstr('uTorrent/3.5.5'),
+			'creation date' => $this->bint(1234567890),
+			'info'          => $this->singleFileInfo(),
+		));
+	}
+
+	/** A torrent that already carries an announce-list of two groups. */
+	protected function announceListTorrent()
+	{
+		return $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'announce-list' => $this->bannounceList(array(
+				array('http://one.test/announce'),
+				array('udp://two.test/announce', 'udp://two.test/announce2'),
+			)),
+			'created by'    => $this->bstr('uTorrent/3.5.5'),
+			'creation date' => $this->bint(1234567890),
+			'info'          => $this->singleFileInfo(),
+		));
+	}
+
+	/** A private, multi file torrent carrying a comment. */
+	protected function privateMultiFileTorrent()
+	{
+		return $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'comment'       => $this->bstr('from the tracker'),
+			'created by'    => $this->bstr('uTorrent/3.5.5'),
+			'creation date' => $this->bint(1234567890),
+			'encoding'      => $this->bstr('UTF-8'),
+			'info'          => $this->multiFileInfo(true),
+		));
+	}
+
+	/**
+	 * A torrent as rtorrent leaves it in its session directory: the two keys
+	 * it adds are there, and this is what every one of these scripts actually
+	 * opens.
+	 */
+	protected function sessionTorrent()
+	{
+		return $this->bdict(array(
+			'announce'          => $this->bstr('http://one.test/announce'),
+			'announce-list'     => $this->bannounceList(array(
+				array('http://one.test/announce'),
+				array('udp://two.test/announce'),
+			)),
+			'created by'        => $this->bstr('uTorrent/3.5.5'),
+			'creation date'     => $this->bint(1234567890),
+			'info'              => $this->singleFileInfo(),
+			'libtorrent_resume' => $this->resumeDictionary(),
+			'rtorrent'          => $this->rtorrentDictionary(),
+		));
+	}
+
+	// ---- reading what was written ----------------------------------------
+
+	/** The value the class stamps into 'created by' whenever a setter runs. */
+	protected function ourCreator()
+	{
+		return 'ruTorrent (PHP Class - Adrien Gibrat)';
+	}
+
+	/**
+	 * The 'creation date' of a written torrent, read out of the bytes rather
+	 * than off the object: which of the two stores holds it is exactly what
+	 * these tests must not depend on.
+	 */
+	protected function writtenCreationDate($written)
+	{
+		return preg_match('/13:creation datei(\d+)e/', $written, $match) ? intval($match[1]) : null;
+	}
+
+	/** Assert that a setter stamped the creation date, and hand it back so the
+	 * expected bytes can be built with it. */
+	protected function stampedDate($written, $notBefore)
+	{
+		$stamped = $this->writtenCreationDate($written);
+		$this->assertTrue(!is_null($stamped) && $stamped >= $notBefore && $stamped <= time(),
+			'A setter stamped the creation date with the time of the write');
+		return $stamped;
+	}
+}

--- a/tests/plugins/edit/EditActionSequenceTest.php
+++ b/tests/plugins/edit/EditActionSequenceTest.php
@@ -1,0 +1,304 @@
+<?php
+
+require_once(__DIR__ . '/../../php/TestCase.php');
+require_once(__DIR__ . '/../../php/TorrentSequenceFixtures.php');
+
+/**
+ * What plugins/edit/action.php does to a torrent.
+ *
+ * action.php is a top level script -- it reads $_REQUEST, asks rtorrent for
+ * the session path and hands the result to rTorrent::sendTorrent() over SCGI --
+ * so it cannot be included. Its call sequence (action.php lines 95-135) is
+ * transcribed into replay() below and driven against the class; the bencoded
+ * bytes that come out are asserted whole, because those bytes are what is
+ * handed to rtorrent and what a regression in Torrent would corrupt.
+ *
+ * As with the retrackers tests, this pins the transcription rather than the
+ * script: an edit to action.php will not fail it. The subject is Torrent.
+ */
+class EditActionSequenceTest extends TestCase
+{
+	use TorrentSequenceFixtures;
+
+	/**
+	 * plugins/edit/action.php lines 97-121, verbatim but for the RPC either
+	 * side of it. $announce_list is what the script has already assembled out
+	 * of the textarea, and $trackersCount is the number of non-empty lines in
+	 * it.
+	 */
+	private function replay($torrent, $options)
+	{
+		$setPrivate    = isset($options['private']);
+		$private       = $setPrivate ? $options['private'] : null;
+		$setTrackers   = isset($options['announce_list']);
+		$announce_list = $setTrackers ? $options['announce_list'] : array();
+		$trackersCount = 0;
+		foreach ($announce_list as $group) {
+			$trackersCount += count($group);
+		}
+		$setComment    = array_key_exists('comment', $options);
+		$comment       = $setComment ? $options['comment'] : null;
+
+		if ($setPrivate) {
+			$torrent->is_private($private);
+		}
+		if ($setTrackers) {
+			$torrent->clear_announce();
+			$torrent->clear_announce_list();
+			if (count($announce_list) > 0) {
+				$torrent->announce($announce_list[0][0]);
+				if ($trackersCount > 1) {
+					$torrent->announce_list($announce_list);
+				}
+			}
+		}
+		if ($setComment) {
+			$torrent->clear_comment();
+			$comment = trim($comment);
+			if (strlen($comment)) {
+				$torrent->comment($comment);
+			}
+		}
+		if (isset($torrent->{'rtorrent'})) {
+			unset($torrent->{'rtorrent'});
+		}
+	}
+
+	// ---- trackers --------------------------------------------------------
+
+	/**
+	 * More than one tracker: announce holds the first and announce-list holds
+	 * the groups. The list the torrent came with is cleared first, so what is
+	 * written is the new list and nothing of the old one.
+	 */
+	public function testSettingSeveralTrackersReplacesBothKeys()
+	{
+		$before = time();
+		$torrent = new Torrent($this->announceListTorrent());
+		$this->replay($torrent, array('announce_list' => array(
+			array('http://new.test/announce'),
+			array('udp://new.test/announce'),
+		)));
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://new.test/announce'),
+			'announce-list' => $this->bannounceList(array(
+				array('http://new.test/announce'),
+				array('udp://new.test/announce'),
+			)),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->singleFileInfo(),
+		));
+		$this->assertTrue($written === $expected, 'both tracker keys are replaced wholesale');
+
+		$reread = new Torrent($written);
+		$this->assertTrue($reread->announce() === 'http://new.test/announce', 'announce reads back');
+		$this->assertTrue($reread->announce_list() === array(
+				array('http://new.test/announce'), array('udp://new.test/announce')),
+			'announce-list reads back');
+	}
+
+	/**
+	 * A single tracker: the script sets announce and deliberately does not set
+	 * announce-list, so a torrent that had one comes back without it.
+	 */
+	public function testASingleTrackerLeavesTheTorrentWithNoAnnounceList()
+	{
+		$before = time();
+		$torrent = new Torrent($this->announceListTorrent());
+		$this->replay($torrent, array('announce_list' => array(array('http://only.test/announce'))));
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://only.test/announce'),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->singleFileInfo(),
+		));
+		$this->assertTrue($written === $expected, 'the announce-list key is gone from the written torrent');
+
+		$reread = new Torrent($written);
+		$this->assertTrue($reread->announce_list() === null, 'and it reads back as unset');
+	}
+
+	/**
+	 * An empty tracker box clears both keys and puts neither back. A torrent
+	 * with no announce at all is what rtorrent is then handed.
+	 */
+	public function testAnEmptyTrackerListClearsBothKeys()
+	{
+		$before = time();
+		$torrent = new Torrent($this->announceListTorrent());
+		$this->replay($torrent, array('announce_list' => array()));
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->singleFileInfo(),
+		));
+		$this->assertTrue($written === $expected, 'neither tracker key is written');
+	}
+
+	// ---- the private flag ------------------------------------------------
+
+	/** Marking a public torrent private adds info/private, which changes its hash. */
+	public function testMarkingATorrentPrivateWritesTheFlagIntoInfo()
+	{
+		$before = time();
+		$torrent = new Torrent($this->announceOnlyTorrent());
+		$was = $torrent->hash_info();
+		$this->assertTrue($torrent->is_private() === false, 'the fixture is public');
+
+		$this->replay($torrent, array('private' => true));
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->singleFileInfo(true),
+		));
+		$this->assertTrue($written === $expected, 'info/private is written as 1');
+		$this->assertTrue($torrent->is_private() === true, 'and the getter agrees');
+		$this->assertTrue($torrent->hash_info() !== $was, 'the info hash moved, as it must');
+		$this->assertTrue($torrent->hash_info() === strtoupper(sha1($this->singleFileInfo(true))),
+			'and it is the hash of the info dictionary that was written');
+	}
+
+	/**
+	 * Clearing the flag writes info/private as 0 rather than dropping the key:
+	 * the setter is `$private ? 1 : 0`, and the difference is a different info
+	 * hash, so it has to stay exactly as it is.
+	 */
+	public function testUnmarkingATorrentWritesPrivateAsZeroRatherThanDroppingIt()
+	{
+		$before = time();
+		$torrent = new Torrent($this->privateMultiFileTorrent());
+		$this->assertTrue($torrent->is_private() === true, 'the fixture is private');
+
+		$this->replay($torrent, array('private' => false));
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'comment'       => $this->bstr('from the tracker'),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'encoding'      => $this->bstr('UTF-8'),
+			'info'          => $this->multiFileInfo(false),
+		));
+		$this->assertTrue($written === $expected, 'info/private is written as 0 and the files are untouched');
+		$this->assertTrue($torrent->is_private() === false, 'the getter reads it as public');
+	}
+
+	// ---- the comment -----------------------------------------------------
+
+	public function testSettingACommentReplacesTheOne()
+	{
+		$before = time();
+		$torrent = new Torrent($this->privateMultiFileTorrent());
+		$this->replay($torrent, array('comment' => "  edited by the owner \n"));
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'comment'       => $this->bstr('edited by the owner'),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'encoding'      => $this->bstr('UTF-8'),
+			'info'          => $this->multiFileInfo(true),
+		));
+		$this->assertTrue($written === $expected, 'the comment is trimmed and written');
+	}
+
+	/** A comment box left blank drops the key. */
+	public function testAnEmptyCommentDropsTheKey()
+	{
+		$before = time();
+		$torrent = new Torrent($this->privateMultiFileTorrent());
+		$this->replay($torrent, array('comment' => "   "));
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'encoding'      => $this->bstr('UTF-8'),
+			'info'          => $this->multiFileInfo(true),
+		));
+		$this->assertTrue($written === $expected, 'the comment key is not written');
+
+		$reread = new Torrent($written);
+		$this->assertTrue($reread->comment() === null, 'and it reads back as unset');
+	}
+
+	// ---- what rtorrent added ---------------------------------------------
+
+	/**
+	 * Every edit ends by dropping the 'rtorrent' key, so that rtorrent takes
+	 * the reloaded torrent as a new one. The resume data is left alone: the
+	 * script passes $isNew = false to sendTorrent(), which is what stops it
+	 * being dropped as well.
+	 */
+	public function testAnEditOfASessionTorrentDropsRtorrentAndKeepsResumeData()
+	{
+		$before = time();
+		$torrent = new Torrent($this->sessionTorrent());
+		$this->assertTrue(isset($torrent->rtorrent), 'the fixture carries the key rtorrent added');
+
+		$this->replay($torrent, array('comment' => 'edited'));
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'          => $this->bstr('http://one.test/announce'),
+			'announce-list'     => $this->bannounceList(array(
+				array('http://one.test/announce'),
+				array('udp://two.test/announce'),
+			)),
+			'comment'           => $this->bstr('edited'),
+			'created by'        => $this->bstr($this->ourCreator()),
+			'creation date'     => $this->bint($this->stampedDate($written, $before)),
+			'info'              => $this->singleFileInfo(),
+			'libtorrent_resume' => $this->resumeDictionary(),
+		));
+		$this->assertTrue($written === $expected, 'rtorrent is dropped, libtorrent_resume is kept');
+	}
+
+	/**
+	 * All three edits at once, on the torrent rtorrent saved -- the sequence
+	 * as the plugin actually runs it when every box on the form is ticked.
+	 */
+	public function testAllThreeEditsAtOnce()
+	{
+		$before = time();
+		$torrent = new Torrent($this->sessionTorrent());
+		$this->replay($torrent, array(
+			'private'       => true,
+			'announce_list' => array(array('http://new.test/announce', 'http://new.test/announce2')),
+			'comment'       => 'all three',
+		));
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'          => $this->bstr('http://new.test/announce'),
+			'announce-list'     => $this->bannounceList(array(
+				array('http://new.test/announce', 'http://new.test/announce2'),
+			)),
+			'comment'           => $this->bstr('all three'),
+			'created by'        => $this->bstr($this->ourCreator()),
+			'creation date'     => $this->bint($this->stampedDate($written, $before)),
+			'info'              => $this->singleFileInfo(true),
+			'libtorrent_resume' => $this->resumeDictionary(),
+		));
+		$this->assertTrue($written === $expected, 'the three edits land together and nothing else moves');
+
+		$reread = new Torrent($written);
+		$this->assertTrue($reread->is_private() === true, 'private reads back');
+		$this->assertTrue($reread->comment() === 'all three', 'the comment reads back');
+		$this->assertTrue($reread->announce() === 'http://new.test/announce', 'announce reads back');
+		$this->assertTrue(!isset($reread->rtorrent), 'and rtorrent is gone');
+	}
+}

--- a/tests/plugins/retrackers/RetrackersUpdateSequenceTest.php
+++ b/tests/plugins/retrackers/RetrackersUpdateSequenceTest.php
@@ -1,0 +1,365 @@
+<?php
+
+// plugins/retrackers/update.php is a top level script: it reads $argv and,
+// with no torrent hash on the command line, does nothing but declare its two
+// pure helpers and load the plugin's configuration. That makes it includable,
+// so clearTracker() and deleteTrackers() below are the real ones and not a
+// second implementation of them.
+//
+// The profile path is pointed at a directory of our own first -- conf/config.php
+// reads RU_PROFILE_PATH -- so the settings cache it opens on the way in is an
+// empty one, and not whatever this checkout happens to have written there.
+$_ENV['RU_PROFILE_PATH'] = sys_get_temp_dir() . '/rutorrent-retrackers-seq-' . getmypid();
+
+require_once(__DIR__ . '/../../php/TestCase.php');
+require_once(__DIR__ . '/../../php/TorrentSequenceFixtures.php');
+require_once(__DIR__ . '/../../../plugins/retrackers/update.php');
+
+/**
+ * What plugins/retrackers/update.php does to a torrent.
+ *
+ * The script itself cannot be called from a test -- it takes a hash on the
+ * command line, asks rtorrent for the session path, and hands the result to
+ * rTorrent::sendTorrent() over SCGI. What it does in between is a fixed
+ * sequence of calls on a Torrent, and that sequence is replayed here against
+ * the class, with the script's own clearTracker() and deleteTrackers() driving
+ * it.
+ *
+ * The limitation that carries: this pins the transcription, not the script. An
+ * edit to update.php will not fail these tests. They are here for Torrent --
+ * the bencoded bytes it hands back are what a regression in the class would
+ * corrupt, and they are asserted whole.
+ */
+class RetrackersUpdateSequenceTest extends TestCase
+{
+	use TorrentSequenceFixtures;
+
+	public function tearDown()
+	{
+		// Loading the plugin's configuration created the settings directory.
+		$profile = $_ENV['RU_PROFILE_PATH'];
+		foreach (array($profile . '/settings', $profile) as $dir) {
+			if (is_dir($dir)) {
+				@rmdir($dir);
+			}
+		}
+	}
+
+	/** A plugin configuration object, as rRetrackers::load() would return one. */
+	private function retrackers($list, $todelete = array(), $addToBegin = 0)
+	{
+		$trks = new rRetrackers();
+		$trks->list = $list;
+		$trks->todelete = $todelete;
+		$trks->addToBegin = $addToBegin;
+		return $trks;
+	}
+
+	/**
+	 * plugins/retrackers/update.php lines 80-127, verbatim but for the RPC
+	 * either side of it. Returns the two flags the script decides whether to
+	 * rewrite the torrent at all by.
+	 */
+	private function replay($torrent, $trks)
+	{
+		$wasAddition = true;
+		$lst = $torrent->announce_list();
+		if (!$lst) {
+			if (count($trks->list)) {
+				if ($torrent->announce()) {
+					$torrent->announce_list($trks->addToBegin ?
+						array_merge($trks->list, array(array($torrent->announce()))) :
+						array_merge(array(array($torrent->announce())), $trks->list));
+				} else {
+					$torrent->announce($trks->list[0][0]);
+					$torrent->announce_list($trks->list);
+				}
+			} else {
+				$wasAddition = false;
+			}
+		} else {
+			$addition = $trks->list;
+			foreach ($lst as $group) {
+				foreach ($group as $tracker) {
+					$addition = clearTracker($addition, $tracker);
+				}
+			}
+			if (count($addition)) {
+				$torrent->announce_list($trks->addToBegin ?
+					array_merge($addition, $lst) : array_merge($lst, $addition));
+			} else {
+				$wasAddition = false;
+			}
+		}
+
+		$wasDeletion = false;
+		$lst = $torrent->announce_list();
+		if ($lst && count($trks->todelete) && deleteTrackers($lst, $trks->todelete)) {
+			$wasDeletion = true;
+			$torrent->announce_list($lst);
+		}
+
+		if ($wasAddition || $wasDeletion) {
+			if (isset($torrent->{'rtorrent'})) {
+				unset($torrent->{'rtorrent'});
+			}
+		}
+		return array($wasAddition, $wasDeletion);
+	}
+
+	// ---- the helpers the sequence is built out of ------------------------
+
+	public function testTheScriptsHelpersAreTheRealOnes()
+	{
+		$this->assertTrue(function_exists('clearTracker') && function_exists('deleteTrackers'),
+			'update.php was included and its two pure helpers are callable');
+		$this->assertTrue(class_exists('rRetrackers'), 'the plugin configuration class is loadable too');
+	}
+
+	// ---- a torrent with announce and no announce-list --------------------
+
+	/**
+	 * The common case: rtorrent's copy of a single tracker torrent, and one
+	 * tracker group to add. The torrent's own announce goes first.
+	 */
+	public function testAnnounceOnlyTorrentGainsAnAnnounceListEndingWithTheAddition()
+	{
+		$before = time();
+		$torrent = new Torrent($this->announceOnlyTorrent());
+		$this->assertTrue($torrent->errors() === false, 'the fixture parses');
+
+		list($wasAddition, $wasDeletion) = $this->replay($torrent,
+			$this->retrackers(array(array('http://added.test/announce'))));
+
+		$this->assertTrue($wasAddition === true, 'a tracker was added');
+		$this->assertTrue($wasDeletion === false, 'nothing was deleted');
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'announce-list' => $this->bannounceList(array(
+				array('http://one.test/announce'),
+				array('http://added.test/announce'),
+			)),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->singleFileInfo(),
+		));
+		$this->assertTrue($written === $expected,
+			'the whole torrent is written back with the addition appended');
+
+		$reread = new Torrent($written);
+		$this->assertTrue($reread->announce() === 'http://one.test/announce',
+			'the original announce is untouched');
+		$this->assertTrue($reread->announce_list() === array(
+				array('http://one.test/announce'),
+				array('http://added.test/announce')),
+			'and it heads the new announce-list');
+	}
+
+	/** addToBegin puts the configured groups in front of the torrent's own. */
+	public function testAddToBeginPutsTheAdditionFirst()
+	{
+		$before = time();
+		$torrent = new Torrent($this->announceOnlyTorrent());
+		list($wasAddition, $wasDeletion) = $this->replay($torrent,
+			$this->retrackers(array(array('http://added.test/announce')), array(), 1));
+
+		$this->assertTrue($wasAddition === true && $wasDeletion === false, 'an addition, no deletion');
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'announce-list' => $this->bannounceList(array(
+				array('http://added.test/announce'),
+				array('http://one.test/announce'),
+			)),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->singleFileInfo(),
+		));
+		$this->assertTrue($written === $expected, 'the addition is written in front');
+	}
+
+	/**
+	 * With no announce at all the script promotes the first configured tracker
+	 * into announce, which is the only branch that writes both keys.
+	 */
+	public function testATrackerlessTorrentGetsAnnounceAndAnnounceList()
+	{
+		$before = time();
+		$torrent = new Torrent($this->trackerlessTorrent());
+		$this->assertTrue($torrent->announce() === null, 'the fixture has no announce');
+
+		list($wasAddition,) = $this->replay($torrent, $this->retrackers(array(
+			array('http://added.test/announce', 'http://added.test/announce2'),
+			array('udp://added.test/announce'),
+		)));
+		$this->assertTrue($wasAddition === true, 'a tracker was added');
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://added.test/announce'),
+			'announce-list' => $this->bannounceList(array(
+				array('http://added.test/announce', 'http://added.test/announce2'),
+				array('udp://added.test/announce'),
+			)),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->singleFileInfo(),
+		));
+		$this->assertTrue($written === $expected,
+			'the first configured tracker becomes announce and the groups become announce-list');
+	}
+
+	// ---- a torrent that already has an announce-list ---------------------
+
+	/** Groups the torrent already carries are dropped from the addition. */
+	public function testATrackerAlreadyPresentIsNotAddedTwice()
+	{
+		$before = time();
+		$torrent = new Torrent($this->announceListTorrent());
+		list($wasAddition,) = $this->replay($torrent, $this->retrackers(array(
+			array('http://one.test/announce'),
+			array('http://added.test/announce'),
+		)));
+		$this->assertTrue($wasAddition === true, 'the group that was not present is still an addition');
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'announce-list' => $this->bannounceList(array(
+				array('http://one.test/announce'),
+				array('udp://two.test/announce', 'udp://two.test/announce2'),
+				array('http://added.test/announce'),
+			)),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->singleFileInfo(),
+		));
+		$this->assertTrue($written === $expected,
+			'only the group that was missing is appended');
+	}
+
+	/**
+	 * Nothing to add and nothing to delete: the script never reaches
+	 * sendTorrent(), and the torrent must come back byte for byte as it was --
+	 * no setter ran, so not even the creation date moved.
+	 */
+	public function testATorrentThatNeedsNothingIsNotRewritten()
+	{
+		$fixture = $this->announceListTorrent();
+		$torrent = new Torrent($fixture);
+		list($wasAddition, $wasDeletion) = $this->replay($torrent,
+			$this->retrackers(array(array('http://one.test/announce'))));
+
+		$this->assertTrue($wasAddition === false, 'every configured tracker was already there');
+		$this->assertTrue($wasDeletion === false, 'and there was nothing to delete');
+		$this->assertTrue((string)$torrent === $fixture,
+			'the torrent is unchanged, down to the creation date it came with');
+	}
+
+	/** An empty configuration is the same non-event on the no-announce-list branch. */
+	public function testAnEmptyConfigurationChangesNothing()
+	{
+		$fixture = $this->announceOnlyTorrent();
+		$torrent = new Torrent($fixture);
+		list($wasAddition, $wasDeletion) = $this->replay($torrent, $this->retrackers(array()));
+
+		$this->assertTrue($wasAddition === false && $wasDeletion === false, 'neither flag was raised');
+		$this->assertTrue((string)$torrent === $fixture, 'the torrent is unchanged');
+	}
+
+	// ---- deletion --------------------------------------------------------
+
+	/** A todelete entry that matches every tracker in a group removes the group. */
+	public function testDeletingEveryTrackerInAGroupRemovesTheGroup()
+	{
+		$before = time();
+		$torrent = new Torrent($this->announceListTorrent());
+		list($wasAddition, $wasDeletion) = $this->replay($torrent,
+			$this->retrackers(array(), array('two.test')));
+
+		$this->assertTrue($wasAddition === false, 'there was nothing to add');
+		$this->assertTrue($wasDeletion === true, 'the group was deleted');
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'      => $this->bstr('http://one.test/announce'),
+			'announce-list' => $this->bannounceList(array(array('http://one.test/announce'))),
+			'created by'    => $this->bstr($this->ourCreator()),
+			'creation date' => $this->bint($this->stampedDate($written, $before)),
+			'info'          => $this->singleFileInfo(),
+		));
+		$this->assertTrue($written === $expected, 'the emptied group is gone from the written torrent');
+
+		$reread = new Torrent($written);
+		$this->assertTrue($reread->announce_list() === array(array('http://one.test/announce')),
+			'and it reads back as one group');
+	}
+
+	/** Adding and deleting in the same run, on the torrent rtorrent saved. */
+	public function testAdditionAndDeletionTogetherOnASessionTorrent()
+	{
+		$before = time();
+		$torrent = new Torrent($this->sessionTorrent());
+		list($wasAddition, $wasDeletion) = $this->replay($torrent,
+			$this->retrackers(array(array('http://added.test/announce')), array('two.test')));
+
+		$this->assertTrue($wasAddition === true && $wasDeletion === true, 'both flags were raised');
+
+		$written = (string)$torrent;
+		$expected = $this->bdict(array(
+			'announce'          => $this->bstr('http://one.test/announce'),
+			'announce-list'     => $this->bannounceList(array(
+				array('http://one.test/announce'),
+				array('http://added.test/announce'),
+			)),
+			'created by'        => $this->bstr($this->ourCreator()),
+			'creation date'     => $this->bint($this->stampedDate($written, $before)),
+			'info'              => $this->singleFileInfo(),
+			'libtorrent_resume' => $this->resumeDictionary(),
+		));
+		$this->assertTrue($written === $expected,
+			"the 'rtorrent' key is dropped, resume data and info are kept");
+
+		$reread = new Torrent($written);
+		$this->assertTrue(!isset($reread->rtorrent), 'the written torrent no longer carries rtorrent');
+		$this->assertTrue(isset($reread->libtorrent_resume), 'it still carries its resume data');
+	}
+
+	/**
+	 * A session torrent nothing has to be done to keeps its 'rtorrent' key:
+	 * the script only drops it on the branch that rewrites the file.
+	 */
+	public function testASessionTorrentThatNeedsNothingKeepsItsRtorrentKey()
+	{
+		$fixture = $this->sessionTorrent();
+		$torrent = new Torrent($fixture);
+		list($wasAddition, $wasDeletion) = $this->replay($torrent, $this->retrackers(array()));
+
+		$this->assertTrue($wasAddition === false && $wasDeletion === false, 'nothing to do');
+		$this->assertTrue((string)$torrent === $fixture, 'the session torrent is untouched');
+	}
+
+	// ---- the pure helpers on their own -----------------------------------
+
+	public function testClearTrackerDropsAGroupItEmpties()
+	{
+		$addition = array(array('http://a.test/x'), array('http://b.test/x', 'http://c.test/x'));
+		$addition = clearTracker($addition, 'http://a.test/x');
+		$this->assertEquals(array(1 => array('http://b.test/x', 'http://c.test/x')), $addition,
+			'the emptied group is removed and the other is left alone');
+	}
+
+	public function testDeleteTrackersMatchesOnASubstringCaseInsensitively()
+	{
+		$list = array(array('http://ONE.test/announce'), array('http://two.test/announce'));
+		$this->assertTrue(deleteTrackers($list, array('one.TEST')) === true,
+			'a case insensitive substring match is a deletion');
+		$this->assertEquals(array(1 => array('http://two.test/announce')), $list,
+			'and it is taken out of the list by reference');
+		$this->assertTrue(deleteTrackers($list, array('nothing.test')) === false,
+			'a pattern that matches nothing is not a deletion');
+	}
+}


### PR DESCRIPTION
php/Torrent.php has no test of its callers: every script that rewrites a .torrent on disk is a top level script reading $argv or $_REQUEST, so none of them can be included from a test.

Replay each one's call sequence against the class instead, and assert the bencoded bytes it hands to rtorrent: retrackers/update.php, edit/action.php, the add path through addtorrent.php and rTorrent::fastResume(), and the create path through createtorrent.php, correct.php and action.php.

update.php turns out to be includable with no hash on the command line, so its clearTracker() and deleteTrackers() drive the retrackers tests rather than a second copy of them. rTorrent::fastResume() is driven directly as well; php/rtorrent.php is declarations only.

Fixtures are bencoded by hand in the test, so each one is its own expected output and nothing a test compares against was produced by the class under test.

This pins the transcription, not the script: an edit to one of the scripts will not fail these tests. The subject is Torrent.