### PR TITLE
Harden FileUtil log paths and permission handling

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -36,7 +36,7 @@
 	$do_diagnostic = true;			// Diagnose ruTorrent. Recommended to keep enabled, unless otherwise required.
 	$al_diagnostic = true;			// Diagnose auto-loader. Set to "false" to make composer plugins work.
 
-	$log_file = $_ENV['RU_LOG_FILE'] ?? '/tmp/errors.log'; // path to log file (comment or leave blank to disable logging)
+	$log_file = $_ENV['RU_LOG_FILE'] ?? '/tmp/errors.log'; // absolute path or stream URI (comment or leave blank to disable logging)
 
 	$saveUploadedTorrents = true;		// Save uploaded torrents to profile/torrents directory or not
 	$overwriteUploadedTorrents = false;	// Overwrite existing uploaded torrents in profile/torrents directory or make unique name
@@ -84,7 +84,10 @@
     getenv("RU_LOCALHOSTS") && $localhosts[] = $_ENV['RU_LOCALHOSTS'];
 
 	$profilePath = $_ENV['RU_PROFILE_PATH'] ?? '../../share';		// Path to user profiles
-	$profileMask = $_ENV['RU_PROFILE_MASK'] ?? 0777;			// Mask for files and directory creation in user profiles.
+	// Environment values are strings; parse the documented octal notation before using it as a file mode.
+	// An unset, empty, or malformed RU_PROFILE_MASK uses the documented 0777 default.
+	$profileMask = $_ENV['RU_PROFILE_MASK'] ?? '';
+	$profileMask = preg_match('/^0?[0-7]{3}$/D', $profileMask) ? intval($profileMask, 8) : 0777;
 						// Both Webserver and rtorrent users must have read-write access to it.
 						// For example, if Webserver and rtorrent users are in the same group then the value may be 0770.
 

--- a/env_check.php
+++ b/env_check.php
@@ -86,7 +86,51 @@ class Requirements
 	public static function looksAbsolute($path)
 	{
 		if (!is_string($path) || $path === '') return false;
-		return $path[0] === '/' || (bool)preg_match('#^[A-Za-z]:[\\\\/]#', $path);
+		if ($path[0] === '/') return true;
+		return DIRECTORY_SEPARATOR === '\\' &&
+			((bool)preg_match('#^[A-Za-z]:[\\\\/]#', $path) || strncmp($path, '\\\\', 2) === 0);
+	}
+
+	public static function logFileStreamScheme($path)
+	{
+		if (!is_string($path) ||
+			!preg_match('/^([A-Za-z][A-Za-z0-9+.-]*):\/\//', $path, $matches)) return null;
+		return $matches[1];
+	}
+
+	public static function fileUriFilesystemPath($path)
+	{
+		$parts = parse_url($path);
+		if (!is_array($parts) || !isset($parts['scheme']) ||
+			strcasecmp($parts['scheme'], 'file') !== 0 || !isset($parts['path']) ||
+			isset($parts['user']) || isset($parts['pass']) || isset($parts['port']) ||
+			isset($parts['query']) || isset($parts['fragment'])) return null;
+		$host = isset($parts['host']) ? $parts['host'] : '';
+		if ($host === '' || strcasecmp($host, 'localhost') === 0) return $parts['path'];
+		return DIRECTORY_SEPARATOR === '\\'
+			? '\\\\' . $host . str_replace('/', '\\', $parts['path']) : null;
+	}
+
+	public static function logFilePathValid($path)
+	{
+		$scheme = self::logFileStreamScheme($path);
+		if ($scheme !== null && strcasecmp($scheme, 'file') === 0) {
+			$filesystemPath = self::fileUriFilesystemPath($path);
+			return $filesystemPath !== null && self::looksAbsolute($filesystemPath);
+		}
+		return self::looksAbsolute($path) || $scheme !== null;
+	}
+
+	public static function logFileStreamAvailable($path, $wrappers)
+	{
+		$scheme = self::logFileStreamScheme($path);
+		if ($scheme === null || !is_array($wrappers)) return false;
+		if (in_array($scheme, $wrappers, true)) return true;
+		// PHP's built-in wrappers are case-insensitive; user-registered wrappers are not.
+		$builtin = array('https', 'ftps', 'compress.zlib', 'php', 'file',
+			'glob', 'data', 'http', 'ftp', 'phar');
+		$lower = strtolower($scheme);
+		return in_array($lower, $builtin, true) && in_array($lower, $wrappers, true);
 	}
 }
 
