### PR TITLE
Read one XMLRPC proxy policy at both entry points

### DIFF
--- a/plugins/httprpc/action.php
+++ b/plugins/httprpc/action.php
@@ -685,10 +685,23 @@ switch($mode)
 	{
 		if(isset($HTTP_RAW_POST_DATA))
 		{
+			// The policy is shared with rpc2.php: one statement of what a
+			// caller may name, for every door that reaches rtorrent through
+			// this filter. The plugin conf is evaluated after it, so a
+			// deployment that means this door to differ still says so there.
+			$policyFile = dirname(__FILE__).'/../../conf/xmlrpc_proxy.php';
+			if(is_file($policyFile) && is_readable($policyFile))
+				require_once($policyFile);
 			eval(FileUtil::getPluginConf('httprpc'));
 			$proxyMode = isset($XMLRPCProxy) ? $XMLRPCProxy : 'sanitize';
 			$proxyLog = isset($XMLRPCProxyLog) ? $XMLRPCProxyLog : true;
 			$proxySafeParams = isset($XMLRPCProxySafeParams) ? $XMLRPCProxySafeParams : array();
+			// With no policy at all every command parameter is stripped, which
+			// costs a client its labels and directories and looks to it like a
+			// client problem. Name the cause instead.
+			if($proxyLog && (count($proxySafeParams) == 0))
+				FileUtil::toLog("xmlrpc-proxy: no \$XMLRPCProxySafeParams is defined in "
+					."conf/xmlrpc_proxy.php or plugins/httprpc/conf.php");
 			$proxyLocalPaths = isset($XMLRPCProxyAllowLocalPaths) ? $XMLRPCProxyAllowLocalPaths : false;
 			// d.directory.set names the directory rtorrent writes a download
 			// into, and the caller supplies the torrent, so it names the file

--- a/plugins/httprpc/conf.php
+++ b/plugins/httprpc/conf.php
@@ -31,27 +31,11 @@ $XMLRPCProxyLog = true;
 // does not affect it.
 $XMLRPCProxyAllowLocalPaths = false;
 
-// Command names allowed as load.* parameters in sanitize mode.
-// External clients (Prowlarr, Sonarr, Radarr, Transdroid, cross-seed)
-// attach these to load.start / load.raw_start to set labels, directories,
-// priorities, etc. Quoted values (d.custom1.set="cross-seed") are accepted.
-// Entries are full command names and are matched exactly: 'd.custom' does
-// NOT cover 'd.custom1.set'. A param whose command name is not listed is
-// stripped and logged. Add entries here if your external client needs
-// additional commands.
-$XMLRPCProxySafeParams = array(
-	'd.custom1.set',            // label
-	'd.custom2.set',            // custom field
-	'd.custom3.set',            // custom field
-	'd.custom4.set',            // custom field
-	'd.custom5.set',            // used by erasedata
-	'd.custom.set',             // generic custom field
-	'd.directory.set',          // download directory
-	'd.directory_base.set',     // base directory
-	'd.priority.set',           // priority
-	'd.throttle_name.set',      // throttle group
-	'd.views.push_back_unique', // view membership
-
-	// Actions (not setters):
-	'd.delete_tied',            // delete .torrent on remove
-);
+// The command names a caller may attach to a load.* or to a multicall are
+// $XMLRPCProxySafeParams in conf/xmlrpc_proxy.php, which action.php loads
+// before this file. One list serves every entry point that fronts rtorrent,
+// so a client that works through one works through all of them.
+//
+// Setting the list here is still honoured, and still wins, because this file
+// is evaluated after that one -- but it then applies to this entry point
+// alone. Set it here only when this one is meant to differ.

--- a/tests/php/XMLRPCProxyEntrypointTest.php
+++ b/tests/php/XMLRPCProxyEntrypointTest.php
@@ -106,6 +106,47 @@ class XMLRPCProxyEntrypointTest extends TestCase
 			'rpc2 refusal returns the XMLRPC -501 envelope');
 	}
 
