### PR TITLE
Restore PHP 7.4 Torrent metadata compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,14 @@ on:
 jobs:
   php:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['7.4', '8.1']
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ matrix.php }}
           extensions: posix, dom, xml, mbstring, iconv, json, curl
       - name: PHP test suite
         run: bash php-test.sh

--- a/php/Torrent.php
+++ b/php/Torrent.php
@@ -24,17 +24,17 @@ class Torrent
 	/** Keys of the torrent's top level dictionary.
 	 *
 	 * Declared, so that reading or writing one is a property a reader and a
-	 * static analyser can both check. They are typed mixed and default to
+	 * static analyser can both check. They use PHPDoc mixed and default to
 	 * null: a torrent carries whatever its writer put there, this class
 	 * re-emits it unchanged, and null means the torrent has no such key.
 	 */
-	public mixed $announce = null;
-	public mixed $comment = null;
-	public mixed $encoding = null;
-	public mixed $httpseeds = null;
-	public mixed $info = null;
-	public mixed $libtorrent_resume = null;
-	public mixed $rtorrent = null;
+	/** @var mixed */ public $announce = null;
+	/** @var mixed */ public $comment = null;
+	/** @var mixed */ public $encoding = null;
+	/** @var mixed */ public $httpseeds = null;
+	/** @var mixed */ public $info = null;
+	/** @var mixed */ public $libtorrent_resume = null;
+	/** @var mixed */ public $rtorrent = null;
 
 	/** The keys that are not declared properties above.
 	 *
@@ -69,6 +69,7 @@ class Torrent
 	 */
 	public function setMeta( $key, $value )
 	{
+		$key = (string) $key;
 		switch( $key )
 		{
 			case 'announce':		$this->announce = $value; break;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
 	level: 0
+	phpVersion: 70400
 
 	paths:
 		- php


### PR DESCRIPTION

## Summary

ruTorrent documents PHP 7.4 or newer as supported, but the native `mixed`
property declarations in `Torrent` require PHP 8.0 and prevent the file from
being parsed on PHP 7.4.

- Replace the seven native `mixed` declarations with PHPDoc-annotated public
  properties, preserving declared-property behavior and null defaults.
- Normalize metadata keys to strings before `setMeta()` dispatch. This prevents
  numeric bencode dictionary keys from matching named switch cases through
  PHP 7.4 loose comparison.
- Configure PHPStan for the documented PHP 7.4 floor.
- Run the PHP CI job on both PHP 7.4 and PHP 8.1.

## Verification

- Linted all 385 PHP/INC files on PHP 7.4 and PHP 8.1.
- Ran the complete 47-file PHP test harness on both runtimes.
- Ran PHPStan 2.2.9 with `phpVersion: 70400`: no errors.
- Verified the existing numeric-key dictionary regression on both runtimes.
- Confirmed that restoring native `mixed` breaks PHP 7.4 lint/PHPStan.
- Confirmed that removing key normalization breaks the numeric-key test on
  PHP 7.4 while PHP 8.1 remains green.
