### PR TITLE
Pin the editorconfig-checker download in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: editorconfig-checker
-        run: npx --yes editorconfig-checker@5
+        # Both halves are pinned on purpose. The wrapper has to be one that
+        # knows the current release asset names as well as the legacy ones,
+        # and EC_VERSION pins the checker it downloads -- left to itself it
+        # takes whatever release is latest, so an upstream change lands here
+        # without a commit.
+        env:
+          EC_VERSION: v4.0.1
+        run: npx --yes editorconfig-checker@7
 
   eslint:
     # Advisory for now (same plan as editorconfig).


### PR DESCRIPTION
The lint job runs `npx --yes editorconfig-checker@5`, which asks for a release asset named `ec-linux-amd64*` and takes whichever release is currently latest. editorconfig-checker renamed its assets in v4.0.0 -- `editorconfig-checker-linux-amd64.tar.gz` now -- and v4.0.1 became the latest release on 2026-09-04, so the download fails on every branch:

    Failed to download binary:
    Error: The binary 'ec-linux-amd64*' not found

Version 7 of the npm wrapper builds both the current and the legacy asset name, so it resolves either way. EC_VERSION pins the checker itself, which the wrapper otherwise resolves as "latest" on every run -- which is how an upstream release changed this job with no commit here.

Checked against v4.0.1: no findings on the tree, and a file carrying trailing whitespace still fails the job.