### PR TITLE
Make settings saves recover socket allocation failures

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -190,7 +190,7 @@ const theOptionsWindow = {
 						$("<label>").attr({for: id}).text(label + ": "),
 					),
 					$("<div>").addClass("col-md-4").append(
-						$("<input>").attr({type: "number", id: id}).prop("maxlength", 6),
+						$("<input>").attr({type: "number", id: id}).addClass("num").prop("maxlength", 6),
 					),
 				)),
 				$("<div>").addClass("row").attr({id: "socket_alloc_budget_row"}).hide().append(

--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -946,8 +946,8 @@ rTorrentStub.prototype.getResponse = function(data)
 					this.faultString.push("XMLRPC Error: "+message+" ["+this.action+"]");
 				}
 				else
-					for(var i=0; i<memberFaults.length; i++)
-						this.faultString.push("XMLRPC Error: "+memberFaults[i]+" ["+this.action+"]");
+					for(var j=0; j<memberFaults.length; j++)
+						this.faultString.push("XMLRPC Error: "+memberFaults[j]+" ["+this.action+"]");
 			}
 		}
 		if(!this.xmlRPCFault)

--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -383,13 +383,7 @@ rTorrentStub.prototype.setsettings = function()
 		var prmType = "string";
 		var prm = this.vs[i];
 		if(this.ss[i].charAt(0)=='n')
-		{
 			prmType = "i8";
-			// Match the httprpc door: an empty numeric field is a valid zero,
-			// not an undecodable empty XML-RPC integer that rejects the batch.
-			if(prm==="")
-				prm = 0;
-		}
 		var cmd = null;
 		var socketAlloc = theRequestManager.getSocketAllocCategory(this.ss[i]);
 		if(this.ss[i]=="ndht")

--- a/js/rtorrent.js
+++ b/js/rtorrent.js
@@ -377,13 +377,19 @@ rTorrentStub.prototype.recheck = function()
 
 rTorrentStub.prototype.setsettings = function()
 {
-	var adjustAlloc = false;
+	var socketCategories = [];
 	for(var i=0; i<this.vs.length; i++)
 	{
 		var prmType = "string";
-		if(this.ss[i].charAt(0)=='n')
-			prmType = "i8";
 		var prm = this.vs[i];
+		if(this.ss[i].charAt(0)=='n')
+		{
+			prmType = "i8";
+			// Match the httprpc door: an empty numeric field is a valid zero,
+			// not an undecodable empty XML-RPC integer that rejects the batch.
+			if(prm==="")
+				prm = 0;
+		}
 		var cmd = null;
 		var socketAlloc = theRequestManager.getSocketAllocCategory(this.ss[i]);
 		if(this.ss[i]=="ndht")
@@ -405,7 +411,8 @@ rTorrentStub.prototype.setsettings = function()
 			this.commands.push( minCmd );
 			cmd = new rXMLRPCCommand("system.sockets."+socketAlloc+".max_alloc.set");
 			cmd.addParameter("string",'');
-			adjustAlloc = true;
+			if(socketCategories.indexOf(socketAlloc)<0)
+				socketCategories.push(socketAlloc);
 		}
 		else
 			cmd = new rXMLRPCCommand('set_'+this.ss[i].substr(1));
@@ -414,8 +421,131 @@ rTorrentStub.prototype.setsettings = function()
 	}
 	// The staged min_alloc/max_alloc values only take effect once the socket
 	// manager recomputes its allocation. Send it once per batch.
-	if(adjustAlloc)
+	if(socketCategories.length)
+	{
+		// Reads lead this multicall, so a rejected later member can restore the
+		// allocation in effect before this browser changed either bound.
+		var reads = [];
+		for(var c=0; c<socketCategories.length; c++)
+		{
+			reads.push(new rXMLRPCCommand("system.sockets."+socketCategories[c]+".min_alloc"));
+			reads.push(new rXMLRPCCommand("system.sockets."+socketCategories[c]+".max_alloc"));
+		}
+		this.socketAllocCategories = socketCategories;
+		this.commands = reads.concat(this.commands);
 		this.commands.push( new rXMLRPCCommand("system.sockets.adjust_alloc") );
+	}
+}
+
+rTorrentStub.prototype.finishSetsettingsFailure = function()
+{
+	if($type(this.onSetsettingsFailure)=="function")
+	{
+		var callback = this.onSetsettingsFailure;
+		this.onSetsettingsFailure = null;
+		callback();
+	}
+}
+
+rTorrentStub.prototype.finishSocketRestore = function()
+{
+	if($type(this.onSocketRestoreFinished)=="function")
+	{
+		var callback = this.onSocketRestoreFinished;
+		this.onSocketRestoreFinished = null;
+		callback();
+	}
+}
+
+rTorrentStub.prototype.finishXMLFailure = function()
+{
+	if($type(this.onXMLFailure)=="function")
+	{
+		var callback = this.onXMLFailure;
+		this.onXMLFailure = null;
+		callback();
+	}
+}
+
+rTorrentStub.prototype.finishIndeterminateFailure = function()
+{
+	if($type(this.onIndeterminateFailure)=="function")
+	{
+		var callback = this.onIndeterminateFailure;
+		this.onIndeterminateFailure = null;
+		callback();
+		return(true);
+	}
+	return(false);
+}
+
+rTorrentStub.prototype.setsettingsParseXML = function(xml)
+{
+	if(this.socketAllocCategories)
+	{
+		var categories = this.socketAllocCategories;
+		if(!this.savedSocketAlloc)
+		{
+			var values = this.getXMLValues(xml, 2, 1)[0];
+			if(values && (values.length>=2*categories.length))
+			{
+				var bounds = values.slice(0,2*categories.length);
+				if(!bounds.some(function(bound) { return(!(/^\d+$/).test(bound)); }))
+					this.savedSocketAlloc = bounds;
+			}
+		}
+		if(this.isError())
+		{
+			// A restore is asynchronous; complete failure recovery only after its
+			// response so this WebUI cannot start another Save against stale bounds.
+			this.socketAllocCategories = null;
+			if(this.savedSocketAlloc)
+			{
+				var restore = "";
+				for(var i=0; i<categories.length; i++)
+					restore+=("&s="+categories[i]+"&v="+this.savedSocketAlloc[2*i]+","+this.savedSocketAlloc[2*i+1]);
+				var restoreStub = new rTorrentStub("?action=restoresocketalloc"+restore);
+				restoreStub.onSocketRestoreFinished = this.finishSetsettingsFailure.bind(this);
+				restoreStub.onIndeterminateFailure = this.finishIndeterminateFailure.bind(this);
+				restoreStub.onXMLFailure = restoreStub.finishSocketRestore.bind(restoreStub);
+				var finishRestoreError = function(status, text)
+				{
+					if($type(theWebUI.error)=="function")
+						theWebUI.error(status, text);
+					restoreStub.finishSocketRestore();
+				};
+				Ajax(restoreStub, true, restoreStub.finishSocketRestore.bind(restoreStub),
+					restoreStub.finishSocketRestore.bind(restoreStub), finishRestoreError);
+				return(xml);
+			}
+		}
+	}
+	if(this.isError())
+		this.finishSetsettingsFailure();
+	return(xml);
+}
+
+rTorrentStub.prototype.restoresocketallocParseXML = function(xml)
+{
+	this.finishSocketRestore();
+	return(xml);
+}
+
+rTorrentStub.prototype.restoresocketalloc = function()
+{
+	for(var i=0; i<this.ss.length; i++)
+	{
+		var bounds = this.vs[i].split(",");
+		var minCmd = new rXMLRPCCommand("system.sockets."+this.ss[i]+".min_alloc.set");
+		minCmd.addParameter("string",'');
+		minCmd.addParameter("i8",bounds[0]);
+		this.commands.push( minCmd );
+		var maxCmd = new rXMLRPCCommand("system.sockets."+this.ss[i]+".max_alloc.set");
+		maxCmd.addParameter("string",'');
+		maxCmd.addParameter("i8",bounds[1]);
+		this.commands.push( maxCmd );
+	}
+	this.commands.push( new rXMLRPCCommand("system.sockets.adjust_alloc") );
 }
 
 rTorrentStub.prototype.getsettings = function()
@@ -793,19 +923,35 @@ rTorrentStub.prototype.getResponse = function(data)
 		{
 			var names = data.getElementsByTagName('value');
 			this.faultString.push("XMLRPC Error: "+this.getXMLValue(names,2)+" ["+this.action+"]");
+			this.xmlRPCFault = true;
 		}
 		else
 		{
 			names = data.getElementsByTagName('name');
 			if(names)
+			{
+				var memberFaults = [];
 				for(var i=0; i<names.length; i++)
 					if(names[i].childNodes[0].data=="faultString")
 					{
 						var values = names[i].parentNode.getElementsByTagName('value');
-						this.faultString.push("XMLRPC Error: "+this.getXMLValue(values,0)+" ["+this.action+"]");
+						memberFaults.push(this.getXMLValue(values,0));
 					}
+				if((this.action=="setsettings") && memberFaults.length)
+				{
+					var message = memberFaults[0];
+					if(memberFaults.length>1)
+						message+=" ("+(memberFaults.length-1)+" additional member fault"+
+							((memberFaults.length>2) ? "s" : "")+")";
+					this.faultString.push("XMLRPC Error: "+message+" ["+this.action+"]");
+				}
+				else
+					for(var i=0; i<memberFaults.length; i++)
+						this.faultString.push("XMLRPC Error: "+memberFaults[i]+" ["+this.action+"]");
+			}
 		}
-		responseData = this.processAction('ParseXML', responseData);
+		if(!this.xmlRPCFault)
+			responseData = this.processAction('ParseXML', responseData);
 	}
 	if(!this.isError())
 		ret = this.processAction('Response', responseData);
@@ -1300,13 +1446,23 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout, partialD
 	{
 		Ajax_UpdateTime(jqXHR);
 
-		if(jqXHR.status == 401)	// auth/session expired -- re-authenticate instead of spamming parse errors
+		if((jqXHR.status == 401) && !stub.handleUnauthorizedAsError)
+			// Auth normally navigates globally. A request owning a terminal lock can
+			// opt into its scoped error callback so it can diagnose and release.
 		{
 			if(!theWebUI.authExpired)
 			{
 				theWebUI.authExpired = true;
 				window.location.reload();	// navigation -> auth layer redirects to login
 			}
+			stub = null;
+			return;
+		}
+		// A local timeout or status-zero transport failure cannot prove whether a
+		// settings write (or its restore) completed remotely. A scoped callback
+		// keeps that Save locked instead of treating the client timer as a barrier.
+		if(((jqXHR.status == 0) || (textStatus=="timeout")) && stub.finishIndeterminateFailure())
+		{
 			stub = null;
 			return;
 		}
@@ -1321,6 +1477,7 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout, partialD
 				response = errorThrown;
 			onError(status+" ["+textStatus+","+stub.action+"]",response);
 		}
