### PR TITLE
Title: trafic: keep the ratio columns filled, and let rStat read another profile

### DIFF
--- a/plugins/trafic/init.js
+++ b/plugins/trafic/init.js
@@ -209,7 +209,6 @@ if(plugin.canChangeTabs())
 
 if(plugin.canChangeColumns() && plugin.collectStatForTorrents)
 {
-	plugin.ratioChanged = false;
 	plugin.config = theWebUI.config;
 	theWebUI.config = function()
 	{
@@ -278,29 +277,22 @@ if(plugin.canChangeColumns() && plugin.collectStatForTorrents)
 
 	plugin.updateRatios = function( d )
 	{
-		plugin.ratioChanged = true;
 		window.setTimeout( plugin.startRatios, plugin.updateInterval*60000 );
 	}
 
 	plugin.addTorrents = theWebUI.addTorrents;
 	theWebUI.addTorrents = function(data)
 	{
-		if(plugin.ratioChanged)
+		$.each(data.torrents, function(hash,torrent)
 		{
-			$.each(data.torrents, function(hash,torrent)
+			if($type(theWebUI.ratiosStat[hash]) && torrent.size)
 			{
-				if($type(theWebUI.ratiosStat[hash]) && torrent.size)
-				{
-					torrent.ratioday = theWebUI.ratiosStat[hash][0]/torrent.size;
-					torrent.ratioweek = theWebUI.ratiosStat[hash][1]/torrent.size;
-					torrent.ratiomonth = theWebUI.ratiosStat[hash][2]/torrent.size;
-				}
-			});
-			plugin.addTorrents.call(this, data);
-			plugin.ratioChanged = false;
-		}
-		else
-			plugin.addTorrents.call(this, data);
+				torrent.ratioday = theWebUI.ratiosStat[hash][0]/torrent.size;
+				torrent.ratioweek = theWebUI.ratiosStat[hash][1]/torrent.size;
+				torrent.ratiomonth = theWebUI.ratiosStat[hash][2]/torrent.size;
+			}
+		});
+		plugin.addTorrents.call(this, data);
 	}
 
 	rTorrentStub.prototype.getratios = function()

--- a/plugins/trafic/stat.php
+++ b/plugins/trafic/stat.php
@@ -24,9 +24,11 @@ class rStat
 			(strpos($name,"\0")===false) && ($name!=='.') && ($name!=='..') );
 	}
 
