### PR TITLE
check_port: make the yougetsignal answer testable, and send Origin

### DIFF
--- a/plugins/check_port/action.php
+++ b/plugins/check_port/action.php
@@ -1,6 +1,7 @@
 <?php
 require_once(dirname(__FILE__) . "/../../php/settings.php");
 require_once(dirname(__FILE__) . "/../../php/Snoopy.class.inc");
+require_once(dirname(__FILE__) . "/parse.php");
 
 // Load the plugin's configuration settings from conf.php
 eval(FileUtil::getPluginConf('check_port'));
@@ -60,6 +61,11 @@ function check_port_yougetsignal($ip, $port, $timeout) {
 	$client->read_timeout = (int)$timeout;
 	$client->proxy_host = ""; // Do not use a proxy for this check
 
+	// The API is the one the site's own front end calls, and it is reached
+	// with the headers a browser on that site would send.
+	$client->rawheaders['Origin'] = "https://www.yougetsignal.com";
+	$client->referer = "https://www.yougetsignal.com/";
+
 	// Obtain a session device ID cookie required by the API
 	@$client->fetch("https://api.connected.app/deviceId");
 	if ($client->status != 204 && $client->status != 200) {
@@ -74,17 +80,12 @@ function check_port_yougetsignal($ip, $port, $timeout) {
 		'query' => $query,
 		'variables' => ['input' => ['host' => $ip, 'port' => (int)$port]],
 	]);
-	$client->referer = "https://www.yougetsignal.com/";
 	@$client->fetch("https://api.connected.app/graphql", "POST", "application/json", $post_data);
 
 	if ($client->status == 200) {
-		$json = json_decode($client->results, true);
-		$parsed = $json['data']['networkToolRunPortCheck']['output']['parsed'] ?? null;
-		if ($parsed && ($parsed['kind'] ?? '') === 'success') {
-			$state = $parsed['port']['state'] ?? '';
-            if ($state === 'closed' || $state === 'filtered') return 1;
-			if ($state === 'open') return 2;
-		}
+		$status = check_port_parse_yougetsignal($client->results);
+		if ($status)
+			return $status;
 		error_log("check_port: yougetsignal unexpected response for IP {$ip}. Response: " . substr($client->results, 0, 500));
 	} else {
 		error_log("check_port: Failed fetch from yougetsignal for IP {$ip}. Status: {$client->status}, Error: {$client->error}");

--- a/plugins/check_port/parse.php
+++ b/plugins/check_port/parse.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Reads the port state out of a yougetsignal GraphQL answer.
+ *
+ * Kept apart from action.php, which cannot be loaded from a test: it requires
+ * settings.php and evaluates the plugin's conf.php at top level. The shape of
+ * this answer belongs to a third party and has already changed once, so it is
+ * the part worth pinning.
+ *
+ * @param string $body The raw response body
+ * @return int Status code (0: unknown, 1: closed, 2: open)
+ */
+function check_port_parse_yougetsignal($body)
+{
+	// A body that is not an answer at all -- the HTML page the old endpoint
+	// serves now, or nothing -- decodes to a scalar or null, and the lookup
+	// below yields null for all of them.
+	$json = json_decode($body, true);
+
+	$parsed = $json['data']['networkToolRunPortCheck']['output']['parsed'] ?? null;
+	if (($parsed['kind'] ?? '') !== 'success')
+		return 0;
+
+	// nmap's own states. "filtered" means nothing answered, which for a port
+	// check is the same news as closed.
+	$state = $parsed['port']['state'] ?? '';
+	if ($state === 'closed' || $state === 'filtered')
+		return 1;
+	if ($state === 'open')
+		return 2;
+
+	return 0;
+}

--- a/tests/plugins/check_port/YouGetSignalParseTest.php
+++ b/tests/plugins/check_port/YouGetSignalParseTest.php
@@ -1,0 +1,93 @@
+<?php
+
+require_once(__DIR__ . '/../../php/TestCase.php');
+require_once(__DIR__ . '/../../../plugins/check_port/parse.php');
+
+/**
+ * The shape of a yougetsignal answer belongs to a third party. It changed once
+ * already -- the old endpoint was replaced by a GraphQL API, and the only
+ * symptom in the interface was a port whose state stayed unknown, with nothing
+ * to say why. These pin the shape so the next move is a failing test instead.
+ *
+ * Bodies are the real ones: nmap behind the API reports open, closed or
+ * filtered, and filtered -- nothing answered -- is the same news as closed for
+ * a port check.
+ */
+class YouGetSignalParseTest extends TestCase
+{
+	private function body($state, $kind = 'success')
+	{
+		return json_encode(array('data' => array('networkToolRunPortCheck' => array(
+			'output' => array(
+				'toolType' => 'PortCheck',
+				'parsed' => array(
+					'kind' => $kind,
+					'nmapVersion' => '7.93',
+					'hostIpAddress' => '8.8.8.8',
+					'port' => array(
+						'number' => 80,
+						'state' => $state,
+						'protocol' => 'tcp',
+						'service' => 'http',
+					),
+				),
+			),
+		))));
+	}
+
+	public function testAnOpenPortIsOpen()
+	{
+		$this->assertEquals(2, check_port_parse_yougetsignal($this->body('open')),
+			'an open port reads as open');
+	}
+
+	public function testAClosedPortIsClosed()
+	{
+		$this->assertEquals(1, check_port_parse_yougetsignal($this->body('closed')),
+			'a closed port reads as closed');
+	}
+
+	public function testAFilteredPortIsClosed()
+	{
+		// Nothing answered. The user cannot be reached either way.
+		$this->assertEquals(1, check_port_parse_yougetsignal($this->body('filtered')),
+			'a filtered port reads as closed');
+	}
+
+	public function testAScanThatDidNotSucceedIsUnknown()
+	{
+		$this->assertEquals(0, check_port_parse_yougetsignal($this->body('open', 'failure')),
+			'a kind other than success is not read as a result');
+	}
+
+	public function testAStateNobodyKnowsIsUnknown()
+	{
+		$this->assertEquals(0, check_port_parse_yougetsignal($this->body('unfiltered')),
+			'an unrecognised state is unknown rather than a guess');
+	}
+
+	public function testAnAnswerWithoutTheResultIsUnknown()
+	{
+		$this->assertEquals(0, check_port_parse_yougetsignal(
+			'{"data":{"networkToolRunPortCheck":{"output":{"toolType":"PortCheck"}}}}'),
+			'an answer carrying no parsed result is unknown');
+	}
+
+	public function testAGraphQlErrorIsUnknown()
+	{
+		$this->assertEquals(0, check_port_parse_yougetsignal(
+			'{"errors":[{"message":"Cannot query field"}],"data":null}'),
+			'a GraphQL error is unknown');
+	}
+
+	public function testSomethingThatIsNotJsonIsUnknown()
+	{
+		// What the old endpoint returns today: an HTML page, or nothing at all.
+		$this->assertEquals(0, check_port_parse_yougetsignal('<!DOCTYPE html><html></html>'),
+			'a page instead of an answer is unknown');
+		$this->assertEquals(0, check_port_parse_yougetsignal(''),
+			'an empty body is unknown');
+		$this->assertEquals(0, check_port_parse_yougetsignal('error code: 522'),
+			'an edge error is unknown');
+	}
+}


### PR DESCRIPTION
The shape of that answer belongs to a third party and has already moved once. The only symptom in the interface was a port state that stayed unknown, with nothing to say why, so the reading of it is worth a test.

It could not have one where it was: action.php requires settings.php and evaluates the plugin's conf.php at top level, so nothing can include it. The reading now lives in check_port_parse_yougetsignal() in its own file, covered for open, closed, filtered, a scan that did not succeed, a state nobody knows, an answer carrying no result, a GraphQL error, and a body that is not JSON at all -- which is what the old endpoint serves today.

The request also carries the Origin header the site's own front end sends. It is accepted without one at the moment; every other header of that request is already being reproduced, and this is the one such an endpoint is most likely to start checking.