### PR TITLE
Say when a profile mask could not be read, and pin the log path rules

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -85,8 +85,11 @@
 
 	$profilePath = $_ENV['RU_PROFILE_PATH'] ?? '../../share';		// Path to user profiles
 	// Environment values are strings; parse the documented octal notation before using it as a file mode.
-	// An unset, empty, or malformed RU_PROFILE_MASK uses the documented 0777 default.
+	// An unset, empty, or malformed RU_PROFILE_MASK uses the documented 0777 default -- and a mask that
+	// was set but could not be read says so, because the default is wider than any mask worth setting.
 	$profileMask = $_ENV['RU_PROFILE_MASK'] ?? '';
+	if(($profileMask !== '') && !preg_match('/^0?[0-7]{3}$/D', $profileMask))
+		trigger_error('RU_PROFILE_MASK is not three or four octal digits; using the 0777 default.', E_USER_WARNING);
 	$profileMask = preg_match('/^0?[0-7]{3}$/D', $profileMask) ? intval($profileMask, 8) : 0777;
 						// Both Webserver and rtorrent users must have read-write access to it.
 						// For example, if Webserver and rtorrent users are in the same group then the value may be 0770.

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -45,11 +45,49 @@ class ConfigTest extends TestCase
 		);
 	}
 
+	public function testAMaskThatCouldNotBeReadSaysSo()
+	{
+		// The fallback is 0777, which is wider than any mask an admin sets one
+		// for. Taking it silently turns a typo into world-writable profiles.
+		$warned = null;
+		set_error_handler(function ($errno, $errstr) use (&$warned) {
+			$warned = $errstr;
+			return true;
+		});
+		$mask = $this->configuredProfileMask('02770');
+		restore_error_handler();
+
+		$this->assertEquals(0777, $mask, 'a mask that could not be read falls back to the default');
+		$this->assertTrue($warned !== null, 'and the fallback is reported');
+		$this->assertTrue(strpos($warned, 'RU_PROFILE_MASK') !== false,
+			'and the report names the setting: ' . var_export($warned, true));
+	}
+
+	public function testAMaskThatIsSimplyUnsetSaysNothing()
+	{
+		$warned = null;
+		set_error_handler(function ($errno, $errstr) use (&$warned) {
+			$warned = $errstr;
+			return true;
+		});
+		$mask = $this->configuredProfileMask('');
+		restore_error_handler();
+
+		$this->assertEquals(0777, $mask, 'an empty mask uses the documented default');
+		$this->assertTrue($warned === null, 'and says nothing, because nothing was asked for');
+	}
+
 	public function testInvalidEnvironmentProfileMaskUsesTheDefault()
 	{
+		// The fallback now reports itself; the handler keeps that out of the
+		// suite log without changing what this case asserts.
+		set_error_handler(function () { return true; });
+		$mask = $this->configuredProfileMask('not-a-mask');
+		restore_error_handler();
+
 		$this->assertEquals(
 			0777,
-			$this->configuredProfileMask('not-a-mask'),
+			$mask,
 			'An invalid RU_PROFILE_MASK cannot reach chmod or mkdir as a string'
 		);
 	}