+	public function testBothDoorsDecideTheSameTrustForTheSameRequest()
+	{
+		$httprpc = $this->runEntrypoint('action', $this->viewActionXml(), true);
+		$this->assertEquals(true, $httprpc['state']['trusted'],
+			'httprpc sends a view-action multicall on a trusted connection');
+		$this->assertTrue(in_array('xmlrpc-proxy: trusted: d.multicall2 (3 params)',
+			$httprpc['state']['logs'], true),
+			'httprpc rebuilt the multicall from the shared policy');
+
+		$rpc2 = $this->runEntrypoint('rpc2', $this->viewActionXml(), true);
+		$this->assertRpc2Log($rpc2, 'trusted: d.multicall2 (3 params)',
+			'rpc2 reaches that same decision on that same request');
+		$this->assertTrue(strpos($rpc2['rpc2logs'], 'untrusted') === false,
+			'and neither door falls back to forwarding it untrusted');
+	}
+
+	public function testHttprpcNamesAMissingPolicyRatherThanStrippingInSilence()
+	{
+		$result = $this->runEntrypoint('action', $this->viewActionXml(), true, 'success', 'none');
+		$this->assertTrue(in_array('xmlrpc-proxy: no $XMLRPCProxySafeParams is defined in '
+			. 'conf/xmlrpc_proxy.php or plugins/httprpc/conf.php',
+			$result['state']['logs'], true),
+			'a tree with no policy says so rather than letting it read as a client fault');
+		$this->assertEquals(false, $result['state']['trusted'],
+			'with no policy every command parameter is stripped and the call goes untrusted');
+	}
+
+	/**
+	 * "Stop all": what a client sends to act on a whole view. rtorrent refuses
+	 * d.stop to an untrusted caller, so a door that forwards this untrusted
+	 * answers a fault where the other door succeeds.
+	 */
+	private function viewActionXml()
+	{
+		return '<?xml version="1.0"?><methodCall><methodName>d.multicall2</methodName>'
+			. '<params><param><value><string></string></value></param>'
+			. '<param><value><string>default</string></value></param>'
+			. '<param><value><string>d.stop=</string></value></param>'
+			. '</params></methodCall>';
+	}
+
 	private function deniedXml()
 	{
 		return '<?xml version="1.0"?><methodCall><methodName>execute.capture</methodName>'
@@ -118,7 +159,7 @@ class XMLRPCProxyEntrypointTest extends TestCase
 			. '<params></params></methodCall>';
 	}
 
