### PR TITLE
Read a numeric torrent key back by either spelling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,13 +7,16 @@ on:
 
 jobs:
   php-syntax:
-    # Blocking: every PHP file must parse.
+    # Blocking: every PHP file must parse, on every PHP the README supports.
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['7.4', '8.1']
     steps:
       - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{ matrix.php }}
       - name: php -l
         run: |
           fail=0

--- a/php/Torrent.php
+++ b/php/Torrent.php
@@ -51,6 +51,7 @@ class Torrent
 	 */
 	public function meta( $key )
 	{
+		$key = (string) $key;
 		switch( $key )
 		{
 			case 'announce':		return($this->announce);

--- a/tests/php/TorrentMetaTest.php
+++ b/tests/php/TorrentMetaTest.php
@@ -223,6 +223,26 @@ class TorrentMetaTest extends TestCase
 	}
 
 	/**
+	 * A key read back the way it was written. A bencode dictionary key that
+	 * looks like a number arrives from the decoder as an int, and below PHP 8
+	 * an int matches the first case of a switch over strings -- so meta(0)
+	 * answered with the announce URL while meta('0') answered correctly.
+	 */
+	public function testANumericKeyIsReadBackByEitherSpelling()
+	{
+		$raw = 'd' . $this->bstr('announce') . $this->bstr('http://a/announce')
+			. $this->bstr('0') . $this->bstr('zero') . 'e';
+		$torrent = new Torrent($raw);
+		$this->assertTrue($torrent->errors() === false, 'The torrent parses');
+		$this->assertTrue($torrent->meta('0') === 'zero',
+			"meta('0') reads the key the torrent carries");
+		$this->assertTrue($torrent->meta(0) === 'zero',
+			'meta(0) reads the same key, not the first named one');
+		$this->assertTrue($torrent->announce === 'http://a/announce',
+			'and announce is left alone');
+	}
+
+	/**
 	 * The keys that are identifiers are declared properties, and no magic
 	 * accessor stands between a caller and one of them -- a __get() would
 	 * make every property access on a torrent, including a misspelt one,


### PR DESCRIPTION
setMeta() normalises the key it is given; meta() switches over the same names and did not, so below PHP 8 an int key matched the first case and meta(0) answered with the announce URL while meta('0') answered with the key the torrent carries. The write side stored it correctly, so the value was there to be read all along.

The test fails on 7.4 and passes on 8.x, which is what the suite now runs on both of.

php-syntax is matrixed to match. Its job is that every file parses, and the parse error it exists to catch was one only 7.4 raised.