### PR TITLE
Ask for an XMLRPC size limit rtorrent accepts

### DIFF
--- a/php/settings.php
+++ b/php/settings.php
@@ -280,10 +280,17 @@ class rTorrentSettings
 			{
 				if(!$req->fault)
 					$this->badXMLRPCVersion = false;
-				// The size limit is a request, not a reading. rtorrent refuses
-				// one above SCgiTask::max_content_size, and inside the batch
-				// below that refusal would take every reading with it.
-				$req = new rXMLRPCRequest( new rXMLRPCCommand("set_xmlrpc_size_limit",67108863) );
+				// The size limit is a request, not a reading. Sent inside the
+				// batch below, a refusal would take every reading with it.
+				//
+				// 16777216 is SCgiTask::max_content_size, which the SCGI
+				// transport applies to CONTENT_LENGTH: a request larger than
+				// that is refused whatever this limit says, so asking for more
+				// buys nothing and from 0.16.22 rtorrent refuses to set it.
+				// Worth asking for at all because the default, 524288, is
+				// smaller than plenty of torrent files, and load.raw_start
+				// carries them through here.
+				$req = new rXMLRPCRequest( new rXMLRPCCommand("set_xmlrpc_size_limit",16777216) );
 				$req->important = false;
 				$req->success();
 


### PR DESCRIPTION
php/settings.php asks for 67108863. rtorrent 0.16.22 refuses it -- "XMLRPC size limit cannot exceed the SCGI content size limit" -- so since #3257 sent the request on its own it fails quietly and the limit stays at the default of 524288. Torrent files travel through XMLRPC in load.raw_start, so on 0.16.22 only small ones can be added.

The value was never reachable on any version. SCgiTask::max_content_size is (2 << 23) in 0.16.21 and 0.16.22 alike and scgi_task.cc refuses any request whose CONTENT_LENGTH exceeds it: on 0.16.21 a request declaring 16777217 is closed unanswered while 16777216 is served. 0.16.22 only began refusing to configure a size its transport was never going to carry.

16777216 is that ceiling. Both versions accept it, it raises the limit where 67108863 left it at the default, and it is already the maximum php/xmlrpc_proxy.php lets a caller ask for.