### PR TITLE
Test rTorrent 0.16.21 compatibility

### DIFF
--- a/tests/js/rtorrent.spec.js
+++ b/tests/js/rtorrent.spec.js
@@ -142,7 +142,7 @@ describe("xmlrpc calls", () => {
       expect(theRequestManager.map("port_open")).toBe("network.port_open");
     });
 
-    for (const version of [0x1012, 0x1013]) {
+    for (const version of [0x1012, 0x1013, 0x1015]) {
       withRtorrentVersion(version, () => {
         expect(theRequestManager.map("get_port_range")).toBe(
           "network.listen.port.range"
@@ -202,6 +202,11 @@ describe("xmlrpc calls", () => {
       );
     });
     withRtorrentVersion(0x1014, () => {
+      expect(theRequestManager.map("d.is_partially_done=")).toBe(
+        "d.is_partially_done="
+      );
+    });
+    withRtorrentVersion(0x1015, () => {
       expect(theRequestManager.map("d.is_partially_done=")).toBe(
         "d.is_partially_done="
       );

--- a/tests/php/RequirementsTest.php
+++ b/tests/php/RequirementsTest.php
@@ -10,7 +10,7 @@ class RequirementsTest extends TestCase
 {
 	public function testRtorrentSupportedVersions()
 	{
-		foreach (array('0.9.8', '0.9.8-1', '0.16.0', '0.16.14', '0.16.17', '0.16.19') as $v) {
+		foreach (array('0.9.8', '0.9.8-1', '0.16.0', '0.16.14', '0.16.17', '0.16.19', '0.16.21') as $v) {
 			list($ok, ) = Requirements::rtorrentSupport($v);
 			$this->assertTrue($ok, "rtorrent $v should be supported");
 		}

--- a/tests/php/RtorrentCompatibilityTest.php
+++ b/tests/php/RtorrentCompatibilityTest.php
@@ -184,7 +184,7 @@ class RtorrentCompatibilityTest extends TestCase
 			'set_port_open' => 'cat',
 			'port_open' => 'cat',
 		);
-		foreach (array(0x1012 => '0.16.18', 0x1013 => '0.16.19') as $version => $label) {
+		foreach (array(0x1012 => '0.16.18', 0x1013 => '0.16.19', 0x1015 => '0.16.21') as $version => $label) {
 			$settings = $this->makeSettings($version);
 			foreach ($canonicalAliases as $alias => $command) {
 				$this->assertEquals($command, $settings->getCommand($alias), 'rTorrent '.$label.' maps '.$alias.' to its canonical command');
@@ -200,7 +200,7 @@ class RtorrentCompatibilityTest extends TestCase
 		$this->assertEquals('cat', $settings->getCommand('d.is_partially_done'), 'rTorrent 0.8.9 answers the partially done question with the no-op cat');
 		$this->assertEquals('cat=', $settings->getCommand('d.is_partially_done='), 'the no-op keeps the trailing = so the multicall field stays in place');
 
-		foreach (array(0x900 => '0.9.0', 0x908 => '0.9.8', 0x1014 => '0.16.20') as $version => $label) {
+		foreach (array(0x900 => '0.9.0', 0x908 => '0.9.8', 0x1014 => '0.16.20', 0x1015 => '0.16.21') as $version => $label) {
 			$settings = $this->makeSettings($version);
 			$this->assertEquals('d.is_partially_done', $settings->getCommand('d.is_partially_done'), 'rTorrent '.$label.' asks the daemon directly');
 		}


### PR DESCRIPTION
## Summary

Add explicit rTorrent 0.16.21 coverage to the existing compatibility tests.

## Why this is needed

ruTorrent's runtime compatibility logic already supports rTorrent 0.16.21, but the tests covered only earlier releases explicitly. A future compatibility-table change could therefore break 0.16.21 aliases or version handling without a release-specific CI failure.

## Before

rTorrent 0.16.21 support was covered only implicitly by the surrounding version ranges.

## After

The test suite explicitly verifies that rTorrent 0.16.21:

- inherits the canonical port-command aliases;
- keeps `d.is_partially_done` as a direct command;
- satisfies the declared environment support policy.

No runtime behavior changes are included.

## Tests

- `npm test -- --runInBand js/rtorrent.spec.js` — 20/20 passed;
- focused `RequirementsTest` and `RtorrentCompatibilityTest` passed on PHP 7.4, 8.1, and 8.5;
- JavaScript/PHP syntax checks and `git diff --check` passed.