### PR TITLE
Read RU_LOCALHOSTS from the source the rest of the file reads

### DIFF
--- a/conf/config.php
+++ b/conf/config.php
@@ -81,7 +81,11 @@
 		"localhost",
 	);
 
-    getenv("RU_LOCALHOSTS") && $localhosts[] = $_ENV['RU_LOCALHOSTS'];
+	// Read from $_ENV, like every other RU_ setting here. Asking getenv()
+	// whether it is set and then reading $_ENV disagrees whenever
+	// variables_order has no E, which appends null instead of the address.
+	if(isset($_ENV['RU_LOCALHOSTS']) && ($_ENV['RU_LOCALHOSTS'] !== ''))
+		$localhosts[] = $_ENV['RU_LOCALHOSTS'];
 
 	$profilePath = $_ENV['RU_PROFILE_PATH'] ?? '../../share';		// Path to user profiles
 	// Environment values are strings; parse the documented octal notation before using it as a file mode.

--- a/tests/php/ConfigTest.php
+++ b/tests/php/ConfigTest.php
@@ -6,11 +6,15 @@ class ConfigTest extends TestCase
 {
 	private $hadProfileMask;
 	private $oldProfileMask;
+	private $hadLocalhosts;
+	private $oldLocalhosts;
 
 	public function setUp()
 	{
 		$this->hadProfileMask = array_key_exists('RU_PROFILE_MASK', $_ENV);
 		$this->oldProfileMask = $_ENV['RU_PROFILE_MASK'] ?? null;
+		$this->hadLocalhosts = array_key_exists('RU_LOCALHOSTS', $_ENV);
+		$this->oldLocalhosts = $_ENV['RU_LOCALHOSTS'] ?? null;
 	}
 
 	public function tearDown()
@@ -19,6 +23,11 @@ class ConfigTest extends TestCase
 			$_ENV['RU_PROFILE_MASK'] = $this->oldProfileMask;
 		} else {
 			unset($_ENV['RU_PROFILE_MASK']);
+		}
+		if ($this->hadLocalhosts) {
+			$_ENV['RU_LOCALHOSTS'] = $this->oldLocalhosts;
+		} else {
+			unset($_ENV['RU_LOCALHOSTS']);
 		}
 	}
 
@@ -90,5 +99,83 @@ class ConfigTest extends TestCase
 			$mask,
 			'An invalid RU_PROFILE_MASK cannot reach chmod or mkdir as a string'
 		);
+	}
+
+	/**
+	 * The list config.php builds. setUp() runs once for the file, not once per
+	 * test, so a mask an earlier case left behind would be read here too --
+	 * these cases are about RU_LOCALHOSTS and nothing else.
+	 */
+	private function configuredLocalhosts()
+	{
+		unset($_ENV['RU_PROFILE_MASK']);
+		include(__DIR__ . '/../../conf/config.php');
+		return $localhosts;
+	}
+
+	public function testAnAddressFromTheEnvironmentJoinsTheLocalInterfaces()
+	{
+		$_ENV['RU_LOCALHOSTS'] = '10.1.2.3';
+		$hosts = $this->configuredLocalhosts();
+		$this->assertTrue(in_array('10.1.2.3', $hosts, true),
+			'RU_LOCALHOSTS is added to the local interfaces');
+		$this->assertTrue(in_array('127.0.0.1', $hosts, true),
+			'and the built-in ones are kept');
+	}
+
+	/**
+	 * The list must never carry a null. It is compared against the address a
+	 * request came from, and an entry that is not an address is at best noise
+	 * in a security decision.
+	 */
+	public function testAnEnvironmentWithoutTheSettingAddsNothing()
+	{
+		unset($_ENV['RU_LOCALHOSTS']);
+		$hosts = $this->configuredLocalhosts();
+		$this->assertEquals(array('::1', '127.0.0.1', 'localhost'), $hosts,
+			'an unset RU_LOCALHOSTS leaves the list as it ships');
+	}
+
+	public function testAnEmptySettingAddsNothing()
+	{
+		$_ENV['RU_LOCALHOSTS'] = '';
+		$hosts = $this->configuredLocalhosts();
+		$this->assertEquals(array('::1', '127.0.0.1', 'localhost'), $hosts,
+			'an empty RU_LOCALHOSTS adds no entry');
+	}
+
+	/**
+	 * getenv() and $_ENV disagree whenever variables_order has no E, which is
+	 * the CLI default: the process carries the variable and the superglobal
+	 * does not. Testing one and reading the other appended a null.
+	 *
+	 * The disagreement is created here rather than inherited from whatever the
+	 * suite happens to be run with -- otherwise this passes on a clean machine
+	 * whether the bug is present or not.
+	 */
+	public function testTheListIsBuiltWithoutReadingAKeyThatIsNotThere()
+	{
+		putenv('RU_LOCALHOSTS=10.9.9.9');
+		unset($_ENV['RU_LOCALHOSTS']);
+		$this->assertTrue(getenv('RU_LOCALHOSTS') === '10.9.9.9',
+			'the process carries the variable');
+		$this->assertTrue(!isset($_ENV['RU_LOCALHOSTS']),
+			'and the superglobal does not');
+
+		$raised = null;
+		set_error_handler(function ($errno, $errstr) use (&$raised) {
+			$raised = $errstr;
+			return true;
+		});
+		$hosts = $this->configuredLocalhosts();
+		restore_error_handler();
+		putenv('RU_LOCALHOSTS');
+
+		$this->assertTrue($raised === null,
+			'building the list raises no diagnostic: ' . var_export($raised, true));
+		$this->assertTrue(!in_array(null, $hosts, true),
+			'and the list carries no null entry');
+		$this->assertEquals(array('::1', '127.0.0.1', 'localhost'), $hosts,
+			'and nothing was added from a source config.php does not read');
 	}
 }


### PR DESCRIPTION
The line asked getenv() whether RU_LOCALHOSTS was set and then read the value out of $_ENV. Those two answer differently whenever variables_order has no E, which is the CLI default, so the setting failed in both directions: with the variable exported but $_ENV empty it appended null to the list of local interfaces and raised "Undefined array key", and with $_ENV populated -- what the official FPM images do, and what every other RU_ setting in this file relies on -- getenv() returned false and the address was ignored.

It reads $_ENV now, like $log_file, $topDirectory and the rest.

That list decides whether a request is treated as coming from a local interface, so an entry that is not an address does not belong in it.