### PR TITLE
Declare the PHP extensions the bundled plugins use, and check them

### DIFF
--- a/env_check.php
+++ b/env_check.php
@@ -103,6 +103,62 @@ class Requirements
 		return is_string($value) && (bool)preg_match('/^0?[0-7]{3}$/D', $value);
 	}
 
+	/**
+	 * The PHP extensions a plugin says it needs, read from its plugin.info.
+	 * Returns array('error' => array(...), 'warning' => array(...)) -- error
+	 * means the plugin is disabled without it, warning that one of its
+	 * features is.
+	 */
+	public static function pluginExtensions($info)
+	{
+		$ret = array('error' => array(), 'warning' => array());
+		if (!is_string($info) || $info === '') return $ret;
+		foreach (preg_split('/\r\n|\r|\n/', $info) as $line) {
+			if (!preg_match('/^\s*php\.extensions\.(error|warning)\s*:\s*(.+)$/', $line, $m)) continue;
+			foreach (explode(',', $m[2]) as $ext) {
+				$ext = trim($ext);
+				if ($ext !== '' && !in_array($ext, $ret[$m[1]], true)) $ret[$m[1]][] = $ext;
+			}
+		}
+		return $ret;
+	}
+
+	/**
+	 * Which of the extensions the plugins declare are not loaded, and what
+	 * each absence costs. $byPlugin is plugin name => the array
+	 * pluginExtensions() returned for it; $loaded is the extension names PHP
+	 * has. Returns extension => array('disables' => array(...),
+	 * 'limits' => array(...)), keyed in a stable order.
+	 */
+	public static function missingPluginExtensions($byPlugin, $loaded)
+	{
+		$wanted = array();
+		foreach ($byPlugin as $plugin => $needs)
+			foreach (array('error', 'warning') as $severity)
+				foreach ((isset($needs[$severity]) ? $needs[$severity] : array()) as $ext) {
+					if (!isset($wanted[$ext])) $wanted[$ext] = array();
+					// A plugin that cannot run without it outranks one that
+					// only loses a feature, so error wins for the same pair.
+					if (!isset($wanted[$ext][$plugin]) || ($severity === 'error'))
+						$wanted[$ext][$plugin] = $severity;
+				}
+		ksort($wanted);
+		// get_loaded_extensions() answers with the name each extension
+		// registered -- Phar, SimpleXML -- while plugin.info spells them
+		// lower case, and extension_loaded() does not care either way.
+		$have = array_map('strtolower', $loaded);
+		$ret = array();
+		foreach ($wanted as $ext => $plugins) {
+			if (in_array(strtolower($ext), $have, true)) continue;
+			ksort($plugins);
+			$ret[$ext] = array(
+				'disables' => array_keys(array_filter($plugins, function ($s) { return $s === 'error'; })),
+				'limits'   => array_keys(array_filter($plugins, function ($s) { return $s === 'warning'; })),
+			);
+		}
+		return $ret;
+	}
+
 	public static function logFileStreamScheme($path)
 	{
 		if (!is_string($path) ||
@@ -278,6 +334,31 @@ if ($cfg === null) {
 	}
 }
 
+// ---- what the bundled plugins declare they need ---------------------------
+// Read from each plugin.info rather than a list kept here, so a plugin that
+// declares a new dependency is checked without this file being touched. A
+// missing extension disables one plugin, not ruTorrent, so these are warnings.
+$pluginDir = __DIR__ . '/plugins';
+if (@is_dir($pluginDir)) {
+	$byPlugin = array();
+	foreach (@scandir($pluginDir) ?: array() as $entry) {
+		if (($entry === '.') || ($entry === '..')) continue;
+		$info = @file_get_contents($pluginDir . '/' . $entry . '/plugin.info');
+		if ($info === false) continue;
+		$byPlugin[$entry] = Requirements::pluginExtensions($info);
+	}
+	$missing = Requirements::missingPluginExtensions($byPlugin, get_loaded_extensions());
+	foreach ($missing as $ext => $cost) {
+		$detail = array();
+		if ($cost['disables']) $detail[] = 'disables ' . implode(', ', $cost['disables']);
+		if ($cost['limits'])   $detail[] = 'limits ' . implode(', ', $cost['limits']);
+		check('plugins', false, "PHP extension: $ext", implode('; ', $detail));
+	}
+	if (!$missing)
+		check('plugins', true, 'plugin extensions',
+			'every extension the bundled plugins declare is loaded');
+}
+
 // ---- rtorrent version (needs config + a running rtorrent) ----------------
 function scgi_params($params) {
 	$xml = '';
@@ -341,7 +422,7 @@ $mark = function($ok, $section) {
 	if ($ok) return 'OK  ';
 	return $section === 'req' ? 'FAIL' : 'WARN';
 };
-$sections = array('req' => 'Required', 'rec' => 'Recommended', 'config' => 'Configuration', 'rtorrent' => 'rtorrent');
+$sections = array('req' => 'Required', 'rec' => 'Recommended', 'config' => 'Configuration', 'plugins' => 'Plugins', 'rtorrent' => 'rtorrent');
 $lines = array();
 $lines[] = "ruTorrent prerequisites & install check  (PHP " . PHP_VERSION . ")";
 $lines[] = str_repeat('-', 74);

--- a/plugins/bulk_magnet/plugin.info
+++ b/plugins/bulk_magnet/plugin.info
@@ -1,3 +1,4 @@
 plugin.description: This plugin allows bulk operations with magnet links.
 plugin.author: Novik
 plugin.version: 5.1
+php.extensions.error: json

--- a/plugins/create/plugin.info
+++ b/plugins/create/plugin.info
@@ -8,4 +8,5 @@ rtorrent.external.error: php
 rtorrent.script.error: buildtorrent.sh,createtorrent.sh,inner.sh,mktorrent.sh,transmissioncli.sh
 rtorrent.php.error: correct.php,createtorrent.php,conf.php
 php.extensions.error: json
+php.extensions.warning: mbstring
 plugin.help: https://github.com/Novik/ruTorrent/wiki/PluginCreate

--- a/plugins/datadir/plugin.info
+++ b/plugins/datadir/plugin.info
@@ -2,6 +2,6 @@ plugin.description: This plugin is intended for moving torrent data files.
 plugin.author: dmrom
 plugin.version: 5.1
 rtorrent.remote: error
-php.extensions.error: json
+php.extensions.error: json,ctype
 rtorrent.external.error: php
 plugin.help: https://github.com/Novik/ruTorrent/wiki/PluginDataDir

--- a/plugins/diskspace/plugin.info
+++ b/plugins/diskspace/plugin.info
@@ -2,4 +2,5 @@ plugin.description: This plugin adds an easy-to-read disk meter to the bottom ba
 plugin.author: Novik
 plugin.version: 5.1
 rtorrent.need: 0
+php.extensions.error: json
 plugin.help: https://github.com/Novik/ruTorrent/wiki/PluginDiskspace

--- a/plugins/extsearch/plugin.info
+++ b/plugins/extsearch/plugin.info
@@ -4,4 +4,5 @@ plugin.version: 5.1
 plugin.runlevel: 10.5
 rtorrent.need: 0
 php.extensions.error: json
+php.extensions.warning: dom
 plugin.help: https://github.com/Novik/ruTorrent/wiki/PluginExtsearch

--- a/plugins/geoip/plugin.info
+++ b/plugins/geoip/plugin.info
@@ -2,5 +2,6 @@ plugin.description: This plugin shows the geolocation of peers for the selected 
 plugin.author: Zoltan Csala,Novik
 plugin.runlevel: 15
 plugin.version: 5.1
-php.extensions.error: json
+php.extensions.error: json,phar
+php.extensions.warning: sqlite3
 plugin.help: https://github.com/Novik/ruTorrent/wiki/PluginGeoIP

--- a/plugins/log_history/plugin.info
+++ b/plugins/log_history/plugin.info
@@ -6,4 +6,5 @@ plugin.runlevel: 10.0
 plugin.may_be_launched: 1
 plugin.may_be_shutdowned: 1
 rtorrent.need: 0
+php.extensions.error: json
 php.version: 5.0.0

--- a/plugins/rutracker_check/plugin.info
+++ b/plugins/rutracker_check/plugin.info
@@ -1,6 +1,7 @@
 plugin.description: This plugin checks the rutracker.org tracker for updated/deleted torrents.
 plugin.author: Novik
 plugin.version: 5.1
+php.extensions.warning: ctype,json
 rtorrent.remote: error
 rtorrent.external.error: php
 plugin.dependencies: loginmgr

--- a/plugins/source/plugin.info
+++ b/plugins/source/plugin.info
@@ -1,5 +1,6 @@
 plugin.description: This plugin allows you to copy the source .torrent file from the host to the local machine.
 plugin.author: Novik
 plugin.version: 5.1
+php.extensions.warning: zip
 rtorrent.remote: error
 plugin.help: https://github.com/Novik/ruTorrent/wiki/PluginSource

--- a/plugins/throttle/plugin.info
+++ b/plugins/throttle/plugin.info
@@ -2,5 +2,6 @@ plugin.description: This plugin gives convenient control over speed limits for g
 plugin.author: Novik
 plugin.runlevel: 11.2
 plugin.version: 5.1
+php.extensions.error: ctype
 rtorrent.version: 0.8.4
 plugin.help: https://github.com/Novik/ruTorrent/wiki/PluginThrottle

--- a/plugins/tracklabels/plugin.info
+++ b/plugins/tracklabels/plugin.info
@@ -2,4 +2,5 @@ plugin.description: This plugin adds tracker-based labels to the category panel.
 plugin.author: Novik
 plugin.runlevel: 11
 plugin.version: 5.1
+php.extensions.error: fileinfo,json
 plugin.help: https://github.com/Novik/ruTorrent/wiki/PluginTracklabels

--- a/plugins/xmpp/plugin.info
+++ b/plugins/xmpp/plugin.info
@@ -2,6 +2,8 @@ plugin.description: This plugin sends notifications about finished downloads via
 plugin.author: DeadMor0z
 plugin.runlevel: 5
 plugin.version: 0.1
+php.extensions.error: mbstring
+php.extensions.warning: openssl
 rtorrent.remote: error
 rtorrent.external.error: php
 rtorrent.php.error: xmpp.php

--- a/tests/php/PluginExtensionsTest.php
+++ b/tests/php/PluginExtensionsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+
+define('RUTORRENT_REQUIREMENTS_LIB', true);
+require_once(__DIR__ . '/../../env_check.php');
+
+/**
+ * What a plugin declares in its plugin.info is the only record of the PHP
+ * extensions it needs, and nothing read it outside the plugin loader -- so an
+ * installer had no way to learn that a missing extension was why a plugin was
+ * absent. env_check reads those declarations now; these cover the reading and
+ * the verdict, which is the part with no network and no filesystem in it.
+ */
+class PluginExtensionsTest extends TestCase
+{
+	private function info($lines)
+	{
+		return implode("\n", $lines) . "\n";
+	}
+
+	public function testItReadsBothSeverities()
+	{
+		$needs = Requirements::pluginExtensions($this->info(array(
+			'plugin.author: someone',
+			'php.extensions.error: json,ctype',
+			'php.extensions.warning: zip',
+		)));
+		$this->assertEquals(array('json', 'ctype'), $needs['error'], 'the error list is read');
+		$this->assertEquals(array('zip'), $needs['warning'], 'and the warning list');
+	}
+
+	public function testItToleratesSpacingAndRepeats()
+	{
+		$needs = Requirements::pluginExtensions($this->info(array(
+			'php.extensions.error:   json ,  ctype ,json ',
+		)));
+		$this->assertEquals(array('json', 'ctype'), $needs['error'],
+			'spacing is trimmed and a repeat is not listed twice');
+	}
+
+	public function testAPluginInfoWithoutExtensionsAsksForNothing()
+	{
+		$needs = Requirements::pluginExtensions($this->info(array('plugin.version: 5.1')));
+		$this->assertEquals(array(), $needs['error'], 'no error list');
+		$this->assertEquals(array(), $needs['warning'], 'no warning list');
+	}
+
+	public function testAnUnreadableInfoAsksForNothing()
+	{
+		// file_get_contents() answers false for a plugin without a plugin.info.
+		$needs = Requirements::pluginExtensions(false);
+		$this->assertEquals(array(), $needs['error'], 'a missing plugin.info is not a demand');
+	}
+
+	public function testItReportsOnlyWhatIsNotLoaded()
+	{
+		$missing = Requirements::missingPluginExtensions(
+			array('alpha' => array('error' => array('json'), 'warning' => array())),
+			array('json', 'pcre'));
+		$this->assertEquals(array(), $missing, 'an extension that is loaded is not reported');
+	}
+
+	public function testItSaysWhatEachAbsenceCosts()
+	{
+		$missing = Requirements::missingPluginExtensions(array(
+			'alpha' => array('error' => array('ctype'), 'warning' => array()),
+			'beta'  => array('error' => array(), 'warning' => array('ctype')),
+		), array('json'));
+		$this->assertTrue(isset($missing['ctype']), 'the missing extension is reported');
+		$this->assertEquals(array('alpha'), $missing['ctype']['disables'],
+			'a plugin that declared it an error is disabled');
+		$this->assertEquals(array('beta'), $missing['ctype']['limits'],
+			'a plugin that declared it a warning is limited');
+	}
+
+	/** The stronger claim wins when one plugin says both. */
+	public function testErrorOutranksWarningForTheSamePlugin()
+	{
+		$missing = Requirements::missingPluginExtensions(
+			array('alpha' => array('error' => array('zip'), 'warning' => array('zip'))),
+			array());
+		$this->assertEquals(array('alpha'), $missing['zip']['disables'], 'it counts as disabling');
+		$this->assertEquals(array(), $missing['zip']['limits'], 'and not also as limiting');
+	}
+
+	/**
+	 * get_loaded_extensions() answers with the name each extension registered,
+	 * which is not how plugin.info spells them.
+	 */
+	public function testItMatchesTheNameCasePhpReports()
+	{
+		$missing = Requirements::missingPluginExtensions(
+			array('geoip' => array('error' => array('phar'), 'warning' => array('sqlite3'))),
+			array('Phar', 'SimpleXML', 'sqlite3'));
+		$this->assertEquals(array(), $missing,
+			'Phar answers for phar, however either side spells it');
+	}
+
+	/** Every plugin.info that ships must parse, and name real extensions. */
+	public function testEveryShippedDeclarationIsReadable()
+	{
+		$root = dirname(dirname(__DIR__));
+		$declared = array();
+		foreach (scandir($root . '/plugins') as $entry) {
+			if (($entry === '.') || ($entry === '..')) continue;
+			$path = $root . '/plugins/' . $entry . '/plugin.info';
+			if (!is_file($path)) continue;
+			$needs = Requirements::pluginExtensions(file_get_contents($path));
+			foreach (array_merge($needs['error'], $needs['warning']) as $ext)
+				$declared[$ext] = true;
+		}
+		$this->assertTrue(count($declared) > 0, 'the shipped plugins declare extensions');
+		foreach (array_keys($declared) as $ext)
+			$this->assertTrue((bool)preg_match('/^[a-z0-9_]+$/', $ext),
+				'a declared extension name is a plain extension name: ' . var_export($ext, true));
+	}
+}


### PR DESCRIPTION
A plugin that calls into an extension nobody declared fails at the point of the call. On PHP 8 that is a fatal, so the interface loses a dialog or an endpoint with no message, and the plugin loader -- which reads these declarations and can disable a plugin cleanly with an explanation -- never gets the chance.

  bulk_magnet      error json          its only response is JSON::safeEncode
  create           warning mbstring    mb_substr, only on the invalid-directory message
  datadir          error ctype         ctype_xdigit validates every hash it is given
  diskspace        error json          its only response
  extsearch        warning dom         DOMDocument in the IPTorrents and Zooqle engines
  geoip            error phar          the bundled library loads over phar://
  geoip            warning sqlite3     only the comments database
  log_history      error json          its responses
  rutracker_check  warning ctype,json  the rutracker and nnmclub trackers only
  source           warning zip         only the multi-torrent download
  throttle         error ctype         ctype_xdigit on the main path
  tracklabels      error fileinfo,json mime_content_type gates every icon upload
  xmpp             error mbstring      mb_substr in XMLStream::send()
  xmpp             warning openssl     only when encryption is enabled

Left alone deliberately: extsearch, geoip and rss also call iconv and mbstring, but each of those sites tests function_exists() first and falls back, so the extension is genuinely optional there and a declaration would report a problem that does not exist.

env_check reads these declarations rather than a list of its own, so a plugin that starts needing something is checked without this file being touched. A missing extension costs one plugin rather than ruTorrent, so it reports as a warning and names what is lost:

  Plugins:
    [WARN] PHP extension: ctype    disables datadir, throttle; limits rutracker_check

The reading and the verdict are separate functions with no filesystem or network in them, and tests/php/PluginExtensionsTest.php covers both -- including that Phar answers for a plugin.info that says phar, since get_loaded_extensions() reports the name each extension registered.