### PR TITLE
_getdir plugin: require PHP mbstring extensions

### DIFF
--- a/plugins/_getdir/plugin.info
+++ b/plugins/_getdir/plugin.info
@@ -3,5 +3,6 @@ plugin.author: dmrom
 plugin.runlevel: 1
 plugin.version: 5.1
 rtorrent.need: 0
+php.extensions.error: mbstring
 php.extensions.warning: json
 plugin.help: https://github.com/Novik/ruTorrent/wiki/Plugin_getdir


### PR DESCRIPTION
I'm not sure what we should use php.extensions.warning or php.extensions.error?

<details>
  <summary>ruTorrent PHP EXTENSION DEPENDENCY AUDIT</summary>

 ============================================================
ruTorrent PHP EXTENSION DEPENDENCY AUDIT
============================================================

Report generated by: ChatGPT
Audit date: September 1, 2026
Audited repository: Novik/ruTorrent
Audited snapshot: ruTorrent-master.zip provided for this audit


============================================================
1. EXECUTIVE SUMMARY
============================================================

The audit identified several real dependency problems.

CRITICAL / ERROR — missing required PHP extensions:

1. _getdir          -> mbstring
2. datadir          -> ctype
3. throttle         -> ctype
4. rutracker_check  -> ctype
5. tracklabels      -> fileinfo
6. xmpp             -> mbstring
7. geoip            -> phar

WARNING — missing extensions required only for specific/optional
functionality:

8. extsearch        -> dom
9. geoip            -> sqlite3
10. source          -> zip
11. xmpp            -> openssl

INCORRECT SEVERITY:

12. _getdir          -> json is declared as warning but is actually required
13. cookies          -> json is declared as warning but is actually required
14. loginmgr         -> json is declared as warning but is actually required
15. lookat           -> json is declared as warning but is actually required
16. retrackers       -> json is declared as warning but is actually required

UNNECESSARY DECLARATION:

17. uploadeta        -> json is declared but the plugin does not use JSON APIs.


============================================================
2. AUDIT SCOPE AND METHODOLOGY
============================================================

The audit was performed against the uploaded ruTorrent source tree.

The following was analyzed:

- all plugin directories under plugins/
- all plugin.info files
- all PHP files under plugins/
- actual PHP function usage
- actual PHP class usage
- actual PHP constants where relevant
- function_exists()
- extension_loaded()
- class_exists()
- fallback implementations
- conditional feature paths
- plugin.info php.extensions.error declarations
- plugin.info php.extensions.warning declarations

The objective was to determine:

1. Which PHP extensions are actually required by each plugin.
2. Which extensions are optional.
3. Which declared extensions are unnecessary.
4. Which dependencies are incorrectly classified as warning instead of error.
5. Which dependencies are completely missing from plugin.info.


============================================================
3. _getdir
============================================================

FILE:

plugins/_getdir/listdir.php:12

CODE:

return( strcmp(mb_strtolower($a), mb_strtolower($b)) );

PROBLEM:

mb_strtolower() belongs to the mbstring PHP extension.

The call is unconditional.

There is no:
- function_exists()
- extension_loaded()
- fallback implementation

Without mbstring, PHP will terminate with:

Call to undefined function mb_strtolower()

Current plugin.info:

php.extensions.warning: json

Missing:

php.extensions.error: mbstring

RECOMMENDATION:

php.extensions.error: json,mbstring


IMPORTANT:

plugins/_getdir/info.php already contains a fallback:

function_exists("mb_strtolower")
    ? mb_strtolower(...)
    : strtolower(...)

Therefore, an even better code-level fix would be to use the same
fallback in listdir.php.

After adding the fallback, mbstring could be classified as warning
or removed from the plugin dependency list entirely.


============================================================
4. _getdir — JSON
============================================================

listdir.php and info.php use:

JSON::safeEncode()

JSON::safeEncode() ultimately calls:

json_encode()

There is no fallback.

Therefore JSON is a hard dependency for these code paths.

Current:

php.extensions.warning: json

Recommended:

php.extensions.error: json

This is primarily a metadata/severity issue because ruTorrent already
has JSON as a global requirement.


============================================================
5. datadir
============================================================

FILE:

plugins/datadir/action.php:36

USAGE:

ctype_xdigit($hash)

The function is called unconditionally.

ctype_xdigit() belongs to the ctype extension.

Without ctype:

Call to undefined function ctype_xdigit()

RECOMMENDATION:

php.extensions.error: json,ctype

STATUS:

MISSING REQUIRED EXTENSION.


============================================================
6. throttle
============================================================

FILE:

plugins/throttle/throttle.php:131

USAGE:

ctype_xdigit($hash)

The call is unguarded.

Without ctype the code can terminate with:

Call to undefined function ctype_xdigit()

