### PR TITLE
erasedata: queue erase requests so mass erases cannot flood rtorrent

### DIFF
--- a/plugins/erasedata/conf.php
+++ b/plugins/erasedata/conf.php
@@ -6,6 +6,12 @@
 
 	$erasedebug_enabled = false;
 
+  // The maximum amount of times a download is attempted to be marked for erasure before it is skipped,
+  // Setting a limit here prevents a problematic case being retried indefinitely and blocking other RPC calls.
+  //
+  // 0 disables the limit and will retry indefinitely.
+	$erasePendingMaxAttempts = 10;
+
 	// Replaces "remove" option in torrent menu to always delete with data
 	// Refrains from showing other options on web interface
 	$replaceRemoveTorrent = false;

--- a/plugins/erasedata/erase.php
+++ b/plugins/erasedata/erase.php
@@ -1,8 +1,8 @@
 <?php
 
 // CLI entry point for "erase this download and delete its data", for callers
-// that run inside rtorrent and have no PHP context of their own -- the ratio
-// group commands built in plugins/ratio/ratio.php.
+// that run inside rtorrent and have no PHP context of their own. (Its one
+// caller today is the group command built in plugins/ratio/ratio.php.)
 //
 // Usage: php erase.php <hash> [force] [user]
 //   force: 1 = delete the download's own files (default), 2 = delete the whole
@@ -10,9 +10,8 @@
 //   user:  the ruTorrent user, on multi-user installs. Trails the other
 //          arguments because it is empty on a single-user install.
 //
-// The file list is read over RPC and recorded for the garbage collector before
-// the download is erased, which is the sequence the web UI's "Remove and delete
-// data" takes as well.
+// This records the request, then drains the queue if no other firing is already
+// doing so.
 
 $hash = isset($argv[1]) ? $argv[1] : "";
 $force = (isset($argv[2]) && ($argv[2] !== "")) ? $argv[2] : "1";
@@ -23,12 +22,16 @@ if(!preg_match('/^[0-9A-Fa-f]{40}$/', $hash))
 if($user !== "")
 	$_SERVER['REMOTE_USER'] = $user;
 
-require_once( dirname(__FILE__)."/../../php/xmlrpc.php" );
-require_once( dirname(__FILE__)."/removewithdata.php" );
+require_once( dirname(__FILE__)."/../../php/util.php" );
+require_once( dirname(__FILE__)."/pending.php" );
+eval(FileUtil::getPluginConf('erasedata'));
 
-// A ratio group command runs on every check until the download is gone, so a
-// hash already recorded is left to the garbage collector.
-if(is_file(FileUtil::getSettingsPath()."/erasedata/".$hash.".list"))
-	exit(0);
+$listPath = FileUtil::getSettingsPath()."/erasedata";
+@FileUtil::makeDirectory($listPath);
 
-exit((erasedataRemoveWithData(array($hash), $force) === false) ? 1 : 0);
+if(!erasedataQueueRequest($listPath, $hash, $force))
+	exit(1);
+
+erasedataDrainQueue($listPath,
+	isset($erasePendingMaxAttempts) ? intval($erasePendingMaxAttempts) : 10);
+exit(0);

