### PR TITLE
check_port: add provider failover and Globalping

### DIFF
--- a/plugins/check_port/action.php
+++ b/plugins/check_port/action.php
@@ -2,6 +2,7 @@
 require_once(dirname(__FILE__) . "/../../php/settings.php");
 require_once(dirname(__FILE__) . "/../../php/Snoopy.class.inc");
 require_once(dirname(__FILE__) . "/parse.php");
+require_once(dirname(__FILE__) . "/providers.php");
 
 // Load the plugin's configuration settings from conf.php
 eval(FileUtil::getPluginConf('check_port'));
@@ -10,6 +11,14 @@ eval(FileUtil::getPluginConf('check_port'));
 $currentCheckPortTimeout = isset($checkPortTimeout) ? (int)$checkPortTimeout : 15;
 $currentUseWebsiteIPv4 = isset($useWebsiteIPv4) ? $useWebsiteIPv4 : "yougetsignal";
 $currentUseWebsiteIPv6 = isset($useWebsiteIPv6) ? $useWebsiteIPv6 : "portchecker";
+
+$currentFailoverProvidersIPv4 = isset($failoverProvidersIPv4)
+	? $failoverProvidersIPv4
+	: array("portchecker", "globalping");
+
+$currentFailoverProvidersIPv6 = isset($failoverProvidersIPv6)
+	? $failoverProvidersIPv6
+	: array("globalping");
 
 /**
  * Gets the public IP address (IPv4 or IPv6) from ipify.org
@@ -24,171 +33,104 @@ function get_public_ip($version, $timeout) {
 		error_log("check_port plugin: 'curl' executable not found");
 		return null;
 	}
-	// Initialize the Snoopy client
+
 	$snoopy = new Snoopy();
 	$snoopy->agent = "ruTorrent CheckPort Plugin/IP Check";
-	// Set a timeout for the request, with a minimum of 5 seconds
-	$snoopy->read_timeout = max(5, (int)($timeout / 2));
-	$snoopy->proxy_host = ""; // Do not use a proxy for this external IP check
+	$snoopy->read_timeout = max(1, (int)floor($timeout));
+	$snoopy->proxy_host = "";
 
-	// Select the correct ipify API URL based on the requested IP version
 	$url = ($version == '6') ? "https://api64.ipify.org/" : "https://api4.ipify.org/";
-	@$snoopy->fetch($url); // Fetch the URL
+	@$snoopy->fetch($url);
 
-	// Check if the request was successful and returned content
 	if ($snoopy->status == 200 && !empty($snoopy->results)) {
 		$ip = trim($snoopy->results);
-		// Validate the returned IP address to ensure it's a valid IPv4 or IPv6
 		$flag = ($version == '6') ? FILTER_FLAG_IPV6 : FILTER_FLAG_IPV4;
 		if (filter_var($ip, FILTER_VALIDATE_IP, $flag)) {
-			return $ip; // Return the valid IP
+			return $ip;
 		}
-	} else {
-	}
-	return null; // Return null on failure
-}
-
-/**
- * Checks port status using yougetsignal.com
- *
- * @param string $ip The IP address to check
- * @param int $port The port number to check
- * @param int $timeout Request timeout in seconds
- * @return int Status code (0: unknown, 1: closed, 2: open)
- */
-function check_port_yougetsignal($ip, $port, $timeout) {
-	$client = new Snoopy();
-	$client->read_timeout = (int)$timeout;
-	$client->proxy_host = ""; // Do not use a proxy for this check
-
-	// The API is the one the site's own front end calls, and it is reached
-	// with the headers a browser on that site would send.
-	$client->rawheaders['Origin'] = "https://www.yougetsignal.com";
-	$client->referer = "https://www.yougetsignal.com/";
-
-	// Obtain a session device ID cookie required by the API
-	@$client->fetch("https://api.connected.app/deviceId");
-	if ($client->status != 204 && $client->status != 200) {
-		error_log("check_port: Failed to obtain yougetsignal device ID. Status: {$client->status}");
-		return 0;
-	}
-	$client->setcookies();
-
-	// Run the port check via the GraphQL API
-	$query = 'mutation NetworkToolRunPortCheck($input: NetworkToolPortCheckInput!) { networkToolRunPortCheck(input: $input) { output } }';
-	$post_data = json_encode([
-		'query' => $query,
-		'variables' => ['input' => ['host' => $ip, 'port' => (int)$port]],
-	]);
-	@$client->fetch("https://api.connected.app/graphql", "POST", "application/json", $post_data);
-
-	if ($client->status == 200) {
-		$status = check_port_parse_yougetsignal($client->results);
-		if ($status)
-			return $status;
-		error_log("check_port: yougetsignal unexpected response for IP {$ip}. Response: " . substr($client->results, 0, 500));
-	} else {
-		error_log("check_port: Failed fetch from yougetsignal for IP {$ip}. Status: {$client->status}, Error: {$client->error}");
-	}
-	return 0;
-}
-
-/**
- * Checks port status using portchecker.co
- *
- * @param string $ip The IP address to check
- * @param int $port The port number to check
- * @param int $timeout Request timeout in seconds
- * @return int Status code (0: unknown, 1: closed, 2: open)
- */
-function check_port_portchecker($ip, $port, $timeout) {
-	$client = new Snoopy();
-	$client->read_timeout = (int)$timeout;
-	$client->proxy_host = ""; // Do not use a proxy for this check
-
-	// Fetch the main page to acquire a CSRF token and session cookie
-	@$client->fetch("https://portchecker.co/");
-	if ($client->status != 200) {
-		error_log("check_port: Could not fetch portchecker.co main page. Status: {$client->status}");
-		return 0;
-	}
-	$client->setcookies(); // Store cookies to be sent in the next request
-
-	// Extract the CSRF token from the page content
-	$csrf_token = '';
-	if (preg_match('/name="_csrf" value="(?P<csrf>[^"]+)"/', $client->results, $match)) {
-		$csrf_token = $match["csrf"];
-	}
-	// If no token is found, the check cannot proceed
-	if (empty($csrf_token)) {
-		error_log("check_port: CSRF token not found from portchecker.co for IP: {$ip}");
-		return 0;
 	}
 
-	// Prepare the POST data for the port check request, including the CSRF token
-	$post_data = "target_ip=" . urlencode($ip) . "&port=" . urlencode($port) . "&_csrf=" . urlencode($csrf_token);
-	$client->referer = "https://portchecker.co/"; // Set the referer header
-
-	// Make the actual port check request to the API endpoint
-	@$client->fetch("https://portchecker.co/check-v0", "POST", "application/x-www-form-urlencoded", $post_data);
-
-	// Parse the JSON response to determine port status
-	if ($client->status == 200) {
-		if (stripos($client->results, 'is <span class="red">closed</span>') !== false) return 1; // Port is closed
-		if (stripos($client->results, 'is <span class="green">open</span>') !== false) return 2; // Port is open
-		error_log("check_port: portchecker response indicators not found for IP {$ip}. Response: " . substr($client->results, 0, 500));
-	} else {
-		error_log("check_port: Failed fetch from portchecker endpoint for IP {$ip}. Status: {$client->status}, Error: {$client->error}");
-	}
-	return 0; // Status is unknown
+	return null;
 }
 
 /**
  * Main logic to get an IP and check its port status for a given IP version
  *
- * @param string $ip_version '4' or '6', for IPv4 or IPv6
- * @param string $use_website The checking service to use ('yougetsignal' or 'portchecker')
+ * @param string $ip_version '4' or '6'
+ * @param string $use_website Primary checking service
  * @param string $rtorrent_ip The IP address configured in rTorrent (if any)
  * @param int $rtorrent_port The listening port configured in rTorrent
- * @param int $timeout The request timeout in seconds
+ * @param int $timeout Total time budget for IP detection and the provider chain
  * @return array An associative array with 'ip' and 'status' keys
  */
 function get_and_check_ip($ip_version, $use_website, $rtorrent_ip, $rtorrent_port, $timeout) {
+	global $checkPortProviders, $currentFailoverProvidersIPv4, $currentFailoverProvidersIPv6;
+
 	$ip_to_check = null;
 	$flag = ($ip_version == '6') ? FILTER_FLAG_IPV6 : FILTER_FLAG_IPV4;
+	$deadline = microtime(true) + max(1, (int)$timeout);
 
 	if (!empty($rtorrent_ip) && filter_var($rtorrent_ip, FILTER_VALIDATE_IP, $flag)) {
 		$ip_to_check = $rtorrent_ip;
-		// If rTorrent's IP is not set or invalid for the version, fetch the public IP
 	} else {
-		$ip_to_check = get_public_ip($ip_version, $timeout);
+		$remaining = $deadline - microtime(true);
+		if ($remaining >= 1) {
+			$ip_to_check = get_public_ip($ip_version, $remaining);
+		}
 	}
 
-	// If an IP was determined, proceed to check the port
 	if ($ip_to_check) {
-		$status = 0;
-		// Call the appropriate checking function based on the selected service
-		if ($use_website == "yougetsignal") {
-			$status = check_port_yougetsignal($ip_to_check, $rtorrent_port, $timeout);
-		} elseif ($use_website == "portchecker") {
-			$status = check_port_portchecker($ip_to_check, $rtorrent_port, $timeout);
+		$version = ($ip_version == '4') ? 'ipv4' : 'ipv6';
+		$failover = ($ip_version == '4')
+			? $currentFailoverProvidersIPv4
+			: $currentFailoverProvidersIPv6;
+		$providers = array_unique(array_merge([$use_website], $failover));
+
+		foreach ($providers as $provider) {
+			if (
+				!isset($checkPortProviders[$provider]) ||
+				empty($checkPortProviders[$provider][$version])
+			) {
+				continue;
+			}
+
+			$remaining = $deadline - microtime(true);
+			if ($remaining < 1) {
+				break;
+			}
+
+			// Provider timeout is an integer number of seconds and must never
+			// exceed the remaining shared budget.
+			$providerTimeout = max(1, (int)floor($remaining));
+
+			$status = call_user_func(
+				$checkPortProviders[$provider]["function"],
+				$ip_to_check,
+				$rtorrent_port,
+				$providerTimeout
+			);
+
+			if ($status === 1 || $status === 2) {
+				return [
+					"ip" => $ip_to_check,
+					"status" => $status
+				];
+			}
 		}
-		return ["ip" => $ip_to_check, "status" => $status];
+
+		return [
+			"ip" => $ip_to_check,
+			"status" => 0
+		];
 	}
-	// Return a default "not available" state if no IP could be determined
+
 	return ["ip" => "-", "status" => -1];
 }
 
 // --- Main Execution ---
-// Get rTorrent's listening port and configured IP from settings
 $port = rTorrentSettings::get()->port;
 $ip_glob = rTorrentSettings::get()->ip;
 
-// Optional: force a specific listening port before checking it. rtorrent
-// >= 0.16.18 exposes network.listen.port.set, which changes the live listening
-// port with no restart. Requires a trusted connection (the default here). The
-// port check below then runs against the new port so the user can immediately
-// confirm reachability.
 if (isset($_REQUEST['setport'])) {
 	$newport = (int)$_REQUEST['setport'];
 	if ($newport >= 1 && $newport <= 65535) {
@@ -198,25 +140,21 @@ if (isset($_REQUEST['setport'])) {
 	}
 }
 
-// Initialize the response structure that will be sent to the client
 $response = [
 	"ipv4" => "-", "ipv4_port" => (int)$port, "ipv4_status" => -1,
 	"ipv6" => "-", "ipv6_port" => (int)$port, "ipv6_status" => -1,
 ];
 
-// Perform the IPv4 check if it's enabled in conf.php
 if ($currentUseWebsiteIPv4 !== false) {
 	$ipv4_result = get_and_check_ip('4', $currentUseWebsiteIPv4, $ip_glob, $port, $currentCheckPortTimeout);
 	$response["ipv4"] = $ipv4_result["ip"];
 	$response["ipv4_status"] = $ipv4_result["status"];
 }
 
-// Perform the IPv6 check if it's enabled in conf.php
 if ($currentUseWebsiteIPv6 !== false) {
 	$ipv6_result = get_and_check_ip('6', $currentUseWebsiteIPv6, $ip_glob, $port, $currentCheckPortTimeout);
 	$response["ipv6"] = $ipv6_result["ip"];
 	$response["ipv6_status"] = $ipv6_result["status"];
 }
 
-// Send the final JSON response to the client
 CachedEcho::send(JSON::safeEncode($response), "application/json");

--- a/plugins/check_port/conf.php
+++ b/plugins/check_port/conf.php
@@ -7,9 +7,27 @@ $useWebsiteIPv4 = "yougetsignal";	// Valid choices:
 									// "portchecker" - use https://portchecker.co/
 
 $useWebsiteIPv6 = "portchecker";	// Valid choices:
-									// false - disable IPv6 port check
 									// "portchecker" - use https://portchecker.co/ (Known to work for IPv6)
 									// Note: yougetsignal does not appear to support IPv6 checks
 
-$checkPortTimeout = 15; // Timeout in seconds for external port checking services
-						// (e.g., yougetsignal, portchecker) and for IP detection services (e.g., ipify)
+$checkPortTimeout = 15; // Total timeout budget in seconds for the check,
+									// including provider failover and IP detection.
+
+// Providers tried in order when the primary provider
+// cannot return a definitive result.
+//
+// Valid providers:
+//   yougetsignal
+//   portchecker
+//   globalping
+$failoverProvidersIPv4 = [
+	"portchecker",
+	"globalping",
+];
+
+$failoverProvidersIPv6 = [
+	"globalping",
+];
+
+// Globalping's unauthenticated API is rate-limited per source IP.
+// If enabled as a provider, use it with an appropriate fallback chain.

--- a/plugins/check_port/init.php
+++ b/plugins/check_port/init.php
@@ -2,10 +2,39 @@
 
 // Load the plugin's configuration settings from conf.php
 eval(FileUtil::getPluginConf($plugin["name"]));
+require_once(dirname(__FILE__) . "/providers.php");
 
-// A service is considered validly configured if set to a known provider
-$isIPv4Valid = in_array($useWebsiteIPv4, ["yougetsignal", "portchecker"]);
-$isIPv6Valid = in_array($useWebsiteIPv6, ["portchecker"]);
+// A service is considered valid if configured with a provider
+// that supports the requested IP version.
+$isIPv4Valid = isset($checkPortProviders[$useWebsiteIPv4]) &&
+        !empty($checkPortProviders[$useWebsiteIPv4]["ipv4"]);
+
+$isIPv6Valid = isset($checkPortProviders[$useWebsiteIPv6]) &&
+        !empty($checkPortProviders[$useWebsiteIPv6]["ipv6"]);
+
+if ($isIPv4Valid && isset($failoverProvidersIPv4)) {
+        foreach ($failoverProvidersIPv4 as $provider) {
+                if (
+                        !isset($checkPortProviders[$provider]) ||
+                        empty($checkPortProviders[$provider]["ipv4"])
+                ) {
+                        $isIPv4Valid = false;
+                        break;
+                }
+        }
+}
+
+if ($isIPv6Valid && isset($failoverProvidersIPv6)) {
+        foreach ($failoverProvidersIPv6 as $provider) {
+                if (
+                        !isset($checkPortProviders[$provider]) ||
+                        empty($checkPortProviders[$provider]["ipv6"])
+                ) {
+                        $isIPv6Valid = false;
+                        break;
+                }
+        }
+}
 
 // The plugin should be active if at least one service is validly configured
 if ($isIPv4Valid || $isIPv6Valid) {

--- a/plugins/check_port/plugin.info
+++ b/plugins/check_port/plugin.info
@@ -1,6 +1,6 @@
 plugin.description: This plugin adds an incoming port status indicator to the bottom bar.
 plugin.author: Novik
-plugin.version: 5.1
+plugin.version: 5.2
 rtorrent.need: 1
 rtorrent.php.error: conf.php
 php.extensions.error: json

--- a/plugins/check_port/providers.php
+++ b/plugins/check_port/providers.php
@@ -1,0 +1,22 @@
+<?php
+require_once(dirname(__FILE__) . "/providers/yougetsignal.php");
+require_once(dirname(__FILE__) . "/providers/portchecker.php");
+require_once(dirname(__FILE__) . "/providers/globalping.php");
+
+$checkPortProviders = [
+	"yougetsignal" => [
+		"function" => "check_port_yougetsignal",
+		"ipv4" => true,
+		"ipv6" => false,
+	],
+	"portchecker" => [
+		"function" => "check_port_portchecker",
+		"ipv4" => true,
+		"ipv6" => true,
+	],
+	"globalping" => [
+		"function" => "check_port_globalping",
+		"ipv4" => true,
+		"ipv6" => true,
+	],
+];

--- a/plugins/check_port/providers/globalping.php
+++ b/plugins/check_port/providers/globalping.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Checks port status using Globalping.
+ *
+ * Returns 0 = unknown, 1 = closed, 2 = open.
+ */
+function check_port_globalping($ip, $port, $timeout) {
+	$client = new Snoopy();
+	$client->read_timeout = max(1, min((int)$timeout, 5));
+	$client->proxy_host = "";
+
+	$payload = json_encode([
+		"target" => $ip,
+		"type" => "ping",
+		"measurementOptions" => [
+			"protocol" => "TCP",
+			"port" => (int)$port,
+		],
+	]);
+
+	@$client->fetch(
+		"https://api.globalping.io/v1/measurements",
+		"POST",
+		"application/json",
+		$payload
+	);
+
+	if ($client->status < 200 || $client->status >= 300) {
+		error_log(
+			"check_port: Globalping create failed for {$ip}. " .
+			"Status: {$client->status}, Error: {$client->error}"
+		);
+		return 0;
+	}
+
+	$created = json_decode($client->results, true);
+	if (!is_array($created) || empty($created["id"])) {
+		error_log(
+			"check_port: Invalid Globalping create response for {$ip}. " .
+			"Response: " . substr($client->results, 0, 500)
+		);
+		return 0;
+	}
+
+	$id = $created["id"];
+	$deadline = microtime(true) + $client->read_timeout;
+
+	for ($poll = 0; $poll < 6; $poll++) {
+		if ($poll > 0) {
+			$remaining = $deadline - microtime(true);
+			if ($remaining <= 0) {
+				break;
+			}
+
+			usleep((int)(min(0.5, $remaining) * 1000000));
+		}
+
+		if (microtime(true) >= $deadline) {
+			break;
+		}
+
+		@$client->fetch(
+			"https://api.globalping.io/v1/measurements/" .
+			rawurlencode($id)
+		);
+
+		if ($client->status != 200) {
+			error_log(
+				"check_port: Globalping poll failed for {$id}. " .
+				"Status: {$client->status}, Error: {$client->error}"
+			);
+			return 0;
+		}
+
+		$result = json_decode($client->results, true);
+		if (!is_array($result)) {
+			return 0;
+		}
+
+		if (($result["status"] ?? "") === "in-progress") {
+			continue;
+		}
+
+		if (($result["status"] ?? "") !== "finished") {
+			return 0;
+		}
+
+		$raw = $result["results"][0]["result"]["rawOutput"] ?? "";
+		if (!is_string($raw) || $raw === "") {
+			return 0;
+		}
+
+		// An explicit refusal means the port is closed.
+		if (preg_match('/connection refused|tcp_conn=.*refused/i', $raw)) {
+			return 1;
+		}
+
+		// Globalping includes tcp_conn=N on both reply and no-reply output.
+		// Only a real reply is evidence that the port is open.
+		if (preg_match('/^Reply from .*tcp_conn=\d+/mi', $raw)) {
+			return 2;
+		}
+
+		// No reply means the probe could not establish a TCP connection.
+		// This is inconclusive (for example, filtered), not proof of closure.
+		if (preg_match('/^No reply from /mi', $raw)) {
+			return 0;
+		}
+
+		return 0;
+	}
+
+	return 0;
+}

--- a/plugins/check_port/providers/portchecker.php
+++ b/plugins/check_port/providers/portchecker.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Checks port status using portchecker.co
+ *
+ * @param string $ip The IP address to check
+ * @param int $port The port number to check
+ * @param int $timeout Request timeout in seconds
+ * @return int Status code (0: unknown, 1: closed, 2: open)
+ */
+function check_port_portchecker($ip, $port, $timeout) {
+	$client = new Snoopy();
+	$client->read_timeout = (int)$timeout;
+	$client->proxy_host = ""; // Do not use a proxy for this check
+
+	// Fetch the main page to acquire a CSRF token and session cookie
+	@$client->fetch("https://portchecker.co/");
+	if ($client->status != 200) {
+		error_log("check_port: Could not fetch portchecker.co main page. Status: {$client->status}");
+		return 0;
+	}
+	$client->setcookies(); // Store cookies to be sent in the next request
+
+	// Extract the CSRF token from the page content
+	$csrf_token = '';
+	if (preg_match('/name="_csrf" value="(?P<csrf>[^"]+)"/', $client->results, $match)) {
+		$csrf_token = $match["csrf"];
+	}
+	// If no token is found, the check cannot proceed
+	if (empty($csrf_token)) {
+		error_log("check_port: CSRF token not found from portchecker.co for IP: {$ip}");
+		return 0;
+	}
+
+	// Prepare the POST data for the port check request, including the CSRF token
+	$post_data = "target_ip=" . urlencode($ip) . "&port=" . urlencode($port) . "&_csrf=" . urlencode($csrf_token);
+	$client->referer = "https://portchecker.co/"; // Set the referer header
+
+	// Make the actual port check request to the API endpoint
+	@$client->fetch("https://portchecker.co/check-v0", "POST", "application/x-www-form-urlencoded", $post_data);
+
+	// Parse the JSON response to determine port status
+	if ($client->status == 200) {
+		if (stripos($client->results, 'is <span class="red">closed</span>') !== false) return 1; // Port is closed
+		if (stripos($client->results, 'is <span class="green">open</span>') !== false) return 2; // Port is open
+		error_log("check_port: portchecker response indicators not found for IP {$ip}. Response: " . substr($client->results, 0, 500));
+	} else {
+		error_log("check_port: Failed fetch from portchecker endpoint for IP {$ip}. Status: {$client->status}, Error: {$client->error}");
+	}
+	return 0; // Status is unknown
+}

--- a/plugins/check_port/providers/yougetsignal.php
+++ b/plugins/check_port/providers/yougetsignal.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Checks port status using yougetsignal.com
+ *
+ * @param string $ip The IP address to check
+ * @param int $port The port number to check
+ * @param int $timeout Request timeout in seconds
+ * @return int Status code (0: unknown, 1: closed, 2: open)
+ */
+function check_port_yougetsignal($ip, $port, $timeout) {
+	$client = new Snoopy();
+	$client->read_timeout = (int)$timeout;
+	$client->proxy_host = ""; // Do not use a proxy for this check
+
+	// The API is the one the site's own front end calls, and it is reached
+	// with the headers a browser on that site would send.
+	$client->rawheaders['Origin'] = "https://www.yougetsignal.com";
+	$client->referer = "https://www.yougetsignal.com/";
+
+	// Obtain a session device ID cookie required by the API
+	@$client->fetch("https://api.connected.app/deviceId");
+	if ($client->status != 204 && $client->status != 200) {
+		error_log("check_port: Failed to obtain yougetsignal device ID. Status: {$client->status}");
+		return 0;
+	}
+	$client->setcookies();
+
+	// Run the port check via the GraphQL API
+	$query = 'mutation NetworkToolRunPortCheck($input: NetworkToolPortCheckInput!) { networkToolRunPortCheck(input: $input) { output } }';
+	$post_data = json_encode([
+		'query' => $query,
+		'variables' => ['input' => ['host' => $ip, 'port' => (int)$port]],
+	]);
+	@$client->fetch("https://api.connected.app/graphql", "POST", "application/json", $post_data);
+
+	if ($client->status == 200) {
+		$status = check_port_parse_yougetsignal($client->results);
+		if ($status)
+			return $status;
+		error_log("check_port: yougetsignal unexpected response for IP {$ip}. Response: " . substr($client->results, 0, 500));
+	} else {
+		error_log("check_port: Failed fetch from yougetsignal for IP {$ip}. Status: {$client->status}, Error: {$client->error}");
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary

Adds configurable provider failover to the `check_port` plugin and adds
Globalping as a third port-check provider.

The primary provider remains unchanged by default:

- IPv4: YouGetSignal
- IPv6: PortChecker

Default fallbacks are:

- IPv4: PortChecker → Globalping
- IPv6: Globalping

Provider implementations are moved out of `action.php` into separate files
and registered through a shared provider registry. The dispatcher is
provider-agnostic: providers return `0` (unknown), `1` (closed), or `2` (open),
and the configured chain continues until a definitive result is available.

Globalping is used as the final fallback when earlier providers fail or return
an inconclusive result.

## Testing

Tested on a live ruTorrent/rTorrent installation.

- Verified IPv4 and IPv6 port checks.
- Tested all three providers and provider rotation.
- Tested failover by forcing the primary provider to fail and confirming Globalping supplied the result.
- All changed PHP files pass `php -l`.
- Unchanged frontend and localization files remain identical to upstream.