RECOMMENDATION:

php.extensions.error: ctype

STATUS:

MISSING REQUIRED EXTENSION.


============================================================
7. rutracker_check
============================================================

FILES:

plugins/rutracker_check/trackers/rutracker.php:35
plugins/rutracker_check/trackers/rutracker.php:84
plugins/rutracker_check/trackers/nnmclub.php:178

USAGE:

ctype_digit()

The calls are not protected by a fallback.

ctype_digit() belongs to ctype.

RECOMMENDATION:

php.extensions.error: ctype

STATUS:

MISSING REQUIRED EXTENSION FOR THE AFFECTED TRACKERS.

NOTE:

There is an argument for classifying this as warning rather than error,
because the dependency affects particular tracker implementations
rather than the entire plugin.

If plugin.info is intended to describe requirements for all supported
functionality, error is the more accurate classification.


============================================================
8. tracklabels
============================================================

FILES:

plugins/tracklabels/action.php:99
plugins/tracklabels/action.php:129

USAGE:

mime_content_type()

mime_content_type() is provided by the fileinfo extension.

The calls are not protected by a fallback.

Without fileinfo:

Call to undefined function mime_content_type()

RECOMMENDATION:

php.extensions.error: fileinfo

STATUS:

MISSING REQUIRED EXTENSION.


============================================================
9. extsearch
============================================================

FILES:

plugins/extsearch/engines/IPTorrents.php
plugins/extsearch/engines/mTeam.php
plugins/extsearch/engines/Zooqle.php

USAGE:

DOMDocument

DOMDocument belongs to the dom extension.

Not every extsearch engine uses DOM.

Therefore dom should not necessarily be considered a hard dependency
for the complete plugin.

RECOMMENDATION:

php.extensions.warning: dom

STATUS:

MISSING OPTIONAL / FEATURE-SPECIFIC EXTENSION.


============================================================
10. geoip — phar
============================================================

FILES:

plugins/geoip/lookup.php:9
plugins/geoip/init.php:9

The plugin contains:

geoip2.phar

and loads it using:

require_once(
    'phar://'.dirname(__FILE__).'/geoip2.phar/vendor/autoload.php'
);

This explicitly uses the:

phar://

stream wrapper.

Therefore phar is a real runtime dependency.

Without phar, the GeoIP2 library cannot be loaded.

RECOMMENDATION:

php.extensions.error: json,phar

STATUS:

MISSING REQUIRED EXTENSION.


============================================================
11. geoip — sqlite3
============================================================

FILE:

plugins/geoip/sqlite.php

The code explicitly checks:

class_exists("SQLite3", false)

SQLite3 is used for optional peer-comment functionality.

The GeoIP plugin itself can still operate without SQLite3.

Therefore:

RECOMMENDATION:

php.extensions.warning: sqlite3

STATUS:

MISSING OPTIONAL EXTENSION.


============================================================
12. source — zip
============================================================

FILE:

plugins/source/action.php

The plugin checks:

class_exists('ZipArchive')

and then uses:

new ZipArchive

The code explicitly handles the absence of ZipArchive and returns
a user-facing error.

Therefore zip is a real dependency for the relevant functionality,
but it is already handled as an optional feature.

RECOMMENDATION:

php.extensions.warning: zip

STATUS:

MISSING OPTIONAL EXTENSION.


============================================================
13. xmpp — mbstring
============================================================

FILE:

plugins/xmpp/XMPPHP/XMLStream.php:729

USAGE:

mb_substr($msg, 0, $sentbytes, '8bit')

The function is called unconditionally.

Without mbstring:

Call to undefined function mb_substr()

RECOMMENDATION:

php.extensions.error: mbstring

STATUS:

MISSING REQUIRED EXTENSION.


============================================================
14. xmpp — openssl
============================================================

FILE:

plugins/xmpp/XMPPHP/XMLStream.php:322-325

The plugin uses:

ssl://

for encrypted XMPP connections.

Encryption is enabled by default.

Therefore OpenSSL is a real dependency of the default encrypted
connection mode.

However, encryption can be disabled.

RECOMMENDATION:

php.extensions.warning: openssl

STATUS:

OPTIONAL / CONFIGURATION-DEPENDENT EXTENSION.


============================================================
15. xmpp — curl and simplexml
============================================================

The following APIs are present in:

plugins/xmpp/XMPPHP/BOSH.php

including:

- curl_init()
- curl_exec()
- SimpleXMLElement
- dom_import_simplexml()

However, BOSH.php is not part of the normal execution path of the
standard XMPP plugin.

The normal path uses:

XMPPHP/XMPP.php
XMPPHP/XMLStream.php

Therefore:

DO NOT ADD:

curl
simplexml

to the xmpp plugin dependencies.

