### PR TITLE
Make PHP test failures independent of assertions

### DIFF
--- a/tests/php-test.ini
+++ b/tests/php-test.ini
@@ -1,3 +1,0 @@
-zend.assertions = 1
-;assert.exception = 0
-;assert.bail = 0

--- a/tests/php-test.sh
+++ b/tests/php-test.sh
@@ -26,7 +26,8 @@ do
 	# Absolute: this stands in for __DIR__ below, and a relative path makes a
 	# fixture symlink resolve against the wrong directory.
 	DIR=$(cd "$(dirname "$t")" && pwd)
-	out=$(php -c php-test.ini -f <(cat <(sed "s@__DIR__@\"$DIR\"@g" "$t") <(echo "$TEST_RUN")) 2>&1)
+	out=$(php -d zend.assertions=1 -d error_reporting=-1 -d display_errors=1 \
+		-f <(cat <(sed "s@__DIR__@\"$DIR\"@g" "$t") <(echo "$TEST_RUN")) 2>&1)
 	code=$?
 	printf '%s\n' "$out"
 	if [ "$code" -ne 0 ] || printf '%s\n' "$out" | grep -qE '^Failed:|^not ok|failed with error|PHP (Fatal|Parse) error|Uncaught'; then

--- a/tests/php/TestCase.php
+++ b/tests/php/TestCase.php
@@ -1,11 +1,5 @@
 <?php
 
-foreach (['assert.exception' => 0, 'assert.bail'=> 0] as $configuration => $value) {
-	if ($value !== ($current = ini_get($configuration))) {
-		@ini_set($configuration, $value);
-	}
-}
-
 class TestCase
 {
 	function run() {
@@ -32,18 +26,13 @@ class TestCase
 
 	public function assertEquals($a, $b, $message = null): void
 	{
-		$message = $message ? $message : 'Expected '.json_encode($a).' == '.json_encode($b);
-		if (@assert($a == $b, $message)) {
-			echo "Passed: {$message}\n";
-		} else {
-			echo "Failed: {$message}\n";
-		}
+		$this->assertTrue($a == $b, $message ? $message : 'Expected '.json_encode($a).' == '.json_encode($b));
 	}
 
 	public function assertTrue($bool, $message = null): void
 	{
 		$message = $message ? $message : 'Expected value to be ' . ($bool ? 'true' : 'false');
-		if (@assert($bool, $message)) {
+		if ($bool) {
 			echo "Passed: {$message}\n";
 		} else {
 			echo "Failed: {$message}\n";

--- a/tests/php/TestCaseTest.php
+++ b/tests/php/TestCaseTest.php
@@ -1,0 +1,45 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+
+class TestCaseTest extends TestCase
+{
+	public function testFalseValueIsReportedAsFailureWhenAssertionsAreDisabled(): void
+	{
+		// The suite deliberately enables assertions, so use a fresh process to
+		// prove that TestCase itself does not depend on that runner setting.
+		$script = 'require ' . var_export(__DIR__ . '/TestCase.php', true)
+			. '; (new TestCase())->assertTrue(false, "deliberately false");';
+		$lines = array();
+		$exitCode = 0;
+		exec(escapeshellarg(PHP_BINARY) . ' -d zend.assertions=-1 -r '
+			. escapeshellarg($script), $lines, $exitCode);
+		$output = implode("\n", $lines) . (count($lines) ? "\n" : '');
+
+		if ($exitCode !== 0 || $output !== "Failed: deliberately false\n") {
+			throw new RuntimeException('A false assertion was not reported as Failed');
+		}
+		echo "Passed: a false value is reported as Failed when assertions are disabled\n";
+	}
+
+	public function testRunnerUsesStrictDiagnosticSettings(): void
+	{
+		$actual = array(
+			'zend.assertions' => (int) ini_get('zend.assertions'),
+			'error_reporting' => error_reporting(),
+			'display_errors' => (int) ini_get('display_errors'),
+		);
+		$expected = array(
+			'zend.assertions' => 1,
+			'error_reporting' => -1,
+			'display_errors' => 1,
+		);
+
+		if ($actual !== $expected) {
+			throw new RuntimeException(
+				'Test runner diagnostics differ: ' . json_encode($actual)
+			);
+		}
+		echo "Passed: the runner enables strict diagnostics\n";
+	}
+}


### PR DESCRIPTION
## Summary

- replace native `assert()` calls in `TestCase` with ordinary boolean checks
- preserve the PHP runner's assertion and diagnostic settings through explicit CLI options
- add regression coverage for using `TestCase` with assertions disabled

## Problem

The bundled `php-test.sh` currently loads `php-test.ini`, which sets `zend.assertions=1`. The normal upstream test run is therefore protected.

However, `TestCase::assertTrue()` and `TestCase::assertEquals()` themselves rely on PHP's native `assert()`. When the helper is invoked directly or by another runner under `zend.assertions=-1`, PHP compiles the assertion out and a false check is reported as passed:

```text
Passed: deliberately false
```

This makes the helper's result depend on one specific runner configuration.

## Result

`TestCase` now evaluates comparisons with ordinary PHP conditionals, so its pass/fail result is independent of `zend.assertions`.

```text
Before: false condition -> Passed
After:  false condition -> Failed
```

`php-test.sh` still explicitly enables `zend.assertions=1` and strict diagnostics, preserving the existing suite configuration without the separate `php-test.ini` file.

## Verification

- reproduced the false-positive result by invoking the upstream `TestCase` directly with `zend.assertions=-1`
- confirmed that the same probe reports `Failed` after the change
- Bash syntax check passed
- changed PHP files pass lint on PHP 7.4, 8.1, and 8.5
- full PHP suite passed on PHP 7.4, 8.1, and 8.5
- 49 test files executed per version with no failure markers