### PR TITLE
Avoid probing binary torrent data as filesystem paths

### DIFF
--- a/php/Torrent.php
+++ b/php/Torrent.php
@@ -283,11 +283,17 @@ class Torrent
 		return true;
 	}
 
+	/** Binary bencode strings can contain NUL and are never filesystem paths. */
+	static private function isPathCandidate( $value )
+	{
+		return is_string( $value ) && strpos( $value, "\0" ) === false;
+	}
+
 	/**** Decode BitTorrent ****/
 
 	public function decode( $string )
 	{
-		if(is_file( $string ))
+		if(self::isPathCandidate( $string ) && is_file( $string ))
 		{
 			$this->data = file_get_contents( $string );
 			$this->filename = $string;
@@ -540,12 +546,12 @@ class Torrent
 			$this->info = $this->files( $data, $piece_length );
 	        	return(true);
 		}
-		if( is_dir( $data ) )
+		if( self::isPathCandidate( $data ) && is_dir( $data ) )
 		{
 			$this->info = $this->folder( $data, $piece_length );
 			return(true);
 		}
-        	if( is_file( $data ) && (pathinfo( $data, PATHINFO_EXTENSION ) != 'torrent') )
+		if( self::isPathCandidate( $data ) && is_file( $data ) && (pathinfo( $data, PATHINFO_EXTENSION ) != 'torrent') )
 		{
 			$this->info = $this->file( $data, $piece_length );
 			return(true);

--- a/tests/php/TorrentMetaTest.php
+++ b/tests/php/TorrentMetaTest.php
@@ -112,6 +112,33 @@ class TorrentMetaTest extends TestCase
 			'A parsed torrent re-encodes to the bytes it was read from');
 	}
 
+	public function testBinaryMetainfoIsNotProbedAsAFilesystemPath()
+	{
+		$pieces = str_repeat("\0", 20);
+		$raw = 'd4:infod6:lengthi1e4:name8:seed.bin12:piece lengthi16384e6:pieces20:'
+			. $pieces . 'ee';
+		$warnings = array();
+		set_error_handler(function($severity, $message) use (&$warnings) {
+			if($severity === E_WARNING)
+				$warnings[] = $message;
+			return true;
+		});
+		try
+		{
+			$torrent = new Torrent($raw);
+		}
+		finally
+		{
+			restore_error_handler();
+		}
+
+		$this->assertEquals(array(), $warnings,
+			'Binary metainfo bytes are not passed to filesystem path probes');
+		$this->assertTrue($torrent->errors() === false, 'Binary metainfo parses without errors');
+		$this->assertTrue($torrent->info['pieces'] === $pieces,
+			'The binary pieces field is preserved byte for byte');
+	}
+
 	public function testGettersReadTheKeysThatAreNotIdentifiers()
 	{
 		$torrent = new Torrent($this->fixture());


### PR DESCRIPTION
## Summary

- Treat already-loaded `.torrent` contents containing NUL bytes as data, not as a possible filesystem path.
- Skip `is_dir()` and `is_file()` probes for such binary input.
- Add a regression test covering this behavior on PHP 7.4.

## Why this is needed

`Torrent::__construct()` accepts both a filesystem path and the bencoded contents of a `.torrent` file.

The `pieces` field contains binary SHA-1 data and may legally include NUL bytes. On PHP 7.4, passing that string to `is_dir()` or `is_file()` emits invalid-path warnings. With a strict error handler, a valid torrent may fail before decoding; displayed warnings may also corrupt the response.

## Before

```text
loaded .torrent contents
        ↓
is_dir() / is_file()
        ↓
PHP 7.4 warnings
        ↓
decoding may be interrupted
```

## After

```text
loaded .torrent contents
        ↓
contains NUL → cannot be a path
        ↓
skip filesystem probes
        ↓
decode normally
```

Ordinary filesystem-path handling remains unchanged.

## Tests

- PHP lint passed on PHP 7.4, 8.1, and 8.5.
- Focused torrent tests passed on all three versions: 32 methods, 145 assertions.
- Full PHP suite passed on all three versions: 48 files, 1,810 tests.