### PR TITLE
Ask for the XMLRPC size limit outside the settings batch

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -280,11 +280,17 @@ class rTorrentSettings
 			{
 				if(!$req->fault)
 					$this->badXMLRPCVersion = false;
+				// The size limit is a request, not a reading. rtorrent refuses
+				// one above SCgiTask::max_content_size, and inside the batch
+				// below that refusal would take every reading with it.
+				$req = new rXMLRPCRequest( new rXMLRPCCommand("set_xmlrpc_size_limit",67108863) );
+				$req->important = false;
+				$req->success();
+
 				$req = new rXMLRPCRequest( array(
 					new rXMLRPCCommand("get_directory"),
 					new rXMLRPCCommand("get_session"),
 					new rXMLRPCCommand("system.library_version"),
-					new rXMLRPCCommand("set_xmlrpc_size_limit",67108863),
 					new rXMLRPCCommand("get_name"),
 					new rXMLRPCCommand("get_port_range"),
 					new rXMLRPCCommand("get_bind"),
@@ -295,11 +301,11 @@ class rTorrentSettings
 					$this->directory = $req->val[0];
   		        	        $this->session = $req->val[1];
 					$this->libVersion = $req->val[2];
-					$this->server = $req->val[4];
-					$this->portRange = $req->val[5];
+					$this->server = $req->val[3];
+					$this->portRange = $req->val[4];
 					$this->port = intval($this->portRange);
-					$this->bind = $req->val[6];
-					$this->ip = $req->val[7];
+					$this->bind = $req->val[5];
+					$this->ip = $req->val[6];
 
 					if($this->iVersion>=0x809)
 					{


### PR DESCRIPTION
Fixes #3256.

php/settings.php sent set_xmlrpc_size_limit as one of eight commands in a single batched request, with every other reading assigned only inside the success check that followed. rtorrent 0.16.22 refuses any limit above SCgiTask::max_content_size (16777216); the value asked for, 67108863, is over that on every installation, so the batch faults and takes directory, session, libVersion, server, portRange, port, bind, ip, uid, gid and home down with it — an empty libTorrent version, an unresolved rTorrent user, the daemon's default port, and autotools/xmpp/rutracker_check disabling themselves with an empty session path.

The limit now goes out in its own request marked important = false, the idiom this file already uses for system.api_version and network.listen.port, and the four indices after it in the main batch shift down by one. The limit is still requested; a refusal no longer takes the other seven readings with it.

Verified against rTorrent 0.16.22: version, session path, port and uid all resolve, and the three plugins load. rTorrent 0.16.21, where the limit is accepted, is unaffected.

No automated test: the fault path is inside rTorrentSettings::obtain()'s live daemon handshake, which the suite doesn't mock at the transport level.
