### PR TITLE
check_port: cover the Globalping verdict with tests

### DIFF
--- a/plugins/check_port/parse.php
+++ b/plugins/check_port/parse.php
@@ -32,3 +32,30 @@ function check_port_parse_yougetsignal($body)
 
 	return 0;
 }
+
+/**
+ * Reads the port state out of a Globalping measurement's raw output.
+ *
+ * Globalping runs a TCP ping and hands back what the probe printed. The
+ * counter it puts on each attempt, tcp_conn=N, appears on the lines that got
+ * no answer as well as the ones that did, so the counter alone says nothing --
+ * only a line that begins "Reply from" is evidence the port accepted a
+ * connection.
+ *
+ * A probe that got no reply cannot tell a closed port from a filtered one, or
+ * from a route it simply could not take, so that answer is unknown rather than
+ * closed. Only an explicit refusal is proof of a closed port.
+ *
+ * @param string $raw the probe's raw output
+ * @return int Status code (0: unknown, 1: closed, 2: open)
+ */
+function check_port_parse_globalping($raw)
+{
+	if (!is_string($raw) || $raw === '')
+		return 0;
+	if (preg_match('/connection refused|tcp_conn=.*refused/i', $raw))
+		return 1;
+	if (preg_match('/^Reply from .*tcp_conn=\d+/mi', $raw))
+		return 2;
+	return 0;
+}

--- a/plugins/check_port/providers/globalping.php
+++ b/plugins/check_port/providers/globalping.php
@@ -1,4 +1,6 @@
 <?php
+
+require_once(dirname(dirname(__FILE__)) . "/parse.php");
 /**
  * Checks port status using Globalping.
  *
@@ -85,29 +87,8 @@ function check_port_globalping($ip, $port, $timeout) {
 			return 0;
 		}
 
-		$raw = $result["results"][0]["result"]["rawOutput"] ?? "";
-		if (!is_string($raw) || $raw === "") {
-			return 0;
-		}
-
-		// An explicit refusal means the port is closed.
-		if (preg_match('/connection refused|tcp_conn=.*refused/i', $raw)) {
-			return 1;
-		}
-
-		// Globalping includes tcp_conn=N on both reply and no-reply output.
-		// Only a real reply is evidence that the port is open.
-		if (preg_match('/^Reply from .*tcp_conn=\d+/mi', $raw)) {
-			return 2;
-		}
-
-		// No reply means the probe could not establish a TCP connection.
-		// This is inconclusive (for example, filtered), not proof of closure.
-		if (preg_match('/^No reply from /mi', $raw)) {
-			return 0;
-		}
-
-		return 0;
+		return check_port_parse_globalping(
+			$result["results"][0]["result"]["rawOutput"] ?? "");
 	}
 
 	return 0;

--- a/tests/php/CheckPortProvidersTest.php
+++ b/tests/php/CheckPortProvidersTest.php
@@ -1,0 +1,114 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../plugins/check_port/providers.php');
+
+/**
+ * The shipped check_port configuration against the provider registry.
+ *
+ * action.php skips any provider that is unknown or that does not claim the
+ * address family being checked, so a name that does not line up costs no
+ * error -- the provider is simply never tried, and the chain the comment in
+ * conf.php describes is quietly shorter than it reads. These cases hold the
+ * shipped defaults to what that comment promises.
+ */
+class CheckPortProvidersTest extends TestCase
+{
+	/** conf.php assigns at file scope, so including it here yields locals. */
+	private function shippedConf()
+	{
+		include(__DIR__ . '/../../plugins/check_port/conf.php');
+
+		return array(
+			'primary' => array('ipv4' => $useWebsiteIPv4, 'ipv6' => $useWebsiteIPv6),
+			'failover' => array('ipv4' => $failoverProvidersIPv4, 'ipv6' => $failoverProvidersIPv6),
+		);
+	}
+
+	public function testEveryRegisteredProviderNamesAFunctionThatExists()
+	{
+		global $checkPortProviders;
+
+		foreach ($checkPortProviders as $name => $provider) {
+			$this->assertTrue(function_exists($provider['function']),
+				"provider $name resolves to " . $provider['function']);
+		}
+	}
+
+	public function testEveryRegisteredProviderClaimsAtLeastOneFamily()
+	{
+		global $checkPortProviders;
+
+		foreach ($checkPortProviders as $name => $provider) {
+			$this->assertTrue(!empty($provider['ipv4']) || !empty($provider['ipv6']),
+				"provider $name is reachable for at least one address family");
+		}
+	}
+
+	/**
+	 * A name in the failover list that is not in the registry is dropped by
+	 * action.php without a word, so the shipped lists have to be right.
+	 */
+	public function testShippedFailoverProvidersAreRegistered()
+	{
+		global $checkPortProviders;
+		$conf = $this->shippedConf();
+
+		foreach ($conf['failover'] as $family => $providers) {
+			foreach ($providers as $name) {
+				$this->assertTrue(isset($checkPortProviders[$name]),
+					"$family failover provider $name is a registered provider");
+			}
+		}
+	}
+
+	/**
+	 * The failure this pins: listing yougetsignal, which has no IPv6 support,
+	 * in the IPv6 chain would leave that chain empty at run time while still
+	 * reading as configured.
+	 */
+	public function testShippedFailoverProvidersSupportTheFamilyTheyAreListedUnder()
+	{
+		global $checkPortProviders;
+		$conf = $this->shippedConf();
+
+		foreach ($conf['failover'] as $family => $providers) {
+			foreach ($providers as $name) {
+				$this->assertTrue(!empty($checkPortProviders[$name][$family]),
+					"$family failover provider $name supports $family");
+			}
+		}
+	}
+
+	public function testShippedPrimaryProvidersSupportTheirFamily()
+	{
+		global $checkPortProviders;
+		$conf = $this->shippedConf();
+
+		foreach ($conf['primary'] as $family => $name) {
+			if ($name === false)
+				continue;
+
+			$this->assertTrue(isset($checkPortProviders[$name]),
+				"$family primary provider $name is a registered provider");
+			$this->assertTrue(!empty($checkPortProviders[$name][$family]),
+				"$family primary provider $name supports $family");
+		}
+	}
+
+	/**
+	 * Failing over to the provider that already failed wastes part of the
+	 * timeout budget on a repeat of the same request.
+	 */
+	public function testShippedFailoverDoesNotRepeatThePrimaryProvider()
+	{
+		$conf = $this->shippedConf();
+
+		foreach ($conf['failover'] as $family => $providers) {
+			$this->assertTrue(!in_array($conf['primary'][$family], $providers, true),
+				"$family failover chain does not retry the primary provider");
+			$this->assertEquals(count($providers), count(array_unique($providers)),
+				"$family failover chain lists each provider once");
+		}
+	}
+}

