### PR TITLE
fix(seedingtime): clamp elapsed duration to zero on clock skew

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -382,7 +382,7 @@ var theConverter =
 		if((noRound==null) && (tm >= 2419200))
 			return "\u221e";
 //		var val = tm % (604800 * 52);
-		var val = tm;
+		var val = Math.max(0, tm);
 		var w = iv(val / 604800);
 		val = val % 604800;
 		var d = iv(val / 86400);

--- a/plugins/seedingtime/init.js
+++ b/plugins/seedingtime/init.js
@@ -25,7 +25,7 @@ if(plugin.canChangeColumns())
 		plugin.reqId1 = theRequestManager.addRequest("trt", theRequestManager.map("d.get_custom=")+"seedingtime",function(hash,torrent,value)
 		{
 			const epochSeconds = iv(value);
-			torrent.seedingtime = (epochSeconds > 3600*24*365) ? new Date().getTime()/1000-(epochSeconds+theWebUI.deltaTime/1000) : -1;
+			torrent.seedingtime = (epochSeconds > 3600*24*365) ? Math.max(0, new Date().getTime()/1000-(epochSeconds+theWebUI.deltaTime/1000)) : -1;
 		});
 		plugin.reqId2 = theRequestManager.addRequest("trt", theRequestManager.map("d.get_custom=")+"addtime",function(hash,torrent,value)
 		{

--- a/tests/js/common.spec.js
+++ b/tests/js/common.spec.js
@@ -567,3 +567,19 @@ describe("socketAllocationFits", () => {
     expect(window.socketAllocationFits(3448, "", "")).toBe(true);
   });
 });
+
+describe("theConverter.time", () => {
+  it("formats 0 as 0s", () => {
+    expect(window.theConverter.time(0, true)).toBe("0s");
+  });
+
+  it("clamps negative durations to 0s", () => {
+    expect(window.theConverter.time(-5, true)).toBe("0s");
+    expect(window.theConverter.time(-15, true)).toBe("0s");
+  });
+
+  it("formats positive durations correctly", () => {
+    expect(window.theConverter.time(65, true)).toBe("1m 5s");
+    expect(window.theConverter.time(3600, true)).toBe("1h 0s");
+  });
+});

--- a/tests/plugins/seedingtime/init.spec.js
+++ b/tests/plugins/seedingtime/init.spec.js
@@ -79,6 +79,12 @@ describe("seedingtime custom-field requests", () => {
     expect(torrent.seedingtime).toBe(3 * 86400 - BIG_DELTA / 1000);
   });
 
+  it("clamps seedingtime to zero when clock skew places the epoch in the future", () => {
+    const torrent = {};
+    seedingtimeCallback("HASH", torrent, String(NOW / 1000 + 10));
+    expect(torrent.seedingtime).toBe(0);
+  });
+
   it("stores addtime as the raw epoch no matter how skewed the clock is", () => {
     const torrent = {};
     theWebUI.deltaTime = BIG_DELTA;


### PR DESCRIPTION
### Problem
When clock skew, client-server latency, or coarse 1-second HTTP Date header resolution causes the browser's estimated current time (`(new Date().getTime() - theWebUI.deltaTime) / 1000`) to lag slightly behind the completion timestamp captured on the server (`d.custom=seedingtime` via `date +%s`), the elapsed duration evaluates to a small negative number.

Because neither `plugins/seedingtime/init.js` nor `theConverter.time` checked for negative values, ruTorrent formatted this directly as minus seconds (e.g. `-15s`) in the "Finished" column until the browser clock passed the finish timestamp.

### Solution
1. In `plugins/seedingtime/init.js`, clamp `torrent.seedingtime` to a minimum of `0` with `Math.max(0, ...)`.
2. In `js/common.js`, clamp duration values in `theConverter.time` with `Math.max(0, tm)` so negative durations are never displayed.
3. Added unit tests in `tests/plugins/seedingtime/init.spec.js` and `tests/js/common.spec.js` covering clock skew and negative duration clamping.

### Testing
- Tested on a live instance on FreeBSD 15.1 with rTorrent 0.16.x and ruTorrent behind Apache mod_proxy_scgi.
- Ran the full Jest test suite (`npm test` in `tests/`): all 24 test suites and 290 tests pass.