### PR TITLE
Fix the PHPStan level-0 findings in the vendored XMPPHP and JShrink

### DIFF
--- a/php/utility/minifier.php
+++ b/php/utility/minifier.php
@@ -319,12 +319,12 @@ class Minifier
      */
     protected function clean()
     {
-        unset($this->input);
+        $this->input = null;
         $this->len = 0;
         $this->index = 0;
         $this->a = $this->b = '';
-        unset($this->c);
-        unset($this->options);
+        $this->c = null;
+        $this->options = null;
     }
 
     /**
@@ -337,7 +337,7 @@ class Minifier
         // Check to see if we had anything in the look ahead buffer and use that.
         if (isset($this->c)) {
             $char = $this->c;
-            unset($this->c);
+            $this->c = null;
         } else {
             // Otherwise we start pulling from the input.
             $char = $this->index < $this->len ? $this->input[$this->index] : false;
@@ -445,7 +445,7 @@ class Minifier
         // kill rest of line
         $this->getNext("\n");
 
-        unset($this->c);
+        $this->c = null;
 
         if ($thirdCommentString == '@') {
             $endPoint = $this->index - $startIndex;

--- a/plugins/xmpp/XMPPHP/BOSH.php
+++ b/plugins/xmpp/XMPPHP/BOSH.php
@@ -48,7 +48,10 @@ class XMPPHP_BOSH extends XMPPHP_XMPP {
 		protected $http_buffer = Array();
 		protected $session = false;
 
-		public function connect($server, $wait='1', $session=false) {
+		public function connect($server = null, $wait = '1', $session = false) {
+			if($server === null) {
+				throw new XMPPHP_Exception("XMPPHP_BOSH::connect() requires a BOSH endpoint URL.");
+			}
 			$this->http_server = $server;
 			$this->use_encryption = false;
 			$this->session = $session;
@@ -147,7 +150,15 @@ class XMPPHP_BOSH extends XMPPHP_XMPP {
 			}
 		}
 
-		public function send($msg) {
+		/**
+		 * Send to the BOSH endpoint.
+		 *
+		 * @param string $msg
+		 * @param integer $timeout Accepted for signature compatibility with
+		 *                         XMPPHP_XMLStream::send(); BOSH writes over cURL
+		 *                         rather than a socket, so there is nothing to time out on.
+		 */
+		public function send($msg, $timeout = null) {
 			$this->log->log("SEND: $msg",  XMPPHP_Log::LEVEL_VERBOSE);
 			$msg = new SimpleXMLElement($msg);
 			#$msg->addAttribute('xmlns', 'jabber:client');
@@ -157,7 +168,6 @@ class XMPPHP_BOSH extends XMPPHP_XMPP {
 
 		public function reset() {
 			$this->xml_depth = 0;
-			unset($this->xmlobj);
 			$this->xmlobj = array();
 			$this->setupParser();
 			#$this->send($this->stream_start);

--- a/plugins/xmpp/XMPPHP/XMLStream.php
+++ b/plugins/xmpp/XMPPHP/XMLStream.php
@@ -223,8 +223,6 @@ class XMPPHP_XMLStream {
 
 	/**
 	 * Set SSL
-	 *
-	 * @return integer
 	 */
 	public function useSSL($use=true) {
 		$this->use_ssl = $use;
@@ -447,10 +445,10 @@ class XMPPHP_XMLStream {
 	/**
 	 * Process
 	 *
-	 * @return string
+	 * @return bool
 	 */
 	public function process() {
-		$this->__process(NULL);
+		return $this->__process(NULL);
 	}
 
 	/**
@@ -748,7 +746,6 @@ class XMPPHP_XMLStream {
 	 */
 	public function reset() {
 		$this->xml_depth = 0;
-		unset($this->xmlobj);
 		$this->xmlobj = array();
 		$this->setupParser();
 		if(!$this->is_server) {

--- a/plugins/xmpp/XMPPHP/XMPP.php
+++ b/plugins/xmpp/XMPPHP/XMPP.php
@@ -73,6 +73,13 @@ class XMPPHP_XMPP extends XMPPHP_XMLStream {
 	protected $basejid;
 
 	/**
+	 * Bare JID (user@host), assigned once resource binding succeeds.
+	 *
+	 * @var string
+	 */
+	protected $jid;
+
+	/**
 	 * @var boolean
 	 */
 	protected $authed = false;

--- a/tests/php/MinifierCleanupTest.php
+++ b/tests/php/MinifierCleanupTest.php
@@ -1,0 +1,171 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/utility/minifier.php');
+
+// Exposes the protected look-ahead machinery so the buffer contract can be
+// asserted directly rather than inferred from minified output.
+class MinifierCleanupProbe extends \JShrink\Minifier
+{
+	public function primeInput($js)
+	{
+		$this->initialize($js, []);
+	}
+
+	public function primeLookAhead($char)
+	{
+		$this->c = $char;
+	}
+
+	public function nextChar()
+	{
+		return $this->getChar();
+	}
+
+	public function runClean()
+	{
+		$this->clean();
+	}
+
+	public function lookAheadIsSet()
+	{
+		return isset($this->c);
+	}
+
+	public function inputIsSet()
+	{
+		return isset($this->input);
+	}
+
+	public function optionsIsSet()
+	{
+		return isset($this->options);
+	}
+}
+
+// JShrink's look-ahead buffer ($this->c) and its end-of-run cleanup are gated
+// entirely on isset(). getChar() consumes the buffer only when isset($this->c)
+// is true, and must leave it empty afterwards or the same character is emitted
+// twice. clean() must return the object to the state a freshly constructed one
+// is in, which for these untyped declared properties is null (isset() false).
+//
+// The output tests below are golden values: representative JavaScript in, the
+// exact minified string out. They exist so any future change to the cleanup
+// path has to produce byte-identical output or fail here. getplugins.php feeds
+// the whole concatenated plugin bundle through Minifier::minify() in one pass,
+// so a single character of drift there rewrites every plugin in the UI.
+class MinifierCleanupTest extends TestCase
+{
+	private function minify($js)
+	{
+		return \JShrink\Minifier::minify($js);
+	}
+
+	public function testLookAheadBufferIsConsumedExactlyOnce()
+	{
+		$probe = new MinifierCleanupProbe();
+		$probe->primeInput('XY');
+		$probe->primeLookAhead('Q');
+
+		$this->assertTrue($probe->lookAheadIsSet(),
+			'a primed look-ahead buffer must read as set');
+		$this->assertEquals('Q', $probe->nextChar(),
+			'getChar() must return the buffered character');
+		$this->assertTrue(!$probe->lookAheadIsSet(),
+			'getChar() must clear the look-ahead buffer after consuming it');
+		$this->assertEquals('X', $probe->nextChar(),
+			'the character after the buffered one must come from the input, not the buffer again');
+		$this->assertEquals('Y', $probe->nextChar(),
+			'the input must keep advancing normally');
+	}
+
+	public function testFreshObjectHasNoLookAheadBuffer()
+	{
+		$probe = new MinifierCleanupProbe();
+		$this->assertTrue(!$probe->lookAheadIsSet(),
+			'a freshly constructed Minifier must have no look-ahead buffer');
+	}
+
+	public function testCleanRestoresTheFreshObjectState()
+	{
+		$probe = new MinifierCleanupProbe();
+		$probe->primeInput('var a = 1;');
+		$probe->primeLookAhead('Z');
+
+		$this->assertTrue($probe->inputIsSet(), 'initialize() must set the input');
+		$this->assertTrue($probe->optionsIsSet(), 'initialize() must set the options');
+
+		$probe->runClean();
+
+		$this->assertTrue(!$probe->lookAheadIsSet(),
+			'clean() must leave the look-ahead buffer unset');
+		$this->assertTrue(!$probe->inputIsSet(),
+			'clean() must release the input');
+		$this->assertTrue(!$probe->optionsIsSet(),
+			'clean() must release the options');
+	}
+
+	public function testConditionalOneLineComment()
+	{
+		// Drives processOneLineComments(), which clears the look-ahead buffer
+		// and then conditionally rewrites it.
+		$this->assertEquals(
+			'var a=1;var b=2;var c=3;',
+			$this->minify("//@cc_on\nvar a = 1;\n//@if (1)\nvar b = 2;\n//@end\nvar c = 3;\n"),
+			'conditional one-line comments minify to their historical output');
+	}
+
+	public function testFlaggedMultiLineComment()
+	{
+		$this->assertEquals(
+			"/*! keep me */\nvar a=1;var b=2;",
+			$this->minify("/*! keep me */\nvar a=1; /* drop me */ var b = 2;\n"),
+			'a flagged comment is kept and an ordinary one dropped');
+	}
+
+	public function testDivisionLookahead()
+	{
+		// Drives getReal(): the buffer is filled with the character after '/'
+		// and handed back through getChar().
+		$this->assertEquals(
+			'var x=a / b;var y=c / d;var z=1;',
+			$this->minify("var x = a / b; var y = c /* c */ / d;\nvar z = 1;\n"),
+			'division survives the look-ahead round trip');
+	}
+
+	public function testRegexCharacterClass()
+	{
+		$this->assertEquals(
+			'var m=s.match(/themes\\/([^/]+)\\//);var t=1;',
+			$this->minify("var m = s.match(/themes\\/([^/]+)\\//);\nvar t = 1;\n"),
+			'a regex with a class-internal slash is preserved verbatim');
+	}
+
+	public function testStringsAndTemplates()
+	{
+		$this->assertEquals(
+			'var s="a//b",t=\'c/*d*\'+e,u=`f/g${h}`;',
+			$this->minify("var s = \"a//b\", t = 'c/*d*'+e, u = `f/g\${h}`;\n"),
+			'comment-looking sequences inside string and template literals are untouched');
+	}
+
+	public function testKeywordThenRegex()
+	{
+		$this->assertEquals(
+			'return/a/.test(x);typeof/b/;do{}while(0);',
+			$this->minify("return /a/.test(x); typeof /b/; do { } while (0);\n"),
+			'a regex directly after a keyword minifies to its historical output');
+	}
+
+	public function testRepeatedMinificationIsStable()
+	{
+		// Every minify() call builds its own Minifier and ends in clean(), so a
+		// cleanup that left residue behind would show up as run-to-run drift.
+		$js = "//@cc_on\nvar a = 1; /*! flag */ var b = s.match(/x\\/[^/]+\\//); var c = a / b;\n";
+		$first = $this->minify($js);
+		$this->assertEquals($first, $this->minify($js),
+			'minifying the same source twice must give the same result');
+		$this->assertEquals($first, $this->minify($js),
+			'and a third time');
+	}
+}

--- a/tests/plugins/xmpp/XmppLibraryTest.php
+++ b/tests/plugins/xmpp/XmppLibraryTest.php
@@ -1,0 +1,214 @@
+<?php
+
+require_once(__DIR__ . '/../../php/TestCase.php');
+require_once(__DIR__ . '/../../../plugins/xmpp/XMPPHP/XMPP.php');
+
+// Drives resource_bind_handler() without a socket. send() is the only thing the
+// handler reaches for that needs one, so overriding it is enough to run the real
+// bind path in-process.
+class XmppBindProbe extends XMPPHP_XMPP
+{
+	public $sent = array();
+
+	public function send($msg, $timeout = null)
+	{
+		$this->sent[] = $msg;
+		return strlen($msg);
+	}
+
+	public function handleBind($xml)
+	{
+		return $this->resource_bind_handler($xml);
+	}
+
+	public function readJid()
+	{
+		return $this->jid;
+	}
+
+	public function readFullJid()
+	{
+		return $this->fulljid;
+	}
+}
+
+// XMPPHP is vendored under plugins/xmpp/XMPPHP and maintained as part of
+// ruTorrent. Two things it got wrong are load-bearing on modern PHP:
+//
+// 1. resource_bind_handler() assigns $this->jid on the standard RFC 6120 bind
+//    path -- i.e. on every successful connect -- and the property was never
+//    declared. That is a deprecation on PHP 8.2+ and an Error on PHP 9, so the
+//    plugin would stop delivering notifications outright.
+//
+// 2. XMPPHP_BOSH::connect() made parameter #1 required where the parent's is
+//    optional. PHP rejects that at class-declaration time, so BOSH.php was an
+//    unconditional fatal error on PHP 8 -- the file could not be loaded at all.
+class XmppLibraryTest extends TestCase
+{
+	private function bindResult($fulljid)
+	{
+		$jid = new XMPPHP_XMLObj('jid', '', array(), $fulljid);
+		$bind = new XMPPHP_XMLObj('bind', 'urn:ietf:params:xml:ns:xmpp-bind');
+		$bind->subs[] = $jid;
+		$iq = new XMPPHP_XMLObj('iq', 'jabber:client', array('type' => 'result', 'id' => '1'));
+		$iq->subs[] = $bind;
+
+		return $iq;
+	}
+
+	private function newProbe()
+	{
+		// Suppressed diagnostic: XMLStream::setupParser() drives the XML parser
+		// through xml_set_object() and string method names, which PHP 8.4
+		// deprecates. That is a pre-existing XMPPHP issue and not what these
+		// tests are about; without the @ every construction below buries the
+		// suite log in the same three notices.
+		return @new XmppBindProbe('example.org', 5222, 'user', 'secret', 'rutorrent');
+	}
+
+	public function testJidIsADeclaredProperty()
+	{
+		$declared = array();
+		$reflection = new ReflectionClass('XMPPHP_XMPP');
+		foreach ($reflection->getProperties() as $property) {
+			$declared[] = $property->getName();
+		}
+
+		$this->assertTrue(in_array('jid', $declared, true),
+			'XMPPHP_XMPP must declare $jid; resource_bind_handler() assigns it on every connect');
+	}
+
+	public function testBindResultPopulatesJid()
+	{
+		$probe = $this->newProbe();
+		$probe->handleBind($this->bindResult('user@example.org/rutorrent'));
+
+		$this->assertEquals('user@example.org/rutorrent', $probe->readFullJid(),
+			'the full JID from the bind result must be stored');
+		$this->assertEquals('user@example.org', $probe->readJid(),
+			'the bare JID must be the full JID with the resource stripped');
+	}
+
+	public function testBindDoesNotCreateADynamicProperty()
+	{
+		$probe = $this->newProbe();
+		$probe->handleBind($this->bindResult('user@example.org/rutorrent'));
+
+		$property = new ReflectionProperty($probe, 'jid');
+		$this->assertTrue($property->isDefault(),
+			'$jid must resolve to the declared property, not a dynamic one');
+	}
+
+	public function testBindRaisesNoDeprecation()
+	{
+		// Only the bind call is instrumented. Constructing the probe sets up the
+		// XML parser, which has diagnostics of its own that are not this test's
+		// subject.
+		$probe = $this->newProbe();
+		$bind = $this->bindResult('user@example.org/rutorrent');
+
+		$notices = array();
+		set_error_handler(function ($errno, $errstr) use (&$notices) {
+			$notices[] = $errstr;
+
+			return true;
+		}, E_ALL);
+
+		try {
+			$probe->handleBind($bind);
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertTrue(count($notices) === 0,
+			'binding a resource must not raise a diagnostic (a dynamic $jid raises one on PHP 8.2+), got: '
+			. implode(' | ', $notices));
+	}
+
+	public function testBindContinuesTheSessionHandshake()
+	{
+		$probe = $this->newProbe();
+		$probe->handleBind($this->bindResult('user@example.org/rutorrent'));
+
+		$this->assertEquals(1, count($probe->sent),
+			'the bind handler must send exactly one follow-up stanza');
+		$this->assertTrue(strpos($probe->sent[0], 'urn:ietf:params:xml:ns:xmpp-session') !== false,
+			'the follow-up stanza must be the session request');
+	}
+
+	public function testNonResultBindIsIgnored()
+	{
+		$iq = new XMPPHP_XMLObj('iq', 'jabber:client', array('type' => 'error', 'id' => '1'));
+		$probe = $this->newProbe();
+		$probe->handleBind($iq);
+
+		$this->assertEquals(null, $probe->readJid(),
+			'a bind error must leave the JID unset');
+	}
+
+	// The BOSH override signatures are a class-declaration-time contract: PHP
+	// refuses to load the class if they are wrong, and that fatal cannot be
+	// caught from inside the process that hits it. A subprocess is the only way
+	// to turn it into a pass/fail.
+	public function testBoshClassCanBeLoaded()
+	{
+		$path = __DIR__ . '/../../../plugins/xmpp/XMPPHP/BOSH.php';
+		$command = escapeshellarg(PHP_BINARY)
+			. ' -d display_errors=1 -d error_reporting=-1 -r '
+			. escapeshellarg('require ' . var_export($path, true) . '; echo "BOSH_LOADED";')
+			. ' 2>&1';
+		$output = shell_exec($command);
+
+		$this->assertTrue(strpos((string) $output, 'BOSH_LOADED') !== false,
+			'BOSH.php must load; its overrides have to stay signature-compatible with XMPPHP_XMLStream. Got: '
+			. trim((string) $output));
+	}
+
+	public function testBoshOverridesAcceptEverythingTheParentAccepts()
+	{
+		require_once(__DIR__ . '/../../../plugins/xmpp/XMPPHP/BOSH.php');
+
+		$child = new ReflectionClass('XMPPHP_BOSH');
+		foreach ($child->getMethods() as $method) {
+			if ($method->getDeclaringClass()->getName() !== 'XMPPHP_BOSH') {
+				continue;
+			}
+
+			$parentClass = $child->getParentClass();
+			if (!$parentClass->hasMethod($method->getName())) {
+				continue;
+			}
+			$parent = $parentClass->getMethod($method->getName());
+			if ($parent->isPrivate()) {
+				// A private parent method is not inherited, so a same-named
+				// child method is a separate method rather than an override
+				// (XMLStream::__process() vs BOSH::__process()).
+				continue;
+			}
+
+			$this->assertTrue(
+				$method->getNumberOfParameters() >= $parent->getNumberOfParameters(),
+				"XMPPHP_BOSH::{$method->getName()}() must accept at least as many parameters as the method it overrides");
+			$this->assertTrue(
+				$method->getNumberOfRequiredParameters() <= $parent->getNumberOfRequiredParameters(),
+				"XMPPHP_BOSH::{$method->getName()}() must not make a parameter required that the method it overrides leaves optional");
+		}
+	}
+
+	public function testBoshConnectRejectsAMissingEndpoint()
+	{
+		require_once(__DIR__ . '/../../../plugins/xmpp/XMPPHP/BOSH.php');
+
+		// @ for the same setupParser() deprecations described in newProbe().
+		$bosh = @new XMPPHP_BOSH('example.org', 5222, 'user', 'secret', 'rutorrent');
+		$message = null;
+		try {
+			$bosh->connect();
+		} catch (XMPPHP_Exception $e) {
+			$message = $e->getMessage();
+		}
+
+		$this->assertTrue($message !== null,
+			'connect() without an endpoint must raise XMPPHP_Exception rather than proceeding with a null URL');
+	}
+}


### PR DESCRIPTION
Both libraries are maintained as part of ruTorrent -- XMPPHP's upstream last published in 2010 and JShrink is already at its newest release -- so the findings are fixed in place rather than excluded.

XMPPHP_XMPP::resource_bind_handler() assigned an undeclared $jid on the standard RFC 6120 bind path, i.e. on every successful connect. That is a deprecation on PHP 8.2+ and an Error on PHP 9. Declare the property.

XMPPHP_BOSH::connect() made parameter #1 required where the parent leaves it optional, which PHP rejects at class-declaration time: BOSH.php was an unconditional fatal error on PHP 8 and could not be loaded at all. Give $server a default and reject a missing endpoint explicitly. BOSH::send() now accepts the parent's $timeout, which BOSH has nothing to apply it to because it writes over cURL rather than a socket.

useSSL() and process() carried return annotations they never honoured. useSSL() is a setter, so the annotation goes; process() now returns the __process() result the way processTime() already does. The two unset($this->xmlobj) calls were each immediately followed by a reassignment, so they are dropped.

JShrink cleared three properties with unset(), which PHP 8.4 rejects because a subclass could give them hooks. The only thing in the file that distinguishes cleared from set is isset(), and these properties are untyped and so default to null, which means assigning null leaves the object in exactly the state a freshly constructed one is in. Minified output is byte-identical for every .js in the tree and for the concatenated bundle getplugins.php passes through Minifier::minify().

Tests cover the parts with behaviour: that $jid is declared and populated from a bind result without raising a diagnostic, that BOSH.php loads and its overrides stay signature-compatible, and that the JShrink look-ahead buffer is consumed exactly once and cleanup returns the object to its fresh state. The signature and annotation changes are structural and have no behaviour to assert beyond the class loading.