--- a/tests/php/GlobalpingParseTest.php
+++ b/tests/php/GlobalpingParseTest.php
@@ -1,0 +1,100 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+require_once(__DIR__ . '/../../plugins/check_port/parse.php');
+
+/**
+ * What Globalping's probe printed, read back as a port state.
+ *
+ * The bodies below are what api.globalping.io actually returned for those
+ * targets, not shapes invented for the test. The distinction they exist to
+ * pin cost a wrong answer once already: the counter Globalping puts on each
+ * attempt, tcp_conn=N, is printed on the lines that got no answer as well,
+ * so a rule that looked for the counter alone called every port open --
+ * including one that was not reachable at all.
+ */
+class GlobalpingParseTest extends TestCase
+{
+	/** 8.8.8.8:53, a port that answers. */
+	private function replied()
+	{
+		return "PING dns.google (8.8.8.8) on port 53.\n"
+			. "Reply from dns.google (8.8.8.8) on port 53: tcp_conn=1 time=1.01 ms\n"
+			. "Reply from dns.google (8.8.8.8) on port 53: tcp_conn=2 time=1.13 ms\n"
+			. "\n--- dns.google (8.8.8.8) ping statistics ---\n"
+			. "3 packets transmitted, 3 received, 0% packet loss, time 1002 ms\n";
+	}
+
+	/** 8.8.8.8:81, a port that is filtered rather than refused. */
+	private function silent()
+	{
+		return "PING dns.google (8.8.8.8) on port 81.\n"
+			. "No reply from dns.google (8.8.8.8) on port 81: tcp_conn=1\n"
+			. "No reply from dns.google (8.8.8.8) on port 81: tcp_conn=2\n"
+			. "\n--- dns.google (8.8.8.8) ping statistics ---\n"
+			. "3 packets transmitted, 0 received, 100% packet loss, time 2003 ms\n";
+	}
+
+	public function testAPortThatRepliesIsOpen()
+	{
+		$this->assertEquals(2, check_port_parse_globalping($this->replied()),
+			'a reply on the port is the only evidence that it is open');
+	}
+
+	/**
+	 * The case the counter alone got wrong. Every "No reply" line carries
+	 * tcp_conn=N too, so this must not read as open.
+	 */
+	public function testAPortThatNeverRepliesIsNotOpen()
+	{
+		$this->assertTrue(strpos($this->silent(), 'tcp_conn=') !== false,
+			'the no-reply output does carry the attempt counter');
+		$this->assertEquals(0, check_port_parse_globalping($this->silent()),
+			'and it is still not an open port');
+	}
+
+	/**
+	 * Nor is it a closed one. A probe that heard nothing cannot tell a closed
+	 * port from a filtered one, and saying "closed" would send someone looking
+	 * at a firewall rule that is doing exactly what they meant it to.
+	 */
+	public function testSilenceIsUnknownRatherThanClosed()
+	{
+		$this->assertTrue(check_port_parse_globalping($this->silent()) !== 1,
+			'no reply is not reported as closed');
+	}
+
+	public function testAnExplicitRefusalIsClosed()
+	{
+		$raw = "PING host (192.0.2.1) on port 81.\n"
+			. "connection refused from host (192.0.2.1) on port 81\n";
+		$this->assertEquals(1, check_port_parse_globalping($raw),
+			'a refusal is the one answer that proves the port is closed');
+	}
+
+	public function testAnEmptyOrAbsentOutputIsUnknown()
+	{
+		$this->assertEquals(0, check_port_parse_globalping(''), 'an empty output says nothing');
+		$this->assertEquals(0, check_port_parse_globalping(false),
+			'and neither does a measurement that carried no output at all');
+	}
+
+	public function testOutputInAnUnfamiliarShapeIsUnknown()
+	{
+		$this->assertEquals(0, check_port_parse_globalping("something Globalping has never printed\n"),
+			'an answer nobody recognises is unknown rather than a guess');
+	}
+
+	/**
+	 * "Reply from" has to start a line. Globalping names the host in the
+	 * header line, and a hostname could otherwise carry the phrase into a
+	 * verdict.
+	 */
+	public function testTheReplyMarkerIsAnchoredToTheStartOfALine()
+	{
+		$raw = "PING no-Reply from tcp_conn=1 (192.0.2.1) on port 81.\n"
+			. "No reply from no-Reply from tcp_conn=1 (192.0.2.1) on port 81: tcp_conn=1\n";
+		$this->assertEquals(0, check_port_parse_globalping($raw),
+			'the phrase appearing mid-line is not a reply');
+	}
+}


### PR DESCRIPTION
The Globalping provider added in #3245 read an open port out of rawOutput. Before it was corrected, the rule matched the tcp_conn=N attempt counter anywhere in the output, and Globalping prints that counter on its "No reply" lines too, so every port came back open -- including ports that never answered at all. Because Globalping runs last in the failover chain, that verdict reached the user exactly when no other provider could answer.

Nothing held the corrected rule in place: the verdict was inline in check_port_globalping(), next to the HTTP call, so no test could reach it without the network.

Move it to check_port_parse_globalping() in parse.php, beside check_port_parse_yougetsignal(), and cover it with the two rawOutput shapes the API actually returns -- a reply on 8.8.8.8:53 and no reply on 8.8.8.8:81 -- plus a refusal, an empty body, and output in an unfamiliar shape. Silence stays "unknown" rather than "closed": a probe that heard nothing cannot tell a filtered port from a closed one.

Also check the shipped configuration against the provider registry. action.php skips any provider that is unknown or that does not claim the address family being checked, so a name that does not line up costs no error -- the provider is simply never tried, and the chain is quietly shorter than the comment in conf.php reads.

Each case was confirmed to fail with the check it guards removed.