@@ -185,8 +229,23 @@ if ($cfg === null) {
 		check('config', $ok, '$topDirectory', ($ok ? 'ok: ' : 'not an existing readable directory: ') . $cfg['topdir']);
 	}
 	if (!empty($cfg['log'])) {
-		$dir = dirname($cfg['log']);
-		check('config', @is_dir($dir) && @is_writable($dir), '$log_file writable', "log dir: $dir");
+		$scheme = Requirements::logFileStreamScheme($cfg['log']);
+		$isFileStream = $scheme !== null && strcasecmp($scheme, 'file') === 0;
+		$available = $scheme === null || Requirements::logFileStreamAvailable($cfg['log'], stream_get_wrappers());
+		if (!$available) {
+			check('config', false, '$log_file stream', "stream wrapper is not available: $scheme");
+		} elseif ($scheme !== null && !$isFileStream) {
+			check('config', null, '$log_file stream',
+				"registered $scheme wrapper; writability is checked on first write");
+		} else {
+			$path = $isFileStream ? Requirements::fileUriFilesystemPath($cfg['log']) : $cfg['log'];
+			$validPath = Requirements::logFilePathValid($cfg['log']);
+			$dir = $validPath ? dirname($path) : null;
+			$ok = $validPath && @is_dir($dir) && @is_writable($dir);
+			$detail = $validPath ? "log dir: $dir"
+				: 'must be an absolute path or stream URI: ' . $cfg['log'];
+			check('config', $ok, '$log_file writable', $detail);
+		}
 	}
 	if (!empty($cfg['tmp'])) {
 		check('config', @is_dir($cfg['tmp']) && @is_writable($cfg['tmp']), '$tempDirectory writable', $cfg['tmp']);

--- a/php/utility/fileutil.php
+++ b/php/utility/fileutil.php
@@ -25,6 +25,39 @@ class FileUtil
 		return( (($len == 0) || ($str[$len-1] != '/')) ? $str : substr($str,0,$len-1) );
 	}
 