-	private function runEntrypoint($door, $body, $logging, $send = 'success')
+	private function runEntrypoint($door, $body, $logging, $send = 'success', $policy = 'shipped')
 	{
 		$tree = sys_get_temp_dir() . '/rutorrent-entrypoint-' . uniqid('', true);
 		$process = null;
@@ -126,7 +167,7 @@ class XMLRPCProxyEntrypointTest extends TestCase
 		{
 			if(!mkdir($tree, 0700, true) && !is_dir($tree))
 				throw new Exception('could not create entrypoint fixture tree');
-			$this->copyProductionTree($tree);
+			$this->copyProductionTree($tree, $policy);
 			$state = $tree . '/state.json';
 			file_put_contents($state, json_encode(array(
 				'sends' => 0, 'responses' => 0, 'logs' => array(),
@@ -175,13 +216,21 @@ class XMLRPCProxyEntrypointTest extends TestCase
 		}
 	}
 
-	private function copyProductionTree($tree)
+	private function copyProductionTree($tree, $policy = 'shipped')
 	{
 		$files = array(
 			'plugins/httprpc/action.php',
 			'php/xmlrpc_proxy.php',
 			'rpc2.php',
 		);
+		// The shipped policy files, so that what a door decides here is what it
+		// decides on an install rather than what this fixture invented. "none"
+		// copies neither, which is a tree missing its configuration.
+		if($policy === 'shipped')
+		{
+			$files[] = 'conf/xmlrpc_proxy.php';
+			$files[] = 'plugins/httprpc/conf.php';
+		}
 		foreach($files as $relative)
 		{
 			$source = $this->sourceRoot . '/' . $relative;
@@ -195,7 +244,8 @@ class XMLRPCProxyEntrypointTest extends TestCase
 
 	private function writeStubs($tree)
 	{
-		mkdir($tree . '/conf', 0700, true);
+		if(!is_dir($tree . '/conf'))
+			mkdir($tree . '/conf', 0700, true);
 		file_put_contents($tree . '/php/xmlrpc.php', <<<'PHP'
 <?php
 function entrypoint_state($key, $value = null)
@@ -221,7 +271,12 @@ class FileUtil
 {
 	public static function getPluginConf($plugin)
 	{
-		return '$XMLRPCProxy = "sanitize"; $XMLRPCProxyLog = '
+		// Production evaluates the plugin's own conf file here. The logging
+		// setting is appended after it, which is where a deployment's own
+		// override lands too.
+		$conf = dirname(__FILE__) . '/../plugins/' . $plugin . '/conf.php';
+		return (is_file($conf) ? 'require("' . $conf . '");' : '')
+			. '$XMLRPCProxyLog = '
 			. ((getenv('XMLRPC_ENTRYPOINT_LOGGING') === '1') ? 'true' : 'false') . ';';
 	}
 	public static function toLog($message) { entrypoint_state('log', $message); }
@@ -250,8 +305,10 @@ PHP
 		file_put_contents($tree . '/plugins/httprpc/rpccache.php', "<?php\n");
 		file_put_contents($tree . '/conf/config.php', <<<'PHP'
 <?php
-$topDirectory = '/';
-$XMLRPCProxyAllowRootDirectory = true;
+// A real directory rather than "/": the shipped policy leaves
+// $XMLRPCProxyAllowRootDirectory false, and rpc2.php refuses to serve at all
+// while the boundary is one that confines nothing.
+$topDirectory = realpath(dirname(__FILE__) . '/..');
 $log_file = dirname(__FILE__) . '/../rpc2.log';
 $scgi_host = '127.0.0.1';
 $scgi_port = 1;

--- a/tests/php/XMLRPCProxyPolicyParityTest.php
+++ b/tests/php/XMLRPCProxyPolicyParityTest.php
@@ -1,0 +1,98 @@
+<?php
+
+require_once(__DIR__ . '/TestCase.php');
+
+/**
+ * One safe-parameter policy, for every entry point.
+ *
+ * conf/xmlrpc_proxy.php states which command names a caller may attach to a
+ * load.* or to a multicall. A second $XMLRPCProxySafeParams elsewhere in the
+ * shipped tree replaces it for whichever entry point loads that file, and
+ * nothing about two lists says they are meant to agree: they drift, and a
+ * client that works through one entry point is refused through the other.
+ *
+ * A shipped file may still restate the policy. This asserts only that it does
+ * not restate it differently.
+ */
+class XMLRPCProxyPolicyParityTest extends TestCase
+{
+	private $root = null;
+	private $reference = null;
+
+	public function setUp()
+	{
+		$this->root = realpath(__DIR__ . '/../..');
+		$this->reference = $this->safeParamsOf($this->root . '/conf/xmlrpc_proxy.php');
+	}
+
+	/**
+	 * The list a policy file defines on its own, or null when it defines none.
+	 * Evaluated inside a closure so one file's other variables cannot reach the
+	 * next.
+	 */
+	private function safeParamsOf($file)
+	{
+		$read = function ($f) {
+			$XMLRPCProxySafeParams = null;
+			require($f);
+			return $XMLRPCProxySafeParams;
+		};
+		return $read($file);
+	}
+
+	/** Every shipped conf file that assigns the list, other than the reference. */
+	private function otherDefiners()
+	{
+		$found = array();
+		foreach (array('/conf', '/plugins') as $sub) {
+			$dir = $this->root . $sub;
+			if (!is_dir($dir)) {
+				continue;
+			}
+			$walk = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(
+				$dir, FilesystemIterator::SKIP_DOTS));
+			foreach ($walk as $file) {
+				$path = $file->getPathname();
+				if (!preg_match('`/(conf|conf\.local|xmlrpc_proxy)\.php$`', $path)) {
+					continue;
+				}
+				if ($path === $this->root . '/conf/xmlrpc_proxy.php') {
+					continue;
+				}
+				$src = @file_get_contents($path);
+				if (($src !== false) && preg_match('`\$XMLRPCProxySafeParams\s*=`', $src)) {
+					$found[] = $path;
+				}
+			}
+		}
+		sort($found);
+		return $found;
+	}
+
+	public function testTheSharedPolicyCarriesTheViewActions()
+	{
+		$this->assertTrue(is_array($this->reference) && (count($this->reference) > 0),
+			'conf/xmlrpc_proxy.php defines $XMLRPCProxySafeParams');
+		// A client sends these as a multicall over a view to stop or resume
+		// everything. Left out, the multicall carries a command this side does
+		// not rebuild, so it goes to rtorrent untrusted -- which refuses d.stop
+		// and d.start to an untrusted caller.
+		foreach (array('d.open', 'd.close', 'd.start', 'd.stop') as $action) {
+			$this->assertTrue(in_array($action, (array)$this->reference, true),
+				"the shared policy allows {$action}");
+		}
+	}
+
+	public function testEveryOtherDefinitionOfThePolicyAgreesWithIt()
+	{
+		$reference = (array)$this->reference;
+		sort($reference);
+		foreach ($this->otherDefiners() as $path) {
+			$theirs = (array)$this->safeParamsOf($path);
+			sort($theirs);
+			$name = substr($path, strlen($this->root) + 1);
+			$this->assertEquals(json_encode($reference), json_encode($theirs),
+				"{$name} states the same safe-parameter policy as conf/xmlrpc_proxy.php");
+		}
+	}
+}


### PR DESCRIPTION
#3188 moved the raw XMLRPC pass-through policy into conf/xmlrpc_proxy.php so that one file would state it for every entry point, and left the older copy in plugins/httprpc/conf.php in place. Nothing loads the new file except rpc2.php, so the two lists were free to drift, and they did: the shared policy allows d.open, d.close, d.start and d.stop, and the plugin conf does not.

The same request therefore gets a different answer depending on which entry point it arrives at. A client stopping a whole view sends d.multicall2 carrying d.stop=; through rpc2.php that is rebuilt and sent trusted, and through the httprpc plugin it is forwarded untrusted, where rtorrent refuses d.stop to an untrusted caller. Measured on 0.16.21 and 0.16.20.

action.php now loads the shared policy before evaluating the plugin conf, which is the order conf/xmlrpc_proxy.php already documents: a deployment that means this entry point to differ says so in the plugin conf, and that still wins. The shipped plugin conf no longer restates the list.

A tree that defines no policy at all now says so in the log, rather than stripping every command parameter in silence and leaving it to read as a client fault.