-	public function __construct( $prefix )
+	public function __construct( $prefix, $settingsPath = null )
 	{
-		$this->fname = FileUtil::getSettingsPath().'/trafic/'.$prefix;
+		if(is_null($settingsPath))
+			$settingsPath = FileUtil::getSettingsPath();
+		$this->fname = $settingsPath.'/trafic/'.$prefix;
 		if($file=@fopen($this->fname,"r"))
 		{
 			$hourUp = fgetcsv($file, 0, ",", "\"", "");

--- a/tests/plugins/trafic/SettingsPathTest.php
+++ b/tests/plugins/trafic/SettingsPathTest.php
@@ -1,0 +1,81 @@
+<?php
+
+require_once(__DIR__ . '/../../php/TestCase.php');
+require_once(__DIR__ . '/../../../plugins/trafic/stat.php');
+
+/**
+ * Statistics are stored per profile, and a front end that serves more than one
+ * rtorrent has to read them from the profile of whoever owns the torrent --
+ * which is not the profile the request arrived under. The directory is an
+ * argument for that; left out, it is the current profile as before.
+ */
+class SettingsPathTest extends TestCase
+{
+	private $dir = '';
+
+	private function storage()
+	{
+		if ($this->dir === '') {
+			$this->dir = sys_get_temp_dir() . '/rutorrent-trafic-' . getmypid();
+			@mkdir($this->dir . '/trafic/torrents', 0777, true);
+		}
+		return ($this->dir);
+	}
+
+	// One day's worth of upload in the current hour, and a month's worth in the
+	// current day, written as update.php writes them.
+	private function writeStat($name, $hourUp, $monthUp)
+	{
+		$now = getdate();
+		$rows = array(
+			$this->bucket(24, $now['hours'], $hourUp),
+			array_fill(0, 24, 0),
+			$this->bucket(24, $now['hours'], $now[0]),
+			$this->bucket(31, $now['mday'] - 1, $monthUp),
+			array_fill(0, 31, 0),
+			$this->bucket(31, $now['mday'] - 1, $now[0]),
+			array_fill(0, 12, 0),
+			array_fill(0, 12, 0),
+			array_fill(0, 12, 0),
+		);
+		$file = fopen($this->storage() . '/trafic/torrents/' . $name, 'w');
+		foreach ($rows as $row) {
+			fputcsv($file, $row, ",", "\"", "");
+		}
+		fclose($file);
+	}
+
+	private function bucket($size, $ndx, $value)
+	{
+		$row = array_fill(0, $size, 0);
+		$row[$ndx] = $value;
+		return ($row);
+	}
+
+	public function testItReadsTheProfileItIsGiven()
+	{
+		$this->writeStat('A1.csv', 4096, 8192);
+
+		$st = new rStat('torrents/A1.csv', $this->storage());
+		$ratios = $st->getRatios(time());
+
+		$this->assertEquals(4096, $ratios[0], 'the day comes from the hour buckets');
+		$this->assertEquals(8192, $ratios[1], 'the week from the day buckets');
+		$this->assertEquals(8192, $ratios[2], 'and so does the month');
+	}
+
+	public function testWithoutOneItIsTheCurrentProfile()
+	{
+		$st = new rStat('torrents/A1.csv');
+
+		$this->assertEquals(FileUtil::getSettingsPath() . '/trafic/torrents/A1.csv', $st->fname,
+			'the profile of the user the request arrived under');
+	}
+
+	public function testAProfileWithoutTheFileReportsNothing()
+	{
+		$st = new rStat('torrents/missing.csv', $this->storage());
+
+		$this->assertEquals(array(0, 0, 0), $st->getRatios(time()), 'no file, no traffic');
+	}
+}

--- a/tests/plugins/trafic/ratios.spec.js
+++ b/tests/plugins/trafic/ratios.spec.js
@@ -1,0 +1,131 @@
+import { readFileSync } from "fs";
+
+window.$ = window.jQuery = require("jquery");
+
+window.theUILang = {
+  traf: "Traffic", perDay: "Per day", perMonth: "Per month", perYear: "Per year",
+  allTrackers: "All trackers", ClearButton: "Clear", selectedTorrent: "Selected",
+  ratioDay: "Ratio/day", ratioWeek: "Ratio/week", ratioMonth: "Ratio/month",
+};
+window.TYPE_NUMBER = "number";
+window.theWebUI = { settings: {}, torrents: {} };
+window.theTabs = { onShow: function () {} };
+window.thePlugins = { isInstalled: () => false };
+window.rTorrentStub = function () {};
+window.rGraph = class {};
+
+// The getratios response is a <script> the browser runs: it assigns
+// theWebUI.ratiosStat and the callback marks it fresh.
+let ratiosCallback = null;
+
+window.theWebUI.request = function (url, cb) {
+  expect(url).toBe("?action=getratios");
+  ratiosCallback = cb; // [handler, context], as the core request() takes it
+};
+window.theWebUI.addTorrents = function () {};
+
+const load = (src) => {
+  const el = document.createElement("script");
+  el.textContent = readFileSync(src, { encoding: "utf-8" });
+  document.body.appendChild(el);
+};
+
+load("../js/common.js");   // $type
+load("../js/stable.js");   // the real dxSTable, for the row half of the story
+
+// The plugin file as the browser gets it, with the tab half switched off: the
+// ratio columns live under canChangeColumns(), which is the part under test.
+const code = readFileSync("../plugins/trafic/init.js", { encoding: "utf-8" });
+const el = document.createElement("script");
+el.textContent =
+  "var plugin = { canChangeTabs: () => false, canChangeColumns: () => true," +
+  " collectStatForTorrents: true, updateInterval: 15, allStuffLoaded: false," +
+  " loadLang: () => {} };" +
+  "window.traficPlugin = plugin;" + code;
+document.body.appendChild(el);
+
+const plugin = window.traficPlugin;
+
+// A getratios round trip: the response script sets ratiosStat, then the
+// callback runs.
+function ratiosArrive(stat) {
+  window.theWebUI.ratiosStat = stat;
+  const [handler, context] = ratiosCallback;
+  handler.call(context, stat);
+}
+
+const HASH = "613BC75564F589B579D7040CF8E82525E81EF80C";
+const SIZE = 1000;
+const listResponse = () => ({ torrents: { [HASH]: { size: SIZE, name: "x" } } });
+
+describe("trafic ratio columns", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    window.theWebUI.ratiosStat = {};
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("fills the columns on the update that follows a getratios answer", () => {
+    ratiosArrive({ [HASH]: [100, 200, 300] });
+
+    const data = listResponse();
+    window.theWebUI.addTorrents(data);
+
+    expect(data.torrents[HASH].ratioday).toBe(0.1);
+    expect(data.torrents[HASH].ratioweek).toBe(0.2);
+    expect(data.torrents[HASH].ratiomonth).toBe(0.3);
+  });
+
+  it("fills them on every later update too", () => {
+    ratiosArrive({ [HASH]: [100, 200, 300] });
+    window.theWebUI.addTorrents(listResponse());
+
+    // rtorrent.js builds a fresh torrent object per poll, so each update has
+    // to be given the ratios again.
+    const next = listResponse();
+    window.theWebUI.addTorrents(next);
+
+    expect(next.torrents[HASH].ratioday).toBe(0.1);
+    expect(next.torrents[HASH].ratioweek).toBe(0.2);
+    expect(next.torrents[HASH].ratiomonth).toBe(0.3);
+  });
+
+  it("has nothing to add before the first answer arrives", () => {
+    const data = listResponse();
+    window.theWebUI.addTorrents(data);
+
+    expect("ratioday" in data.torrents[HASH]).toBe(false);
+  });
+});
+
+describe("what the table does with an update that omits the ratios", () => {
+  const IDS = ["name", "ratioday", "ratioweek", "ratiomonth"];
+
+  it("keeps the cells of an existing row as they were", () => {
+    const written = [];
+    const table = {
+      ids: IDS,
+      setValue: (row, col, val) => {
+        written.push([IDS[col], val]);
+        return true;
+      },
+    };
+
+    window.dxSTable.prototype.setValuesByIds.call(table, "ROW1", { name: "x" });
+
+    expect(written).toEqual([["name", "x"]]);
+  });
+
+  it("writes null into a new row, which is a blank cell", () => {
+    let cols = null;
+    const table = { ids: IDS, addRow: (c) => { cols = c; return true; } };
+
+    window.dxSTable.prototype.addRowById.call(table, { name: "x" }, "ROW1", null, {});
+
+    expect(cols).toEqual(["x", null, null, null]);
+  });
+});


### PR DESCRIPTION
Fixes #3269.

**The blank columns**

`plugin.startRatios()` fetches `?action=getratios` once per `$updateInterval` (15
minutes by default). The answer is a script that assigns `theWebUI.ratiosStat` and
sets `plugin.ratioChanged`. The `theWebUI.addTorrents` override merged the ratios
into the torrent list only while that flag was up, and cleared it immediately — one
update out of every fifteen minutes.

Nothing carries the values over in between: `rTorrentStub.prototype.listResponse`
builds a fresh torrent object per poll. What made it look intermittent rather than
broken is in `stable.js` — `setValuesByIds` skips a property the update does not
carry, so an **existing** row keeps its cells, while `addRowById` maps
`ids[id] ?? null`, so a **new** row is blank.

At page load every row is new, so the result depends on which response arrives
first. If the torrent list wins, all three columns are created blank and stay blank
until the next interval; a torrent added later is blank just as long. If
`getratios` wins, they are filled and then persist. Reloading re-runs the race,
which is what the report describes as needing several refreshes.

Merging on every update removes the race. The statistics themselves are still
fetched on the plugin's interval, so this costs three divisions per torrent per
poll against a map that is rebuilt anyway.

**The rStat argument**

Second commit, independent of the fix. `rStat` resolved its file under
`FileUtil::getSettingsPath()`, i.e. the profile of the user the request arrived as
— the only profile a front end serving a single rtorrent has. A front end serving
several needs the profile of the user who owns the torrent, and that path cannot be
swapped around the call: `FileUtil::getProfilePath()` memoizes into a static. The
directory is now an optional second argument; omitted, the file is resolved exactly
as before.

**Tests**

`tests/plugins/trafic/ratios.spec.js` loads the real `plugins/trafic/init.js`,
`js/stable.js` and `js/common.js` in jsdom and drives the override directly: ratios
land on the first update after an answer *and* on later ones; nothing is added
before the first answer; and the two `dxSTable` paths are pinned — an update
omitting the properties leaves an existing row's cells alone, a new row gets
`null`.

`tests/plugins/trafic/SettingsPathTest.php` writes a stat file into a temporary
profile and reads it back through the new argument, checks the default still
resolves under the current profile, and checks a missing file reports zeros.

Both fail on `master` before the corresponding commit — the spec with
`Expected: 0.1 / Received: undefined`, the PHP test with three failures and a
non-zero suite exit.

Full suites green: `tests/php-test.sh` on PHP 8.4 and on `php:7.4-cli` (2228
assertions, 0 failures each), Jest 286/286, PHPStan clean, editorconfig-checker and
eslint 9 clean. Behaviour confirmed in a browser against a live install running
rtorrent 0.16.20.