+	private static function logFileStreamScheme( $path )
+	{
+		if( !is_string( $path ) ||
+			!preg_match('/^([A-Za-z][A-Za-z0-9+.-]*):\/\//', $path, $matches) )
+			return(null);
+		return($matches[1]);
+	}
+
+	private static function fileUriFilesystemPath( $path )
+	{
+		$parts = parse_url($path);
+		if( !is_array($parts) || !isset($parts['scheme']) ||
+			(strcasecmp($parts['scheme'], 'file') != 0) || !isset($parts['path']) ||
+			isset($parts['user']) || isset($parts['pass']) || isset($parts['port']) ||
+			isset($parts['query']) || isset($parts['fragment']) )
+			return(null);
+		$host = isset($parts['host']) ? $parts['host'] : '';
+		if( ($host === '') || (strcasecmp($host, 'localhost') == 0) )
+			return($parts['path']);
+		return( (DIRECTORY_SEPARATOR == '\\') ?
+			'\\\\'.$host.str_replace('/', '\\', $parts['path']) : null );
+	}
+
+	private static function isAbsoluteLogPath( $path )
+	{
+		if( !is_string( $path ) || ($path === '') )
+			return(false);
+		if( $path[0] == '/' )
+			return(true);
+		return( (DIRECTORY_SEPARATOR == '\\') &&
+			(preg_match('/^[A-Za-z]:[\\\\\/]/', $path) || (strncmp($path, '\\\\', 2) == 0)) );
+	}
+
 	public static function fullpath($path,$base = '')
 	{
 		$root  = '';
@@ -247,13 +280,26 @@ class FileUtil
 		global $log_file, $profileMask;
 		if( $log_file && strlen( $log_file ) > 0 )
 		{
-			// dmrom: set proper permissions (need if rtorrent user differs from www user)
-			if( !is_file( $log_file ) )
+			$streamScheme = self::logFileStreamScheme( $log_file );
+			$isFileStream = !is_null($streamScheme) && (strcasecmp($streamScheme, 'file') == 0);
+			$isFilesystem = is_null($streamScheme) || $isFileStream;
+			$filesystemPath = $isFileStream ? self::fileUriFilesystemPath($log_file) : $log_file;
+			if( $isFilesystem && (is_null($filesystemPath) || !self::isAbsoluteLogPath( $filesystemPath )) )
 			{
-				touch( $log_file );
-				chmod( $log_file, (isset($profileMask) ? $profileMask : 0777) & 0666 );
+				trigger_error('$log_file must be an absolute path or stream URI; the log line was not written.', E_USER_WARNING);
+				return;
 			}
-			$w = fopen( $log_file, "ab+" );
+			$logTarget = $isFilesystem ? $filesystemPath : $log_file;
+			$exists = $isFilesystem ? file_exists( $logTarget ) : @file_exists( $logTarget );
+			// dmrom: set proper permissions (need if rtorrent user differs from www user)
+			if( !$exists && $isFilesystem )
+			{
+				touch( $logTarget );
+				chmod( $logTarget, (isset($profileMask) ? $profileMask : 0777) & 0666 );
+			}
+			// Regular and unstatable stream logs only need write access. Keep the
+			// old mode for FIFOs, where a write-only open blocks until a reader appears.
+			$w = fopen( $logTarget, (!$isFilesystem && !$exists) || is_file( $logTarget ) ? "ab" : "ab+" );
 			if( $w )
 			{
 				fputs( $w, "[".date_create()->format('Y-m-d H:i:s')."] {$str}\n" );

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -1,0 +1,56 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+
+class ConfigTest extends TestCase
+{
+	private $hadProfileMask;
+	private $oldProfileMask;
+
+	public function setUp()
+	{
+		$this->hadProfileMask = array_key_exists('RU_PROFILE_MASK', $_ENV);
+		$this->oldProfileMask = $_ENV['RU_PROFILE_MASK'] ?? null;
+	}
+
+	public function tearDown()
+	{
+		if ($this->hadProfileMask) {
+			$_ENV['RU_PROFILE_MASK'] = $this->oldProfileMask;
+		} else {
+			unset($_ENV['RU_PROFILE_MASK']);
+		}
+	}
+
+	private function configuredProfileMask($value)
+	{
+		$_ENV['RU_PROFILE_MASK'] = $value;
+		include(__DIR__ . '/../../conf/config.php');
+		return $profileMask;
+	}
+
+	public function testEnvironmentProfileMaskIsParsedAsOctalInteger()
+	{
+		$mask = $this->configuredProfileMask('0770');
+		$this->assertTrue(is_int($mask), 'RU_PROFILE_MASK becomes an integer before permission operations');
+		$this->assertEquals(0770, $mask, 'RU_PROFILE_MASK=0770 keeps its documented octal meaning');
+	}
+
+	public function testEmptyEnvironmentProfileMaskUsesTheDefault()
+	{
+		$this->assertEquals(
+			0777,
+			$this->configuredProfileMask(''),
+			'An empty RU_PROFILE_MASK behaves like an unset value instead of crashing requests'
+		);
+	}
+
+	public function testInvalidEnvironmentProfileMaskUsesTheDefault()
+	{
+		$this->assertEquals(
+			0777,
+			$this->configuredProfileMask('not-a-mask'),
+			'An invalid RU_PROFILE_MASK cannot reach chmod or mkdir as a string'
+		);
+	}
+}

--- a/tests/php/EnvCheckTest.php
+++ b/tests/php/EnvCheckTest.php
@@ -1,0 +1,29 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+
+class EnvCheckTest extends TestCase
+{
+	public function testInvalidFileLogUriIsReportedWithoutACheckerDeprecation()
+	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			return;
+		}
+		$checker = __DIR__ . '/../../env_check.php';
+		$command = 'RU_LOG_FILE=' . escapeshellarg('file://relative/path') . ' ' .
+			escapeshellarg(PHP_BINARY) .
+			' -d variables_order=EGPCS -d error_reporting=E_ALL -d display_errors=1 ' .
+			escapeshellarg($checker) . ' 2>&1';
+		$output = array();
+		exec($command, $output);
+		$transcript = implode("\n", $output);
+		$this->assertTrue(
+			strpos($transcript, '[WARN] $log_file writable') !== false,
+			'An invalid file URI is reported as a configuration warning'
+		);
+		$this->assertTrue(
+			strpos($transcript, 'dirname(): Passing null') === false,
+			'An invalid file URI does not trigger a checker deprecation'
+		);
+	}
+}

--- a/tests/php/LogFileModeTest.php
+++ b/tests/php/LogFileModeTest.php
@@ -3,6 +3,64 @@
 require_once(__DIR__ . '/TestCase.php');
 require_once(__DIR__ . '/../../php/utility/fileutil.php');
 
+class LogFileModeStream
+{
+	public $context;
+	public static $fileType;
+	public static $exists;
+	public static $metadataCalls;
+	public static $openModes;
+	public static $body;
+
+	public static function reset($fileType, $exists = true)
+	{
+		clearstatcache(true, 'rutorrent-log-test://sink');
+		self::$fileType = $fileType;
+		self::$exists = $exists;
+		self::$metadataCalls = array();
+		self::$openModes = array();
+		self::$body = '';
+	}
+
+	private static function statResult()
+	{
+		$mode = self::$fileType | 0600;
+		$size = strlen(self::$body);
+		return array(
+			2 => $mode, 7 => $size,
+			'mode' => $mode, 'size' => $size,
+		);
+	}
+
+	public function url_stat($path, $flags)
+	{
+		return self::$exists ? self::statResult() : false;
+	}
+
+	public function stream_open($path, $mode, $options, &$openedPath)
+	{
+		self::$openModes[] = $mode;
+		return true;
+	}
+
+	public function stream_write($data)
+	{
+		self::$body .= $data;
+		return strlen($data);
+	}
+
+	public function stream_flush()
+	{
+		return true;
+	}
+
+	public function stream_metadata($path, $option, $value)
+	{
+		self::$metadataCalls[] = $option;
+		return true;
+	}
+}
+
 /**
  * FileUtil::toLog() creates $log_file on first write. $profileMask is the only
  * knob an operator has for saying how permissive ruTorrent may be when it
@@ -22,6 +80,9 @@ class LogFileModeTest extends TestCase
 
 	public function setUp()
 	{
+		if (!in_array('rutorrent-log-test', stream_get_wrappers(), true)) {
+			stream_wrapper_register('rutorrent-log-test', 'LogFileModeStream');
+		}
 		$this->dir = sys_get_temp_dir() . '/rutorrent-log-file-mode-test-' . getmypid();
 		if (!is_dir($this->dir)) {
 			mkdir($this->dir, 0777, true);
@@ -34,6 +95,9 @@ class LogFileModeTest extends TestCase
 		$this->clean();
 		if (is_dir($this->dir)) {
 			rmdir($this->dir);
+		}
+		if (in_array('rutorrent-log-test', stream_get_wrappers(), true)) {
+			stream_wrapper_unregister('rutorrent-log-test');
 		}
 	}
 
@@ -150,6 +214,202 @@ class LogFileModeTest extends TestCase
 		$this->assertTrue(
 			strpos($body, 'probe') !== false && strpos($body, 'second line') !== false,
 			'Both lines are appended to the log'
+		);
+	}
+
+	public function testAnExistingNonRegularLogIsNotTouchedOrReChmodded()
+	{
+		LogFileModeStream::reset(0010000); // FIFO
+		$GLOBALS['log_file'] = 'rutorrent-log-test://sink';
+		$GLOBALS['profileMask'] = 0777;
+		FileUtil::toLog('probe');
+		$this->assertEquals(
+			array(),
+			LogFileModeStream::$metadataCalls,
+			'An existing non-regular log keeps its operator-assigned permissions'
+		);
+	}
+
+	public function testAnExistingNonRegularFilesystemPathIsNotReChmodded()
+	{
+		$target = $this->dir . '/non-regular-target';
+		mkdir($target, 0700);
+		chmod($target, 0700);
+		$GLOBALS['log_file'] = $target;
+		$GLOBALS['profileMask'] = 0777;
+		set_error_handler(function () { return true; });
+		try {
+			FileUtil::toLog('probe');
+			$mode = $this->modeOf($target);
+		} finally {
+			restore_error_handler();
+			chmod($target, 0700);
+			rmdir($target);
+		}
+		$this->assertEquals(
+			0700,
+			$mode,
+			'An existing non-regular filesystem target keeps its operator-assigned permissions'
+		);
+	}
+
+	public function testARegularLogIsOpenedWriteOnly()
+	{
+		LogFileModeStream::reset(0100000); // Regular file
+		$GLOBALS['log_file'] = 'rutorrent-log-test://sink';
+		FileUtil::toLog('probe');
+		$this->assertEquals(
+			array('ab'),
+			LogFileModeStream::$openModes,
+			'A regular log does not require read permission just to append a line'
+		);
+	}
+
+	public function testANonRegularLogKeepsTheNonBlockingReadWriteMode()
+	{
+		LogFileModeStream::reset(0010000); // FIFO
+		$GLOBALS['log_file'] = 'rutorrent-log-test://sink';
+		FileUtil::toLog('probe');
+		$this->assertEquals(
+			array('ab+'),
+			LogFileModeStream::$openModes,
+			'A non-regular log keeps the mode that does not wait forever for a FIFO reader'
+		);
+	}
+
+	public function testARelativeLogPathIsRejectedBeforeItCanSplitByWorkingDirectory()
+	{
+		$this->clean();
+		$GLOBALS['log_file'] = 'relative.log';
+		$oldDirectory = getcwd();
+		$warning = '';
+		chdir($this->dir);
+		set_error_handler(function ($number, $message) use (&$warning) {
+			$warning = $message;
+			return true;
+		});
+		try {
+			FileUtil::toLog('probe');
+		} finally {
+			restore_error_handler();
+			chdir($oldDirectory);
+		}
+		$this->assertTrue(
+			!file_exists($this->dir . '/relative.log'),
+			'A relative log path cannot create different files from different entry-point directories'
+		);
+		$this->assertTrue(
+			strpos($warning, '$log_file must be an absolute path') !== false,
+			'An invalid $log_file names the configuration error and its consequence'
+		);
+	}
+
+	public function testAnUnstatableStreamSkipsFilesystemMetadataAndOpensWriteOnly()
+	{
+		LogFileModeStream::reset(0100000, false);
+		$GLOBALS['log_file'] = 'rutorrent-log-test://sink';
+		FileUtil::toLog('probe');
+		$this->assertEquals(
+			array(),
+			LogFileModeStream::$metadataCalls,
+			'A stream URI is not touched or chmodded like a filesystem path'
+		);
+		$this->assertEquals(
+			array('ab'),
+			LogFileModeStream::$openModes,
+			'A stream URI only needs write access to append a line'
+		);
+	}
+
+	public function testBuiltinStreamDoesNotEmitFilesystemMetadataWarnings()
+	{
+		$GLOBALS['log_file'] = 'php://temp';
+		$warning = '';
+		set_error_handler(function ($number, $message) use (&$warning) {
+			$warning .= $message;
+			return true;
+		});
+		try {
+			FileUtil::toLog('probe');
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertEquals('', $warning, 'A built-in stream log emits no touch or chmod warning');
+	}
+
+	public function testFileStreamHonorsTheSameMaskAsAPlainPath()
+	{
+		$target = $this->dir . '/file-stream.log';
+		$GLOBALS['log_file'] = 'file://' . $target;
+		$GLOBALS['profileMask'] = 0700;
+		$oldMask = umask(0);
+		try {
+			FileUtil::toLog('probe');
+		} finally {
+			umask($oldMask);
+		}
+		$this->assertTrue(is_file($target), 'A file URI creates its local log target');
+		$this->assertEquals(
+			0600,
+			$this->modeOf($target),
+			'A file URI obeys the same profile mask as a plain filesystem path'
+		);
+	}
+
+	public function testLocalhostFileStreamUsesAnAbsoluteLocalTarget()
+	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			return;
+		}
+		$target = $this->dir . '/localhost-file-stream.log';
+		$GLOBALS['log_file'] = 'file://localhost' . $target;
+		$GLOBALS['profileMask'] = 0700;
+		FileUtil::toLog('probe');
+		$this->assertTrue(is_file($target), 'A localhost file URI writes to its absolute local target');
+		$this->assertEquals(0600, $this->modeOf($target), 'A localhost file URI obeys the profile mask');
+	}
+
+	public function testRelativeFileStreamIsRejectedAtRuntime()
+	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			return;
+		}
+		$GLOBALS['log_file'] = 'file://relative/path';
+		$warning = '';
+		set_error_handler(function ($number, $message) use (&$warning) {
+			$warning = $message;
+			return true;
+		});
+		try {
+			FileUtil::toLog('probe');
+		} finally {
+			restore_error_handler();
+		}
+		$this->assertTrue(
+			strpos($warning, '$log_file must be an absolute path') !== false,
+			'A relative file URI is visibly rejected by the runtime parser'
+		);
+	}
+
+	public function testAWindowsPathIsRelativeOnUnix()
+	{
+		if (DIRECTORY_SEPARATOR === '\\') {
+			return;
+		}
+		$this->clean();
+		$GLOBALS['log_file'] = 'C:\\logs\\rutorrent.log';
+		$oldDirectory = getcwd();
+		chdir($this->dir);
+		set_error_handler(function () { return true; });
+		try {
+			FileUtil::toLog('probe');
+		} finally {
+			restore_error_handler();
+			chdir($oldDirectory);
+		}
+		$this->assertTrue(
+			!file_exists($this->dir . '/C:\\logs\\rutorrent.log'),
+			'A Windows drive path cannot become a relative filename on Unix'
 		);
 	}
 }

--- a/tests/php/RequirementsTest.php
+++ b/tests/php/RequirementsTest.php
@@ -69,9 +69,60 @@ class RequirementsTest extends TestCase
 	public function testLooksAbsolute()
 	{
 		$this->assertTrue(Requirements::looksAbsolute('/torrents/data'), 'unix absolute');
-		$this->assertTrue(Requirements::looksAbsolute('C:\\torrents'), 'windows absolute');
+		$this->assertEquals(
+			DIRECTORY_SEPARATOR === '\\',
+			Requirements::looksAbsolute('C:\\torrents'),
+			'Windows drive paths are absolute only on Windows'
+		);
 		$this->assertTrue(!Requirements::looksAbsolute('relative/path'), 'relative is not absolute');
 		$this->assertTrue(!Requirements::looksAbsolute(''), 'empty is not absolute');
+	}
+
+	public function testLogFilePathIsStableAcrossEntryPointDirectories()
+	{
+		$this->assertTrue(Requirements::logFilePathValid('/tmp/errors.log'), 'absolute log path');
+		$this->assertTrue(Requirements::logFilePathValid('php://stderr'), 'stream log URI');
+		$this->assertTrue(Requirements::logFilePathValid('file:///tmp/errors.log'), 'absolute file URI');
+		$this->assertTrue(Requirements::logFilePathValid('file://localhost/tmp/errors.log'), 'localhost file URI');
+		$this->assertEquals(
+			DIRECTORY_SEPARATOR === '\\',
+			Requirements::logFilePathValid('file://server/share/errors.log'),
+			'A remote file authority is a UNC path only on Windows'
+		);
+		$this->assertTrue(!Requirements::logFilePathValid('errors.log'), 'relative log path is unstable');
+	}
+
+	public function testLogFileStreamScheme()
+	{
+		$this->assertEquals('php', Requirements::logFileStreamScheme('php://stderr'));
+		$this->assertEquals('custom-1', Requirements::logFileStreamScheme('custom-1://sink'));
+		$this->assertEquals('MyScheme', Requirements::logFileStreamScheme('MyScheme://sink'));
+		$this->assertTrue(Requirements::logFileStreamScheme('/tmp/errors.log') === null, 'plain path has no stream scheme');
+	}
+
+	public function testLogFileStreamAvailability()
+	{
+		$wrappers = array('file', 'http', 'php', 'MyScheme');
+		$this->assertTrue(
+			Requirements::logFileStreamAvailable('php://stderr', $wrappers),
+			'A registered log stream wrapper is available'
+		);
+		$this->assertTrue(
+			Requirements::logFileStreamAvailable('PHP://stderr', $wrappers),
+			'A built-in log stream wrapper is case-insensitive'
+		);
+		$this->assertTrue(
+			Requirements::logFileStreamAvailable('MyScheme://sink', $wrappers),
+			'A mixed-case custom wrapper keeps its registered spelling'
+		);
+		$this->assertTrue(
+			!Requirements::logFileStreamAvailable('myscheme://sink', $wrappers),
+			'A custom wrapper with the wrong case is unavailable'
+		);
+		$this->assertTrue(
+			!Requirements::logFileStreamAvailable('nosuch://sink', $wrappers),
+			'An unregistered log stream wrapper is unavailable'
+		);
 	}
 
 	public function testRutorrentHandlersIgnoresRtorrentBuiltins()


### PR DESCRIPTION
## Summary

- parse `RU_PROFILE_MASK` as validated octal at the configuration boundary;
- preserve existing FIFO and device permissions while using write-only append for regular logs;
- require stable absolute filesystem log paths while retaining `file://` and registered stream support;
- make `env_check.php` report invalid paths and unavailable stream wrappers correctly.

## Why

Official PHP FPM images populate `$_ENV`. Previously, an empty `RU_PROFILE_MASK` reached filesystem operations as a string and could terminate a real request with a `TypeError`; octal strings also produced incorrect permission bits.

`FileUtil::toLog()` used `is_file()` as an existence check, so an existing FIFO or device could be touched and re-chmodded on every write. Regular logs were opened with `ab+`, unnecessarily requiring read access. Relative log paths could also resolve to different files depending on the entry point's working directory.

## Before / after

Before:

- an empty environment mask could return HTTP 500;
- string masks produced incorrect modes;
- existing non-regular log targets could have their permissions widened;
- write-only regular logs could not receive entries;
- one relative setting could create logs in multiple directories.

After:

- environment masks are validated and converted to octal integers;
- existing FIFO and device permissions are preserved;
- regular logs use write-only append while FIFO behavior remains non-blocking;
- filesystem logs must use stable absolute paths;
- stream and `file://` targets are validated according to their actual behavior.

## Tests

- full PHP suite on PHP 7.4, 8.1, and 8.5: 50 files, 318 methods, 1843 passing assertions and 127 TAP checks per runtime;
- PHPStan 2.2.9;
- syntax checks for all seven changed paths on all three PHP versions;
- focused RED/GREEN checks and ten targeted regression mutations;
- real PHP 8.1 FPM request with empty `RU_PROFILE_MASK`: current base returns HTTP 500, this branch returns HTTP 200;
- direct FIFO, write-only regular-file, and relative-path probes.