### PR TITLE
Give the RSS and Ratio rules dialogs distinct titles

### DIFF
--- a/plugins/extratio/lang/en.js
+++ b/plugins/extratio/lang/en.js
@@ -6,7 +6,7 @@
  * Author:
  */
 
- theUILang.ratioRulesManager	= "Rules Manager";
+ theUILang.ratioRulesManager	= "Ratio Rules Manager";
  theUILang.mnu_ratiorule	= "Ratio Rules";
  theUILang.ratAddRule		= "Add";
  theUILang.ratDelRule		= "Delete";

--- a/plugins/rssurlrewrite/lang/en.js
+++ b/plugins/rssurlrewrite/lang/en.js
@@ -8,7 +8,7 @@
 
  theUILang.rssNewRule		= "New rule";
  theUILang.mnu_rssurlrewrite	= "URL Replacement in RSS";
- theUILang.rssRulesManager	= "Rules Manager";
+ theUILang.rssRulesManager	= "RSS Rules Manager";
  theUILang.rssAddRule		= "Add";
  theUILang.rssDelRule		= "Delete";
  theUILang.rssCheckRule		= "?";


### PR DESCRIPTION
Fixes #3237.

Two commits:
- rssurlrewrite: title the rules dialog "RSS Rules Manager" (the fix)
- extratio: title the rules dialog "Ratio Rules Manager" (symmetry, optional — happy to drop if you'd rather leave Ratio as is)