+		stub.finishSetsettingsFailure();
 		stub = null; // Cleanup memory leak
 	});
 
@@ -1328,9 +1485,9 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout, partialD
 	{
 		Ajax_UpdateTime(jqXHR);
 
+		var responseText = stub.getResponse(data);
 		stub.logErrorMessages();
 		if(!stub.isError()) {
-			var responseText = stub.getResponse(data);
 			if (partialData) {
 				if (responseText instanceof Object && !(responseText instanceof XMLDocument)) {
 					// merge responses for this.hashes with previous partialData
@@ -1361,6 +1518,12 @@ function Ajax(URI, isASync, onComplete, onTimeout, onError, reqTimeout, partialD
 				}
 			}
 			responseText = null; // Cleanup memory leak
+		}
+		else
+		{
+			if(stub.xmlRPCFault)
+				stub.finishSetsettingsFailure();
+			stub.finishXMLFailure();
 		}
 		stub = null; // Cleanup memory leak
 	});

--- a/js/webui.js
+++ b/js/webui.js
@@ -782,6 +782,7 @@ var theWebUI = {
 		var needResize = false;
 		let needCatListSync = false;
 		var reply = null;
+		var pendingRTorrentSettings = {};
 		var emptyLimitLeavesUnchanged = {
 			max_uploads_global: true,
 			max_downloads_global: true,
@@ -808,9 +809,9 @@ var theWebUI = {
 				}
 				if(nv!=v)
 				{
-					theWebUI.settings[i] = nv;
 					if((/^webui\./).test(i))
 					{
+						theWebUI.settings[i] = nv;
 						needSave = true;
 						switch(i) {
 						        case "webui.effects":
@@ -893,6 +894,9 @@ var theWebUI = {
 					}
 					else
 					{
+						// Keep the read-back model at daemon-confirmed values until the
+						// entire rTorrent batch passes local preflight and is actually sent.
+						pendingRTorrentSettings[i] = nv;
 						// A number input is a numeric setting whether or not it also
 						// carries the legacy "num" class, and the prefix decides both
 						// the cast in action.php and which settings take the socket
@@ -914,6 +918,7 @@ var theWebUI = {
 		if((req.length>0) && theWebUI.systemInfo.rTorrent.started &&
 			this.socketAllocationAccepted())
 		{
+			$.each(pendingRTorrentSettings, function(i,v) { theWebUI.settings[i] = v; });
 			this.settingsSavePending = true;
 			this.setSettingsSaveButtons(true);
 			this.deferredSettingsSave = needSave ? { reply: reply } : null;

--- a/js/webui.js
+++ b/js/webui.js
@@ -739,8 +739,12 @@ var theWebUI = {
 		if(!filesField.length || !httpField.length)
 			return(true);
 
-		var files = iv(filesField.val());
-		var http = iv(httpField.val());
+		// A cleared numeric field means "leave unchanged". Validate the last
+		// known value so another setting can still be saved in the same pass.
+		var filesValue = filesField.val();
+		var httpValue = httpField.val();
+		var files = iv(filesValue==="" ? this.settings.max_open_files : filesValue);
+		var http = iv(httpValue==="" ? this.settings.max_open_http : httpValue);
 		var filesMin = this.socketAllocLimit('socketFilesAllocMin');
 		var filesMax = this.socketAllocLimit('socketFilesAllocMax');
 		var httpMax = this.socketAllocLimit('socketHttpAllocMax');
@@ -778,11 +782,23 @@ var theWebUI = {
 		var needResize = false;
 		let needCatListSync = false;
 		var reply = null;
+		var emptyLimitLeavesUnchanged = {
+			max_uploads_global: true,
+			max_downloads_global: true,
+			max_memory_usage: true,
+			max_open_files: true,
+			max_open_http: true
+		};
 		$.each(this.settings, function(i,v) {
 			var o = $$(i);
 			if (o) {
 				o = $(o);
+				var numericInput = o.hasClass("num") || o.is("input[type=number]");
 				var nv = o.is("input:checkbox") ? (o.prop('checked') ? 1 : 0) : o.val();
+				// Clearing one of these five rTorrent limits is not an instruction to
+				// write zero. Other numeric inputs may use empty as a real UI sentinel.
+				if(nv==="" && emptyLimitLeavesUnchanged[i]===true)
+					return;
 				switch(i) {
 					case "max_memory_usage":
 						nv *= 1024;  // falls through
@@ -881,8 +897,7 @@ var theWebUI = {
 						// carries the legacy "num" class, and the prefix decides both
 						// the cast in action.php and which settings take the socket
 						// allocation path.
-						var k_type = o.is("input:checkbox") || o.is("select") || o.hasClass("num") ||
-							o.is("input[type=number]") ? "n" : "s";
+						var k_type = o.is("input:checkbox") || o.is("select") || numericInput ? "n" : "s";
 						req+=("&s="+k_type+i+"&v="+nv);
 					}
 				}
@@ -923,6 +938,7 @@ var theWebUI = {
 
 	releaseSettingsSave: function()
 	{
+		$("#settings_save_indeterminate").empty().hide();
 		this.settingsSavePending = false;
 		this.setSettingsSaveButtons(false);
 	},
@@ -932,7 +948,13 @@ var theWebUI = {
 		// Do not let a deferred reload erase the only same-document lock while the
 		// server may still be applying the write or its restore.
 		this.deferredSettingsSave = null;
-		noty("Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds.","error");
+		var message = theUILang.Settings_save_indeterminate;
+		var persistent = $("#settings_save_indeterminate");
+		if(!persistent.length)
+			persistent = $("<div>").attr({id:"settings_save_indeterminate",role:"alert","aria-live":"assertive"})
+				.addClass("alert alert-danger").insertBefore("#st_btns");
+		persistent.text(message).show();
+		noty(message,"error");
 	},
 
 	setSettingsSaveButtons: function(disabled)

--- a/js/webui.js
+++ b/js/webui.js
@@ -769,6 +769,10 @@ var theWebUI = {
 	},
 
 	setSettings: function() {
+		// Serialize only this browser's Save/restore/refresh chain. rTorrent does
+		// not provide a transaction boundary against another client.
+		if(this.settingsSavePending)
+			return;
 		var req = '';
 		var needSave = false;
 		var needResize = false;
@@ -894,9 +898,61 @@ var theWebUI = {
 			this.resize();
 		if((req.length>0) && theWebUI.systemInfo.rTorrent.started &&
 			this.socketAllocationAccepted())
-			this.request("?action=setsettings" + req,null,true);
-		if(needSave)
+		{
+			this.settingsSavePending = true;
+			this.setSettingsSaveButtons(true);
+			this.deferredSettingsSave = needSave ? { reply: reply } : null;
+			var request = new rTorrentStub(this.url + "?action=setsettings" + req);
+			request.onSetsettingsFailure = function() { theWebUI.refreshSettingsAfterFailedSave(); };
+			request.onIndeterminateFailure = function() { theWebUI.finishSettingsSaveIndeterminate(); };
+			this.request(request,[this.finishSettingsSave, this],true);
+		}
+		else if(needSave)
 			this.save(reply);
+	},
+
+	finishSettingsSave: function()
+	{
+		var deferredSave = this.deferredSettingsSave;
+		this.deferredSettingsSave = null;
+		if(deferredSave)
+			this.save(deferredSave.reply, this.releaseSettingsSave.bind(this));
+		else
+			this.releaseSettingsSave();
+	},
+
+	releaseSettingsSave: function()
+	{
+		this.settingsSavePending = false;
+		this.setSettingsSaveButtons(false);
+	},
+
+	finishSettingsSaveIndeterminate: function()
+	{
+		// Do not let a deferred reload erase the only same-document lock while the
+		// server may still be applying the write or its restore.
+		this.deferredSettingsSave = null;
+		noty("Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds.","error");
+	},
+
+	setSettingsSaveButtons: function(disabled)
+	{
+		$("#st_btns").find("button").not(".Cancel").prop("disabled", disabled);
+	},
+
+	refreshSettingsAfterFailedSave: function()
+	{
+		var request = new rTorrentStub(this.url + "?action=getsettings");
+		request.onXMLFailure = this.finishSettingsSave.bind(this);
+		this.requestWithTimeout(request, [this.finishSettingsRefresh, this],
+			function() { theWebUI.timeout(); theWebUI.finishSettingsSave(); },
+			function(status, text) { theWebUI.error(status, text); theWebUI.finishSettingsSave(); }, true);
+	},
+
+	finishSettingsRefresh: function(data)
+	{
+		this.addSettings(data);
+		this.finishSettingsSave();
 	},
 
    	reload: function()
@@ -924,10 +980,14 @@ var theWebUI = {
 		theDialogManager.show("stg");
 	},
 
-        save: function(reply)
+	save: function(reply, onTerminal)
 	{
-	        if(!theWebUI.configured)
+		if(!theWebUI.configured)
+		{
+			if(onTerminal)
+				onTerminal();
 			return;
+		}
 	        $.each(theWebUI.tables, function(ndx,table)
 		{
 	   		var width = [];
@@ -955,7 +1015,27 @@ var theWebUI = {
 				cookie[i] = v;
 		}
 		// We must encode the URL here to avoid injection with the "&" symbol from search results
-		theWebUI.request("?action=setuisettings&v=" + encodeURIComponent(JSON.stringify(cookie)), reply);
+		var query = "?action=setuisettings&v=" + encodeURIComponent(JSON.stringify(cookie));
+		if(onTerminal)
+		{
+			var finished = false;
+			var finish = function()
+			{
+				if(!finished)
+				{
+					finished = true;
+					onTerminal();
+				}
+			};
+			var request = new rTorrentStub(theWebUI.url + query);
+			request.handleUnauthorizedAsError = true;
+			theWebUI.requestWithTimeout(request,
+				function(data) { try { if(reply) reply(data); } finally { finish(); } },
+				function() { try { theWebUI.timeout(); } finally { finish(); } },
+				function(status, text) { try { theWebUI.error(status, text); } finally { finish(); } });
+		}
+		else
+			theWebUI.request(query, reply);
 	},
 
 //
@@ -2512,7 +2592,7 @@ var theWebUI = {
 	},
 
 	requestWithTimeout: function(qs, onComplite, onTimeout, onError, isASync) {
-		Ajax(this.url + qs, isASync, onComplite, onTimeout, onError, this.settings["webui.reqtimeout"]);
+		Ajax(qs instanceof rTorrentStub ? qs : this.url + qs, isASync, onComplite, onTimeout, onError, this.settings["webui.reqtimeout"]);
 	},
 
 	requestWithoutTimeout: function(qs, onComplite, isASync) {

--- a/lang/bn.js
+++ b/lang/bn.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "টরেন্ট (গুলি)",
  copyToClipboardFailed		: "কপি ফাংশন আপনার ব্রাউজারে কাজ করছে না।\nদয়া করে এই কন্টেন্টটি ম্যানুয়ালি কপি করুন:\n\n",
  copyToClipboardSuccess		: "সফলভাবে ক্লিপবোর্ডে কপি করা হয়েছে!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/cs.js
+++ b/lang/cs.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/da.js
+++ b/lang/da.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/el.js
+++ b/lang/el.js
@@ -322,5 +322,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "Η λειτουργία αντιγραφής δεν λειτουργεί στον περιηγητή σας.\nΠαρακαλώ αντιγράψτε αυτό το περιεχόμενο χειροκίνητα:\n\n",
  copyToClipboardSuccess		: "Αντιγράφηκε με επιτυχία στο πρόχειρο!",
- normalizeTorrentName		: "Ταξινόμηση με χρήση κανονικοποιημένου ονόματος torrent και αναγνώριση ετικέτας ονόματος"
+ normalizeTorrentName		: "Ταξινόμηση με χρήση κανονικοποιημένου ονόματος torrent και αναγνώριση ετικέτας ονόματος",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -329,5 +329,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using the normalized torrent name and recognize the name label"
+ normalizeTorrentName		: "Sort using the normalized torrent name and recognize the name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/fi.js
+++ b/lang/fi.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "La fonction copier ne fonctionne pas dans votre navigateur.\nVeuillez copier ce contenu manuellement :\n\n",
  copyToClipboardSuccess		: "Copié dans le presse-papier avec succès !",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/hu.js
+++ b/lang/hu.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(ek)",
  copyToClipboardFailed		: "A másolás funkció nem működik a böngésződben.\nKérlek, másold le ezt a tartalmat kézzel:\n\n",
  copyToClipboardSuccess		: "Sikeresen átmásoltam a vágólapra!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/it.js
+++ b/lang/it.js
@@ -324,5 +324,6 @@ var theUILang =
  Torrents			: "Torrent",
  copyToClipboardFailed		: "La funzione copia non funziona nel tuo browser.\nCopia il contenuto manualmente:\n\n",
  copyToClipboardSuccess		: "Copiato con successo negli appunti!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -321,5 +321,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/lv.js
+++ b/lang/lv.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/no.js
+++ b/lang/no.js
@@ -322,5 +322,6 @@ var theUILang =
  Torrents			: "Torrent(er)",
  copyToClipboardFailed		: "Kopier-funksjonen virker ikke i nettleseren din.\nVennligst kopier dette innholdet manuelt:\n\n",
  copyToClipboardSuccess		: "Kopiert til utklippstavlen!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -324,5 +324,6 @@ var theUILang =
  Torrents			: "Torrent(y)",
  copyToClipboardFailed		: "Funkcja kopiowania nie działa w Twojej przeglądarce.\nSkopiuj tę zawartość ręcznie:\n\n",
  copyToClipboardSuccess		: "Pomyślnie skopiowano do schowka!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/pt-br.js
+++ b/lang/pt-br.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "A função de cópia não está funcionando no seu navegador.\nPor favor, copie este conteúdo manualmente:\n\n",
  copyToClipboardSuccess		: "Copiado para a área de transferência com sucesso!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/pt-pt.js
+++ b/lang/pt-pt.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "A função de cópia não está a funcionar no navegador.\nCopia este conteúdo manualmente:\n\n",
  copyToClipboardSuccess		: "Copiado para a área de transferência com sucesso!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Торренты",
  copyToClipboardFailed		: "Функция копирования не работает в вашем браузере.\nСкопируйте требуемое вручную.\n\n",
  copyToClipboardSuccess		: "Успешно скопировано!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Результат сохранения неизвестен. Сохранение заблокировано; перезагрузите страницу вручную только после восстановления ответа rTorrent."
 };

--- a/lang/sk.js
+++ b/lang/sk.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -321,5 +321,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -321,5 +321,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents: "Torrent",
  copyToClipboardFailed : "Tarayıcınızda kopyalama işlevi çalışmıyor.\nLütfen bunu kendiniz kopyalayın:\n\n",
  copyToClipboardSuccess : "Panoya başarıyla kopyalandı.",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/uk.js
+++ b/lang/uk.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Результат збереження невідомий. Збереження заблоковано; перезавантажте сторінку вручну лише після відновлення відповіді rTorrent."
 };

--- a/lang/vi.js
+++ b/lang/vi.js
@@ -321,5 +321,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -323,5 +323,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -321,5 +321,6 @@ var theUILang =
  Torrents			: "Torrent(s)",
  copyToClipboardFailed		: "The copy function isn't working in your browser.\nPlease copy this content manually:\n\n",
  copyToClipboardSuccess		: "Copied to clipboard successfully!",
- normalizeTorrentName		: "Sort using normalized torrent name and recognize name label"
+ normalizeTorrentName		: "Sort using normalized torrent name and recognize name label",
+ Settings_save_indeterminate	: "Settings outcome is unknown. Save remains locked; reload manually only after rTorrent responds."
 };

--- a/tests/js/lang.spec.js
+++ b/tests/js/lang.spec.js
@@ -86,6 +86,16 @@ describe("localization", () => {
     expect(unknown).toEqual([]);
   });
 
+  it("defines persistent settings-save recovery guidance in every core language", () => {
+    const missing = [];
+    for (const name of fs.readdirSync(path.join(ROOT, "lang"))) {
+      if (!name.endsWith(".js") || name === "langs.js") continue;
+      const value = keysOf([path.join(ROOT, "lang", name)]).Settings_save_indeterminate;
+      if (typeof value !== "string" || value.trim() === "") missing.push("lang/" + name);
+    }
+    expect(missing).toEqual([]);
+  });
+
   it("keeps every plugin translation to the keys that plugin's en.js defines", () => {
     const unknown = [];
     for (const file of pluginEn) {

--- a/tests/js/setsettings.spec.js
+++ b/tests/js/setsettings.spec.js
@@ -33,14 +33,18 @@ function commandsFor(query) {
   ]);
 }
 
-// rtorrent 0.16.19.
-const V_SOCKET_ALLOC = 0x1013;
+const V_SOCKET_ALLOC = [
+  ["0.16.19", 0x1013],
+  ["0.16.21", 0x1015],
+];
 
-describe("setsettings on rtorrent with adjustable socket allocation", () => {
-  beforeEach(() => loadUI(V_SOCKET_ALLOC));
+describe.each(V_SOCKET_ALLOC)("setsettings on rtorrent %s with adjustable socket allocation", (_name, iVersion) => {
+  beforeEach(() => loadUI(iVersion));
 
   it("sets both bounds and recomputes for max open files", () => {
     expect(commandsFor("?action=setsettings&s=nmax_open_files&v=20000")).toStrictEqual([
+      ["system.sockets.files.min_alloc"],
+      ["system.sockets.files.max_alloc"],
       ["system.sockets.files.min_alloc.set", "string:", "i8:20000"],
       ["system.sockets.files.max_alloc.set", "string:", "i8:20000"],
       ["system.sockets.adjust_alloc"],
@@ -49,6 +53,8 @@ describe("setsettings on rtorrent with adjustable socket allocation", () => {
 
   it("sets both bounds and recomputes for max open http", () => {
     expect(commandsFor("?action=setsettings&s=nmax_open_http&v=1024")).toStrictEqual([
+      ["system.sockets.http.min_alloc"],
+      ["system.sockets.http.max_alloc"],
       ["system.sockets.http.min_alloc.set", "string:", "i8:1024"],
       ["system.sockets.http.max_alloc.set", "string:", "i8:1024"],
       ["system.sockets.adjust_alloc"],
@@ -62,6 +68,10 @@ describe("setsettings on rtorrent with adjustable socket allocation", () => {
       "?action=setsettings&s=nmax_open_files&v=20000&s=nmax_open_http&v=1024"
     );
     expect(commands).toStrictEqual([
+      ["system.sockets.files.min_alloc"],
+      ["system.sockets.files.max_alloc"],
+      ["system.sockets.http.min_alloc"],
+      ["system.sockets.http.max_alloc"],
       ["system.sockets.files.min_alloc.set", "string:", "i8:20000"],
       ["system.sockets.files.max_alloc.set", "string:", "i8:20000"],
       ["system.sockets.http.min_alloc.set", "string:", "i8:1024"],
@@ -90,12 +100,969 @@ describe("setsettings on rtorrent with adjustable socket allocation", () => {
     expect(
       commandsFor("?action=setsettings&s=nmax_open_files&v=20000&s=nmax_uploads&v=50")
     ).toStrictEqual([
+      ["system.sockets.files.min_alloc"],
+      ["system.sockets.files.max_alloc"],
       ["system.sockets.files.min_alloc.set", "string:", "i8:20000"],
       ["system.sockets.files.max_alloc.set", "string:", "i8:20000"],
       ["throttle.max_uploads.set", "string:", "i8:50"],
       ["system.sockets.adjust_alloc"],
     ]);
   });
+});
+
+describe("direct setsettings refusal recovery", () => {
+  beforeEach(() => loadUI(V_SOCKET_ALLOC[0][1]));
+  afterEach(() => jest.restoreAllMocks());
+
+  function value(v) {
+    return `<value><array><data><value><i8>${v}</i8></value></data></array></value>`;
+  }
+
+  function fault(message) {
+    return (
+      "<value><struct>" +
+      "<member><name>faultCode</name><value><i4>-501</i4></value></member>" +
+      `<member><name>faultString</name><value><string>${message}</string></value></member>` +
+      "</struct></value>"
+    );
+  }
+
+  function multicallResponse(members) {
+    return new DOMParser().parseFromString(
+      '<?xml version="1.0"?><methodResponse><params><param><value><array><data>' +
+        members.join("") +
+        "</data></array></value></param></params></methodResponse>",
+      "text/xml"
+    );
+  }
+
+  it("writes zero for a cleared numeric setting but keeps a cleared string empty", () => {
+    expect(commandsFor("?action=setsettings&s=nmax_uploads_global&v=")).toStrictEqual([
+      ["throttle.max_uploads.global.set", "string:", "i8:0"],
+    ]);
+    expect(new rTorrentStub("?action=setsettings&s=nmax_uploads_global&v=").content).toContain("<i8>0</i8>");
+    expect(commandsFor("?action=setsettings&s=sdirectory&v=")).toStrictEqual([
+      ["directory.default.set", "string:", "string:"],
+    ]);
+  });
+
+  it("restores both socket categories once after a fault and keeps the snapshot across responses", () => {
+    const stub = new rTorrentStub(
+      "?action=setsettings&s=nmax_open_files&v=20000&s=nmax_open_http&v=1024"
+    );
+    const restoreCalls = [];
+    window.Ajax = jest.fn((uri, _async, complete) => {
+      restoreCalls.push(uri);
+      complete();
+    });
+    const afterFailure = jest.fn();
+    stub.onSetsettingsFailure = afterFailure;
+
+    stub.getResponse(multicallResponse([value(1024), value(4096), value(32), value(64)]));
+    expect(afterFailure).not.toHaveBeenCalled();
+    stub.getResponse(multicallResponse([value(0), value(0), value(0), value(0), fault("over budget")]));
+
+    expect(restoreCalls).toHaveLength(1);
+    expect(commandsFor(restoreCalls[0].URI)).toStrictEqual([
+      ["system.sockets.files.min_alloc.set", "string:", "i8:1024"],
+      ["system.sockets.files.max_alloc.set", "string:", "i8:4096"],
+      ["system.sockets.http.min_alloc.set", "string:", "i8:32"],
+      ["system.sockets.http.max_alloc.set", "string:", "i8:64"],
+      ["system.sockets.adjust_alloc"],
+    ]);
+    expect(afterFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invent a restore when a bound is faulted", () => {
+    const stub = new rTorrentStub("?action=setsettings&s=nmax_open_files&v=20000");
+    window.Ajax = jest.fn();
+    stub.getResponse(multicallResponse([
+      fault("missing min bound"), value(4096), value(0), value(0), fault("over budget"),
+    ]));
+    expect(window.Ajax).not.toHaveBeenCalled();
+  });
+
+  it("restores socket bounds when an unrelated batch member faults", () => {
+    const stub = new rTorrentStub(
+      "?action=setsettings&s=nmax_open_files&v=20000&s=nmax_uploads&v=50"
+    );
+    const restores = [];
+    window.Ajax = jest.fn((request, _async, complete) => {
+      restores.push(request);
+      complete();
+    });
+
+    stub.getResponse(multicallResponse([
+      value(1024), value(4096), value(0), value(0), fault("throttle refused"), value(0),
+    ]));
+
+    expect(restores).toHaveLength(1);
+    expect(commandsFor(restores[0].URI)).toStrictEqual([
+      ["system.sockets.files.min_alloc.set", "string:", "i8:1024"],
+      ["system.sockets.files.max_alloc.set", "string:", "i8:4096"],
+      ["system.sockets.adjust_alloc"],
+    ]);
+  });
+
+  it("parses a direct XML-RPC fault before showing its one diagnostic or running success", () => {
+    const deferred = $.Deferred();
+    const headers = { getResponseHeader: () => null };
+    jest.spyOn($, "ajax").mockReturnValue(deferred);
+    const notice = jest.spyOn(window, "noty").mockImplementation(() => {});
+    const success = jest.fn();
+
+    Ajax("?action=setsettings&s=nmax_uploads_global&v=1", true, success);
+    deferred.resolve(
+      new DOMParser().parseFromString(
+        "<methodResponse><fault><value><struct><member><name>faultCode</name><value><i4>-501</i4></value></member><member><name>faultString</name><value><string>denied</string></value></member></struct></value></fault></methodResponse>",
+        "text/xml"
+      ),
+      "success",
+      headers
+    );
+
+    expect(notice).toHaveBeenCalledTimes(1);
+    expect(notice).toHaveBeenCalledWith(expect.stringContaining("denied"), "error");
+    expect(success).not.toHaveBeenCalled();
+  });
+
+	it("reports one useful diagnostic for a setsettings batch with two faulted members", () => {
+    const deferred = $.Deferred();
+    const headers = { getResponseHeader: () => null };
+    jest.spyOn($, "ajax").mockReturnValue(deferred);
+    const notice = jest.spyOn(window, "noty").mockImplementation(() => {});
+
+    Ajax("?action=setsettings&s=nmax_uploads_global&v=1", true);
+    deferred.resolve(multicallResponse([fault("setter refused"), fault("allocation refused")]), "success", headers);
+
+    expect(notice).toHaveBeenCalledTimes(1);
+		expect(notice).toHaveBeenCalledWith(expect.stringContaining("setter refused"), "error");
+	});
+
+	it("keeps member diagnostics separate for other actions", () => {
+		const deferred = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		jest.spyOn($, "ajax").mockReturnValue(deferred);
+		const notice = jest.spyOn(window, "noty").mockImplementation(() => {});
+
+		Ajax("?action=getsettings", true);
+		deferred.resolve(multicallResponse([fault("first read refused"), fault("second read refused")]), "success", headers);
+
+		expect(notice).toHaveBeenCalledTimes(2);
+	});
+
+	it("waits for the direct restore response before completing failure recovery", () => {
+    const first = $.Deferred();
+    const restore = $.Deferred();
+    const headers = { getResponseHeader: () => null };
+    jest.spyOn($, "ajax").mockImplementationOnce(() => first).mockImplementationOnce(() => restore);
+    const recovered = jest.fn();
+    const stub = new rTorrentStub("?action=setsettings&s=nmax_open_files&v=20000");
+    stub.onSetsettingsFailure = recovered;
+
+    Ajax(stub, true);
+    first.resolve(
+      multicallResponse([value(1024), value(4096), value(0), value(0), fault("over budget")]),
+      "success",
+      headers
+    );
+    expect(recovered).not.toHaveBeenCalled();
+
+    restore.resolve(multicallResponse([value(0), value(0), value(0)]), "success", headers);
+    expect(recovered).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts reconciliation after the HTTP setsettings response fails", () => {
+    const request = $.Deferred();
+    jest.spyOn($, "ajax").mockReturnValue(request);
+    const recovered = jest.fn();
+    const stub = new rTorrentStub("?action=setsettings&s=nmax_open_files&v=20000");
+    stub.onSetsettingsFailure = recovered;
+
+    Ajax(stub, true);
+    request.reject({ status: 500, responseText: "rolled back", getResponseHeader: () => null }, "error", "error");
+
+    expect(recovered).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("the options save request", () => {
+	let optionsLoaded = false;
+	let restoreHttprpc = null;
+	afterEach(() => {
+		if (restoreHttprpc) {
+			restoreHttprpc();
+			restoreHttprpc = null;
+		}
+		jest.restoreAllMocks();
+	});
+
+	function loadSettingsUI() {
+    window.theUILang = new Proxy({}, { get: (_target, prop) => prop });
+    window.theFormatter = {};
+    window.TYPE_STRING = "string";
+    window.TYPE_NUMBER = "number";
+    window.TYPE_PROGRESS = "progress";
+    window.TYPE_PEERS = "peers";
+    window.TYPE_SEEDS = "seeds";
+    window.ALIGN_RIGHT = "right";
+    window.dxSTable = function () {};
+    window.rSpeedGraph = function () {};
+    window.Timer = function () {};
+    window.bootstrap = { Tab: { getOrCreateInstance: () => ({ show() {} }) } };
+    window.AvailableLanguages = { en: "English" };
+    window.GetActiveLanguage = () => "en";
+    document.body.innerHTML = '<div id="stg_c"><div class="list-group"></div><div id="st_btns"></div></div>';
+
+    for (const src of ["../js/common.js", "../js/webui.js", "../js/content.js", "../js/rtorrent.js"]) {
+      let code = readFileSync(src, { encoding: "utf-8" });
+      code = code.replace(/\n\$\(document\)\.ready\(function\(\)\n\{[\s\S]*?\n\}\);\s*$/, "");
+      const scriptEl = document.createElement("script");
+      scriptEl.textContent = code;
+      document.body.appendChild(scriptEl);
+    }
+    if (!optionsLoaded) {
+      const scriptEl = document.createElement("script");
+      scriptEl.textContent = readFileSync("../js/options.js", { encoding: "utf-8" }).replace(
+        /\n\$\(document\)\.ready\(function\(\)\n\{[\s\S]*?\n\}\);\s*$/,
+        ""
+      );
+      document.body.appendChild(scriptEl);
+      optionsLoaded = true;
+    }
+    theOptionsWindow.init();
+		theWebUI.systemInfo = { rTorrent: { apiVersion: 24, iVersion: V_SOCKET_ALLOC[0][1], started: true } };
+	}
+
+	function addSettingsSaveButton() {
+		const button = document.createElement("button");
+		button.textContent = "Save";
+		button.addEventListener("click", (event) => {
+			event.preventDefault();
+			event.stopPropagation();
+			theWebUI.setSettings();
+		});
+		document.querySelector("#st_btns").append(button);
+		return button;
+	}
+
+	function enableHttprpc() {
+		const descriptors = Object.getOwnPropertyDescriptors(rTorrentStub.prototype);
+		const mountPoint = theURLs.XMLRPCMountPoint;
+		const scriptEl = document.createElement("script");
+		scriptEl.textContent =
+			"(function () { var plugin = { enabled: true };\n" +
+			readFileSync("../plugins/httprpc/init.js", { encoding: "utf-8" }) +
+			"\n})();";
+		document.body.appendChild(scriptEl);
+		restoreHttprpc = () => {
+			for (const name of Object.getOwnPropertyNames(rTorrentStub.prototype)) {
+				if (!(name in descriptors))
+					delete rTorrentStub.prototype[name];
+			}
+			Object.defineProperties(rTorrentStub.prototype, descriptors);
+			theURLs.XMLRPCMountPoint = mountPoint;
+		};
+	}
+
+	function configureUISave() {
+		theWebUI.configured = true;
+		theWebUI.tables = {};
+		theWebUI.activeView = "all";
+	}
+
+	function value(v) {
+		return `<value><array><data><value><i8>${v}</i8></value></data></array></value>`;
+	}
+
+	function fault(message) {
+		return (
+			"<value><struct>" +
+			"<member><name>faultCode</name><value><i4>-501</i4></value></member>" +
+			`<member><name>faultString</name><value><string>${message}</string></value></member>` +
+			"</struct></value>"
+		);
+	}
+
+	function multicallResponse(members) {
+		return new DOMParser().parseFromString(
+			'<?xml version="1.0"?><methodResponse><params><param><value><array><data>' +
+				members.join("") +
+				"</data></array></value></param></params></methodResponse>",
+			"text/xml"
+		);
+	}
+
+	function topLevelFaultResponse(message) {
+		return new DOMParser().parseFromString(
+			"<methodResponse><fault><value><struct>" +
+			"<member><name>faultCode</name><value><i4>-501</i4></value></member>" +
+			`<member><name>faultString</name><value><string>${message}</string></value></member>` +
+			"</struct></value></fault></methodResponse>",
+			"text/xml"
+		);
+	}
+
+  it("marks every other-limiting input numeric before serializing it", () => {
+    loadSettingsUI();
+    const ids = [
+      "max_uploads_global",
+      "max_downloads_global",
+      "max_memory_usage",
+      "max_open_files",
+      "max_open_http",
+    ];
+    expect(ids.map((id) => $("#" + $.escapeSelector(id)).hasClass("num"))).toStrictEqual([
+      true, true, true, true, true,
+    ]);
+    theWebUI.settings = Object.fromEntries(ids.map((id) => [id, 1]));
+    ids.forEach((id) => $("#" + $.escapeSelector(id)).val("2"));
+    const requests = [];
+    theWebUI.request = function (request) { requests.push(request); };
+    theWebUI.setSettings();
+    expect(requests).toHaveLength(1);
+    expect(requests[0].ss.sort()).toStrictEqual(ids.map((id) => "n" + id).sort());
+  });
+
+	it("disables the real Save button until a failed direct save finishes reconciliation", () => {
+		loadSettingsUI();
+		theWebUI.settings = { max_open_files: 1024 };
+		$("#max_open_files").val("20000");
+		const save = addSettingsSaveButton();
+		const saveRequest = $.Deferred();
+		const restoreRequest = $.Deferred();
+		const refreshRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		const ajax = jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => saveRequest)
+			.mockImplementationOnce(() => restoreRequest)
+			.mockImplementationOnce(() => refreshRequest);
+		const notice = jest.spyOn(window, "noty").mockImplementation(() => {});
+
+		save.click();
+		expect(save.disabled).toBe(true);
+		expect(ajax).toHaveBeenCalledTimes(1);
+		$("#max_open_files").val("30000");
+		save.click();
+		expect(ajax).toHaveBeenCalledTimes(1);
+
+		saveRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), fault("over budget")]),
+			"success",
+			headers
+		);
+		expect(ajax).toHaveBeenCalledTimes(2);
+		expect(save.disabled).toBe(true);
+		restoreRequest.resolve(multicallResponse([value(0), value(0), value(0)]), "success", headers);
+		expect(ajax).toHaveBeenCalledTimes(3);
+
+		refreshRequest.resolve(multicallResponse([fault("getsettings refused")]), "success", headers);
+		expect(notice).toHaveBeenCalledWith(expect.stringContaining("getsettings refused"), "error");
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+	});
+
+	it("blocks repeated physical Save until the deferred reload-capable UI request settles", () => {
+		loadSettingsUI();
+		configureUISave();
+		theWebUI.settings = { max_open_files: 1024, "webui.normalize_torrent_name": 0 };
+		$("#max_open_files").val("20000");
+		$("#" + $.escapeSelector("webui.normalize_torrent_name")).prop("checked", true);
+		const save = addSettingsSaveButton();
+		const setsettingsRequest = $.Deferred();
+		const restoreRequest = $.Deferred();
+		const refreshRequest = $.Deferred();
+		const uiSaveRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		const ajax = jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => setsettingsRequest)
+			.mockImplementationOnce(() => restoreRequest)
+			.mockImplementationOnce(() => refreshRequest)
+			.mockImplementationOnce(() => uiSaveRequest);
+		const reloadStates = [];
+		const reload = jest.spyOn(theWebUI, "reload").mockImplementation(() => {
+			reloadStates.push({
+				pending: theWebUI.settingsSavePending,
+				disabled: save.disabled,
+			});
+		});
+		jest.spyOn(theWebUI, "addSettings").mockImplementation(() => {});
+
+		save.click();
+		expect(ajax).toHaveBeenCalledTimes(1);
+		expect(ajax.mock.calls[0][0].data).toContain("system.sockets.files.min_alloc");
+		expect(save.disabled).toBe(true);
+		expect(reload).not.toHaveBeenCalled();
+
+		setsettingsRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), fault("over budget")]),
+			"success",
+			headers
+		);
+		expect(ajax).toHaveBeenCalledTimes(2);
+		restoreRequest.resolve(multicallResponse([value(0), value(0), value(0)]), "success", headers);
+		expect(ajax).toHaveBeenCalledTimes(3);
+		expect(reload).not.toHaveBeenCalled();
+
+		refreshRequest.resolve(multicallResponse([value(0)]), "success", headers);
+		expect(theWebUI.settingsSavePending).toBe(true);
+		expect(save.disabled).toBe(true);
+		expect(ajax).toHaveBeenCalledTimes(4);
+		expect(ajax.mock.calls[3][0].url).toBe(theURLs.SetSettingsURL);
+		expect(reload).not.toHaveBeenCalled();
+
+		$("#max_open_files").val("30000");
+		const reopenedSave = addSettingsSaveButton();
+		reopenedSave.click();
+		expect(ajax).toHaveBeenCalledTimes(4);
+
+		uiSaveRequest.resolve("", "success", headers);
+		expect(reload).toHaveBeenCalledTimes(1);
+		expect(reloadStates).toStrictEqual([{ pending: true, disabled: true }]);
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+		expect(reopenedSave.disabled).toBe(false);
+	});
+
+	it("releases the Save lock after a deferred reload callback throws", () => {
+		loadSettingsUI();
+		configureUISave();
+		theWebUI.settings = { max_open_files: 1024, "webui.normalize_torrent_name": 0 };
+		$("#max_open_files").val("20000");
+		$("#" + $.escapeSelector("webui.normalize_torrent_name")).prop("checked", true);
+		const save = addSettingsSaveButton();
+		const setsettingsRequest = $.Deferred();
+		const uiSaveRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => setsettingsRequest)
+			.mockImplementationOnce(() => uiSaveRequest);
+		jest.spyOn(theWebUI, "reload").mockImplementation(() => {
+			expect(theWebUI.settingsSavePending).toBe(true);
+			expect(save.disabled).toBe(true);
+			throw new Error("reload failed");
+		});
+
+		save.click();
+		setsettingsRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), value(0)]),
+			"success",
+			headers
+		);
+		expect(theWebUI.settingsSavePending).toBe(true);
+		expect(save.disabled).toBe(true);
+
+		expect(() => uiSaveRequest.resolve("", "success", headers)).toThrow("reload failed");
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+	});
+
+	it("releases the Save lock after a deferred non-reload success", () => {
+		loadSettingsUI();
+		configureUISave();
+		theWebUI.settings = { max_open_files: 1024, "webui.ignore_timeouts": 0 };
+		$("#max_open_files").val("20000");
+		$("#" + $.escapeSelector("webui.ignore_timeouts")).prop("checked", true);
+		const save = addSettingsSaveButton();
+		const setsettingsRequest = $.Deferred();
+		const uiSaveRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		const ajax = jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => setsettingsRequest)
+			.mockImplementationOnce(() => uiSaveRequest);
+		const reload = jest.spyOn(theWebUI, "reload").mockImplementation(() => {});
+
+		save.click();
+		setsettingsRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), value(0)]),
+			"success",
+			headers
+		);
+		expect(ajax).toHaveBeenCalledTimes(2);
+		expect(theWebUI.settingsSavePending).toBe(true);
+		expect(save.disabled).toBe(true);
+
+		uiSaveRequest.resolve("", "success", headers);
+		expect(reload).not.toHaveBeenCalled();
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+	});
+
+	it("releases without reload after a deferred UI HTTP error", () => {
+		loadSettingsUI();
+		configureUISave();
+		theWebUI.settings = { max_open_files: 1024, "webui.normalize_torrent_name": 0 };
+		$("#max_open_files").val("20000");
+		$("#" + $.escapeSelector("webui.normalize_torrent_name")).prop("checked", true);
+		const save = addSettingsSaveButton();
+		const setsettingsRequest = $.Deferred();
+		const uiSaveRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => setsettingsRequest)
+			.mockImplementationOnce(() => uiSaveRequest);
+		const diagnostic = jest.spyOn(theWebUI, "error").mockImplementation(() => {});
+		const reload = jest.spyOn(theWebUI, "reload").mockImplementation(() => {});
+
+		save.click();
+		setsettingsRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), value(0)]),
+			"success",
+			headers
+		);
+		expect(theWebUI.settingsSavePending).toBe(true);
+		expect(save.disabled).toBe(true);
+		uiSaveRequest.reject(
+			{ status: 500, responseText: "UI save refused", getResponseHeader: () => null },
+			"error",
+			"error"
+		);
+
+		expect(diagnostic).toHaveBeenCalledWith(expect.stringContaining("500"), "UI save refused");
+		expect(reload).not.toHaveBeenCalled();
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+	});
+
+	it("routes deferred UI HTTP 401 through one terminal error without reload", () => {
+		loadSettingsUI();
+		configureUISave();
+		theWebUI.authExpired = false;
+		theWebUI.settings = { max_open_files: 1024, "webui.normalize_torrent_name": 0 };
+		$("#max_open_files").val("20000");
+		$("#" + $.escapeSelector("webui.normalize_torrent_name")).prop("checked", true);
+		const save = addSettingsSaveButton();
+		const setsettingsRequest = $.Deferred();
+		const uiSaveRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		const ajax = jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => setsettingsRequest)
+			.mockImplementationOnce(() => uiSaveRequest);
+		const diagnostic = jest.spyOn(theWebUI, "error").mockImplementation(() => {});
+		const savedReload = jest.spyOn(theWebUI, "reload").mockImplementation(() => {});
+		jest.spyOn(console, "error").mockImplementation(() => {});
+
+		save.click();
+		setsettingsRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), value(0)]),
+			"success",
+			headers
+		);
+		expect(ajax).toHaveBeenCalledTimes(2);
+		expect(theWebUI.settingsSavePending).toBe(true);
+		expect(save.disabled).toBe(true);
+
+		uiSaveRequest.reject(
+			{ status: 401, responseText: "UI session expired", getResponseHeader: () => null },
+			"error",
+			"error"
+		);
+
+		expect(diagnostic).toHaveBeenCalledTimes(1);
+		expect(diagnostic).toHaveBeenCalledWith(expect.stringContaining("401"), "UI session expired");
+		expect(savedReload).not.toHaveBeenCalled();
+		expect(theWebUI.authExpired).toBe(false);
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+		expect(ajax).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps global auth handling for an unrelated HTTP 401 request", () => {
+		loadSettingsUI();
+		theWebUI.authExpired = false;
+		const request = $.Deferred();
+		const ajax = jest.spyOn($, "ajax").mockReturnValue(request);
+		const diagnostic = jest.spyOn(theWebUI, "error").mockImplementation(() => {});
+		jest.spyOn(console, "error").mockImplementation(() => {});
+
+		theWebUI.request("?action=getsettings");
+		request.reject(
+			{ status: 401, responseText: "session expired", getResponseHeader: () => null },
+			"error",
+			"error"
+		);
+
+		expect(ajax).toHaveBeenCalledTimes(1);
+		expect(theWebUI.authExpired).toBe(true);
+		expect(diagnostic).not.toHaveBeenCalled();
+	});
+
+	it("releases without reload after a deferred UI timeout", () => {
+		loadSettingsUI();
+		configureUISave();
+		theWebUI.settings = { max_open_files: 1024, "webui.normalize_torrent_name": 0 };
+		$("#max_open_files").val("20000");
+		$("#" + $.escapeSelector("webui.normalize_torrent_name")).prop("checked", true);
+		const save = addSettingsSaveButton();
+		const setsettingsRequest = $.Deferred();
+		const uiSaveRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => setsettingsRequest)
+			.mockImplementationOnce(() => uiSaveRequest);
+		const diagnostic = jest.spyOn(theWebUI, "timeout").mockImplementation(() => {});
+		const reload = jest.spyOn(theWebUI, "reload").mockImplementation(() => {});
+
+		save.click();
+		setsettingsRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), value(0)]),
+			"success",
+			headers
+		);
+		expect(theWebUI.settingsSavePending).toBe(true);
+		expect(save.disabled).toBe(true);
+		uiSaveRequest.reject(
+			{ status: 504, responseText: "UI save timed out", getResponseHeader: () => null },
+			"timeout",
+			"timeout"
+		);
+
+		expect(diagnostic).toHaveBeenCalledTimes(1);
+		expect(reload).not.toHaveBeenCalled();
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+	});
+
+	it("releases without reload after a deferred UI status-zero error", () => {
+		loadSettingsUI();
+		configureUISave();
+		theWebUI.settings = { max_open_files: 1024, "webui.normalize_torrent_name": 0 };
+		$("#max_open_files").val("20000");
+		$("#" + $.escapeSelector("webui.normalize_torrent_name")).prop("checked", true);
+		const save = addSettingsSaveButton();
+		const setsettingsRequest = $.Deferred();
+		const uiSaveRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => setsettingsRequest)
+			.mockImplementationOnce(() => uiSaveRequest);
+		const diagnostic = jest.spyOn(theWebUI, "error").mockImplementation(() => {});
+		const reload = jest.spyOn(theWebUI, "reload").mockImplementation(() => {});
+
+		save.click();
+		setsettingsRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), value(0)]),
+			"success",
+			headers
+		);
+		expect(theWebUI.settingsSavePending).toBe(true);
+		expect(save.disabled).toBe(true);
+		uiSaveRequest.reject(
+			{ status: 0, responseText: "", getResponseHeader: () => null },
+			"error",
+			"error"
+		);
+
+		expect(diagnostic).toHaveBeenCalledWith(expect.stringContaining("0"), "");
+		expect(reload).not.toHaveBeenCalled();
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+	});
+
+	it("releases when the deferred UI save is an early configured-false no-op", () => {
+		loadSettingsUI();
+		let pendingWhenConfiguredWasChecked = null;
+		Object.defineProperty(theWebUI, "configured", {
+			configurable: true,
+			get() {
+				pendingWhenConfiguredWasChecked = theWebUI.settingsSavePending;
+				return false;
+			},
+		});
+		theWebUI.settings = { max_open_files: 1024, "webui.normalize_torrent_name": 0 };
+		$("#max_open_files").val("20000");
+		$("#" + $.escapeSelector("webui.normalize_torrent_name")).prop("checked", true);
+		const save = addSettingsSaveButton();
+		const setsettingsRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		const ajax = jest.spyOn($, "ajax").mockReturnValue(setsettingsRequest);
+		const reload = jest.spyOn(theWebUI, "reload").mockImplementation(() => {});
+
+		save.click();
+		setsettingsRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), value(0)]),
+			"success",
+			headers
+		);
+
+		expect(ajax).toHaveBeenCalledTimes(1);
+		expect(pendingWhenConfiguredWasChecked).toBe(true);
+		expect(reload).not.toHaveBeenCalled();
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+	});
+
+	it("keeps a WebUI-only reload-capable save immediate", () => {
+		loadSettingsUI();
+		configureUISave();
+		theWebUI.settings = { "webui.normalize_torrent_name": 0 };
+		$("#" + $.escapeSelector("webui.normalize_torrent_name")).prop("checked", true);
+		const uiSaveRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		const ajax = jest.spyOn($, "ajax").mockReturnValue(uiSaveRequest);
+		const reload = jest.spyOn(theWebUI, "reload").mockImplementation(() => {});
+
+		theWebUI.setSettings();
+		expect(ajax).toHaveBeenCalledTimes(1);
+		expect(ajax.mock.calls[0][0].url).toBe(theURLs.SetSettingsURL);
+		expect(theWebUI.settingsSavePending).not.toBe(true);
+		expect(reload).not.toHaveBeenCalled();
+		uiSaveRequest.resolve("", "success", headers);
+		expect(reload).toHaveBeenCalledTimes(1);
+	});
+
+	it("fails closed when the initial setsettings outcome is indeterminate", () => {
+		loadSettingsUI();
+		configureUISave();
+		theWebUI.settings = { max_open_files: 1024, "webui.normalize_torrent_name": 0 };
+		$("#max_open_files").val("20000");
+		$("#" + $.escapeSelector("webui.normalize_torrent_name")).prop("checked", true);
+		const save = addSettingsSaveButton();
+		const setsettingsRequest = $.Deferred();
+		const ajax = jest.spyOn($, "ajax").mockReturnValue(setsettingsRequest);
+		const notice = jest.spyOn(window, "noty").mockImplementation(() => {});
+		const reload = jest.spyOn(theWebUI, "reload").mockImplementation(() => {});
+
+		save.click();
+		expect(ajax).toHaveBeenCalledTimes(1);
+		setsettingsRequest.reject(
+			{ status: 0, responseText: "", getResponseHeader: () => null },
+			"error",
+			"error"
+		);
+
+		expect(ajax).toHaveBeenCalledTimes(1);
+		expect(theWebUI.settingsSavePending).toBe(true);
+		expect(save.disabled).toBe(true);
+		expect(reload).not.toHaveBeenCalled();
+		expect(notice).toHaveBeenCalledTimes(1);
+		expect(notice).toHaveBeenCalledWith(expect.stringMatching(/outcome is unknown/i), "error");
+		expect(notice).toHaveBeenCalledWith(expect.stringMatching(/Save remains locked/), "error");
+		expect(notice).toHaveBeenCalledWith(expect.stringMatching(/reload.*after rTorrent responds/i), "error");
+	});
+
+	it("unlocks after getsettings returns an HTTP-200 XML-RPC fault", () => {
+		loadSettingsUI();
+		theWebUI.settings = { max_open_files: 1024 };
+		$("#max_open_files").val("20000");
+		const save = addSettingsSaveButton();
+		const saveRequest = $.Deferred();
+		const restoreRequest = $.Deferred();
+		const refreshRequest = $.Deferred();
+		const laterSaveRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		const ajax = jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => saveRequest)
+			.mockImplementationOnce(() => restoreRequest)
+			.mockImplementationOnce(() => refreshRequest)
+			.mockImplementationOnce(() => laterSaveRequest);
+		const notice = jest.spyOn(window, "noty").mockImplementation(() => {});
+
+		save.click();
+		saveRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), fault("over budget")]),
+			"success",
+			headers
+		);
+		restoreRequest.resolve(multicallResponse([value(0), value(0), value(0)]), "success", headers);
+		refreshRequest.resolve(
+			new DOMParser().parseFromString(
+				"<methodResponse><fault><value><struct>" +
+				"<member><name>faultCode</name><value><i4>-501</i4></value></member>" +
+				"<member><name>faultString</name><value><string>getsettings denied</string></value></member>" +
+				"</struct></value></fault></methodResponse>",
+				"text/xml"
+			),
+			"success",
+			headers
+		);
+
+		expect(notice).toHaveBeenCalledWith(expect.stringContaining("getsettings denied"), "error");
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+		$("#max_open_files").val("4096");
+		save.click();
+		expect(ajax).toHaveBeenCalledTimes(4);
+	});
+
+	it("fails closed when the direct restore outcome is indeterminate", () => {
+		loadSettingsUI();
+		configureUISave();
+		theWebUI.settings = { max_open_files: 1024, "webui.normalize_torrent_name": 0 };
+		$("#max_open_files").val("20000");
+		$("#" + $.escapeSelector("webui.normalize_torrent_name")).prop("checked", true);
+		const save = addSettingsSaveButton();
+		const saveRequest = $.Deferred();
+		const restoreRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		const ajax = jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => saveRequest)
+			.mockImplementationOnce(() => restoreRequest);
+		const notice = jest.spyOn(window, "noty").mockImplementation(() => {});
+		const reload = jest.spyOn(theWebUI, "reload").mockImplementation(() => {});
+
+		save.click();
+		saveRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), fault("over budget")]),
+			"success",
+			headers
+		);
+		restoreRequest.reject(
+			{ status: 0, responseText: "", getResponseHeader: () => null },
+			"timeout",
+			"timeout"
+		);
+		expect(ajax).toHaveBeenCalledTimes(2);
+		expect(theWebUI.settingsSavePending).toBe(true);
+		expect(save.disabled).toBe(true);
+		expect(reload).not.toHaveBeenCalled();
+		expect(notice.mock.calls.filter(([message]) => /outcome is unknown/i.test(message))).toHaveLength(1);
+		expect(notice).toHaveBeenCalledWith(expect.stringMatching(/Save remains locked/), "error");
+	});
+
+	it("reconciles once after a restore HTTP-200 XML-RPC fault and unlocks Save", () => {
+		loadSettingsUI();
+		theWebUI.settings = { max_open_files: 1024 };
+		$("#max_open_files").val("20000");
+		const save = addSettingsSaveButton();
+		const saveRequest = $.Deferred();
+		const restoreRequest = $.Deferred();
+		const refreshRequest = $.Deferred();
+		const laterSaveRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		const ajax = jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => saveRequest)
+			.mockImplementationOnce(() => restoreRequest)
+			.mockImplementationOnce(() => refreshRequest)
+			.mockImplementationOnce(() => laterSaveRequest);
+		const notice = jest.spyOn(window, "noty").mockImplementation(() => {});
+		const addSettings = jest.spyOn(theWebUI, "addSettings").mockImplementation(() => {});
+
+		save.click();
+		saveRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), fault("over budget")]),
+			"success",
+			headers
+		);
+		expect(save.disabled).toBe(true);
+		restoreRequest.resolve(topLevelFaultResponse("restore denied"), "success", headers);
+
+		expect(notice).toHaveBeenCalledTimes(2);
+		expect(notice).toHaveBeenCalledWith(expect.stringContaining("over budget"), "error");
+		expect(notice).toHaveBeenCalledWith(expect.stringContaining("restore denied"), "error");
+		expect(ajax).toHaveBeenCalledTimes(3);
+		expect(save.disabled).toBe(true);
+		refreshRequest.resolve(multicallResponse([value(0)]), "success", headers);
+		expect(addSettings).toHaveBeenCalledTimes(1);
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+		$("#max_open_files").val("4096");
+		save.click();
+		expect(ajax).toHaveBeenCalledTimes(4);
+	});
+
+	it("reports a definitive restore HTTP failure and reconciles once", () => {
+		loadSettingsUI();
+		theWebUI.settings = { max_open_files: 1024 };
+		$("#max_open_files").val("20000");
+		const save = addSettingsSaveButton();
+		const saveRequest = $.Deferred();
+		const restoreRequest = $.Deferred();
+		const refreshRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		const ajax = jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => saveRequest)
+			.mockImplementationOnce(() => restoreRequest)
+			.mockImplementationOnce(() => refreshRequest);
+		const notice = jest.spyOn(window, "noty").mockImplementation(() => {});
+		jest.spyOn(theWebUI, "addSettings").mockImplementation(() => {});
+
+		save.click();
+		saveRequest.resolve(
+			multicallResponse([value(1024), value(4096), value(0), value(0), fault("over budget")]),
+			"success",
+			headers
+		);
+		restoreRequest.reject(
+			{ status: 500, responseText: "restore refused", getResponseHeader: () => null },
+			"error",
+			"error"
+		);
+
+		expect(notice).toHaveBeenCalledWith(expect.stringContaining("restore refused"), "error");
+		expect(ajax).toHaveBeenCalledTimes(3);
+		expect(save.disabled).toBe(true);
+		refreshRequest.resolve(multicallResponse([value(0)]), "success", headers);
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+	});
+
+	it("uses enabled httprpc JSON forms and reconciles after a definitive HTTP refusal", () => {
+		loadSettingsUI();
+		enableHttprpc();
+		theWebUI.settings = { max_open_files: 1024 };
+		$("#max_open_files").val("20000");
+		const save = addSettingsSaveButton();
+		const setsettingsRequest = $.Deferred();
+		const refreshRequest = $.Deferred();
+		const headers = { getResponseHeader: () => null };
+		const ajax = jest.spyOn($, "ajax")
+			.mockImplementationOnce(() => setsettingsRequest)
+			.mockImplementationOnce(() => refreshRequest);
+		jest.spyOn(window, "noty").mockImplementation(() => {});
+		const addSettings = jest.spyOn(theWebUI, "addSettings").mockImplementation(() => {});
+
+		save.click();
+		expect(ajax).toHaveBeenCalledTimes(1);
+		const setsettingsOptions = ajax.mock.calls[0][0];
+		expect(setsettingsOptions.url).toBe("plugins/httprpc/action.php");
+		expect(setsettingsOptions.dataType).toBe("json");
+		expect(setsettingsOptions.contentType).toBe("application/x-www-form-urlencoded");
+		expect(new URLSearchParams(setsettingsOptions.data).get("mode")).toBe("setsettings");
+		expect(new URLSearchParams(setsettingsOptions.data).get("s")).toBe("nmax_open_files");
+
+		setsettingsRequest.reject(
+			{ status: 500, responseText: "allocation rejected after rollback", getResponseHeader: () => null },
+			"error",
+			"error"
+		);
+		expect(ajax).toHaveBeenCalledTimes(2);
+		const refreshOptions = ajax.mock.calls[1][0];
+		expect(refreshOptions.url).toBe("plugins/httprpc/action.php");
+		expect(refreshOptions.dataType).toBe("json");
+		expect(refreshOptions.contentType).toBe("application/x-www-form-urlencoded");
+		expect(new URLSearchParams(refreshOptions.data).get("mode")).toBe("stg");
+		expect(save.disabled).toBe(true);
+
+		refreshRequest.resolve([], "success", headers);
+		expect(addSettings).toHaveBeenCalledTimes(1);
+		expect(theWebUI.settingsSavePending).toBe(false);
+		expect(save.disabled).toBe(false);
+	});
+
+	it("keeps an enabled httprpc status-zero refusal indeterminate", () => {
+		loadSettingsUI();
+		enableHttprpc();
+		theWebUI.settings = { max_open_files: 1024 };
+		$("#max_open_files").val("20000");
+		const save = addSettingsSaveButton();
+		const setsettingsRequest = $.Deferred();
+		const ajax = jest.spyOn($, "ajax").mockReturnValue(setsettingsRequest);
+		const notice = jest.spyOn(window, "noty").mockImplementation(() => {});
+
+		save.click();
+		setsettingsRequest.reject(
+			{ status: 0, responseText: "", getResponseHeader: () => null },
+			"error",
+			"error"
+		);
+
+		expect(ajax).toHaveBeenCalledTimes(1);
+		expect(theWebUI.settingsSavePending).toBe(true);
+		expect(save.disabled).toBe(true);
+		expect(notice).toHaveBeenCalledTimes(1);
+		expect(notice).toHaveBeenCalledWith(expect.stringMatching(/outcome is unknown/i), "error");
+	});
 });
 
 describe("settings read-back", () => {

--- a/tests/js/setsettings.spec.js
+++ b/tests/js/setsettings.spec.js
@@ -505,6 +505,61 @@ describe("the options save request", () => {
 		expect(theWebUI.settings.max_uploads_global).toBe("2");
 	});
 
+	it("keeps a preflight-rejected rTorrent batch out of the accepted settings model", () => {
+		loadSettingsUI();
+		theWebUI.systemInfo.rTorrent.socketAllocBudget = 100;
+		theWebUI.systemInfo.rTorrent.socketFilesAllocMin = 8;
+		theWebUI.systemInfo.rTorrent.socketFilesAllocMax = 90;
+		theWebUI.systemInfo.rTorrent.socketHttpAllocMax = 90;
+		theWebUI.settings = {
+			max_open_files: 10,
+			max_open_http: 10,
+			max_uploads_global: 1,
+		};
+		$("#max_open_files").val("95");
+		$("#max_open_http").val("10");
+		$("#max_uploads_global").val("2");
+		const requests = [];
+		theWebUI.request = function (request) { requests.push(request); };
+
+		theWebUI.setSettings();
+
+		expect(requests).toHaveLength(0);
+		expect(theWebUI.settings.max_open_files).toBe(10);
+		expect(theWebUI.settings.max_open_http).toBe(10);
+		expect(theWebUI.settings.max_uploads_global).toBe(1);
+	});
+
+	it("uses the accepted daemon value after a rejected socket edit is cleared", () => {
+		loadSettingsUI();
+		theWebUI.systemInfo.rTorrent.socketAllocBudget = 100;
+		theWebUI.systemInfo.rTorrent.socketFilesAllocMin = 8;
+		theWebUI.systemInfo.rTorrent.socketFilesAllocMax = 90;
+		theWebUI.systemInfo.rTorrent.socketHttpAllocMax = 90;
+		theWebUI.settings = {
+			max_open_files: 10,
+			max_open_http: 10,
+			max_uploads_global: 1,
+		};
+		$("#max_open_files").val("95");
+		$("#max_open_http").val("10");
+		$("#max_uploads_global").val("1");
+		const requests = [];
+		theWebUI.request = function (request) { requests.push(request); };
+
+		theWebUI.setSettings();
+		expect(requests).toHaveLength(0);
+
+		$("#max_open_files").val("");
+		$("#max_uploads_global").val("2");
+		theWebUI.setSettings();
+
+		expect(requests).toHaveLength(1);
+		expect(requests[0].ss).toStrictEqual(["nmax_uploads_global"]);
+		expect(theWebUI.settings.max_open_files).toBe(10);
+		expect(theWebUI.settings.max_uploads_global).toBe("2");
+	});
+
 	it("keeps an explicitly typed zero as a numeric write", () => {
 		loadSettingsUI();
 		theWebUI.settings = { max_uploads_global: 1 };

--- a/tests/js/setsettings.spec.js
+++ b/tests/js/setsettings.spec.js
@@ -136,11 +136,12 @@ describe("direct setsettings refusal recovery", () => {
     );
   }
 
-  it("writes zero for a cleared numeric setting but keeps a cleared string empty", () => {
+  it("does not silently rewrite an unexpected empty numeric request to zero", () => {
     expect(commandsFor("?action=setsettings&s=nmax_uploads_global&v=")).toStrictEqual([
-      ["throttle.max_uploads.global.set", "string:", "i8:0"],
+      ["throttle.max_uploads.global.set", "string:", "i8:"],
     ]);
-    expect(new rTorrentStub("?action=setsettings&s=nmax_uploads_global&v=").content).toContain("<i8>0</i8>");
+    expect(new rTorrentStub("?action=setsettings&s=nmax_uploads_global&v=").content).toContain("<i8></i8>");
+    expect(new rTorrentStub("?action=setsettings&s=nmax_uploads_global&v=").content).not.toContain("<i8>0</i8>");
     expect(commandsFor("?action=setsettings&s=sdirectory&v=")).toStrictEqual([
       ["directory.default.set", "string:", "string:"],
     ]);
@@ -298,7 +299,10 @@ describe("the options save request", () => {
 	});
 
 	function loadSettingsUI() {
-    window.theUILang = new Proxy({}, { get: (_target, prop) => prop });
+    window.theUILang = new Proxy(
+      { Settings_save_indeterminate: "Localized persistent settings recovery guidance" },
+      { get: (target, prop) => target[prop] ?? prop }
+    );
     window.theFormatter = {};
     window.TYPE_STRING = "string";
     window.TYPE_NUMBER = "number";
@@ -423,6 +427,112 @@ describe("the options save request", () => {
     expect(requests).toHaveLength(1);
     expect(requests[0].ss.sort()).toStrictEqual(ids.map((id) => "n" + id).sort());
   });
+
+	it("leaves all five cleared numeric settings unchanged", () => {
+		loadSettingsUI();
+		const previous = {
+			max_uploads_global: 10,
+			max_downloads_global: 20,
+			max_memory_usage: 30 * 1024 * 1024,
+			max_open_files: 40,
+			max_open_http: 50,
+		};
+		theWebUI.settings = { ...previous };
+		Object.keys(previous).forEach((id) => $("#" + $.escapeSelector(id)).val(""));
+		const requests = [];
+		theWebUI.request = function (request) { requests.push(request); };
+
+		theWebUI.setSettings();
+
+		expect(requests).toHaveLength(0);
+		expect(theWebUI.settings).toStrictEqual(previous);
+	});
+
+	it.each([
+		"max_uploads_global",
+		"max_downloads_global",
+		"max_memory_usage",
+		"max_open_files",
+		"max_open_http",
+	])("leaves one cleared %s unchanged while saving a numeric sibling", (cleared) => {
+		loadSettingsUI();
+		const previous = {
+			max_uploads_global: 10,
+			max_downloads_global: 20,
+			max_memory_usage: 30 * 1024 * 1024,
+			max_open_files: 40,
+			max_open_http: 50,
+		};
+		const displayed = { ...previous, max_memory_usage: 30 };
+		theWebUI.settings = { ...previous };
+		Object.entries(displayed).forEach(([id, value]) =>
+			$("#" + $.escapeSelector(id)).val(String(value)));
+		const changed = cleared === "max_uploads_global" ? "max_downloads_global" : "max_uploads_global";
+		$("#" + $.escapeSelector(cleared)).val("");
+		$("#" + $.escapeSelector(changed)).val(String(displayed[changed] + 1));
+		const requests = [];
+		theWebUI.request = function (request) { requests.push(request); };
+
+		theWebUI.setSettings();
+
+		expect(requests).toHaveLength(1);
+		expect(requests[0].ss).toStrictEqual(["n" + changed]);
+		expect(theWebUI.settings[cleared]).toBe(previous[cleared]);
+	});
+
+	it("skips a cleared socket field while saving a changed numeric sibling", () => {
+		loadSettingsUI();
+		theWebUI.systemInfo.rTorrent.socketAllocBudget = 100;
+		theWebUI.systemInfo.rTorrent.socketFilesAllocMin = 8;
+		theWebUI.systemInfo.rTorrent.socketFilesAllocMax = 90;
+		theWebUI.systemInfo.rTorrent.socketHttpAllocMax = 90;
+		theWebUI.settings = {
+			max_open_files: 10,
+			max_open_http: 10,
+			max_uploads_global: 1,
+		};
+		$("#max_open_files").val("");
+		$("#max_open_http").val("10");
+		$("#max_uploads_global").val("2");
+		const requests = [];
+		theWebUI.request = function (request) { requests.push(request); };
+
+		theWebUI.setSettings();
+
+		expect(requests).toHaveLength(1);
+		expect(requests[0].ss).toStrictEqual(["nmax_uploads_global"]);
+		expect(theWebUI.settings.max_open_files).toBe(10);
+		expect(theWebUI.settings.max_uploads_global).toBe("2");
+	});
+
+	it("keeps an explicitly typed zero as a numeric write", () => {
+		loadSettingsUI();
+		theWebUI.settings = { max_uploads_global: 1 };
+		$("#max_uploads_global").val("0");
+		const requests = [];
+		theWebUI.request = function (request) { requests.push(request); };
+
+		theWebUI.setSettings();
+
+		expect(requests).toHaveLength(1);
+		expect(requests[0].ss).toStrictEqual(["nmax_uploads_global"]);
+		expect(requests[0].vs).toStrictEqual(["0"]);
+		expect(requests[0].content).toContain("<i8>0</i8>");
+	});
+
+	it("keeps an empty WebUI numeric sentinel so Default can be restored", () => {
+		loadSettingsUI();
+		const key = "webui.size_decimal_places.table.mb";
+		theWebUI.configured = true;
+		theWebUI.settings = { [key]: "2" };
+		$("#" + $.escapeSelector(key)).val("");
+		const save = jest.spyOn(theWebUI, "save").mockImplementation(() => {});
+
+		theWebUI.setSettings();
+
+		expect(theWebUI.settings[key]).toBe("");
+		expect(save).toHaveBeenCalledTimes(1);
+	});
 
 	it("disables the real Save button until a failed direct save finishes reconciliation", () => {
 		loadSettingsUI();
@@ -835,10 +945,18 @@ describe("the options save request", () => {
 		expect(theWebUI.settingsSavePending).toBe(true);
 		expect(save.disabled).toBe(true);
 		expect(reload).not.toHaveBeenCalled();
-		expect(notice).toHaveBeenCalledTimes(1);
-		expect(notice).toHaveBeenCalledWith(expect.stringMatching(/outcome is unknown/i), "error");
-		expect(notice).toHaveBeenCalledWith(expect.stringMatching(/Save remains locked/), "error");
-		expect(notice).toHaveBeenCalledWith(expect.stringMatching(/reload.*after rTorrent responds/i), "error");
+		const persistent = document.querySelector("#settings_save_indeterminate");
+		expect(persistent).not.toBeNull();
+		expect(persistent.getAttribute("role")).toBe("alert");
+		expect(persistent.getAttribute("aria-live")).toBe("assertive");
+		expect(persistent.textContent).toBe(theUILang.Settings_save_indeterminate);
+		expect(persistent.style.display).not.toBe("none");
+		$("#stg_c").hide().show();
+		expect(persistent.textContent).toBe(theUILang.Settings_save_indeterminate);
+		expect(save.disabled).toBe(true);
+		expect(notice.mock.calls.filter(([message]) =>
+			message === theUILang.Settings_save_indeterminate)).toHaveLength(1);
+		expect(notice).toHaveBeenCalledWith(theUILang.Settings_save_indeterminate, "error");
 	});
 
 	it("unlocks after getsettings returns an HTTP-200 XML-RPC fault", () => {
@@ -916,8 +1034,9 @@ describe("the options save request", () => {
 		expect(theWebUI.settingsSavePending).toBe(true);
 		expect(save.disabled).toBe(true);
 		expect(reload).not.toHaveBeenCalled();
-		expect(notice.mock.calls.filter(([message]) => /outcome is unknown/i.test(message))).toHaveLength(1);
-		expect(notice).toHaveBeenCalledWith(expect.stringMatching(/Save remains locked/), "error");
+		expect(notice.mock.calls.filter(([message]) =>
+			message === theUILang.Settings_save_indeterminate)).toHaveLength(1);
+		expect(notice).toHaveBeenCalledWith(theUILang.Settings_save_indeterminate, "error");
 	});
 
 	it("reconciles once after a restore HTTP-200 XML-RPC fault and unlocks Save", () => {
@@ -1040,6 +1159,29 @@ describe("the options save request", () => {
 		expect(save.disabled).toBe(false);
 	});
 
+	it("omits a cleared numeric field from an enabled httprpc request", () => {
+		loadSettingsUI();
+		enableHttprpc();
+		theWebUI.settings = {
+			max_open_files: 10,
+			max_open_http: 10,
+			max_uploads_global: 1,
+		};
+		$("#max_open_files").val("");
+		$("#max_open_http").val("10");
+		$("#max_uploads_global").val("2");
+		const requests = [];
+		theWebUI.request = function (request) { requests.push(request); };
+
+		theWebUI.setSettings();
+
+		expect(requests).toHaveLength(1);
+		const params = new URLSearchParams(requests[0].content);
+		expect(params.get("mode")).toBe("setsettings");
+		expect(params.getAll("s")).toStrictEqual(["nmax_uploads_global"]);
+		expect(params.getAll("v")).toStrictEqual(["2"]);
+	});
+
 	it("keeps an enabled httprpc status-zero refusal indeterminate", () => {
 		loadSettingsUI();
 		enableHttprpc();
@@ -1061,7 +1203,7 @@ describe("the options save request", () => {
 		expect(theWebUI.settingsSavePending).toBe(true);
 		expect(save.disabled).toBe(true);
 		expect(notice).toHaveBeenCalledTimes(1);
-		expect(notice).toHaveBeenCalledWith(expect.stringMatching(/outcome is unknown/i), "error");
+		expect(notice).toHaveBeenCalledWith(theUILang.Settings_save_indeterminate, "error");
 	});
 });
 


### PR DESCRIPTION
## Summary

- Treat the five “Other Limiting” fields as numeric rTorrent settings.
- Treat a cleared field as “leave unchanged” while preserving an explicitly entered `0`.
- Keep values rejected by local socket preflight out of the client-side settings model.
- Snapshot active socket allocation bounds before direct XML-RPC writes and restore them if a settings batch fails.
- Re-read effective settings after definitive failures.
- Serialize Save, rollback, reconciliation, and deferred WebUI persistence so repeated saves cannot overlap.
- Keep indeterminate saves locked and show persistent localized recovery guidance.

## Why

rTorrent XML-RPC multicalls are not transactional. A later command can fail after earlier socket-bound writes have already succeeded, leaving partially changed or staged allocation values.

The previous browser flow could also allow another Save while rollback, settings reconciliation, or WebUI persistence was still running. In addition, a locally rejected socket value could enter the client-side model even though it was never sent to rTorrent, causing a later cleared field to reuse the rejected value and block an otherwise valid sibling change.

This PR restores the original socket bounds after definitive direct XML-RPC failures, reconciles the UI with the effective daemon state, and keeps the Save operation serialized through its terminal result. A timeout or status-zero result remains fail-closed because the client cannot know whether the remote write completed.

## Verification

- Focused settings review: 60/60 passed.
- Full Jest suite: 276/276 passed.
- ESLint, JavaScript syntax checks, and `git diff --check` passed.
- Direct XML-RPC success, failure, and restore were verified with disposable rTorrent 0.16.21.
- Enabled httprpc success and server-side rollback were verified in the same container runtime.
- The branch merges cleanly with current upstream `master`.
- Independent full-range review: APPROVED, no findings.