--- a/plugins/erasedata/pending.php
+++ b/plugins/erasedata/pending.php
@@ -1,0 +1,182 @@
+<?php
+
+// The queue between the CLI erase entry point (erase.php) and the RPC work.
+//
+// erase.php may be fired for several hundred downloads in one sweep, and
+// doing the RPC work inline made each firing a blocking client of a server
+// that answers one request at a time: everything timed out, nothing was
+// recorded, and nothing recorded meant the whole sweep came back on the
+// caller's next pass, indefinitely. The queue enables each firing to do
+// only the recording part of the erase request, represented by a local
+// file write, which should not fail however busy the server is. Exactly
+// one firing goes on to do the RPC work for everything queued, one download
+// at a time.
+
+if(!function_exists('erasedataQueueRequest'))
+{
+	// Record an erase request by writing a marker file.
+	function erasedataQueueRequest($listPath, $hash, $force)
+	{
+		global $profileMask;
+		if(!preg_match('/^[0-9A-Fa-f]{40}$/', $hash))
+			return(false);
+		if(($force!=="1") && ($force!=="2"))
+			$force = "1";
+		if(is_file($listPath."/".$hash.".list"))
+      // Already collected, waiting for the garbage collector to apply it.
+			return(true);
+		$marker = $listPath."/".$hash.".pending";
+		// Exclusive create: two firings racing on one hash cannot both conclude
+		// they are first, and a caller that fires again before the queue is
+		// drained is a no-op rather than a second request.
+		$fp = @fopen($marker, "x");
+		if($fp===false)
+			return(is_file($marker));
+		@fwrite($fp, $force."\n0\n");
+		@fclose($fp);
+		@chmod($marker, (isset($profileMask) ? $profileMask : 0666) & 0666);
+		return(true);
+	}
+}
+
+if(!function_exists('erasedataDrainQueue'))
+{
+	// Collect and erase everything queued, or return immediately if another
+	// process is already doing so.
+	//
+	// Returns the number of hashes attempted, or -1 when another drainer holds
+	// the lock.
+	function erasedataDrainQueue($listPath, $maxAttempts = 10)
+	{
+    // Check the lock to see if another process has already taken responsibilty for draining the queue.
+		$lock = @fopen($listPath."/drain.lock", "c");
+		if($lock===false)
+			return(-1);
+		if(!@flock($lock, LOCK_EX | LOCK_NB))
+		{
+			fclose($lock);
+			return(-1);
+		}
+
+		// Only the winner needs to talk to rtorrent, so only the winner pays for
+		// loading the RPC layer. Everyone else has already returned above.
+		require_once( dirname(__FILE__)."/../../php/xmlrpc.php" );
+		require_once( dirname(__FILE__)."/removewithdata.php" );
+
+		$attempted = array();
+		$done = 0;
+		while(true)
+		{
+			$batch = erasedataPendingHashes($listPath, $attempted);
+			if(!count($batch))
+				break;
+			foreach($batch as $hash=>$force)
+				$attempted[$hash] = true;
+			$done += erasedataDrainOnce($listPath, $batch, $maxAttempts);
+		}
+
+		flock($lock, LOCK_UN);
+		fclose($lock);
+		return($done);
+	}
+
+	// The queue as it stands, minus anything this drainer has already tried.
+	// Re-read every pass so requests arriving mid-drain are picked up by the
+	// drainer already running rather than waiting for the caller's next sweep.
+	function erasedataPendingHashes($listPath, $attempted)
+	{
+		$ret = array();
+		$pending = @glob($listPath.'/*.pending');
+		if(!is_array($pending))
+			return($ret);
+		sort($pending);
+		foreach($pending as $item)
+		{
+			$hash = basename($item, '.pending');
+			if(!preg_match('/^[0-9A-Fa-f]{40}$/', $hash))
+			{
+				@unlink($item);
+				continue;
+			}
+			if(array_key_exists($hash, $attempted))
+				continue;
+			// Collected by the web UI's "Remove and delete data" between the
+			// marker being written and this pass.
+			if(is_file($listPath.'/'.$hash.'.list'))
+			{
+				@unlink($item);
+				continue;
+			}
+			$lines = @file($item, FILE_IGNORE_NEW_LINES);
+			$ret[$hash] = (is_array($lines) && isset($lines[0]) && ($lines[0]==="2")) ? "2" : "1";
+		}
+		return($ret);
+	}
+
+	function erasedataDrainOnce($listPath, $batch, $maxAttempts)
+	{
+		// Drop what rtorrent no longer has before asking about it, so a marker
+		// left behind for a download that was deleted some other way (the web
+		// UI, say) is not retried into the give-up log.
+		$live = erasedataLiveHashes();
+		if(is_array($live))
+		{
+			foreach(array_keys($batch) as $hash)
+				if(!array_key_exists(strtoupper($hash), $live))
+				{
+					@unlink($listPath.'/'.$hash.'.pending');
+					unset($batch[$hash]);
+				}
+		}
+		if(!count($batch))
+			return(0);
+
+    // Split the batch into at most two arrays, one for each force mode (1 and 2).
+		$byForce = array("1"=>array(), "2"=>array());
+		foreach($batch as $hash=>$force)
+			$byForce[$force][] = $hash;
+		foreach($byForce as $force=>$hashes)
+			if(count($hashes))
+				erasedataRemoveWithData($hashes, $force);
+
+    // Clear the successful deletions from the queue by checking for the .list file
+    // that is created by erasedataRemoveWithData() when it succeeds.
+		foreach($batch as $hash=>$force)
+		{
+			$marker = $listPath.'/'.$hash.'.pending';
+			// Once the .list exists, the garbage collector finishes the deletion
+			if(is_file($listPath.'/'.$hash.'.list'))
+			{
+				@unlink($marker);
+				continue;
+			}
+			$lines = @file($marker, FILE_IGNORE_NEW_LINES);
+			$attempts = (is_array($lines) && isset($lines[1])) ? intval($lines[1])+1 : 1;
+			if(($maxAttempts>0) && ($attempts>=$maxAttempts))
+			{
+				// Giving up leaves the download in place, data intact and still
+				// identified by its own torrent, which is the safe end state.
+				FileUtil::toLog("erasedata: giving up on ".$hash." after ".$attempts.
+					" attempts, torrent not erased");
+				@unlink($marker);
+			}
+			else
+				@file_put_contents($marker, $force."\n".$attempts."\n");
+		}
+		return(count($batch));
+	}
+
+	// The hashes rtorrent currently holds, or null when it will not say.
+	function erasedataLiveHashes()
+	{
+		$req = new rXMLRPCRequest( new rXMLRPCCommand("d.multicall",
+			array("default", getCmd("d.get_hash="))) );
+		$req->important = false;
+		if(!$req->success())
+			return(null);
+		$ret = array();
+		foreach($req->val as $hash)
+			$ret[strtoupper($hash)] = true;
+		return($ret);
+	}
+}


### PR DESCRIPTION
Introduces a queue to erasedata alongside an upper bound of failed attempts, so that large amounts of erasure requests don't flood the rtorrent RPC endpoint and leave it unresponsive to everything else.

Previously, large quantities of erasure requests at the erasedata plugin would trigger a substantial number of simultaneous RPC calls, which could (and would) hit RPC timeouts. This would leave the erasures as failed, and they would be re-attempted ad nauseam, continuing to hit the RPC timeout, and causing lockups.

This is fixed by the introduction of a queue, which acts as a shim between the erasure requests and the RPC calls. Each request records a marker file (which can't fail due to a busy rtorrent), and exactly one of the firing processes then drains the whole queue at rtorrent's pace. Success is defined by the .list file the pre-existing garbage collector consumes; a request that keeps failing is retried on later sweeps and abandoned after $erasePendingMaxAttempts, leaving the torrent and data in place.

This keeps the existing (and unfortunate) pattern where a torrent disappears from ruTorrent/rtorrent before its data is deleted: d.erase is only sent after the .list file is recorded, and the garbage collector deletes the data on its next pass (up to $garbageCheckInterval later). Failures before that handoff leave the torrent and its data in place to be retried, but failures after it (a GC unlink error, a lost .list) can still orphan data with the torrent already gone. This patch doesn't introduce that issue, but also doesn't fix it.