### PR TITLE
Add a PHPStan level 0 gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,3 +45,15 @@ jobs:
         run: npm install --no-save eslint@9 @eslint/js@9
       - name: eslint
         run: npx eslint "js/**/*.js" "plugins/**/*.js"
+
+  phpstan:
+    # Blocking: the tree is at zero level-0 findings and stays there.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: phpstan:2.2.9
+      - name: phpstan
+        run: phpstan analyse --no-progress --memory-limit=512M --error-format=github

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,15 @@
+parameters:
+	level: 0
+
+	paths:
+		- php
+		- plugins
+		# Snoopy is a .php file in all but name, and PHPStan only walks
+		# .php when it scans a directory, so it is named here explicitly.
+		- php/Snoopy.class.inc
+
+	# GeoIp2 ships as a phar that plugins/geoip/lookup.php requires at
+	# runtime. PHPStan reads class declarations straight out of it, so the
+	# classes resolve without the phar being unpacked or excluded.
+	scanDirectories:
+		- phar://%currentWorkingDirectory%/plugins/geoip/geoip2.phar/src


### PR DESCRIPTION
The tree has no level-0 findings left, so the check can block rather than carry a baseline

 There are no excluded paths: Snoopy is listed by name because PHPStan only walks .php when scanning a directory, and GeoIp2's class declarations are read out of the phar the geoip plugin requires at runtime.

Closes #3207 