This is an important example where a simple grep of the entire plugin
directory would produce false dependencies.


============================================================
16. uploadeta — unnecessary JSON declaration
============================================================

FILE:

plugins/uploadeta/plugin.info

CURRENT:

php.extensions.error: json

However, no PHP code in the uploadeta plugin uses:

json_encode()
json_decode()
JSON::safeEncode()

or another JSON API.

RECOMMENDATION:

REMOVE:

php.extensions.error: json

STATUS:

UNNECESSARY DECLARATION.


============================================================
17. JSON WARNINGS — INCORRECT SEVERITY
============================================================

The following plugins currently declare:

php.extensions.warning: json

but use JSON without a fallback:

_getdir
cookies
loginmgr
lookat
retrackers

They use:

JSON::safeEncode()
or direct json_* APIs.

Therefore:

warning

is semantically incorrect.

Recommended:

php.extensions.error: json

NOTE:

This has limited practical impact because ruTorrent already requires
JSON globally.

It is nevertheless incorrect plugin metadata.


============================================================
18. CORRECT OPTIONAL DEPENDENCIES
============================================================

DO NOT ADD:

sysvsem

for autotools/datadir.

The code checks:

function_exists("sem_get")

and provides a fallback.

Therefore sysvsem is optional.


DO NOT ADD:

mbstring
iconv

to extsearch where the code already provides fallbacks.


DO NOT ADD:

mbstring
iconv

to rss.

RSS has fallback implementations.


DO NOT ADD:

mbstring

to geoip where the usage is protected by function_exists().


DO NOT ADD:

iconv
mbstring

to rutracker_check where fallback implementations are already present.


DO NOT ADD:

mbstring

to tracklabels where a strtolower() fallback exists.


============================================================
19. PROPOSED plugin.info CHANGES
============================================================

_getdir:

php.extensions.error: json,mbstring


datadir:

php.extensions.error: json,ctype


extsearch:

php.extensions.error: json
php.extensions.warning: dom


geoip:

php.extensions.error: json,phar
php.extensions.warning: sqlite3


rutracker_check:

php.extensions.error: ctype


source:

php.extensions.warning: zip


throttle:

php.extensions.error: ctype


tracklabels:

php.extensions.error: fileinfo


uploadeta:

REMOVE:

php.extensions.error: json


xmpp:

php.extensions.error: mbstring
php.extensions.warning: openssl


cookies:

php.extensions.error: json


loginmgr:

php.extensions.error: json


lookat:

php.extensions.error: json


retrackers:

php.extensions.error: json


============================================================
20. ADDITIONAL CODE ISSUES
============================================================

1. create/action.php:225

The following functions are used:

mb_substr()
mb_strlen()

They are used while constructing an error message.

This is not a core functional dependency of the plugin.

Recommendation:

Add a fallback instead of making mbstring a hard plugin dependency.


2. _getdir/listdir.php

mb_strtolower() is used without a fallback.

However, _getdir/info.php already implements a fallback.

Recommendation:

Use the same fallback in listdir.php.

After that change, mbstring can become optional.


============================================================
21. DEPENDENCY CLASSIFICATION
============================================================

HARD / ERROR:

_getdir          -> json, mbstring
datadir          -> json, ctype
throttle         -> ctype
rutracker_check  -> ctype
tracklabels      -> fileinfo
xmpp             -> mbstring
geoip            -> json, phar


SOFT / WARNING:

extsearch        -> dom
geoip            -> sqlite3
source            -> zip
xmpp              -> openssl


REMOVE:

uploadeta        -> json


CHANGE WARNING -> ERROR:

_getdir          -> json
cookies           -> json
loginmgr          -> json
lookat            -> json
retrackers        -> json


============================================================
22. FINAL CONCLUSIONS
============================================================

The original _getdir example was a valid finding:

plugins/_getdir/listdir.php:
mb_strtolower()

is an actual missing dependency.

The full audit shows that this is not an isolated case.

The most important confirmed missing PHP extensions are:

- _getdir -> mbstring
- datadir -> ctype
- throttle -> ctype
- rutracker_check -> ctype
- tracklabels -> fileinfo
- xmpp -> mbstring
- geoip -> phar

Additional feature-level dependencies:

- extsearch -> dom
- geoip -> sqlite3
- source -> zip
- xmpp -> openssl

There is also one confirmed unnecessary dependency:

- uploadeta -> json

Finally, several plugins classify JSON as warning even though the
corresponding code paths require JSON without a fallback.

The recommended changes should therefore update plugin.info metadata,
while some cases — especially _getdir/listdir.php and create/action.php —
would benefit from code-level fallbacks instead of simply adding more
hard dependencies.


============================================================
END OF REPORT
============================================================

Generated by ChatGPT 

</details>