--- a/tests/php/LogPathAgreementTest.php
+++ b/tests/php/LogPathAgreementTest.php
@@ -1,0 +1,133 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/utility/fileutil.php');
+
+// env_check.php is standalone by design -- it never requires the runtime, so it
+// carries its own copy of the log path rules. Load only the class; the constant
+// stops the checker from running its live probing.
+define('RUTORRENT_REQUIREMENTS_LIB', true);
+require_once(__DIR__ . '/../../env_check.php');
+
+/**
+ * The checker and the runtime hold the same rule in two places, and the failure
+ * that costs an installer a day is the one where they disagree: env_check says
+ * the log file is fine and toLog() then refuses to write it, or the other way
+ * round. Neither copy can be shared -- the checker must run with nothing loaded
+ * -- so what is pinned here is that they answer alike.
+ *
+ * The runtime's own helpers are private, which is right: what a caller can
+ * observe is whether the line was written, so that is what is compared.
+ */
+class LogPathAgreementTest extends TestCase
+{
+	private $root;
+	private $refused;
+
+	public function setUp()
+	{
+		$this->root = sys_get_temp_dir() . '/rutorrent-log-path-agreement-' . getmypid();
+		$this->wipe();
+		mkdir($this->root, 0777, true);
+	}
+
+	public function tearDown()
+	{
+		$this->wipe();
+	}
+
+	private function wipe()
+	{
+		if (!is_dir($this->root)) {
+			return;
+		}
+		foreach (array_diff(scandir($this->root), array('.', '..')) as $entry) {
+			$path = $this->root . '/' . $entry;
+			is_dir($path) ? rmdir($path) : unlink($path);
+		}
+		rmdir($this->root);
+	}
+
+	/**
+	 * True when toLog() accepted the path as one it could write to -- that is,
+	 * it did not bail out with the "must be an absolute path" warning.
+	 */
+	private function runtimeAccepts($path)
+	{
+		global $log_file, $profileMask;
+		$log_file = $path;
+		$profileMask = 0777;
+
+		$this->refused = false;
+		set_error_handler(function ($errno, $errstr) {
+			if (strpos($errstr, 'absolute path') !== false) {
+				$this->refused = true;
+			}
+			return true;
+		});
+		FileUtil::toLog('agreement probe');
+		restore_error_handler();
+
+		return !$this->refused;
+	}
+
+	/** One table of paths, both verdicts, asserted equal. */
+	public function testTheCheckerAndTheRuntimeAgreeOnEveryShapeOfLogPath()
+	{
+		$abs = $this->root . '/log.txt';
+		$paths = array(
+			'an absolute path'            => $abs,
+			'a bare relative path'        => 'errors.log',
+			'a dotted relative path'      => './errors.log',
+			'a parent-relative path'      => '../errors.log',
+			'a file URI'                  => 'file://' . $abs,
+			'a localhost file URI'        => 'file://localhost' . $abs,
+			'a relative file URI'         => 'file://errors.log',
+			'a file URI with a query'     => 'file://' . $abs . '?x=1',
+			'a remote-host file URI'      => 'file://elsewhere' . $abs,
+		);
+
+		foreach ($paths as $what => $path) {
+			$checker = Requirements::logFilePathValid($path);
+			$runtime = $this->runtimeAccepts($path);
+			$this->assertEquals($checker, $runtime,
+				'env_check and toLog() agree about ' . $what . ': ' . var_export($path, true));
+		}
+	}
+
+	/** The one both must accept, and the log line really lands. */
+	public function testAnAbsolutePathIsAcceptedByBothAndIsWritten()
+	{
+		$abs = $this->root . '/written.txt';
+		$this->assertTrue(Requirements::logFilePathValid($abs), 'the checker accepts an absolute path');
+		$this->assertTrue($this->runtimeAccepts($abs), 'and so does toLog()');
+		$this->assertTrue(is_file($abs), 'and the line was written');
+		$this->assertTrue(strpos(file_get_contents($abs), 'agreement probe') !== false,
+			'and it is the line that was asked for');
+	}
+
+	/**
+	 * An empty $log_file is not a path that failed to validate, it is logging
+	 * turned off -- config.php offers it as such -- so toLog() returns before
+	 * it reaches the rules, and env_check never asks about it.
+	 */
+	public function testAnEmptyLogFileIsLoggingOffRatherThanABadPath()
+	{
+		$before = scandir($this->root);
+		$this->assertTrue($this->runtimeAccepts(''),
+			'an empty $log_file raises no complaint about the path');
+		$this->assertEquals($before, scandir($this->root),
+			'and writes nothing anywhere');
+	}
+
+	/** The one both must refuse, and nothing is written anywhere. */
+	public function testARelativePathIsRefusedByBothAndWritesNothing()
+	{
+		$before = scandir($this->root);
+		$this->assertTrue(Requirements::logFilePathValid('errors.log') === false,
+			'the checker refuses a relative path');
+		$this->assertTrue($this->runtimeAccepts('errors.log') === false,
+			'and so does toLog()');
+		$this->assertEquals($before, scandir($this->root), 'and no file appeared');
+	}
+}


### PR DESCRIPTION
RU_PROFILE_MASK falls back to 0777 when it cannot be parsed, and 0777 is wider than any mask somebody sets one for -- so a typo turned a mask meant to restrict into world-writable profile directories, with nothing said. The fallback stays; it now reports itself, the way the log path rule already does when it refuses a value. An unset mask says nothing, because nothing was asked for.

env_check.php carries its own copy of the log path rules, and has to: it is a standalone diagnostic that never loads the runtime. What it must not do is disagree with the runtime, because then the checker reports a log file as fine and toLog() refuses to write it. One table of paths -- absolute, relative, dotted, file:// with and without a host, with a query -- now goes through both and the two verdicts are asserted equal. The runtime's own helpers stay private: what a caller can observe is whether the line was written, so that is what is compared.