### PR TITLE
Material Design: make placeholder text visible

### DIFF
--- a/plugins/theme/themes/MaterialDesign/style.css
+++ b/plugins/theme/themes/MaterialDesign/style.css
@@ -705,6 +705,22 @@ textarea {
 	border-radius: 2px;
 }
 
+/* Placeholder text. Nothing styled it before: Bootstrap's rule is scoped to
+   .form-control and these fields carry flex-grow-1 instead, so the colour came
+   from the browser. Chrome and Edge use #757575, which against the #6F6F6F
+   these fields are painted is a contrast ratio of 1.09:1 -- the hint is the
+   same grey as the box it sits in. Firefox derives its placeholder from the
+   element's own colour, which the rules above set to #fff, so it stayed
+   readable there and the report only mentioned the other two (Novik#3077).
+   White at .8 gives 3.88:1 on the same background. */
+input[type="number"]::placeholder,
+input[type="text"]::placeholder,
+input[type="password"]::placeholder,
+textarea::placeholder {
+	color: rgba(255, 255, 255, .8);
+	opacity: 1;
+}
+
 button, input[type=button], input[type=submit], input.Button:not([disabled]):focus, .Button {
 	background: var(--btn-bg-color) none repeat scroll 0 0;
 	border-radius:2px;


### PR DESCRIPTION
The add-torrent dialog's "Torrent URLs (one per line)" and "Directory" hints are unreadable in Chrome and Edge (#3077).

Both strings are placeholders rather than labels -- js/content.js sets them on the #url textarea and the #dir_edit input -- and nothing in this theme styled ::placeholder. Bootstrap's rule is scoped to .form-control and those two fields carry flex-grow-1, so no author rule applied at all and the colour came from the browser. Chrome and Edge use #757575; this theme paints the fields #6F6F6F. Measured in Chrome, that is a contrast ratio of 1.09:1 -- the hint is the same grey as the box it sits in.

Firefox derives its placeholder colour from the element's own colour, which the rules above set to #fff, so it stayed readable there. That is why the report named only the other two browsers.

White at .8 gives 3.88:1 against the same background. It still falls short of the 4.5:1 WCAG AA wants for normal text -- #6F6F6F is light enough that only pure white clears that -- but the hint is legible, and darkening the field is a wider change to this theme's palette than a bug fix should make.

The other themes are unaffected: Oblivion and OblivionBlue give these fields a white background with black text, and Dark and DarkBetter do not restyle them, so the browser default reads correctly in all of them.