### PR TITLE
history plugin: Fix context menu delete confirmation

### DIFF
--- a/plugins/history/init.js
+++ b/plugins/history/init.js
@@ -378,7 +378,7 @@ if(plugin.canChangeTabs() || plugin.canChangeColumns())
 			{
 				var self = "theWebUI.getTable('"+this.prefix+"').";
 				theContextMenu.clear();
-				theContextMenu.add([theUILang.Remove, self+"cmdHistory('delete')"]);
+				theContextMenu.add([theUILang.Remove, self+"historyRemove()"]);
 				theContextMenu.show(e.clientX,e.clientY);
 			}
 		}


### PR DESCRIPTION
Use historyRemove() in the History context menu so deleting entries respects the webui.confirm_when_deleting setting and displays the confirmation dialog.