### PR TITLE
Test the rtorrent 0.16.21 socket allocation gate

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -17,6 +17,10 @@ class rTorrentSettings
 	public $version;
 	public $libVersion;
 	public $apiVersion = 0;
+	// rtorrent 0.16.21. system.sockets.available_alloc and the per-category
+	// limits do not exist before it, so the whole probe is gated on this.
+	const SOCKET_ALLOC_VERSION = 0x1015;
+
 	public $socketAllocBudget = 0;
 	public $socketHttpAllocMax = 0;
 	public $socketFilesAllocMax = 0;
@@ -254,7 +258,7 @@ class rTorrentSettings
 			// categories may share. internal and rpc are not exposed on the
 			// settings page, so what is left is what open files and HTTP
 			// connections have between them. Absent before rtorrent 0.16.21.
-			if($this->iVersion>=0x1015)
+			if(self::socketAllocSupported($this->iVersion))
 			{
 				$req = new rXMLRPCRequest( array(
 					new rXMLRPCCommand("system.sockets.available_alloc"),
@@ -264,13 +268,8 @@ class rTorrentSettings
 					new rXMLRPCCommand("system.sockets.files.max_alloc.limit"),
 					new rXMLRPCCommand("system.sockets.files.min_alloc.limit") ) );
 				$req->important = false;
-				if($req->success() && (count($req->val)==6))
-				{
-					$this->socketAllocBudget = max(0,$req->val[0]-$req->val[1]-$req->val[2]);
-					$this->socketHttpAllocMax = $req->val[3];
-					$this->socketFilesAllocMax = $req->val[4];
-					$this->socketFilesAllocMin = $req->val[5];
-				}
+				if($req->success())
+					$this->applySocketAllocLimits($req->val);
 			}
 
 			$req = new rXMLRPCRequest(new rXMLRPCCommand(
@@ -379,6 +378,44 @@ class rTorrentSettings
 		$cmd->addParameters($args);
 		return($cmd);
 	}
+	/**
+	 * Whether the daemon reports its socket allocation limits at all.
+	 *
+	 * @param int|null $iVersion packed rtorrent version, or null when unknown
+	 */
+	public static function socketAllocSupported( $iVersion )
+	{
+		// null before the version has been read, and 0 is the sentinel
+		// php/getplugins.php emits while the daemon is unreachable. Both
+		// compare below the threshold, so neither is asked.
+		return($iVersion>=self::SOCKET_ALLOC_VERSION);
+	}
+
+	/**
+	 * Take the limits out of the answer to the six-command probe.
+	 *
+	 * The budget is what the two categories the settings page offers have
+	 * between them: the total, less the two categories it does not offer. A
+	 * daemon that answered with anything else leaves the defaults alone --
+	 * a zero budget is read as "unknown" by the settings page, and a wrong
+	 * one would be offered to the user as a limit to type against.
+	 *
+	 * @param array $val the six values, in the order they were asked for
+	 */
+	public function applySocketAllocLimits( $val )
+	{
+		if(!is_array($val) || (count($val)!=6))
+			return(false);
+		foreach($val as $v)
+			if(!is_numeric($v))
+				return(false);
+		$this->socketAllocBudget = max(0,$val[0]-$val[1]-$val[2]);
+		$this->socketHttpAllocMax = $val[3];
+		$this->socketFilesAllocMax = $val[4];
+		$this->socketFilesAllocMin = $val[5];
+		return(true);
+	}
+
 	public function getOnInsertCommand($args)
 	{
 		return($this->getEventCommand('on_insert','inserted_new',$args));

--- a/tests/php/SocketAllocLimitsTest.php
+++ b/tests/php/SocketAllocLimitsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../php/settings.php');
+
+/**
+ * The settings page offers the user a maximum for open files and for HTTP
+ * connections, and states the budget the two share. rTorrent reports that
+ * budget only from 0.16.21 -- system.sockets.available_alloc and the
+ * per-category limits do not exist before it -- so the probe is version-gated
+ * and the fields stay at zero, which the page reads as "unknown".
+ *
+ * Nothing covered the gate: a settings page that offered limits an older
+ * daemon will reject, or a six-command multicall sent to a daemon that cannot
+ * answer it, would both have passed CI.
+ */
+class SocketAllocLimitsTest extends TestCase
+{
+	private function settings()
+	{
+		$reflection = new ReflectionClass('rTorrentSettings');
+		return $reflection->newInstanceWithoutConstructor();
+	}
+
+	public function testTheProbeIsSentOnlyFromTheReleaseThatAnswersIt()
+	{
+		$this->assertTrue(rTorrentSettings::socketAllocSupported(0x1015),
+			'0.16.21 reports its socket allocation limits');
+		$this->assertTrue(rTorrentSettings::socketAllocSupported(0x1016),
+			'and so does anything after it');
+		$this->assertTrue(!rTorrentSettings::socketAllocSupported(0x1014),
+			'0.16.20 does not, and must not be asked');
+		$this->assertTrue(!rTorrentSettings::socketAllocSupported(0x908),
+			'nor does the 0.9.8 baseline');
+	}
+
+	public function testAnUnknownDaemonIsNotAsked()
+	{
+		// php/getplugins.php emits 0 while the daemon is unreachable, and
+		// iVersion is null before the version has been read at all.
+		$this->assertTrue(!rTorrentSettings::socketAllocSupported(0),
+			'the unreachable-daemon sentinel is not a version that answers');
+		$this->assertTrue(!rTorrentSettings::socketAllocSupported(null),
+			'and neither is not having asked yet');
+	}
+
+	public function testTheBudgetIsWhatTheOfferedCategoriesShare()
+	{
+		$settings = $this->settings();
+		// available, internal, rpc, http max, files max, files min
+		$this->assertTrue($settings->applySocketAllocLimits(array(65536, 1024, 1448, 4096, 65536, 4)),
+			'a well-formed answer is taken');
+		$this->assertEquals(63064, $settings->socketAllocBudget,
+			'the budget is the total less the categories the page does not offer');
+		$this->assertEquals(4096, $settings->socketHttpAllocMax, 'the HTTP maximum is carried through');
+		$this->assertEquals(65536, $settings->socketFilesAllocMax, 'and the files maximum');
+		$this->assertEquals(4, $settings->socketFilesAllocMin, 'and the files minimum');
+	}
+
+	public function testABudgetCannotBeNegative()
+	{
+		$settings = $this->settings();
+		$settings->applySocketAllocLimits(array(1024, 2048, 512, 4096, 65536, 4));
+		$this->assertEquals(0, $settings->socketAllocBudget,
+			'a total already spent leaves nothing to share rather than a negative budget');
+	}
+
+	public function testAnAnswerOfTheWrongShapeLeavesTheDefaults()
+	{
+		$settings = $this->settings();
+		$this->assertTrue(!$settings->applySocketAllocLimits(array(65536, 1024, 1448)),
+			'a short answer is refused');
+		$this->assertEquals(0, $settings->socketAllocBudget, 'and the budget stays unknown');
+		$this->assertEquals(0, $settings->socketFilesAllocMax, 'and so do the limits');
+	}
+
+	public function testAnAnswerThatIsNotNumbersLeavesTheDefaults()
+	{
+		$settings = $this->settings();
+		$this->assertTrue(!$settings->applySocketAllocLimits(array('n/a', 1024, 1448, 4096, 65536, 4)),
+			'an answer that is not numbers is refused');
+		$this->assertEquals(0, $settings->socketAllocBudget,
+			'rather than offering the user a limit computed from it');
+	}
+}


### PR DESCRIPTION
The settings page offers a maximum for open files and for HTTP connections and states the budget the two share. rTorrent reports that budget only from 0.16.21, so the probe is version-gated and the fields stay at zero, which the page reads as unknown.

Nothing covered the gate. A settings page offering limits an older daemon will reject, or a six-command multicall sent to a daemon that cannot answer it, would both have passed CI -- and #3230 could not reach it, because 0x1015 in a >= loop takes the same path as the versions already there.

The version test and the arithmetic are their own methods now, which is what makes them reachable: the block around them builds an rXMLRPCRequest and talks to the daemon, and rXMLRPCRequest::send() is called through self:: so nothing can stand in for it.

An answer that is not six numbers is refused rather than used. Before, a non-numeric value reached the subtraction, which is a TypeError on PHP 8 -- so a daemon answering oddly took the interface down instead of leaving the budget unknown.